### PR TITLE
Avoid crash with EGLFS

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -17,6 +17,8 @@
 #endif
 
 #ifdef MIXXX_USE_QOPENGL
+#include <QGuiApplication>
+
 #include "widget/tooltipqopengl.h"
 #include "widget/winitialglwidget.h"
 #endif

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -180,7 +180,7 @@ void MixxxMainWindow::initializeQOpenGL() {
             // information (version, driver, etc) in WaveformWidgetFactory.
             // The "SharedGLContext" terminology here doesn't really apply,
             // but allows us to take advantage of the existing classes.
-            WInitialGLWidget* pWidget = new WInitialGLWidget(this);
+            auto pWidget = make_parented<WInitialGLWidget>(this);
             pWidget->setGeometry(QRect(0, 0, 3, 3));
             SharedGLContext::setWidget(pWidget);
             // When the widget's QOpenGLWindow has been initialized, we continue

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -3,6 +3,7 @@
 #include "waveform/waveform.h"
 
 #ifdef MIXXX_USE_QOPENGL
+#include <QGuiApplication>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLWindow>
 #else
@@ -185,17 +186,30 @@ WaveformWidgetFactory::WaveformWidgetFactory()
 
             m_openGLShaderAvailable = QOpenGLShaderProgram::hasOpenGLShaderPrograms(pContext);
 
-            m_openGLVersion = pContext->isOpenGLES() ? "ES " : "";
+            // With EGLFS there is always exactly one native window and one EGL window surface
+            // OpenGL windows cannot be embedded into our QWidgets main window we already have.
+            // That's why m_openGlesAvailable is not set to true. TODO: use GL Widgets for all
+            // https://doc.qt.io/qt-6/embedded-linux.html
+            bool isEglfs = QGuiApplication::platformName() == "eglfs";
+
+            if (isEglfs) {
+                m_openGLVersion = "EGLFS ";
+            } else if (pContext->isOpenGLES()) {
+                m_openGLVersion = "ES ";
+            }
+
             m_openGLVersion += majorVersion == 0 ? QString("None") : versionString;
 
-            // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0
-            if (pContext->isOpenGLES()) {
-                if (majorVersion * 100 + minorVersion >= 200) {
-                    m_openGlesAvailable = true;
-                }
-            } else {
-                if (majorVersion * 100 + minorVersion >= 201) {
-                    m_openGlAvailable = true;
+            if (!isEglfs) {
+                // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0
+                if (pContext->isOpenGLES()) {
+                    if (majorVersion * 100 + minorVersion >= 200) {
+                        m_openGlesAvailable = true;
+                    }
+                } else {
+                    if (majorVersion * 100 + minorVersion >= 201) {
+                        m_openGlAvailable = true;
+                    }
                 }
             }
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1365,10 +1365,12 @@ QString WaveformWidgetAbstractHandle::getDisplayName(WaveformWidgetType::Type ty
 }
 
 // static
-QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer config) {
+QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer pConfig) {
     // The first call should pass the config to set the vsync mode. Subsequent
     // calls will use the value as set on the first call.
-    static const auto vsyncMode = config->getValue(kVSyncKey, 0);
+    static const VSyncThread::VSyncMode vsyncMode = pConfig
+            ? pConfig->getValue(kVSyncKey, VSyncThread::ST_DEFAULT)
+            : VSyncThread::ST_DEFAULT;
 
     QSurfaceFormat format;
     // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0, default is 2.0

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -191,10 +191,11 @@ WaveformWidgetFactory::WaveformWidgetFactory()
             // That's why m_openGlesAvailable is not set to true. TODO: use GL Widgets for all
             // https://doc.qt.io/qt-6/embedded-linux.html
             bool isEglfs = QGuiApplication::platformName() == QStringLiteral("eglfs");
+            bool isOpenGles = pContext->isOpenGLES();
 
             if (isEglfs) {
                 m_openGLVersion = QStringLiteral("EGLFS ");
-            } else if (pContext->isOpenGLES()) {
+            } else if (isOpenGles) {
                 m_openGLVersion = QStringLiteral("ES ");
             }
             // else m_openGLVersion is still empty
@@ -203,16 +204,10 @@ WaveformWidgetFactory::WaveformWidgetFactory()
             m_openGLVersion += majorVersion == 0 ? tr("None") : versionString;
 
             if (!isEglfs) {
-                // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0
-                if (pContext->isOpenGLES()) {
-                    if (majorVersion * 100 + minorVersion >= 200) {
-                        m_openGlesAvailable = true;
-                    }
-                } else {
-                    if (majorVersion * 100 + minorVersion >= 201) {
-                        m_openGlAvailable = true;
-                    }
-                }
+                // Qt >= 5 requires at least OpenGL 2.1 or OpenGL ES 2.0
+                int combinedVersion = majorVersion * 100 + minorVersion;
+                m_openGlesAvailable = isOpenGles && combinedVersion >= 200;
+                m_openGlAvailable = !isOpenGles && combinedVersion >= 201;
             }
 
             if (!rendererString.isEmpty()) {

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -190,6 +190,7 @@ WaveformWidgetFactory::WaveformWidgetFactory()
             // OpenGL windows cannot be embedded into our QWidgets main window we already have.
             // That's why m_openGlesAvailable is not set to true. TODO: use GL Widgets for all
             // https://doc.qt.io/qt-6/embedded-linux.html
+            // See https://doc.qt.io/qt-6/qguiapplication.html#platformName-prop for possible values
             bool isEglfs = QGuiApplication::platformName() == QStringLiteral("eglfs");
             bool isOpenGles = pContext->isOpenGLES();
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -190,15 +190,17 @@ WaveformWidgetFactory::WaveformWidgetFactory()
             // OpenGL windows cannot be embedded into our QWidgets main window we already have.
             // That's why m_openGlesAvailable is not set to true. TODO: use GL Widgets for all
             // https://doc.qt.io/qt-6/embedded-linux.html
-            bool isEglfs = QGuiApplication::platformName() == "eglfs";
+            bool isEglfs = QGuiApplication::platformName() == QStringLiteral("eglfs");
 
             if (isEglfs) {
-                m_openGLVersion = "EGLFS ";
+                m_openGLVersion = QStringLiteral("EGLFS ");
             } else if (pContext->isOpenGLES()) {
-                m_openGLVersion = "ES ";
+                m_openGLVersion = QStringLiteral("ES ");
             }
+            // else m_openGLVersion is still empty
 
-            m_openGLVersion += majorVersion == 0 ? QString("None") : versionString;
+            //: This refers to a missing openGL version
+            m_openGLVersion += majorVersion == 0 ? tr("None") : versionString;
 
             if (!isEglfs) {
                 // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0
@@ -214,7 +216,7 @@ WaveformWidgetFactory::WaveformWidgetFactory()
             }
 
             if (!rendererString.isEmpty()) {
-                m_openGLVersion += " (" + rendererString + ")";
+                m_openGLVersion += QStringLiteral(" (") + rendererString + QChar(')');
             }
         } else {
             qDebug() << "QOpenGLContext::currentContext() returns nullptr";

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -206,7 +206,7 @@ class WaveformWidgetFactory : public QObject,
     static int toUntilMarkTextHeightLimitIndex(float value);
 
     /// Returns the desired surface format for the OpenGLWindow
-    static QSurfaceFormat getSurfaceFormat(UserSettingsPointer config = nullptr);
+    static QSurfaceFormat getSurfaceFormat(UserSettingsPointer pConfig = nullptr);
 
   protected:
     bool setWidgetType(


### PR DESCRIPTION
With EGLFS we can use either QWidgets or OpenGL, not both at the same time. 
This is a band aid that shall avoid the fatal abort reported in #15863. 

A better fix would be to use only GELS. 
This type of refactoring is probably not beneficial because we are already working in a QML GUI which likely works with EGLFS. We need to investigate with this.  