### PR TITLE
Don't user internal qt includes

### DIFF
--- a/src/qml/qmlpreferencesproxy.h
+++ b/src/qml/qmlpreferencesproxy.h
@@ -1,10 +1,5 @@
 #pragma once
 
-#include <qglobal.h>
-#include <qqmlintegration.h>
-#include <qstringliteral.h>
-#include <qtmetamacros.h>
-
 #include <QDialog>
 #include <QObject>
 #include <QQmlEngine>


### PR DESCRIPTION
Qt provides capitalized headers that are intended to be used in client applications. This improves compatibility across QT versions, 