### PR TITLE
Controller mapping preferences: strip leading whitespaces for display

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -1073,6 +1073,12 @@ void DlgPrefController::showMapping(std::shared_ptr<LegacyControllerMapping> pMa
         scriptFileLinks = mappingFileLinks(pMapping);
     }
 
+    // In order to ease pre-formatting of the description in xml
+    // we remove leading whitespaces from each line.
+    // (apparently this also removes leading blank lines)
+    static QRegularExpression re(QStringLiteral("(?m)^\\s+"));
+    description.remove(re);
+
     m_ui.labelMappingNameValue->setText(name);
     m_ui.labelMappingDescriptionValue->setText(description);
     m_ui.labelMappingAuthorValue->setText(author);


### PR DESCRIPTION
Just a small tweak that allows to pre-format mapping descritions in xml while avoiding confusing indentations.

This xml snip
```xml
        <description>


          Hotcue 1: GoToItem

          Hotcue 2: ToggleSelectedSidebarItem
          Hotcue 3: Focus fwd
        </description>
```
nows results in this display:

<img width="276" height="141" alt="mappdesc2" src="https://github.com/user-attachments/assets/45e924d9-187f-4e8c-98f2-36784de93f9d" />


before:
<img width="294" height="193" alt="mappdesc1" src="https://github.com/user-attachments/assets/b7667c02-b061-4850-ad5d-9b6ff2bfaca4" />
