### PR TITLE
(fix) Key delegate: apply 'played' color

### DIFF
--- a/src/library/tabledelegates/defaultdelegate.cpp
+++ b/src/library/tabledelegates/defaultdelegate.cpp
@@ -16,14 +16,14 @@ void DefaultDelegate::paint(
     initStyleOption(&opt, index);
 
     if (opt.state & QStyle::State_Selected) {
-        setHighlightedTextColor(opt, index);
+        setTextColor(opt, index);
     }
     // TODO Guarantee font/bg contrast with ALL track colors
 
     QStyledItemDelegate::paint(painter, opt, index);
 }
 
-void DefaultDelegate::setHighlightedTextColor(
+void DefaultDelegate::setTextColor(
         QStyleOptionViewItem& option,
         const QModelIndex& index) const {
     // Get the palette's selected text color

--- a/src/library/tabledelegates/defaultdelegate.h
+++ b/src/library/tabledelegates/defaultdelegate.h
@@ -14,7 +14,7 @@ class DefaultDelegate : public QStyledItemDelegate {
             const QStyleOptionViewItem& option,
             const QModelIndex& index) const override;
 
-    void setHighlightedTextColor(
+    void setTextColor(
             QStyleOptionViewItem& option,
             const QModelIndex& index) const;
 };

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -33,12 +33,15 @@ void KeyDelegate::paintItem(
             Qt::ElideRight,
             columnWidth(index) - rectWidth);
 
-    if (option.state & QStyle::State_Selected) {
-        // This uses selection-color from stylesheet for the text pen:
-        // #LibraryContainer QTableView {
-        //   selection-color: #fff;
-        // }
-        painter->setPen(QPen(option.palette.highlightedText().color()));
+    // This is not picking up the 'missing' or 'played' text color via
+    // ForegroundRole from BaseTrackTableModel::data().
+    // Set the palette colors manually and select the appropriate one.
+    QStyleOptionViewItem opt = option;
+    setTextColor(opt, index);
+    if (opt.state & QStyle::State_Selected) {
+        painter->setPen(QPen(opt.palette.highlightedText().color()));
+    } else {
+        painter->setPen(QPen(opt.palette.text().color()));
     }
 
     painter->drawText(option.rect.x() + rectWidth,

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -48,7 +48,7 @@ QWidget* StarDelegate::createEditor(QWidget* parent,
     // state changes, the polygon color will not be updated (though that's a
     // confusing situation anyway since changed index (row) data will trigger a
     // paint event which resets the pending (unsaved) rating anyway.
-    setHighlightedTextColor(newOption, index);
+    setTextColor(newOption, index);
 
     StarEditor* editor =
             new StarEditor(parent, m_pTableView, index, newOption, m_focusBorderColor);

--- a/src/library/tabledelegates/tableitemdelegate.cpp
+++ b/src/library/tabledelegates/tableitemdelegate.cpp
@@ -41,7 +41,7 @@ void TableItemDelegate::paint(
     initStyleOption(&opt, index);
 
     if (opt.state & QStyle::State_Selected) {
-        setHighlightedTextColor(opt, index);
+        setTextColor(opt, index);
     }
 
     QBrush brush;


### PR DESCRIPTION
Most delegates need some individual color handling, and we missed this one for Key