### PR TITLE
Library sidebar: add drag hover styles

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -261,7 +261,9 @@ WLibrarySidebar::item:selected,
 WLibrarySidebar::item:selected:focus {
   outline: none;
 }
-WLibrarySidebar::item:!selected:focus {
+WLibrarySidebar::item:!selected:focus,
+/* This, in conjunction with the c++ counterpart, styles only items hovered while dragging */
+WLibrarySidebar[dragHover="true"]::item:hover {
   outline: none;
   border: 1px solid white;
 }

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2216,7 +2216,9 @@ WTrackTableView::item:selected,
 WLibrarySidebar::item:selected:focus {
   outline: none;
 }
-WLibrarySidebar::item:!selected:focus {
+WLibrarySidebar::item:!selected:focus,
+/* This, in conjunction with the c++ counterpart, styles only items hovered while dragging */
+WLibrarySidebar[dragHover="true"]::item:hover {
   outline: none;
   border: 1px solid white;
 }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2695,7 +2695,9 @@ WTrackTableView::item:selected,
 WLibrarySidebar::item:selected:focus {
   outline: none;
 }
-WLibrarySidebar::item:!selected:focus {
+WLibrarySidebar::item:!selected:focus,
+/* This, in conjunction with the c++ counterpart, styles only items hovered while dragging */
+WLibrarySidebar[dragHover="true"]::item:hover {
   outline: none;
   border: 1px solid white;
 }

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -565,7 +565,9 @@ WLibrarySidebar {
 WLibrarySidebar::item:selected:focus {
   outline: none;
 }
-WLibrarySidebar::item:!selected:focus {
+WLibrarySidebar::item:!selected:focus,
+/* This, in conjunction with the c++ counterpart, styles only items hovered while dragging */
+WLibrarySidebar[dragHover="true"]::item:hover {
   outline: none;
   border: 1px solid white;
 }

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2763,7 +2763,9 @@ WLibrarySidebar::item:!selected {
 WLibrarySidebar::item:selected:focus {
   outline: none;
 }
-WLibrarySidebar::item:!selected:focus {
+WLibrarySidebar::item:!selected:focus,
+/* This, in conjunction with the c++ counterpart, styles only items hovered while dragging */
+WLibrarySidebar[dragHover="true"]::item:hover {
   outline: none;
   border: 1px solid white;
 }

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -65,9 +65,20 @@ void WLibrarySidebar::dragEnterEvent(QDragEnterEvent* pEvent) {
     // QTreeView::dragEnterEvent(pEvent);
 }
 
+/// Drag leave event, happens when leaving and when the drag is aborted, eg. with Esc.
+/// We override this only to reset the drag hover property.
+void WLibrarySidebar::dragLeaveEvent(QDragLeaveEvent* pEvent) {
+    // qDebug() << "WLibrarySidebar::dragLeaveEvent";
+    toggleDragHoverPropertyAndUpdateStyle(false);
+
+    QTreeView::dragLeaveEvent(pEvent);
+}
+
 /// Drag move event, happens when a dragged item hovers over the track sources view...
 void WLibrarySidebar::dragMoveEvent(QDragMoveEvent* pEvent) {
-    // qDebug() << "dragMoveEvent" << pEvent->mimeData()->formats();
+    // qDebug() << "WLibrarySidebar::dragMoveEvent" << pEvent->mimeData()->formats();
+    toggleDragHoverPropertyAndUpdateStyle(true);
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QPoint pos = pEvent->position().toPoint();
 #else
@@ -134,7 +145,10 @@ void WLibrarySidebar::timerEvent(QTimerEvent* pEvent) {
 
 // Drag-and-drop "drop" event. Occurs when something is dropped onto the track sources view
 void WLibrarySidebar::dropEvent(QDropEvent* pEvent) {
+    // qDebug() << "WLibrarySidebar::dropEvent";
     resetHoverIndexAndDragMoveResult();
+    toggleDragHoverPropertyAndUpdateStyle(false);
+
     if (!pEvent->mimeData()->hasUrls()) {
         pEvent->ignore();
         return;
@@ -169,6 +183,18 @@ void WLibrarySidebar::dropEvent(QDropEvent* pEvent) {
     } else {
         pEvent->ignore();
     }
+}
+
+void WLibrarySidebar::toggleDragHoverPropertyAndUpdateStyle(bool enabled) {
+    // Set a custom QWidget property that allows to style drag-hovered items.
+    // WLibrarySidebar[dragHover="true"]::item:hover {
+    //   border: 1px solid white;
+    // }
+    // Then force-refresh the style.
+    setProperty("dragHover", enabled);
+    style()->unpolish(this);
+    style()->polish(this);
+    update();
 }
 
 void WLibrarySidebar::resetHoverIndexAndDragMoveResult() {

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -18,6 +18,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void contextMenuEvent(QContextMenuEvent* pEvent) override;
     void dragMoveEvent(QDragMoveEvent* pEvent) override;
     void dragEnterEvent(QDragEnterEvent* pEvent) override;
+    void dragLeaveEvent(QDragLeaveEvent* pEvent) override;
     void dropEvent(QDropEvent* pEvent) override;
     void keyPressEvent(QKeyEvent* pEvent) override;
     void mousePressEvent(QMouseEvent* pEvent) override;
@@ -47,6 +48,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void focusSelectedIndex();
     QModelIndex selectedIndex();
 
+    void toggleDragHoverPropertyAndUpdateStyle(bool enabled);
     void resetHoverIndexAndDragMoveResult();
 
     QBasicTimer m_expandTimer;


### PR DESCRIPTION
As there is no explicit qss selector for "hovered during a QDrag" I had to use a custom QWidget property `dragHover`.

I picked the style of 'focused but not selected' (right-clicked while not selected), I think it's okay. Personally I'd use a dim version of the selected style, but for others that may create confusion as these styles are maybe to similar.

<img width="490" height="314" alt="image" src="https://github.com/user-attachments/assets/1651be39-afc0-4fb7-805b-25f2bba30bfe" />

___
I'm adding this to 2.6 as it not strictly a new feature but rather a UI fix IMO.