### PR TITLE
Adjust ifdefs for FreeBSD

### DIFF
--- a/src/util/battery/battery.cpp
+++ b/src/util/battery/battery.cpp
@@ -11,7 +11,7 @@
 #include "util/battery/batterywindows.h"
 #elif defined(__APPLE__)
 #include "util/battery/batterymac.h"
-#else
+#elif __LINUX__
 #include "util/battery/batterylinux.h"
 #endif
 #endif
@@ -37,8 +37,11 @@ Battery* Battery::getBattery(QObject* parent) {
     return new BatteryWindows(parent);
 #elif defined(Q_OS_MAC)
     return new BatteryMac(parent);
-#else
+#elif __LINUX__
     return new BatteryLinux(parent);
+#else
+    Q_UNUSED(parent);
+    return nullptr;
 #endif
 #else
     Q_UNUSED(parent);

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -70,7 +70,7 @@ CmdlineArgs::CmdlineArgs()
           m_logFlushLevel(mixxx::kLogFlushLevelDefault),
           m_logMaxFileSize(mixxx::kLogMaxFileSizeDefault),
 // We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see #8090
-#if defined(__LINUX__)
+#if defined(__LINUX__) || defined(__BSD__)
 #ifdef MIXXX_SETTINGS_PATH
           m_settingsPath(QDir::homePath().append("/").append(MIXXX_SETTINGS_PATH))
 #else


### PR DESCRIPTION
This consists of two commits:

- [Default to no battery on other platforms](https://github.com/mixxxdj/mixxx/commit/aa791b4bc71407588fd5546018d45d555d5a4a16)

   This stops the repeated warnings about being unable to read Linux
   battery information when running on FreeBSD.

- [Add BSD to the non-XDG directory ifdef](https://github.com/mixxxdj/mixxx/commit/481d27812d38267aa05d19893df9db6fd20ef8d2)

   Mixxx 2.5.3 is still using .mixxx, so we need to include BSD in the
   ifdef to prevent the directory moving when running a more recent
   development version.