### PR TITLE
Fix key color rect when track tuning is unavailable

### DIFF
--- a/lib/qm-dsp/base/Pitch.cpp
+++ b/lib/qm-dsp/base/Pitch.cpp
@@ -32,13 +32,8 @@ Pitch::getPitchForFrequency(float frequency,
 {
     float p = 12.0 * (log(frequency / (concertA / 2.0)) / log(2.0)) + 57.0;
 
-    int midiPitch = int(p + 0.00001);
+    int midiPitch = static_cast<int>(p + 0.5);
     float centsOffset = (p - midiPitch) * 100.0;
-
-    if (centsOffset >= 50.0) {
-        midiPitch = midiPitch + 1;
-        centsOffset = -(100.0 - centsOffset);
-    }
     
     if (centsOffsetReturn) *centsOffsetReturn = centsOffset;
     return midiPitch;

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -940,23 +940,30 @@ QVariant BaseTrackTableModel::roleValue(
             const float tuningHz = (float)rawSiblingValue(
                     index, ColumnCache::COLUMN_LIBRARYTABLE_TUNING_FREQUENCY)
                                            .value<double>();
-            float cents = 0;
-            Pitch::getPitchForFrequency(tuningHz, &cents, 440.0f);
-            cents /= 100.0f; // normalize between -1 and 1
             QVariantMap colorRect;
-            if (cents < 0) {
+            if (tuningHz == 0) { // we do not have tuning information
                 colorRect["top"] = KeyUtils::keyToColor(key, s_keyColorPalette.value());
-                colorRect["bottom"] =
-                        KeyUtils::keyToColor(KeyUtils::scaleKeySteps(key, -1),
-                                s_keyColorPalette.value());
-                colorRect["splitPoint"] = cents + 1;
+                colorRect["bottom"] = colorRect["top"];
+                colorRect["splitPoint"] = 1;
             } else {
-                colorRect["top"] =
-                        KeyUtils::keyToColor(KeyUtils::scaleKeySteps(key, 1),
-                                s_keyColorPalette.value());
-                colorRect["bottom"] = KeyUtils::keyToColor(key, s_keyColorPalette.value());
-                colorRect["splitPoint"] = cents;
+                float cents = 0;
+                Pitch::getPitchForFrequency(tuningHz, &cents, 440.0f);
+                cents /= 100.0f; // normalize between -1 and 1
+                if (cents < 0) {
+                    colorRect["top"] = KeyUtils::keyToColor(key, s_keyColorPalette.value());
+                    colorRect["bottom"] =
+                            KeyUtils::keyToColor(KeyUtils::scaleKeySteps(key, -1),
+                                    s_keyColorPalette.value());
+                    colorRect["splitPoint"] = cents + 1;
+                } else {
+                    colorRect["top"] =
+                            KeyUtils::keyToColor(KeyUtils::scaleKeySteps(key, 1),
+                                    s_keyColorPalette.value());
+                    colorRect["bottom"] = KeyUtils::keyToColor(key, s_keyColorPalette.value());
+                    colorRect["splitPoint"] = cents;
+                }
             }
+
             return colorRect;
         }
         default:

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -34,10 +34,9 @@ void KeyDelegate::paintItem(
     int leftMargin = 0;
 
     const QColor colorTop = colorRect["top"].value<QColor>();
-    const QColor colorBottom = colorRect["bottom"].value<QColor>();
     const double splitPoint = colorRect["splitPoint"].value<double>();
 
-    if (colorTop.isValid() && colorBottom.isValid()) {
+    if (colorTop.isValid()) {
         // Draw the colored rectangle next to the key label
         constexpr int width = 4;
         leftMargin = width + 4; // 4px right padding
@@ -55,12 +54,17 @@ void KeyDelegate::paintItem(
                 width,
                 splitHeight,
                 colorTop);
-        painter->fillRect(
-                x,
-                padTop + splitHeight,
-                width,
-                padHeight - splitHeight,
-                colorBottom);
+
+        // if this track has a tuning, draw the second color
+        if (splitPoint < 1) {
+            const QColor colorBottom = colorRect["bottom"].value<QColor>();
+            painter->fillRect(
+                    x,
+                    padTop + splitHeight,
+                    width,
+                    padHeight - splitHeight,
+                    colorBottom);
+        }
     }
 
     // Determine which tuning symbol to show (if any)


### PR DESCRIPTION
When tuning is unavailable, the cents value would be -inf, causing improper rendering of the key color rect ( https://github.com/mixxxdj/mixxx/pull/15865#issuecomment-3773412820 ).

Fixed by checking if tuning == 0, and then only using the track's own key color. 

---

This will also close #15883