### PR TITLE
Implement Stem VU Meter Control Objects

### DIFF
--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -83,7 +83,7 @@ EngineDeck::EngineDeck(
         m_stemMute.push_back(std::move(pMuteButton));
 
         m_stemVuMeter.emplace_back(std::make_unique<EngineVuMeter>(
-                getGroupForStem(getGroup(), stemIdx)));
+                getGroupForStem(getGroup(), stemIdx), QString(), false));
     }
 #endif
 }

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -103,6 +103,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     std::unique_ptr<ControlObject> m_pStemCount;
     std::vector<std::unique_ptr<ControlPotmeter>> m_stemGain;
     std::vector<std::unique_ptr<ControlPushButton>> m_stemMute;
+    std::vector<std::unique_ptr<EngineVuMeter>> m_stemVuMeter;
     bool m_stemClonedState;
 #endif
 

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -8,7 +8,7 @@ namespace {
 
 // Rate at which the vumeter is updated (using a sample rate of 44100 Hz):
 constexpr unsigned int kVuUpdateRate = 30; // in Hz (1/s), fits to display frame rate
-constexpr int kPeakDuration = 500; // in ms
+constexpr int kPeakDuration = 500;         // in ms
 
 // Smoothing Factors
 // Must be from 0-1 the lower the factor, the more smoothing that is applied
@@ -17,21 +17,27 @@ constexpr CSAMPLE kDecaySmoothing = 0.1f;  //.16//.4
 
 } // namespace
 
-EngineVuMeter::EngineVuMeter(const QString& group, const QString& legacyGroup)
+EngineVuMeter::EngineVuMeter(const QString& group,
+        const QString& legacyGroup,
+        bool createLegacyAliases)
         : m_vuMeter(ConfigKey(group, QStringLiteral("vu_meter"))),
           m_vuMeterLeft(ConfigKey(group, QStringLiteral("vu_meter_left"))),
           m_vuMeterRight(ConfigKey(group, QStringLiteral("vu_meter_right"))),
           m_peakIndicator(ConfigKey(group, QStringLiteral("peak_indicator"))),
-          m_peakIndicatorLeft(ConfigKey(group, QStringLiteral("peak_indicator_left"))),
-          m_peakIndicatorRight(ConfigKey(group, QStringLiteral("peak_indicator_right"))),
+          m_peakIndicatorLeft(
+                  ConfigKey(group, QStringLiteral("peak_indicator_left"))),
+          m_peakIndicatorRight(
+                  ConfigKey(group, QStringLiteral("peak_indicator_right"))),
           m_sampleRate(QStringLiteral("[App]"), QStringLiteral("samplerate")) {
-    const QString& aliasGroup = legacyGroup.isEmpty() ? group : legacyGroup;
-    m_vuMeter.addAlias(ConfigKey(aliasGroup, QStringLiteral("VuMeter")));
-    m_vuMeterLeft.addAlias(ConfigKey(aliasGroup, QStringLiteral("VuMeterL")));
-    m_vuMeterRight.addAlias(ConfigKey(aliasGroup, QStringLiteral("VuMeterR")));
-    m_peakIndicator.addAlias(ConfigKey(aliasGroup, QStringLiteral("PeakIndicator")));
-    m_peakIndicatorLeft.addAlias(ConfigKey(aliasGroup, QStringLiteral("PeakIndicatorL")));
-    m_peakIndicatorRight.addAlias(ConfigKey(aliasGroup, QStringLiteral("PeakIndicatorR")));
+    if (createLegacyAliases) {
+        const QString& aliasGroup = legacyGroup.isEmpty() ? group : legacyGroup;
+        m_vuMeter.addAlias(ConfigKey(aliasGroup, QStringLiteral("VuMeter")));
+        m_vuMeterLeft.addAlias(ConfigKey(aliasGroup, QStringLiteral("VuMeterL")));
+        m_vuMeterRight.addAlias(ConfigKey(aliasGroup, QStringLiteral("VuMeterR")));
+        m_peakIndicator.addAlias(ConfigKey(aliasGroup, QStringLiteral("PeakIndicator")));
+        m_peakIndicatorLeft.addAlias(ConfigKey(aliasGroup, QStringLiteral("PeakIndicatorL")));
+        m_peakIndicatorRight.addAlias(ConfigKey(aliasGroup, QStringLiteral("PeakIndicatorR")));
+    }
     // Initialize the calculation:
     reset();
 }
@@ -105,18 +111,17 @@ void EngineVuMeter::process(CSAMPLE* pIn, const std::size_t bufferSize) {
                     : 0.0);
 }
 
-void EngineVuMeter::doSmooth(CSAMPLE &currentVolume, CSAMPLE newVolume)
-{
+void EngineVuMeter::doSmooth(CSAMPLE& currentVolume, CSAMPLE newVolume) {
     if (currentVolume > newVolume) {
         currentVolume -= kDecaySmoothing * (currentVolume - newVolume);
     } else {
         currentVolume += kAttackSmoothing * (newVolume - currentVolume);
     }
     if (currentVolume < 0) {
-        currentVolume=0;
+        currentVolume = 0;
     }
     if (currentVolume > 1.0) {
-        currentVolume=1.0;
+        currentVolume = 1.0;
     }
 }
 

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -7,14 +7,16 @@
 class EngineVuMeter : public EngineObject {
     Q_OBJECT
   public:
-    EngineVuMeter(const QString& group, const QString& legacyGroup = QString());
+    EngineVuMeter(const QString& group,
+            const QString& legacyGroup = QString(),
+            bool createLegacyAliases = true);
 
     virtual void process(CSAMPLE* pInOut, const std::size_t bufferSize);
 
     void reset();
 
   private:
-    void doSmooth(CSAMPLE &currentVolume, CSAMPLE newVolume);
+    void doSmooth(CSAMPLE& currentVolume, CSAMPLE newVolume);
 
     ControlObject m_vuMeter;
     ControlObject m_vuMeterLeft;

--- a/src/test/stemcontrolobjecttest.cpp
+++ b/src/test/stemcontrolobjecttest.cpp
@@ -365,17 +365,15 @@ TEST_P(StemControlFixture, VuMeter) {
 
     // Process enough buffers to allow VU meter to decay to 0
     // Decay is exponential, so it takes time.
-    for (int i = 0; i < 200; ++i) {
+    for (int i = 0; i < 600; ++i) {
         m_pEngineMixer->process(kProcessBufferSize);
     }
 
     // VU Meter should be near zero (allow small epsilon for imperfect decay)
-    // FIXME: This assertion fails in unit test (value stays 1.0) but passed manual verification.
-    // Likely due to test harness buffer handling or settling time.
-    // EXPECT_NEAR(m_pStem1VuMeter->get(), 0.0, 0.001);
+    EXPECT_NEAR(m_pStem1VuMeter->get(), 0.0, 0.001);
 
     // Stem 2 should still be playing
-    // EXPECT_GT(m_pStem2VuMeter->get(), 0.0);
+    EXPECT_GT(m_pStem2VuMeter->get(), 0.0);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
## Description
This PR implements individual VU Meter Control Objects (COs) for Stems. 

## Key Changes
*   **EngineDeck**: Added `m_stemVuMeter` vector to store`EngineVuMeter` instances for each stem.
*   **Initialization**: Configured stem VU meters in `EngineDeck`constructor with group names like `[ChannelX_StemY]`.
*   **Processing**: Wired `m_stemVuMeter[i]->process()` into `EngineDeck::processStem` to analyze the post-fader stem audio.
*   **Tests**: Added regression tests in `stemcontrolobjecttest.cpp`(to verify COs are created and emit values during playback.)

## Related Issues
Fixes #13699

## Verification
*   Added temporary widget to Tango skin and verified VU meter responds to audio. (Reverted to original state in the PR)

https://github.com/user-attachments/assets/b0f5d2c1-77f5-48db-90bf-3d6431bacc05


*   Verified Mute button stops the VU meter visual (functionally working).
*   Unit tests pass (`m_pStem1VuMeter->get() > 0.0` when active).