### PR TITLE
fix: update marker positions in the waveform slip render

### DIFF
--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -29,6 +29,7 @@ WaveformWidget::WaveformWidget(QWidget* parent,
         : WGLWidget(parent),
           WaveformWidgetAbstract(group),
           m_type(type),
+          m_pWaveformRenderMarkSlip(nullptr),
           m_pWaveformRendererSignal(nullptr) {
     auto pTopNode = std::make_unique<rendergraph::Node>();
     auto pOpacityNode = std::make_unique<rendergraph::OpacityNode>();
@@ -80,7 +81,7 @@ WaveformWidget::WaveformWidget(QWidget* parent,
         pOpacityNode->appendChildNode(
                 addRendererNode<WaveformRenderBeat>(
                         ::WaveformRendererAbstract::Slip));
-        pOpacityNode->appendChildNode(
+        m_pWaveformRenderMarkSlip = pOpacityNode->appendChildNode(
                 addRendererNode<WaveformRenderMark>(
                         ::WaveformRendererAbstract::Slip));
     }
@@ -153,6 +154,9 @@ void WaveformWidget::paintGL() {
 
     m_pWaveformRenderMark->update();
     m_pWaveformRenderMarkRange->update();
+    if (m_pWaveformRenderMarkSlip) {
+        m_pWaveformRenderMarkSlip->update();
+    }
 
     m_pEngine->preprocess();
     m_pEngine->render();

--- a/src/waveform/widgets/allshader/waveformwidget.h
+++ b/src/waveform/widgets/allshader/waveformwidget.h
@@ -69,6 +69,8 @@ class allshader::WaveformWidget final : public ::WGLWidget,
     rendergraph::OpacityNode* m_pOpacityNode;
     WaveformRenderMark* m_pWaveformRenderMark;
     WaveformRenderMarkRange* m_pWaveformRenderMarkRange;
+    WaveformRenderMark* m_pWaveformRenderMarkSlip;
+
     WaveformRendererSignalBase* m_pWaveformRendererSignal;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformWidget);


### PR DESCRIPTION
Currently, the markers don't display in the slip part of the waveform. This is because the renderer needs to be explicitly updated, and this was missing. 

Fixes #15834