### PR TITLE
Fix waveform display freeze on Linux

### DIFF
--- a/src/widget/wglwidgetqopengl.cpp
+++ b/src/widget/wglwidgetqopengl.cpp
@@ -91,7 +91,18 @@ void WGLWidget::swapBuffers() {
 }
 
 bool WGLWidget::shouldRender() const {
-    return m_pOpenGLWindow && m_pOpenGLWindow->isExposed();
+    if (!m_pOpenGLWindow) {
+        return false;
+    }
+    // Prefer isExposed() but fall back to isVisible() if the window
+    // is not exposed but the widget is visible. This works around a Qt bug
+    // where isExposed() incorrectly returns false during certain UI updates.
+    // See: https://github.com/mixxxdj/mixxx/issues/15103
+    if (m_pOpenGLWindow->isExposed()) {
+        return true;
+    }
+    // Fallback: if the widget itself is visible, render anyway
+    return isVisible();
 }
 
 QOpenGLWindow* WGLWidget::getOpenGLWindow() const {


### PR DESCRIPTION
On some Linux systems, the Qt event loop doesn't wake up promptly when cross-thread signals are posted from VSyncThread. This causes the waveform display to freeze until an external event triggers the event loop.

Replace blocking semaphore acquire() calls with tryAcquire() using a 100ms timeout. If the main thread doesn't respond in time, skip the frame and continue rather than blocking forever.

I've tested both ST_PLL and ST_TIMER on Ubuntu 24, both freezing before and both seems to work fine now.

Fixes: #15103 