### PR TITLE
 Allow convert tracks to STEMS using axeldelafosse/stemgen + install stemgen on debian

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,7 +341,7 @@ jobs:
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-        uses: azure/trusted-signing-action@v0.5.10
+        uses: azure/trusted-signing-action@v1.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -407,7 +407,7 @@ jobs:
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-        uses: azure/trusted-signing-action@v0.5.10
+        uses: azure/trusted-signing-action@v1.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,3 @@
-Mixxx is Copyright (C) 2000-2024 by its respective authors. This version
+Mixxx is Copyright (C) 2000-2026 by its respective authors. This version
 of the program is distributed under the General Public License version 2,
 as described in the file LICENSE distributed with the program.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Mixxx 2.5.4, Digital DJ'ing software.
-Copyright (C) 2001-2025 Mixxx Development Team
+Copyright (C) 2001-2026 Mixxx Development Team
 
 Mixxx is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -6,7 +6,7 @@ Source: https://downloads.mixxx.org/
 
 Files: *
 Copyright:
- 2001-2025 Mixxx development team
+ 2001-2026 Mixxx development team
 License: GPL-2+
 
 License: GPL-2+

--- a/packaging/wix/LICENSE.rtf.in
+++ b/packaging/wix/LICENSE.rtf.in
@@ -2,7 +2,7 @@
 {\colortbl ;\red0\green0\blue255;}
 {\*\generator Riched20 10.0.14393}\viewkind4\uc1
 \pard\qj\ul\b\f0\fs22\lang1036 Mixxx @CMAKE_PROJECT_VERSION@, Digital DJ'ing software.\ulnone\b0\fs24\par
-\fs22 Copyright (C) 2001-2025 Mixxx Development Team\par
+\fs22 Copyright (C) 2001-2026 Mixxx Development Team\par
 \par
 Promotional tracks are copyright their respective owners and\par
 distributed with permission.\par

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -67,6 +67,7 @@ class BaseSqlTableModel : public BaseTrackTableModel {
     int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) const override;
 
     void hideTracks(const QModelIndexList& indices) override;
+    void removeTrackRows(const QSet<TrackId>& trackIdsToRemove) override;
 
     void select() override;
 

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -107,9 +107,9 @@ BaseTrackTableModel::BaseTrackTableModel(
           m_trackPlayedColor(QColor(WTrackTableView::kDefaultTrackPlayedColor)),
           m_trackMissingColor(QColor(WTrackTableView::kDefaultTrackMissingColor)) {
     connect(&pTrackCollectionManager->internalCollection()->getTrackDAO(),
-            &TrackDAO::forceModelUpdate,
+            &TrackDAO::tracksRemoved,
             this,
-            &BaseTrackTableModel::slotRefreshAllRows);
+            &BaseTrackTableModel::slotTracksRemoved);
     connect(&PlayerInfo::instance(),
             &PlayerInfo::trackChanged,
             this,
@@ -987,6 +987,10 @@ void BaseTrackTableModel::slotRefreshCoverRows(
 
 void BaseTrackTableModel::slotRefreshAllRows() {
     select();
+}
+
+void BaseTrackTableModel::slotTracksRemoved(const QSet<TrackId>& trackIds) {
+    removeTrackRows(trackIds);
 }
 
 void BaseTrackTableModel::emitDataChangedForMultipleRowsInColumn(

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -248,6 +248,8 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     void slotRefreshAllRows();
 
+    void slotTracksRemoved(const QSet<TrackId>& trackIds);
+
     void slotCoverFound(
             const QObject* pRequester,
             const CoverInfo& coverInfo,

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1111,9 +1111,9 @@ void TrackDAO::afterPurgingTracks(
 #else
     QSet<TrackId> tracksRemovedSet = QSet<TrackId>::fromList(trackIds);
 #endif
+    // Notify BaseTrackCache it should remove tracks and track models
+    // that they should update their cache as well.
     emit tracksRemoved(tracksRemovedSet);
-    // notify trackmodels that they should update their cache as well.
-    emit forceModelUpdate();
 }
 
 namespace {

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -116,6 +116,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void progressVerifyTracksOutside(const QString& path);
     void progressCoverArt(const QString& file);
     void forceModelUpdate();
+    void removeTrackRows(const QSet<TrackId>& trackIds);
 
   public slots:
     // Slots to inform the TrackDAO about changes that

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -41,7 +41,7 @@ TrackCollection::TrackCollection(
     connect(&m_trackDao,
             &TrackDAO::tracksRemoved,
             this,
-            &TrackCollection::tracksRemoved,
+            &TrackCollection::tracksRemoved, // unused
             /*signal-to-signal*/ Qt::DirectConnection);
     connect(&m_trackDao,
             &TrackDAO::forceModelUpdate,

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -243,6 +243,8 @@ class TrackModel {
     virtual void select() {
     }
 
+    virtual void removeTrackRows(const QSet<TrackId>&) {};
+
     /// This is an interface to stop any potentially running
     /// model population when switching models in WTrackTableView.
     /// Only implemented in ProxyTrackModel.

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -218,7 +218,9 @@ void CrateTableModel::removeTracks(const QModelIndexList& indices) {
         return;
     }
 
-    select();
+    // Now remove the track rows
+    QSet<TrackId> tracksRemovedSet = QSet<TrackId>(trackIds.begin(), trackIds.end());
+    removeTrackRows(tracksRemovedSet);
 }
 
 QString CrateTableModel::modelKey(bool noSearch) const {

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -3,6 +3,7 @@
 #include <QDir>
 #include <QList>
 #include <QLocale>
+#include <QMainWindow>
 #include <QScreen>
 #include <QVariant>
 #include <QtGlobal>
@@ -240,8 +241,19 @@ DlgPrefInterface::DlgPrefInterface(
 }
 
 QScreen* DlgPrefInterface::getScreen() const {
-    auto* pScreen =
-            mixxx::widgethelper::getScreen(*this);
+    QScreen* pScreen = nullptr;
+    const QWidgetList topLevelWidgets = QApplication::topLevelWidgets();
+    for (QWidget* pWidget : topLevelWidgets) {
+        // Ignore other popups and hidden track menus
+        QMainWindow* pMainWindow = qobject_cast<QMainWindow*>(pWidget);
+        if (pMainWindow) {
+            pScreen = mixxx::widgethelper::getScreen(*pMainWindow);
+            break;
+        }
+    }
+    VERIFY_OR_DEBUG_ASSERT(pScreen) {
+        pScreen = mixxx::widgethelper::getScreen(*this);
+    }
     if (!pScreen) {
         // Obtain the primary screen. This is necessary if no window is
         // available before the widget is displayed.

--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -62,6 +62,31 @@ case "$1" in
             fi
         fi
 
+		# Check if fonts-ubuntu is available (from non-free repository)
+        if ! apt-cache show fonts-ubuntu 2>/dev/null | grep -q "Package: fonts-ubuntu"; then
+            echo ""
+            echo "⚠️  WARNING: The package 'fonts-ubuntu' is not available."
+            echo "This package is required for Mixxx and is located in the Debian non-free repository."
+            echo ""
+            read -p "Do you want to enable the non-free repository and install fonts-ubuntu? (y/n) " -n 1 -r
+            echo
+            if [[ $REPLY =~ ^[Yy]$ ]]; then
+                echo "Enabling non-free repository..."
+                # Add non-free to sources.list if not already present
+                if ! grep -q " non-free$" /etc/apt/sources.list; then
+                    sudo sed -i 's/^\(deb.*\) \(main\|contrib\|non-free-firmware\)$/\1 \2 non-free/' /etc/apt/sources.list
+                fi
+                echo "Updating package list..."
+                sudo apt-get update
+                FONTS_UBUNTU_AVAILABLE=true
+            else
+                echo "Continuing without fonts-ubuntu..."
+                FONTS_UBUNTU_AVAILABLE=false
+            fi
+        else
+            FONTS_UBUNTU_AVAILABLE=true
+        fi
+
         sudo apt-get install -y --no-install-recommends -- \
             ccache \
             cmake \
@@ -72,7 +97,7 @@ case "$1" in
             docbook-to-man \
             dput \
             fonts-open-sans \
-            fonts-ubuntu-title \
+            $([ "$FONTS_UBUNTU_AVAILABLE" = true ] && echo "fonts-ubuntu") \
             g++ \
             lcov \
             libavformat-dev \

--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -72,7 +72,7 @@ case "$1" in
             docbook-to-man \
             dput \
             fonts-open-sans \
-            fonts-ubuntu \
+            fonts-ubuntu-title \
             g++ \
             lcov \
             libavformat-dev \

--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -52,11 +52,11 @@ case "$1" in
         fi
 
         # Install a faster linker. Prefer mold, fall back to lld
-        if apt-cache show mold 2>%1 >/dev/null;
+        if apt-cache show mold 2>/dev/null >/dev/null;
         then
             sudo apt-get install -y --no-install-recommends mold
         else
-            if apt-cache show lld 2>%1 >/dev/null;
+            if apt-cache show lld 2>/dev/null >/dev/null;
             then
                 sudo apt-get install -y --no-install-recommends lld
             fi


### PR DESCRIPTION
## Description
Allow convert tracks to STEMS using axeldelafosse/stemgen + install stemgen on debian

## Changes
- Asks to user to install stemgen if true, install the dependencies
- Add the option to convert track to stems. Right click on a track > Analize > Convert to stems
- Opens a window to manage conversions (need fix/help, I'm not able to close it)
- Adds a button to open stems conversions window below stems hamburger menu (I'm not able to make it appear)

## Need help
- Allow close stems conversions manager window
- Get the history of conversions working
- Detect when a conversion has finished and reload the library (whole? or only for this track?)
- Get the button of stems conversions manager window, working

This is my first c++ contribution, I'm not used to work with this language, on collaborating with this PR, I'm trying to learn this programming language. Apologies in advance for any damage I might be causing with this piece of code. Also, my apologies for getting a little confused with the PRs on GitHub.

Thanks @daschuer for encouraging me to participate and to learn.

## Related Issues
Related #15307