### PR TITLE
Fixes Stem Control Alignment for long stem names

### DIFF
--- a/res/skins/Deere/stem_channel.xml
+++ b/res/skins/Deere/stem_channel.xml
@@ -37,7 +37,7 @@
         <StemNum><Variable name="StemNum"/></StemNum>
         <Alignment>left</Alignment>
         <Elide>right</Elide>
-        <Size>50,26</Size>
+        <Size>50f,26f</Size>
         <Text></Text>
       </StemLabel>
 

--- a/res/skins/LateNight/stem_channel.xml
+++ b/res/skins/LateNight/stem_channel.xml
@@ -14,7 +14,7 @@
         <StemNum><Variable name="StemNum"/></StemNum>
         <Alignment>left</Alignment>
         <Elide>right</Elide>
-        <Size>50,26</Size>
+        <Size>50f,26f</Size>
         <Text></Text>
       </StemLabel>
 

--- a/res/skins/Tango/stem_channel.xml
+++ b/res/skins/Tango/stem_channel.xml
@@ -34,7 +34,7 @@
         <StemNum><Variable name="stemNum"/></StemNum>
         <Alignment>left</Alignment>
         <Elide>right</Elide>
-        <Size>50,26</Size>
+        <Size>50f,26f</Size>
         <Text></Text>
       </StemLabel>
 

--- a/src/widget/wstemlabel.cpp
+++ b/src/widget/wstemlabel.cpp
@@ -12,6 +12,7 @@ WStemLabel::WStemLabel(QWidget* pParent)
 }
 
 void WStemLabel::setup(const QDomNode& node, const SkinContext& context) {
+    WLabel::setup(node, context);
     m_stemNo = context.selectInt(node, "StemNum");
 
     VERIFY_OR_DEBUG_ASSERT(m_stemNo >= 1 && m_stemNo <= mixxx::kMaxSupportedStems) {


### PR DESCRIPTION
<img width="270" height="137" alt="image" src="https://github.com/user-attachments/assets/ba0ef7ad-68ec-4b92-ab32-18b243cac085" />

Fixes #15878 