### PR TITLE
Changed audio engine to switch to linear scaler upon entering scratching mode

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -951,7 +951,7 @@ void EngineBuffer::processTrackLocked(
         }
     }
 
-    if (speed != 0.0) {
+    if (speed != 0.0 || is_scratching) {
         // Do not switch scaler when we have no transport
         enableIndependentPitchTempoScaling(useIndependentPitchAndTempoScaling,
                 iBufferSize);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -952,10 +952,10 @@ void EngineBuffer::processTrackLocked(
     }
 
     if (speed != 0.0 || is_scratching) {
-        // Do not switch scaler when we have no transport
+        // Do not switch scaler when we have no transport, except when we start scratching.
         enableIndependentPitchTempoScaling(useIndependentPitchAndTempoScaling,
                 iBufferSize);
-    } else if (m_speed_old != 0 && !is_scratching) {
+    } else if (m_speed_old != 0) {
         // we are stopping, collect samples for fade out
         readToCrossfadeBuffer(iBufferSize);
         // Clear the scaler information


### PR DESCRIPTION
There is an issue when using the [new Traktor S2MK3 mapping](https://github.com/mixxxdj/mixxx/pull/15792) I made, which directly sets the speed using `scratch2`. When I scratch back and forth, the track continues to play in the old direction for a moment before correcting itself. This issue might come up in other mappings that directly set `scratch2` as well.

I've attached a video (same as the one in Zulip chat) that hopefully illustrates the point better. In this video, I am moving the IRL jogwheel in a different direction every time I stop, but the virtual jogwheel is "snapping" every time I do that (because it keeps trying to go in the old direction).

https://github.com/user-attachments/assets/b07fce34-f7d9-4d9d-8aec-8865c83a5b3e

(To reproduce the issue: use my mapping w/ the Traktor S2MK3. Tap the top of the jogwheel without moving the jogwheel to enter scratching mode. Then scratch back and forth and you should see the lag)

I suspect this is due to an improper handoff between the SoundTouch/Rubberband algorithms and the linear scaling algorithm when entering/exiting scratching mode. This PR fixes the issue by making the engine switch to the linear scaler when scratching begins, even if the platter is not moving at all (ie speed is 0).