### PR TITLE
feat(library): Add customizable date format option for Library and History

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -115,6 +115,13 @@ void BaseTrackTableModel::setApplyPlayedTrackColor(bool apply) {
     s_bApplyPlayedTrackColor = apply;
 }
 
+const QString BaseTrackTableModel::kDateFormatDefault = QString();
+QString BaseTrackTableModel::s_dateFormat = BaseTrackTableModel::kDateFormatDefault;
+
+void BaseTrackTableModel::setDateFormat(const QString& format) {
+    s_dateFormat = format;
+}
+
 BaseTrackTableModel::BaseTrackTableModel(
         QObject* parent,
         TrackCollectionManager* pTrackCollectionManager,
@@ -689,10 +696,10 @@ QVariant BaseTrackTableModel::roleValue(
             if (field == ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED) {
                 // Timestamp column in history feature:
                 // Use localized date/time format without text: "5/20/98 03:40 AM"
-                return mixxx::displayLocalDateTime(dt);
+                return mixxx::displayLocalDateTime(dt, s_dateFormat);
             }
             // For Date Added, use just the date: "5/20/98"
-            return dt.date();
+            return mixxx::formatDate(dt.date(), s_dateFormat);
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT: {
             QDateTime lastPlayedAt;
@@ -718,7 +725,7 @@ QVariant BaseTrackTableModel::roleValue(
             if (role == Qt::ToolTipRole || role == kDataExportRole) {
                 return dt;
             }
-            return dt.date();
+            return mixxx::formatDate(dt.date(), s_dateFormat);
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_BPM: {
             mixxx::Bpm bpm;

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -9,6 +9,7 @@
 #include "library/trackmodel.h"
 #include "track/track_decl.h"
 #include "util/color/colorpalette.h"
+#include "util/datetime.h"
 
 class TrackCollectionManager;
 
@@ -131,6 +132,18 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     static constexpr bool kApplyPlayedTrackColorDefault = true;
     static void setApplyPlayedTrackColor(bool apply);
+
+    enum class DateFormat {
+        Native = 0,        // System Default
+        ISO8601 = 1,       // yyyy-MM-dd
+        RegionalShort = 2, // d/M/yy
+        RegionalLong = 3,  // dd.MM.yyyy
+        Custom = 4,
+    };
+    Q_ENUM(DateFormat)
+
+    static const QString kDateFormatDefault;
+    static void setDateFormat(const QString& format);
 
   protected:
     // Build a map from the column names to their indices
@@ -307,4 +320,5 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     static std::optional<ColorPalette> s_keyColorPalette;
 
     static bool s_bApplyPlayedTrackColor;
+    static QString s_dateFormat;
 };

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -114,3 +114,8 @@ const ConfigKey mixxx::library::prefs::kTagFetcherApplyCoverConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("TagFetcherApplyCover")};
+
+const ConfigKey mixxx::library::prefs::kDateFormatConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("DateFormat")};

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -58,6 +58,8 @@ extern const ConfigKey kTagFetcherApplyTagsConfigKey;
 
 extern const ConfigKey kTagFetcherApplyCoverConfigKey;
 
+extern const ConfigKey kDateFormatConfigKey;
+
 } // namespace prefs
 
 } // namespace library

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -111,6 +111,27 @@ DlgPrefLibrary::DlgPrefLibrary(
 
     updateSearchLineEditHistoryOptions();
 
+    comboBox_dateFormat->addItem(tr("Native (System Default)"),
+            QVariant::fromValue(BaseTrackTableModel::DateFormat::Native));
+    comboBox_dateFormat->addItem(tr("ISO 8601 (yyyy-MM-dd)"),
+            QVariant::fromValue(BaseTrackTableModel::DateFormat::ISO8601));
+    comboBox_dateFormat->addItem(tr("Regional Short (d/M/yy)"),
+            QVariant::fromValue(BaseTrackTableModel::DateFormat::RegionalShort));
+    comboBox_dateFormat->addItem(tr("Regional Long (dd.MM.yyyy)"),
+            QVariant::fromValue(BaseTrackTableModel::DateFormat::RegionalLong));
+    comboBox_dateFormat->addItem(tr("Custom"),
+            QVariant::fromValue(BaseTrackTableModel::DateFormat::Custom));
+
+    connect(comboBox_dateFormat,
+            &QComboBox::currentIndexChanged,
+            this,
+            &DlgPrefLibrary::slotDateFormatIndexChanged);
+
+    connect(comboBox_dateFormat,
+            &QComboBox::editTextChanged,
+            this,
+            &DlgPrefLibrary::slotDateFormatChanged);
+
     connect(btn_library_font, &QAbstractButton::clicked, this, &DlgPrefLibrary::slotSelectFont);
 
     // TODO(XXX) this string should be extracted from the soundsources
@@ -231,7 +252,7 @@ void DlgPrefLibrary::populateDirList() {
     dirList->setModel(&m_dirListModel);
     dirList->setCurrentIndex(m_dirListModel.index(0, 0));
     // reselect index if it still exists
-    for (int i=0 ; i<m_dirListModel.rowCount() ; ++i) {
+    for (int i = 0; i < m_dirListModel.rowCount(); ++i) {
         const QModelIndex index = m_dirListModel.index(i, 0);
         if (index.data().toString() == selected) {
             dirList->setCurrentIndex(index);
@@ -267,6 +288,16 @@ void DlgPrefLibrary::slotResetToDefaults() {
     comboBox_search_bpm_fuzzy_range->setCurrentIndex(
             comboBox_search_bpm_fuzzy_range->findData(kDefaultFuzzyRateRangePercent));
 
+    int dateIndex = comboBox_dateFormat->findData(
+            QVariant::fromValue(BaseTrackTableModel::DateFormat::Native));
+    if (dateIndex != -1) {
+        comboBox_dateFormat->setCurrentIndex(dateIndex);
+    } else {
+        // Fallback or custom default? Default is usually Native (empty string)
+        // which should be found.
+        comboBox_dateFormat->setCurrentIndex(0);
+    }
+
     checkBox_show_rhythmbox->setChecked(true);
     checkBox_show_banshee->setChecked(true);
     checkBox_show_itunes->setChecked(true);
@@ -297,17 +328,49 @@ void DlgPrefLibrary::slotUpdate() {
             kUseRelativePathOnExportConfigKey, false));
 
     checkBox_show_rhythmbox->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]","ShowRhythmboxLibrary"), true));
+            ConfigKey("[Library]", "ShowRhythmboxLibrary"), true));
     checkBox_show_banshee->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]","ShowBansheeLibrary"), true));
+            ConfigKey("[Library]", "ShowBansheeLibrary"), true));
     checkBox_show_itunes->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]","ShowITunesLibrary"), true));
+            ConfigKey("[Library]", "ShowITunesLibrary"), true));
     checkBox_show_traktor->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]","ShowTraktorLibrary"), true));
+            ConfigKey("[Library]", "ShowTraktorLibrary"), true));
     checkBox_show_rekordbox->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]","ShowRekordboxLibrary"), true));
+            ConfigKey("[Library]", "ShowRekordboxLibrary"), true));
     checkBox_show_serato->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]", "ShowSeratoLibrary"), true));
+
+    QString dateFormat = m_pConfig->getValue(
+            kDateFormatConfigKey,
+            BaseTrackTableModel::kDateFormatDefault);
+
+    // Determine the matching preset or custom
+    BaseTrackTableModel::DateFormat preset = BaseTrackTableModel::DateFormat::Custom;
+    if (dateFormat.isEmpty()) {
+        preset = BaseTrackTableModel::DateFormat::Native;
+    } else if (dateFormat == QStringLiteral("yyyy-MM-dd")) {
+        preset = BaseTrackTableModel::DateFormat::ISO8601;
+    } else if (dateFormat == QStringLiteral("d/M/yy")) {
+        preset = BaseTrackTableModel::DateFormat::RegionalShort;
+    } else if (dateFormat == QStringLiteral("dd.MM.yyyy")) {
+        preset = BaseTrackTableModel::DateFormat::RegionalLong;
+    }
+
+    int dateIndex = comboBox_dateFormat->findData(QVariant::fromValue(preset));
+    if (dateIndex != -1) {
+        comboBox_dateFormat->setCurrentIndex(dateIndex);
+    }
+
+    if (preset == BaseTrackTableModel::DateFormat::Custom) {
+        comboBox_dateFormat->setEditable(true);
+        comboBox_dateFormat->setEditText(dateFormat);
+        m_lastCustomDateFormat = dateFormat;
+    } else {
+        comboBox_dateFormat->setEditable(false);
+    }
+
+    // Ensure the static member is updated on startup/load
+    BaseTrackTableModel::setDateFormat(dateFormat);
 
     switch (m_pConfig->getValue<int>(
             kTrackDoubleClickActionConfigKey,
@@ -372,12 +435,12 @@ void DlgPrefLibrary::slotUpdate() {
             m_pConfig->getValue(
                     kSearchBpmFuzzyRangeConfigKey,
                     BpmFilterNode::kRelativeRangeDefault);
-    int index = comboBox_search_bpm_fuzzy_range->findData(static_cast<int>(searchBpmFuzzyRange));
-    if (index == -1) {
-        index = comboBox_search_bpm_fuzzy_range->findData(kDefaultFuzzyRateRangePercent);
+    int bpmIndex = comboBox_search_bpm_fuzzy_range->findData(static_cast<int>(searchBpmFuzzyRange));
+    if (bpmIndex == -1) {
+        bpmIndex = comboBox_search_bpm_fuzzy_range->findData(kDefaultFuzzyRateRangePercent);
     }
-    comboBox_search_bpm_fuzzy_range->setCurrentIndex(index);
-    slotBpmRangeSelected(index);
+    comboBox_search_bpm_fuzzy_range->setCurrentIndex(bpmIndex);
+    slotBpmRangeSelected(bpmIndex);
 
     const auto bpmColumnPrecision =
             m_pConfig->getValue(
@@ -403,9 +466,9 @@ void DlgPrefLibrary::resetLibraryFont() {
 }
 
 void DlgPrefLibrary::slotAddDir() {
-    QString fd = QFileDialog::getExistingDirectory(
-        this, tr("Choose a music directory"),
-        QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
+    QString fd = QFileDialog::getExistingDirectory(this,
+            tr("Choose a music directory"),
+            QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
     if (!fd.isEmpty()) {
         if (m_pLibrary->requestAddDir(fd)) {
             populateDirList();
@@ -423,29 +486,29 @@ void DlgPrefLibrary::slotRemoveDir() {
     removeMsgBox.setWindowTitle(tr("Confirm Directory Removal"));
 
     removeMsgBox.setText(tr(
-        "Mixxx will no longer watch this directory for new tracks. "
-        "What would you like to do with the tracks from this directory and "
-        "subdirectories?"
-        "<ul>"
-        "<li>Hide all tracks from this directory and subdirectories.</li>"
-        "<li>Delete all metadata for these tracks from Mixxx permanently.</li>"
-        "<li>Leave the tracks unchanged in your library.</li>"
-        "</ul>"
-        "Hiding tracks saves their metadata in case you re-add them in the "
-        "future."));
+            "Mixxx will no longer watch this directory for new tracks. "
+            "What would you like to do with the tracks from this directory and "
+            "subdirectories?"
+            "<ul>"
+            "<li>Hide all tracks from this directory and subdirectories.</li>"
+            "<li>Delete all metadata for these tracks from Mixxx permanently.</li>"
+            "<li>Leave the tracks unchanged in your library.</li>"
+            "</ul>"
+            "Hiding tracks saves their metadata in case you re-add them in the "
+            "future."));
     removeMsgBox.setInformativeText(tr(
-        "Metadata means all track details (artist, title, playcount, etc.) as "
-        "well as beatgrids, hotcues, and loops. This choice only affects the "
-        "Mixxx library. No files on disk will be changed or deleted."));
+            "Metadata means all track details (artist, title, playcount, etc.) as "
+            "well as beatgrids, hotcues, and loops. This choice only affects the "
+            "Mixxx library. No files on disk will be changed or deleted."));
 
     QPushButton* cancelButton =
             removeMsgBox.addButton(QMessageBox::Cancel);
     QPushButton* hideAllButton = removeMsgBox.addButton(
-        tr("Hide Tracks"), QMessageBox::AcceptRole);
+            tr("Hide Tracks"), QMessageBox::AcceptRole);
     QPushButton* deleteAllButton = removeMsgBox.addButton(
-        tr("Delete Track Metadata"), QMessageBox::AcceptRole);
+            tr("Delete Track Metadata"), QMessageBox::AcceptRole);
     QPushButton* leaveUnchangedButton = removeMsgBox.addButton(
-        tr("Leave Tracks Unchanged"), QMessageBox::AcceptRole);
+            tr("Leave Tracks Unchanged"), QMessageBox::AcceptRole);
     Q_UNUSED(leaveUnchangedButton); // Only used in DEBUG_ASSERT
     removeMsgBox.setDefaultButton(cancelButton);
     removeMsgBox.exec();
@@ -487,7 +550,7 @@ void DlgPrefLibrary::slotRelocateDir() {
     }
 
     QString fd = QFileDialog::getExistingDirectory(
-        this, tr("Relink music directory to new location"), startDir);
+            this, tr("Relink music directory to new location"), startDir);
 
     if (!fd.isEmpty() && m_pLibrary->requestRelocateDir(currentFd, fd)) {
         populateDirList();
@@ -541,16 +604,16 @@ void DlgPrefLibrary::slotApply() {
             ConfigValue(checkBox_enable_search_history_shortcuts->isChecked()));
     updateSearchLineEditHistoryOptions();
 
-    m_pConfig->set(ConfigKey("[Library]","ShowRhythmboxLibrary"),
-                ConfigValue((int)checkBox_show_rhythmbox->isChecked()));
-    m_pConfig->set(ConfigKey("[Library]","ShowBansheeLibrary"),
-                ConfigValue((int)checkBox_show_banshee->isChecked()));
-    m_pConfig->set(ConfigKey("[Library]","ShowITunesLibrary"),
-                ConfigValue((int)checkBox_show_itunes->isChecked()));
-    m_pConfig->set(ConfigKey("[Library]","ShowTraktorLibrary"),
-                ConfigValue((int)checkBox_show_traktor->isChecked()));
-    m_pConfig->set(ConfigKey("[Library]","ShowRekordboxLibrary"),
-                ConfigValue((int)checkBox_show_rekordbox->isChecked()));
+    m_pConfig->set(ConfigKey("[Library]", "ShowRhythmboxLibrary"),
+            ConfigValue((int)checkBox_show_rhythmbox->isChecked()));
+    m_pConfig->set(ConfigKey("[Library]", "ShowBansheeLibrary"),
+            ConfigValue((int)checkBox_show_banshee->isChecked()));
+    m_pConfig->set(ConfigKey("[Library]", "ShowITunesLibrary"),
+            ConfigValue((int)checkBox_show_itunes->isChecked()));
+    m_pConfig->set(ConfigKey("[Library]", "ShowTraktorLibrary"),
+            ConfigValue((int)checkBox_show_traktor->isChecked()));
+    m_pConfig->set(ConfigKey("[Library]", "ShowRekordboxLibrary"),
+            ConfigValue((int)checkBox_show_rekordbox->isChecked()));
     m_pConfig->set(ConfigKey("[Library]", "ShowSeratoLibrary"),
             ConfigValue((int)checkBox_show_serato->isChecked()));
 
@@ -587,14 +650,14 @@ void DlgPrefLibrary::slotApply() {
     QFont font = m_pLibrary->getTrackTableFont();
     if (m_originalTrackTableFont != font) {
         m_pConfig->set(ConfigKey("[Library]", "Font"),
-                       ConfigValue(font.toString()));
+                ConfigValue(font.toString()));
         m_originalTrackTableFont = font;
     }
 
     int rowHeight = spinBox_row_height->value();
     if (m_iOriginalTrackTableRowHeight != rowHeight) {
-        m_pConfig->set(ConfigKey("[Library]","RowHeight"),
-                       ConfigValue(rowHeight));
+        m_pConfig->set(ConfigKey("[Library]", "RowHeight"),
+                ConfigValue(rowHeight));
         m_iOriginalTrackTableRowHeight = rowHeight;
     }
 
@@ -660,8 +723,10 @@ void DlgPrefLibrary::setLibraryFont(const QFont& font) {
 void DlgPrefLibrary::slotSelectFont() {
     // False if the user cancels font selection.
     bool ok = false;
-    QFont font = QFontDialog::getFont(&ok, m_pLibrary->getTrackTableFont(),
-                                      this, tr("Select Library Font"));
+    QFont font = QFontDialog::getFont(&ok,
+            m_pLibrary->getTrackTableFont(),
+            this,
+            tr("Select Library Font"));
     if (ok) {
         setLibraryFont(font);
     }

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -13,7 +13,7 @@
 class QWidget;
 class ControlProxy;
 
-class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
+class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg {
     Q_OBJECT
   public:
     enum class TrackDoubleClickAction : int {
@@ -67,6 +67,8 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     void slotBpmRangeSelected(int index);
     void slotBpmColumnPrecisionChanged(int bpmPrecision);
     void slotSeratoMetadataExportClicked(bool);
+    void slotDateFormatIndexChanged(int index);
+    void slotDateFormatChanged(const QString& text);
 
   private:
     void populateDirList();
@@ -74,6 +76,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     void resetLibraryFont();
     void updateSearchLineEditHistoryOptions();
     void setSeratoMetadataEnabled(bool shouldSyncTrackMetadata);
+    void updateDateFormatPreview(const QString& format);
 
     QStandardItemModel m_dirListModel;
     UserSettingsPointer m_pConfig;
@@ -83,4 +86,6 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     int m_iOriginalTrackTableRowHeight;
     // Listen to rate range changes in order to update the fuzzy BPM range
     parented_ptr<ControlProxy> m_pRateRangeDeck1;
+
+    QString m_lastCustomDateFormat;
 };

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -173,7 +173,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_track_table_view">
 
-      <item row="1" column="0" colspan="3">
+      <item row="1" column="0" colspan="4">
        <widget class="QCheckBox" name="checkBox_edit_metadata_selected_clicked">
         <property name="text">
          <string>Edit metadata after clicking selected track</string>
@@ -181,7 +181,7 @@
        </widget>
       </item>
 
-      <item row="2" column="0" colspan="3">
+      <item row="2" column="0" colspan="4">
        <widget class="QLabel" name="label_doubeClickAction">
         <property name="text">
          <string>Track Double-Click Action:</string>
@@ -192,7 +192,7 @@
        </widget>
       </item>
 
-      <item row="3" column="0" colspan="3">
+      <item row="3" column="0" colspan="4">
        <widget class="QRadioButton" name="radioButton_dbclick_deck">
         <property name="text">
          <string>Load track to next available deck</string>
@@ -202,21 +202,21 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="3">
+      <item row="4" column="0" colspan="4">
        <widget class="QRadioButton" name="radioButton_dbclick_bottom">
         <property name="text">
          <string>Add track to Auto DJ queue (bottom)</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="3">
+      <item row="5" column="0" colspan="4">
        <widget class="QRadioButton" name="radioButton_dbclick_top">
         <property name="text">
          <string>Add track to Auto DJ queue (top)</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="0" colspan="3">
+      <item row="6" column="0" colspan="4">
        <widget class="QRadioButton" name="radioButton_dbclick_ignore">
         <property name="text">
          <string>Ignore</string>
@@ -290,12 +290,56 @@
        <widget class="QSpinBox" name="spinbox_bpm_precision"/>
       </item>
 
-      <item row="10" column="0" colspan="3">
+      <item row="10" column="0" colspan="4">
        <widget class="QCheckBox" name="checkbox_played_track_color">
         <property name="text">
          <string>Grey out played tracks</string>
         </property>
        </widget>
+      </item>
+
+      <item row="11" column="0">
+       <widget class="QLabel" name="label_dateFormat">
+        <property name="text">
+         <string>Date Format:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout_dateFormat">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QComboBox" name="comboBox_dateFormat">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_dateFormatPreview">
+          <property name="text">
+           <string>Preview</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
 
      </layout>
@@ -695,6 +739,7 @@
   <tabstop>btn_library_font</tabstop>
   <tabstop>spinbox_bpm_precision</tabstop>
   <tabstop>checkbox_played_track_color</tabstop>
+  <tabstop>comboBox_dateFormat</tabstop>
   <tabstop>spinBox_search_debouncing_timeout</tabstop>
   <tabstop>checkBox_enable_search_completions</tabstop>
   <tabstop>checkBox_enable_search_history_shortcuts</tabstop>

--- a/src/test/datetime_test.cpp
+++ b/src/test/datetime_test.cpp
@@ -1,0 +1,36 @@
+#include "util/datetime.h"
+
+#include <gtest/gtest.h>
+
+#include <QDate>
+#include <QLocale>
+
+namespace mixxx {
+
+TEST(DateTimeTest, FormatDate) {
+    QDate date(2023, 10, 25);
+
+    // Test ISO
+    EXPECT_EQ(formatDate(date, "yyyy-MM-dd"), "2023-10-25");
+
+    // Test Custom
+    EXPECT_EQ(formatDate(date, "dd.MM.yy"), "25.10.23");
+
+    // Test Native (empty string)
+    // Should fallback to QLocale::ShortFormat
+    QString native = QLocale().toString(date, QLocale::ShortFormat);
+    EXPECT_EQ(formatDate(date, ""), native);
+}
+
+TEST(DateTimeTest, FormatDateTime) {
+    QDateTime dt(QDate(2023, 10, 25), QTime(14, 30, 0));
+
+    // Test Custom
+    EXPECT_EQ(formatDateTime(dt, "yyyy-MM-dd HH:mm"), "2023-10-25 14:30");
+
+    // Test Native (empty string)
+    QString native = QLocale().toString(dt, QLocale::ShortFormat);
+    EXPECT_EQ(formatDateTime(dt, ""), native);
+}
+
+} // namespace mixxx

--- a/src/util/datetime.h
+++ b/src/util/datetime.h
@@ -28,11 +28,39 @@ inline QDateTime convertVariantToDateTime(
     return data.toDateTime();
 }
 
+/// Helper to format a QDate according to a format string.
+/// If format is empty, uses the system's default locale short format.
+inline QString formatDate(
+        const QDate& date,
+        const QString& format = QString()) {
+    if (!date.isValid()) {
+        return QString();
+    }
+    if (format.isEmpty()) {
+        return QLocale().toString(date, QLocale::ShortFormat);
+    }
+    return date.toString(format);
+}
+
+/// Helper to format a QDateTime according to a format string.
+/// If format is empty, uses the system's default locale short format.
+inline QString formatDateTime(
+        const QDateTime& dt,
+        const QString& format = QString()) {
+    if (!dt.isValid()) {
+        return QString();
+    }
+    if (format.isEmpty()) {
+        return QLocale().toString(dt, QLocale::ShortFormat);
+    }
+    return dt.toString(format);
+}
+
 /// Format a QDateTime for display to the user using the
-/// application's locale settings.
+/// application's locale settings or specified preference.
 inline QString displayLocalDateTime(
-        const QDateTime& dt) {
-    return QLocale().toString(dt, QLocale::ShortFormat);
+        const QDateTime& dt, const QString& format = QString()) {
+    return formatDateTime(dt, format);
 }
 
 } // namespace mixxx


### PR DESCRIPTION
This commit introduces a user preference to customize how dates are displayed across the Mixxx library and history views. It addresses the request for ISO 8601 compliance and allows completely custom date strings.

## Key Changes:

- **Library Preferences UI**:
  - Added a "Date Format" dropdown with standard presets (**Native**, **ISO 8601**, **Regional Short/Long**).
  - Added full **Custom Format** support: Users can type any valid Qt date format string (e.g., `ddd dd/MM/yyyy`) directly into the combobox.
  - Added a **Live Preview** label that updates instantly as the user types or selects a format.
  - **Smart Persistence**: Note that the logic remembers the user's last custom string even if they temporarily switch to a preset and back.

- **Backend Integration**:
  - `BaseTrackTableModel` now holds a static global date format string, ensuring all Library and History views update dynamically without a restart.
  - The format is saved persistently to `mixxx.cfg` under `[Library], DateFormat`.

- **UI Layout Fixes**:
  - Fixed an existing layout issue in the "Track Table View" preferences group where input fields (Library Font, BPM Precision) were not expanding to fill the available width.
  - Corrected the `QGridLayout` column stretch factors to ensure a consistent, full-width appearance for all preference rows.

<img width="1190" height="922" alt="image" src="https://github.com/user-attachments/assets/b0609114-604b-4e2c-ac21-01d1be174299" />
<img width="764" height="109" alt="image" src="https://github.com/user-attachments/assets/bf17bdec-e8bc-4d3c-ad09-926d54aa7f08" />
<img width="888" height="46" alt="image" src="https://github.com/user-attachments/assets/50a69df1-d10c-439e-b904-c8cd4f9a8607" />

https://github.com/user-attachments/assets/02cc2b0c-e7c8-4e6b-9916-d8dfbe626b1d


Fixes #15327

