### PR TITLE
Tango: Implement 'Track has no STEMs' logic and fix alignment

### DIFF
--- a/res/skins/Tango/skin.xml
+++ b/res/skins/Tango/skin.xml
@@ -72,7 +72,7 @@
       <attribute persist="true" config_key="[Tango],always_visible_quantize">1</attribute>
       <attribute persist="true" config_key="[Skin],timing_shift_buttons">0</attribute>
       <!-- Stem -->
-      <attribute persist="true" config_key="[Skin],show_stem_controls">1</attribute>
+      <attribute persist="true" config_key="[Skin],show_stem_controls">0</attribute>
       <!-- Mixer -->
       <attribute persist="true" config_key="[Skin],show_mixer">0</attribute>
       <attribute persist="true" config_key="[Tango],main_mixer">1</attribute>

--- a/res/skins/Tango/stem_control.xml
+++ b/res/skins/Tango/stem_control.xml
@@ -2,32 +2,61 @@
   <WidgetGroup>
     <Layout>vertical</Layout>
     <Children>
+      <!-- Active Stems -->
       <WidgetGroup>
-        <Size>15f,1me</Size>
+        <Layout>vertical</Layout>
+        <Children>
+          <WidgetGroup>
+            <Size>15f,1me</Size>
+          </WidgetGroup>
+          <Template src="skins:Tango/stem_channel.xml">
+            <SetVariable name="stemNum">1</SetVariable>
+          </Template>
+          <WidgetGroup>
+            <Size>15f,1me</Size>
+          </WidgetGroup>
+          <Template src="skins:Tango/stem_channel.xml">
+            <SetVariable name="stemNum">2</SetVariable>
+          </Template>
+          <WidgetGroup>
+            <Size>15f,1me</Size>
+          </WidgetGroup>
+          <Template src="skins:Tango/stem_channel.xml">
+            <SetVariable name="stemNum">3</SetVariable>
+          </Template>
+          <WidgetGroup>
+            <Size>15f,1me</Size>
+          </WidgetGroup>
+          <Template src="skins:Tango/stem_channel.xml">
+            <SetVariable name="stemNum">4</SetVariable>
+          </Template>
+          <WidgetGroup>
+            <Size>15f,1me</Size>
+          </WidgetGroup>
+        </Children>
+        <Connection>
+          <ConfigKey>[Channel<Variable name="chanNum"/>],stem_count</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
       </WidgetGroup>
-      <Template src="skins:Tango/stem_channel.xml">
-        <SetVariable name="stemNum">1</SetVariable>
-      </Template>
+
+      <!-- No Stems -->
       <WidgetGroup>
-        <Size>15f,1me</Size>
-      </WidgetGroup>
-      <Template src="skins:Tango/stem_channel.xml">
-        <SetVariable name="stemNum">2</SetVariable>
-      </Template>
-      <WidgetGroup>
-        <Size>15f,1me</Size>
-      </WidgetGroup>
-      <Template src="skins:Tango/stem_channel.xml">
-        <SetVariable name="stemNum">3</SetVariable>
-      </Template>
-      <WidgetGroup>
-        <Size>15f,1me</Size>
-      </WidgetGroup>
-      <Template src="skins:Tango/stem_channel.xml">
-        <SetVariable name="stemNum">4</SetVariable>
-      </Template>
-      <WidgetGroup>
-        <Size>15f,1me</Size>
+        <Layout>vertical</Layout>
+        <Children>
+          <WidgetGroup><Size>0min,1me</Size></WidgetGroup>
+          <Label>
+            <ObjectName>StemLabelEmpty</ObjectName>
+            <Text>Track has no STEMs</Text>
+            <Alignment>center</Alignment>
+          </Label>
+          <WidgetGroup><Size>0min,1me</Size></WidgetGroup>
+        </Children>
+        <Connection>
+          <ConfigKey>[Channel<Variable name="chanNum"/>],stem_count</ConfigKey>
+          <Transform><Not/></Transform>
+          <BindProperty>visible</BindProperty>
+        </Connection>
       </WidgetGroup>
     </Children>
   </WidgetGroup>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1,5 +1,10 @@
 /* Tango style sheet */
 
+#StemLabelEmpty {
+  color: #FFFFFF;
+}
+
+
 #Mixxx {  /*
   AlignRight just for testing, to attach SkinSettings to right edge.
   Not working. See https://github.com/mixxxdj/mixxx/issues/8646 */

--- a/res/skins/Tango/waveform.xml
+++ b/res/skins/Tango/waveform.xml
@@ -23,7 +23,7 @@ Variables:
     <Children>
       <WidgetGroup><!-- Stem -->
         <Layout>vertical</Layout>
-        <SizePolicy>15f,min</SizePolicy>
+        <Size>240f,min</Size>
         <Children>
           <Template src="skins:Tango/stem_control.xml">
           </Template>


### PR DESCRIPTION
- Conditionally show 'Track has no STEMs' label when track has no stems
- Fix vertical alignment of waveform when stem panel is toggle
- Set default visibility of stem panel to hidden (0)

Refs #14242