### PR TITLE
Deere: Implement 'Track has no STEMs' logic and fix alignment

### DIFF
--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -24,7 +24,7 @@
       <attribute persist="true" config_key="[Deere],show_bpm_info">1</attribute>
       <attribute persist="true" config_key="[Skin],timing_shift_buttons">0</attribute>
       <!-- Stem -->
-      <attribute persist="true" config_key="[Skin],show_stem_controls">1</attribute>
+      <attribute persist="true" config_key="[Skin],show_stem_controls">0</attribute>
       <!-- Mixer -->
       <attribute persist="true" config_key="[Skin],show_mixer">1</attribute>
       <attribute persist="true" config_key="[Skin],show_faders">1</attribute>

--- a/res/skins/Deere/stem_control.xml
+++ b/res/skins/Deere/stem_control.xml
@@ -1,6 +1,5 @@
 <Template>
   <WidgetGroup>
-    <RequiresStem>true</RequiresStem>
     <ObjectName>StemControls</ObjectName>
     <Layout>vertical</Layout>
     <SizePolicy>max,me</SizePolicy>
@@ -12,7 +11,7 @@
       <WidgetGroup>
         <!-- StemControlsInner -->
         <Layout>horizontal</Layout>
-        <SizePolicy>f,f</SizePolicy>
+        <Size>260f,min</Size>
         <Children>
 
           <WidgetGroup>
@@ -23,66 +22,97 @@
             <!-- StemControls 4ch -->
             <Layout>vertical</Layout>
             <Children>
+              <!-- Show controls if stems exist -->
               <WidgetGroup>
-                <!-- StemCh1 controls  -->
-                <Layout>horizontal</Layout>
+                <Layout>vertical</Layout>
                 <Children>
                   <WidgetGroup>
-                    <Size>1min,2me</Size>
+                    <!-- StemCh1 controls  -->
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <WidgetGroup>
+                        <Size>1min,2me</Size>
+                      </WidgetGroup>
+                      <Template src="skins:Deere/stem_channel.xml">
+                        <SetVariable name="StemNum">1</SetVariable>
+                      </Template>
+                      <WidgetGroup>
+                        <Size>1min,3f</Size>
+                      </WidgetGroup>
+                    </Children>
                   </WidgetGroup>
-                  <Template src="skins:Deere/stem_channel.xml">
-                    <SetVariable name="StemNum">1</SetVariable>
-                  </Template>
                   <WidgetGroup>
-                    <Size>1min,3f</Size>
+                    <!-- StemCh2 controls  -->
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <WidgetGroup>
+                        <Size>1min,2me</Size>
+                      </WidgetGroup>
+                      <Template src="skins:Deere/stem_channel.xml">
+                        <SetVariable name="StemNum">2</SetVariable>
+                      </Template>
+                      <WidgetGroup>
+                        <Size>1min,3f</Size>
+                      </WidgetGroup>
+                    </Children>
+                  </WidgetGroup>
+                  <WidgetGroup>
+                    <!-- StemCh3 controls  -->
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <WidgetGroup>
+                        <Size>1min,2me</Size>
+                      </WidgetGroup>
+                      <Template src="skins:Deere/stem_channel.xml">
+                        <SetVariable name="StemNum">3</SetVariable>
+                      </Template>
+                      <WidgetGroup>
+                        <Size>1min,3f</Size>
+                      </WidgetGroup>
+                    </Children>
+                  </WidgetGroup>
+                  <WidgetGroup>
+                    <!-- StemCh4 controls  -->
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <WidgetGroup>
+                        <Size>1min,2me</Size>
+                      </WidgetGroup>
+                      <Template src="skins:Deere/stem_channel.xml">
+                        <SetVariable name="StemNum">4</SetVariable>
+                      </Template>
+                      <WidgetGroup>
+                        <Size>1min,3f</Size>
+                      </WidgetGroup>
+                    </Children>
                   </WidgetGroup>
                 </Children>
+                <Connection>
+                  <ConfigKey>[Channel<Variable name="ChanNum"/>],stem_count</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
               </WidgetGroup>
+
+              <!-- Show Label if no stems -->
               <WidgetGroup>
-                <!-- StemCh2 controls  -->
-                <Layout>horizontal</Layout>
+                <Layout>vertical</Layout>
+                <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <WidgetGroup>
-                    <Size>1min,2me</Size>
-                  </WidgetGroup>
-                  <Template src="skins:Deere/stem_channel.xml">
-                    <SetVariable name="StemNum">2</SetVariable>
-                  </Template>
-                  <WidgetGroup>
-                    <Size>1min,3f</Size>
-                  </WidgetGroup>
+                  <WidgetGroup><Size>0min,1me</Size></WidgetGroup>
+                  <Label>
+                    <ObjectName>StemLabelEmpty</ObjectName>
+                    <Text>Track has no STEMs</Text>
+                    <Alignment>center</Alignment>
+                  </Label>
+                  <WidgetGroup><Size>0min,1me</Size></WidgetGroup>
                 </Children>
+                <Connection>
+                  <ConfigKey>[Channel<Variable name="ChanNum"/>],stem_count</ConfigKey>
+                  <Transform><Not/></Transform>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
               </WidgetGroup>
-              <WidgetGroup>
-                <!-- StemCh3 controls  -->
-                <Layout>horizontal</Layout>
-                <Children>
-                  <WidgetGroup>
-                    <Size>1min,2me</Size>
-                  </WidgetGroup>
-                  <Template src="skins:Deere/stem_channel.xml">
-                    <SetVariable name="StemNum">3</SetVariable>
-                  </Template>
-                  <WidgetGroup>
-                    <Size>1min,3f</Size>
-                  </WidgetGroup>
-                </Children>
-              </WidgetGroup>
-              <WidgetGroup>
-                <!-- StemCh4 controls  -->
-                <Layout>horizontal</Layout>
-                <Children>
-                  <WidgetGroup>
-                    <Size>1min,2me</Size>
-                  </WidgetGroup>
-                  <Template src="skins:Deere/stem_channel.xml">
-                    <SetVariable name="StemNum">4</SetVariable>
-                  </Template>
-                  <WidgetGroup>
-                    <Size>1min,3f</Size>
-                  </WidgetGroup>
-                </Children>
-              </WidgetGroup>
+
             </Children>
           </WidgetGroup>
           <!-- /StemControls 4ch -->

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -17,9 +17,15 @@
 
 */
 
+/* Label for empty stems */
+#StemLabelEmpty {
+  color: #FFFFFF;
+}
+
 /*******************************************************************************
  ** BORDER *********************************************************************
  *******************************************************************************/
+
 /* These definitions put a faint border around all the widgets. We have to be
    tricky with top/bottom-ness to get things right. */
 #DeckControls {


### PR DESCRIPTION
- Conditionally show 'Track has no STEMs' label when track has no stems
- Fix vertical alignment of waveform when stem panel is toggle
- Set default visibility of stem panel to hidden (0)

Refs #14242