### PR TITLE
Tracks: avoid re-sorting table when purging/hiding tracks

### DIFF
--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -67,6 +67,7 @@ class BaseSqlTableModel : public BaseTrackTableModel {
     int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) const override;
 
     void hideTracks(const QModelIndexList& indices) override;
+    void removeTrackRows(const QSet<TrackId>& trackIdsToRemove) override;
 
     void select() override;
 

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -107,9 +107,9 @@ BaseTrackTableModel::BaseTrackTableModel(
           m_trackPlayedColor(QColor(WTrackTableView::kDefaultTrackPlayedColor)),
           m_trackMissingColor(QColor(WTrackTableView::kDefaultTrackMissingColor)) {
     connect(&pTrackCollectionManager->internalCollection()->getTrackDAO(),
-            &TrackDAO::forceModelUpdate,
+            &TrackDAO::tracksRemoved,
             this,
-            &BaseTrackTableModel::slotRefreshAllRows);
+            &BaseTrackTableModel::slotTracksRemoved);
     connect(&PlayerInfo::instance(),
             &PlayerInfo::trackChanged,
             this,
@@ -987,6 +987,10 @@ void BaseTrackTableModel::slotRefreshCoverRows(
 
 void BaseTrackTableModel::slotRefreshAllRows() {
     select();
+}
+
+void BaseTrackTableModel::slotTracksRemoved(const QSet<TrackId>& trackIds) {
+    removeTrackRows(trackIds);
 }
 
 void BaseTrackTableModel::emitDataChangedForMultipleRowsInColumn(

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -248,6 +248,8 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     void slotRefreshAllRows();
 
+    void slotTracksRemoved(const QSet<TrackId>& trackIds);
+
     void slotCoverFound(
             const QObject* pRequester,
             const CoverInfo& coverInfo,

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1111,9 +1111,9 @@ void TrackDAO::afterPurgingTracks(
 #else
     QSet<TrackId> tracksRemovedSet = QSet<TrackId>::fromList(trackIds);
 #endif
+    // Notify BaseTrackCache it should remove tracks and track models
+    // that they should update their cache as well.
     emit tracksRemoved(tracksRemovedSet);
-    // notify trackmodels that they should update their cache as well.
-    emit forceModelUpdate();
 }
 
 namespace {

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -116,6 +116,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void progressVerifyTracksOutside(const QString& path);
     void progressCoverArt(const QString& file);
     void forceModelUpdate();
+    void removeTrackRows(const QSet<TrackId>& trackIds);
 
   public slots:
     // Slots to inform the TrackDAO about changes that

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -41,7 +41,7 @@ TrackCollection::TrackCollection(
     connect(&m_trackDao,
             &TrackDAO::tracksRemoved,
             this,
-            &TrackCollection::tracksRemoved,
+            &TrackCollection::tracksRemoved, // unused
             /*signal-to-signal*/ Qt::DirectConnection);
     connect(&m_trackDao,
             &TrackDAO::forceModelUpdate,

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -243,6 +243,8 @@ class TrackModel {
     virtual void select() {
     }
 
+    virtual void removeTrackRows(const QSet<TrackId>&) {};
+
     /// This is an interface to stop any potentially running
     /// model population when switching models in WTrackTableView.
     /// Only implemented in ProxyTrackModel.

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -218,7 +218,9 @@ void CrateTableModel::removeTracks(const QModelIndexList& indices) {
         return;
     }
 
-    select();
+    // Now remove the track rows
+    QSet<TrackId> tracksRemovedSet = QSet<TrackId>(trackIds.begin(), trackIds.end());
+    removeTrackRows(tracksRemovedSet);
 }
 
 QString CrateTableModel::modelKey(bool noSearch) const {


### PR DESCRIPTION
Should fix #12565 

### Reproduce the issue:
* go to Tracks, sort by "last played"
* play some tracks
  -> their "last played" values changes, track order is stable
* remove (purge) or hide a track, via hotkey, deck or table track menu
-> table is resorted by "last played" :| sometimes also the selected index is lost

After purge/hide `BaseSqlTableModel::select()` is called, which rebuilds the model cache with with new values from the db. This implies re-sorting.

### The fix:
Based on the assumption that metadata of the tracks remaning after purge/hide is unchanged, we don't need to call `select()` -- we can simply remove the obsolete rows.
This does however not apply to Playlists where removing tracks changes the 'position' value of the others. There we still `select()` for now.

**Note:** so far I only tested with Tracks.
Also test with the Crates and Hidden views.