### PR TITLE
Implement configurable 'Recent Days' filter for Analyze view

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -314,6 +314,10 @@ WTrackPropertyEditor,
   border: 1px solid #006596;
 }
 
+#spinBoxRecentDays {
+  min-width: 55px;
+}
+
 /* checkbox in library "Played" column */
 #LibraryPlayedCheckbox::indicator:unchecked {
   image: url(skin:/../Deere/icon/ic_library_checkbox.svg);
@@ -546,7 +550,6 @@ WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
   /* same as QTreeview */
   color: #d2d2d2;
   margin: 9px 5px 6px 0px;
-  font-size: 12px;
 }
 
 #LibraryFeatureControls QRadioButton::indicator {
@@ -603,7 +606,8 @@ WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
 
 #LibraryFeatureControls QPushButton:focus,
 #fadeModeCombobox:focus,
-#spinBoxTransition:focus {
+#spinBoxTransition:focus
+#spinBoxRecentDays:focus {
   outline: none;
 }
 
@@ -910,7 +914,8 @@ WSearchLineEdit QAbstractScrollArea,
 }
 
 WLabel, #LibraryFeatureControls QLabel,
-WPushButton, #LibraryFeatureControls QPushButton {
+WPushButton, #LibraryFeatureControls QPushButton,
+#LibraryFeatureControls QRadioButton {
   font-size: 12px;
   font-weight: bold;
   text-transform: uppercase;
@@ -988,7 +993,8 @@ WOverview #PassthroughLabel {
 }
 
 WBeatSpinBox,
-#spinBoxTransition {
+#spinBoxTransition,
+#spinBoxRecentDays {
   color: #c1cabe;
   background-color: #1f1e1e;
   border: 1px solid #444342;
@@ -998,18 +1004,26 @@ WBeatSpinBox,
   WBeatSpinBox {
     padding: 2px;
   }
-  #spinBoxTransition {
+  #spinBoxTransition,
+  #spinBoxRecentDays {
     padding: 0px 2px 0px 2px;
     margin: 3px 0px 0px 2px;
   }
   WBeatSpinBox:hover,
   #spinBoxTransition:hover,
+  #spinBoxRecentDays:hover,
   WBeatSpinBox:focus,
-  #spinBoxTransition:focus {
+  #spinBoxTransition:focus,
+  #spinBoxRecentDays:focus {
     border: 1px ridge #015d8d;
   }
+  #spinBoxRecentDays:disabled {
+    color: #555;
+    border-color: #333;
+  }
   WBeatSpinBox::down-button,
-  #spinBoxTransition::down-button {
+  #spinBoxTransition::down-button,
+  #spinBoxRecentDays::down-button {
     subcontrol-origin: border;
     subcontrol-position: bottom right; /* position at the top right corner */
     padding-right: 4px;
@@ -1017,17 +1031,20 @@ WBeatSpinBox,
     border: 0;
   }
   WBeatSpinBox::down-arrow,
-  #spinBoxTransition::down-arrow {
+  #spinBoxTransition::down-arrow,
+  #spinBoxRecentDays::down-arrow {
     width: 9px;
     height: 7px;
     image: url(skin:/../Deere/icon/ic_chevron_down_selector.svg);
   }
   WBeatSpinBox::down-arrow:hover,
-  #spinBoxTransition::down-arrow:hover {
+  #spinBoxTransition::down-arrow:hover,
+  #spinBoxRecentDays::down-arrow:hover {
     image: url(skin:/../Deere/icon/ic_chevron_down_selector_hover.svg);
   }
   WBeatSpinBox::up-button,
-  #spinBoxTransition::up-button {
+  #spinBoxTransition::up-button,
+  #spinBoxRecentDays::up-button {
     subcontrol-origin: border;
     subcontrol-position: top right; /* position at the top right corner */
     padding-right: 4px;
@@ -1035,13 +1052,15 @@ WBeatSpinBox,
     border: 0;
   }
   WBeatSpinBox::up-arrow,
-  #spinBoxTransition::up-arrow {
+  #spinBoxTransition::up-arrow,
+  #spinBoxRecentDays::up-arrow {
     width: 9px;
     height: 7px;
     image: url(skin:/../Deere/icon/ic_chevron_up_selector.svg);
   }
   WBeatSpinBox::up-arrow:hover,
-  #spinBoxTransition::up-arrow:hover {
+  #spinBoxTransition::up-arrow:hover,
+  #spinBoxRecentDays::up-arrow:hover {
     image: url(skin:/../Deere/icon/ic_chevron_up_selector_hover.svg);
   }
 

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -297,7 +297,8 @@ WSearchLineEdit,
 
 WBeatSpinBox,
 WBpmEditor QDoubleSpinBox,
-#spinBoxTransition  {
+#spinBoxTransition,
+#spinBoxRecentDays {
   selection-color: #000;
   selection-background-color: #d2d2d2;
   }
@@ -635,7 +636,8 @@ WLibrary {
 
 WBeatSpinBox,
 WBpmEditor QDoubleSpinBox,
-#spinBoxTransition {
+#spinBoxTransition,
+#spinBoxRecentDays {
   background-color: #0f0f0f;
   }
   WBeatSpinBox {
@@ -648,22 +650,34 @@ WBpmEditor QDoubleSpinBox,
       border-image: url(skins:LateNight/classic/buttons/spinbox_elevated_border_focus.svg) 2 19 2 2;
     }
 
-  #spinBoxTransition {
+  #spinBoxTransition,
+  #spinBoxRecentDays {
     border-width: 3px 19px 2px 3px;
     border-image: url(skins:LateNight/classic/buttons/spinbox_embedded_border.svg) 3 19 2 3;
-    width: 24px;
     height: 19px;
     padding: 0px -15px 0px 0px;
     margin: 0px 2px 3px 5px;
     }
-    #spinBoxTransition:focus {
+  #spinBoxTransition {
+    width: 24px;
+    }
+  #spinBoxRecentDays {
+    width: 45px;
+    }
+    #spinBoxTransition:focus,
+    #spinBoxRecentDays:focus {
       border-image: url(skins:LateNight/classic/buttons/spinbox_embedded_border_focus_orange.svg) 3 19 2 3;
+    }
+    #spinBoxRecentDays:disabled {
+      color: #494949;
     }
 
   WBeatSpinBox::up-button,
   WBeatSpinBox::down-button,
   #spinBoxTransition::up-button,
-  #spinBoxTransition::down-button {
+  #spinBoxTransition::down-button,
+  #spinBoxRecentDays::up-button,
+  #spinBoxRecentDays::down-button {
     subcontrol-origin: content;
     position: relative;
     /* as with spinbox: border is added to size. */
@@ -671,35 +685,41 @@ WBpmEditor QDoubleSpinBox,
     padding: 0px;
     }
     WBeatSpinBox::up-button,
-    #spinBoxTransition::up-button {
+    #spinBoxTransition::up-button,
+    #spinBoxRecentDays::up-button {
       height: 11px;
       subcontrol-position: top right;
       image: url(skins:LateNight/classic/buttons/spinbox_up.svg) no-repeat;
       }
       WBeatSpinBox::up-button:pressed,
-      #spinBoxTransition::up-button:pressed {
+      #spinBoxTransition::up-button:pressed,
+      #spinBoxRecentDays::up-button:pressed {
         image: url(skins:LateNight/classic/buttons/spinbox_up_pressed.svg) no-repeat;
       }
       WBeatSpinBox::up-button {
         margin: -1px 0px 0px 0px;
         }
-      #spinBoxTransition::up-button {
+      #spinBoxTransition::up-button,
+      #spinBoxRecentDays::up-button {
         margin: -2px -3px 0px 0px;
         }
     WBeatSpinBox::down-button,
-    #spinBoxTransition::down-button {
+    #spinBoxTransition::down-button,
+    #spinBoxRecentDays::down-button {
       height: 11px;
       subcontrol-position: bottom right;
       image: url(skins:LateNight/classic/buttons/spinbox_down.svg) no-repeat;
       }
       WBeatSpinBox::down-button:pressed,
-      #spinBoxTransition::down-button:pressed {
+      #spinBoxTransition::down-button:pressed,
+      #spinBoxRecentDays::down-button:pressed {
         image: url(skins:LateNight/classic/buttons/spinbox_down_pressed.svg) no-repeat;
       }
       WBeatSpinBox::down-button {
         margin: 0px 0px -2px 0px;
         }
-      #spinBoxTransition::down-button {
+      #spinBoxTransition::down-button,
+      #spinBoxRecentDays::down-button {
         margin: 0px -3px -1px 0px;
         }
 
@@ -750,6 +770,8 @@ WBpmEditor QDoubleSpinBox::down-button {
   WBpmEditor QDoubleSpinBox::down-button:pressed {
     image: url(skins:LateNight/classic/buttons/btn__bpm_spinbox_minus_pressed.svg) no-repeat;
   }
+
+
 
 
 
@@ -1273,6 +1295,7 @@ WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea,
 WBeatSpinBox,
 #spinBoxTransition,
+#spinBoxRecentDays,
 WBpmEditor QDoubleSpinBox,
 #LibraryFeatureControls QLabel,
 #LibraryFeatureControls QRadioButton {

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -673,13 +673,15 @@ WTrackProperty[selected="true"],
 /********************** Loop Controls / AutoDJ spinbox ************************/
 WBeatSpinBox,
 WBpmEditor QDoubleSpinBox,
-#spinBoxTransition {
+#spinBoxTransition,
+#spinBoxRecentDays {
   selection-color: #a7998b;
   selection-background-color: #111;
   }
   WBeatSpinBox:focus,
   WBpmEditor QDoubleSpinBox:focus,
   #spinBoxTransition:focus,
+  #spinBoxRecentDays:focus,
   #LibraryBPMSpinBox:focus  {
     selection-color: #000;
     selection-background-color: #d2d2d2;
@@ -691,23 +693,35 @@ WBeatSpinBox {
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_spinbox.svg) 3 19 2 3;
 }
 
-#spinBoxTransition {
-  width: 24px;
+#spinBoxTransition,
+#spinBoxRecentDays {
   height: 19px;
   padding: 0px -15px 0px 0px;
   margin: 0px 2px 3px 5px;
   border-width: 3px 19px 2px 3px;
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_spinbox_autodj.svg) 3 19 2 3;
 }
+#spinBoxTransition {
+  width: 24px;
+}
+#spinBoxRecentDays {
+  width: 45px;
+}
 WBeatSpinBox:focus,
-#spinBoxTransition:focus {
+#spinBoxTransition:focus,
+#spinBoxRecentDays:focus {
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_spinbox_focus_blue.svg) 3 19 2 3;
+}
+#spinBoxRecentDays:disabled {
+  color: #494949;
 }
 
 WBeatSpinBox::up-button,
 WBeatSpinBox::down-button,
 #spinBoxTransition::up-button,
-#spinBoxTransition::down-button {
+#spinBoxTransition::down-button,
+#spinBoxRecentDays::up-button,
+#spinBoxRecentDays::down-button {
   subcontrol-origin: content;
   position: relative;
   padding: 0px;
@@ -715,7 +729,8 @@ WBeatSpinBox::down-button,
   }
 
   WBeatSpinBox::up-button,
-  #spinBoxTransition::up-button {
+  #spinBoxTransition::up-button,
+  #spinBoxRecentDays::up-button {
     subcontrol-position: top right;
     image: url(skins:LateNight/palemoon/buttons/btn__spinbox_up.svg) no-repeat;
     height: 11px;
@@ -723,18 +738,21 @@ WBeatSpinBox::down-button,
     WBeatSpinBox::up-button {
       margin: -2px -1px 0px 0px;
     }
-    #spinBoxTransition::up-button {
+    #spinBoxTransition::up-button,
+    #spinBoxRecentDays::up-button {
       margin: -2px -3px 0px 0px;
     }
 
   WBeatSpinBox::down-button,
-  #spinBoxTransition::down-button {
+  #spinBoxTransition::down-button,
+  #spinBoxRecentDays::down-button {
     subcontrol-position: bottom right;
     image: url(skins:LateNight/palemoon/buttons/btn__spinbox_down.svg) no-repeat;
     height: 11px;
     margin: 0px -1px -3px 0px;
     }
-    #spinBoxTransition::down-button {
+    #spinBoxTransition::down-button,
+    #spinBoxRecentDays::down-button {
       margin: 0px -3px -1px 0px;
     }
 
@@ -1360,7 +1378,8 @@ WEffectChainPresetSelector:!editable:on,
 
   WBeatSpinBox,
   WBpmEditor QDoubleSpinBox,
-  #spinBoxTransition {
+  #spinBoxTransition,
+  #spinBoxRecentDays {
     color: #a7998b;
   }
 
@@ -1729,6 +1748,8 @@ WBpmEditor QDoubleSpinBox {
   /* library controls */
   #spinBoxTransition::up-button,
   #spinBoxTransition::down-button,
+  #spinBoxRecentDays::up-button,
+  #spinBoxRecentDays::down-button,
   QPushButton#pushButtonAutoDJ:enabled:!checked,
   #LibraryFeatureControls QPushButton:enabled {
     background-color: #222;
@@ -1816,7 +1837,9 @@ WBpmEditor QDoubleSpinBox::down-button:pressed,
 WBeatSpinBox::up-button:pressed,
 WBeatSpinBox::down-button:pressed,
 #spinBoxTransition::up-button:pressed,
-#spinBoxTransition::down-button:pressed {
+#spinBoxTransition::down-button:pressed,
+#spinBoxRecentDays::up-button:pressed,
+#spinBoxRecentDays::down-button:pressed {
   background-color: #257b82;
   }
   /* Dim blue for assign buttons Fx34 */
@@ -2954,6 +2977,7 @@ WTrackPropertyEditor,
 WLibrary QLineEdit,
 WLibrary QPlainTextEdit,
 #spinBoxTransition,
+#spinBoxRecentDays,
 #LibraryBPMSpinBox {
   background-color: #0f0f0f;
 }
@@ -3321,7 +3345,8 @@ WSearchLineEdit {
 /* add margin to compensate for frameless library table */
 #LibraryFeatureControls QPushButton,
 /* #fadeModeCombobox set below */
-#spinBoxTransition {
+#spinBoxTransition,
+#spinBoxRecentDays {
   margin-top: 4px;
 }
 QLabel#labelProgress, /* Analysis progress */

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -71,7 +71,8 @@ WBeatSpinBox,
 /* For some mysterious reason #DlgAutoDJ QSpinBox
 wouldn't style the respective spinbox in Shade (anymore),
 that's why we do it in another way here */
-#spinBoxTransition {
+#spinBoxTransition,
+#spinBoxRecentDays {
   selection-color: #eee;
   selection-background-color: #060613;
   }
@@ -80,13 +81,15 @@ that's why we do it in another way here */
   }
 
 WBeatSpinBox::up-button,
-#spinBoxTransition::up-button {
+#spinBoxTransition::up-button,
+#spinBoxRecentDays::up-button {
   border-left: 1px solid #060613;
   image: url(skin:/btn/btn_spin_up.png) no-repeat;
 }
 
 WBeatSpinBox::down-button,
-#spinBoxTransition::down-button {
+#spinBoxTransition::down-button,
+#spinBoxRecentDays::down-button {
   border-left: 1px solid #060613;
   image: url(skin:/btn/btn_spin_down.png) no-repeat;
 }
@@ -96,7 +99,9 @@ WBeatSpinBox::down-button {
 }
 
 #spinBoxTransition::up-button,
-#spinBoxTransition::down-button {
+#spinBoxTransition::down-button,
+#spinBoxRecentDays::up-button,
+#spinBoxRecentDays::down-button {
   height: 10px;
 }
 
@@ -142,7 +147,9 @@ WEffectSelector::indicator:unchecked,
 #MainMenu::item,
 WBeatSpinBox,
 #spinBoxTransition:up-button,
-#spinBoxTransition:down-button {
+#spinBoxTransition:down-button,
+#spinBoxRecentDays:up-button,
+#spinBoxRecentDays:down-button {
   color: #000;
   background-color: #8D98A3;
   }
@@ -151,9 +158,13 @@ WBeatSpinBox,
     color: #000;
     background-color: #99a0a4;
   }
-  #spinBoxTransition {
+  #spinBoxTransition,
+  #spinBoxRecentDays {
     color: #000;
     background-color: #72777a;
+  }
+  #spinBoxRecentDays:disabled {
+    color: #333;
   }
 /* hovered items */
 #MainMenu::item:selected,
@@ -249,7 +260,8 @@ WEffectSelector QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea,
 #LibraryFeatureControls QPushButton:enabled,
 WBeatSpinBox,
-#spinBoxTransition {
+#spinBoxTransition,
+#spinBoxRecentDays {
   font-size: 13px;
   }
 WEffectSelector QAbstractScrollArea,
@@ -998,16 +1010,21 @@ WLibrary { margin: 2px 3px 0px 0px; }
       min-width: 40px;
       max-width: 40px;
     }
-  #spinBoxTransition {
-    width: 32px;
+  #spinBoxTransition,
+  #spinBoxRecentDays {
     height: 20px;
     padding: 0px;
-    margin-left: 3px;
     margin: 0px 0px 2px 1px;
   /* omitting the border definition miraculously makes the spinbox grow */
   /* 0px border OTOH makes the spinbox shrink disproportionately
     border: 0px; */
     border: 0px;
+  }
+  #spinBoxTransition {
+    width: 32px;
+  }
+  #spinBoxRecentDays {
+    width: 45px;
   }
 
   #LibraryFeatureControls QPushButton:!enabled {

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -40,12 +40,15 @@ WEffectSelector::indicator:unchecked,
   WBeatSpinBox,
   #spinBoxTransition::up-button,
   #spinBoxTransition::down-button,
+  #spinBoxRecentDays::up-button,
+  #spinBoxRecentDays::down-button,
   #fadeModeCombobox,
   #fadeModeCombobox::down-arrow {
     color: #000;
     background-color: #5C5B5D;
   }
-  #spinBoxTransition {
+  #spinBoxTransition,
+  #spinBoxRecentDays {
     background-color: #444546;
   }
 #MainMenu::item:selected,

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -40,12 +40,15 @@ WEffectSelector::indicator:unchecked,
 WBeatSpinBox,
 #spinBoxTransition::up-button,
 #spinBoxTransition::down-button,
+#spinBoxRecentDays::up-button,
+#spinBoxRecentDays::down-arrow,
 #fadeModeCombobox,
 #fadeModeCombobox::down-arrow {
   color: #060613;
   background-color: #998A3C;
 }
-#spinBoxTransition {
+#spinBoxTransition,
+#spinBoxRecentDays {
   background-color: #7b6f38;
 }
   #MainMenu QMenu::separator,

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1107,7 +1107,8 @@ WLabel#TrackComment {
     }
 
 WBeatSpinBox,
-#spinBoxTransition {
+#spinBoxTransition,
+#spinBoxRecentDays {
   /* Note(ronso0):
   make it 2px smaller in each dimension,
   border is added for final size.
@@ -1131,26 +1132,34 @@ WBeatSpinBox,
     padding: 1px 0px 1px 3px;
     margin: 0px 15px 0px 0px;
   }
-  #spinBoxTransition {
+  #spinBoxTransition,
+  #spinBoxRecentDays {
     /* Note(ronso0):
     Individual padding/margin in AutoDJ feature */
     padding: -1px 3px -1px 3px;
     margin: 0px 17px 3px 3px;
   }
   WBeatSpinBox:hover,
-  #spinBoxTransition:hover {
+  #spinBoxTransition:hover,
+  #spinBoxRecentDays:hover {
     border-color: #888;
   }
   WBeatSpinBox:focus,
-  #spinBoxTransition:focus {
+  #spinBoxTransition:focus,
+  #spinBoxRecentDays:focus {
     border-color: #ff6600;
     color: #ccc;
+  }
+  #spinBoxRecentDays:disabled {
+    color: #555;
   }
 
   WBeatSpinBox::up-button,
   WBeatSpinBox::down-button,
   #spinBoxTransition::up-button,
-  #spinBoxTransition::down-button {
+  #spinBoxTransition::down-button,
+  #spinBoxRecentDays::up-button,
+  #spinBoxRecentDays::down-button {
     subcontrol-origin: padding;
     position: relative;
     background-color: #1e1e1e;
@@ -1160,12 +1169,15 @@ WBeatSpinBox,
     WBeatSpinBox::up-button:hover,
     WBeatSpinBox::down-button:hover,
     #spinBoxTransition::up-button:hover,
-    #spinBoxTransition::down-button:hover {
+    #spinBoxTransition::down-button:hover,
+    #spinBoxRecentDays::up-button:hover,
+    #spinBoxRecentDays::down-button:hover {
       background-color: #0f0f0f;
       }
 
   WBeatSpinBox::up-button,
-  #spinBoxTransition::up-button {
+  #spinBoxTransition::up-button,
+  #spinBoxRecentDays::up-button {
     subcontrol-position: center right;
     /* Note(ronso0):
     Regularly, up/down buttons would be stacked vertically.
@@ -1176,18 +1188,21 @@ WBeatSpinBox,
     image: url(skin:/../Tango/buttons/btn_beatbox_up.svg) no-repeat;
     }
     WBeatSpinBox::up-button:hover,
-    #spinBoxTransition::up-button:hover {
+    #spinBoxTransition::up-button:hover,
+    #spinBoxRecentDays::up-button:hover {
       image: url(skin:/../Tango/buttons/btn_beatbox_up_hover.svg) no-repeat;
     }
   WBeatSpinBox::down-button,
-  #spinBoxTransition::down-button {
+  #spinBoxTransition::down-button,
+  #spinBoxRecentDays::down-button {
     subcontrol-position: center right;
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
     image: url(skin:/../Tango/buttons/btn_beatbox_down.svg) no-repeat;
     }
     WBeatSpinBox::down-button:hover,
-    #spinBoxTransition::down-button:hover {
+    #spinBoxTransition::down-button:hover,
+    #spinBoxRecentDays::down-button:hover {
       image: url(skin:/../Tango/buttons/btn_beatbox_down_hover.svg) no-repeat;
     }
 
@@ -3169,6 +3184,10 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
     #LibraryBPMSpinBox::down-button {
       image: url(skin:/../Tango/buttons/btn_lib_spinbox_down_white.svg) no-repeat;
     }
+
+#spinBoxRecentDays {
+  width: 60px;
+}
 
   /* Button in library "Preview" column */
   #LibraryPreviewButton {

--- a/src/library/analysis/analysislibrarytablemodel.h
+++ b/src/library/analysis/analysislibrarytablemodel.h
@@ -2,16 +2,25 @@
 
 #include "library/librarytablemodel.h"
 
-class AnalysisLibraryTableModel : public LibraryTableModel
-{
+class AnalysisLibraryTableModel : public LibraryTableModel {
     Q_OBJECT
   public:
+    static constexpr unsigned int kDefaultRecentDays = 7;
+
     AnalysisLibraryTableModel(
             QObject* parent,
             TrackCollectionManager* pTrackCollectionManager);
     ~AnalysisLibraryTableModel() override = default;
 
+    void setRecentDays(unsigned int days);
+    unsigned int recentDays() const {
+        return m_recentDays;
+    }
+
     void showRecentSongs();
     void showAllSongs();
     void searchCurrentTrackSet(const QString& text, bool useRecentFilter);
+
+  private:
+    unsigned int m_recentDays;
 };

--- a/src/library/analysis/dlganalysis.h
+++ b/src/library/analysis/dlganalysis.h
@@ -17,9 +17,9 @@ class QItemSelection;
 class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual LibraryView {
     Q_OBJECT
   public:
-    DlgAnalysis(WLibrary *parent,
-               UserSettingsPointer pConfig,
-               Library* pLibrary);
+    DlgAnalysis(WLibrary* parent,
+            UserSettingsPointer pConfig,
+            Library* pLibrary);
     ~DlgAnalysis() override = default;
 
     void onSearch(const QString& text) override;
@@ -34,13 +34,14 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
 
   public slots:
     void tableSelectionChanged(const QItemSelection& selected,
-                               const QItemSelection& deselected);
+            const QItemSelection& deselected);
     void selectAll();
     void analyze();
     void slotAnalysisActive(bool bActive);
     void onTrackAnalysisSchedulerProgress(AnalyzerProgress analyzerProgress, int finishedCount, int totalCount);
     void onTrackAnalysisSchedulerFinished();
     void slotShowRecentSongs();
+    void slotRecentDaysChanged(int days);
     void slotShowAllSongs();
     void installEventFilter(QObject* pFilter);
 
@@ -52,7 +53,8 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
     void trackSelected(TrackPointer pTrack);
 
   private:
-    //Note m_pTrackTablePlaceholder is defined in the .ui file
+    void keyPressEvent(QKeyEvent* pEvent) override;
+    // Note m_pTrackTablePlaceholder is defined in the .ui file
     UserSettingsPointer m_pConfig;
     bool m_bAnalysisActive;
     QButtonGroup m_songsButtonGroup;

--- a/src/library/analysis/dlganalysis.ui
+++ b/src/library/analysis/dlganalysis.ui
@@ -53,10 +53,57 @@
           <enum>Qt::NoFocus</enum>
          </property>
          <property name="toolTip">
-          <string>Shows tracks added to the library within the last 7 days.</string>
+          <string>Shows tracks added to the library recently.</string>
          </property>
          <property name="text">
           <string>New</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="spinBoxRecentDays">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>55</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Number of days to filter recently added tracks.</string>
+         </property>
+         <property name="frame">
+          <bool>false</bool>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>3650</number>
+         </property>
+         <property name="value">
+          <number>7</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labelRecentDaysAppendix">
+         <property name="styleSheet">
+          <string notr="true">margin-left: 5px;</string>
+         </property>
+         <property name="text">
+          <string>days</string>
+         </property>
+         <property name="toolTip">
+          <string>Days</string>
          </property>
         </widget>
        </item>

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -899,14 +899,16 @@ DateAddedFilterNode::DateAddedFilterNode(const QString& argument)
 }
 
 QDateTime DateAddedFilterNode::parseDate(const QString& dateStr) const {
-    // Prior to Qt 6.7 QLocale::toDate() with QLocale::ShortFormat used the
-    // base year 1900. With 6.7+ we can specify the century, ie. 20 for 2000.
-    // Mixxx was created aftre 2000 :)
+    // Try ISO format first (YYYY-MM-DD)
+    QDate date = QDate::fromString(dateStr, Qt::ISODate);
+    if (!date.isValid()) {
+        // Fall back to locale-specific short format
 #if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
-    QDate date = QLocale().toDate(dateStr, QLocale::ShortFormat);
+        date = QLocale().toDate(dateStr, QLocale::ShortFormat);
 #else
-    QDate date = QLocale().toDate(dateStr, QLocale::ShortFormat, 20);
+        date = QLocale().toDate(dateStr, QLocale::ShortFormat, 20);
 #endif
+    }
     if (!date.isValid()) {
         return {};
     }


### PR DESCRIPTION
This PR addresses the limitation where the "Recently Added" filter in the Analyze view was hardcoded to a fixed 7-day window.

Changes
- UI: Added a QSpinBox (spinBoxRecentDays) to the Analyze view controls, allowing users to specify the number of days (range: 1-3650) for the "Recently Added" filter.
- Logic Refactoring: Moved the recentFilter logic into AnalysisLibraryTableModel, making it cleaner and more robust.
- Date Parsing: Fixed issues with locale-dependent date parsing by switching to ISODate for the added:> query, ensuring the filter works correctly in all regions.
- Skin Support: Added dedicated styling for the new spinbox across multiple skins (Deere, Tango, Shade, LateNight) to ensure a consistent and integrated look. The spinbox also correctly handles disabled states (e.g., when "All" is selected).
- Configuration: The selected number of days is now saved and restored from the user's configuration.

Fixes #14689