### PR TITLE
CMake: fail early when MIXXX_VCPKG_ROOT is invalid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,8 +246,8 @@ endif()
 if(DEFINED MIXXX_VCPKG_ROOT)
   # Validate MIXXX_VCPKG_ROOT points to a vcpkg root to avoid confusing follow-up errors.
   set(_vcpkg_toolchain "${MIXXX_VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
-  file(TO_NATIVE_PATH "${_vcpkg_toolchain}" _vcpkg_toolchain_native)
   if(NOT EXISTS "${_vcpkg_toolchain}")
+    file(TO_NATIVE_PATH "${_vcpkg_toolchain}" _vcpkg_toolchain_native)
     message(
       STATUS
       "MIXXX_VCPKG_ROOT was set to \"${MIXXX_VCPKG_ROOT}\", but this is not a valid vcpkg root.\n"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,7 +248,8 @@ if(DEFINED MIXXX_VCPKG_ROOT)
   set(_vcpkg_toolchain "${MIXXX_VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
   file(TO_NATIVE_PATH "${_vcpkg_toolchain}" _vcpkg_toolchain_native)
   if(NOT EXISTS "${_vcpkg_toolchain}")
-    message(STATUS
+    message(
+      STATUS
       "MIXXX_VCPKG_ROOT was set to \"${MIXXX_VCPKG_ROOT}\", but this is not a valid vcpkg root.\n"
       "Expected to find: ${_vcpkg_toolchain_native}\n"
       "Please set MIXXX_VCPKG_ROOT to the vcpkg root directory, the folder containing the vcpkg tool (vcpkg.exe on Windows)."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,16 @@ if(DEFINED MIXXX_VCPKG_ROOT)
     fatal_error_missing_env()
   endif()
 
+  # Validate MIXXX_VCPKG_ROOT points to a vcpkg root to avoid confusing follow-up errors.
+  set(_vcpkg_toolchain "${MIXXX_VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+  if(NOT EXISTS "${_vcpkg_toolchain}")
+    message(FATAL_ERROR
+      "MIXXX_VCPKG_ROOT was set to \"${MIXXX_VCPKG_ROOT}\", but this is not a valid vcpkg root\n"
+      "Expected to find: ${_vcpkg_toolchain}\n"
+      "Please set MIXXX_VCPKG_ROOT to the vcpkg root directory (the folder containing vcpkg.exe)"
+    )
+  endif()
+
   if(NOT DEFINED VCPKG_OVERLAY_PORTS)
     # required for manifest mode
     set(VCPKG_OVERLAY_PORTS "${MIXXX_VCPKG_ROOT}/overlay/ports")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,18 @@ if(DEFINED ENV{MIXXX_VCPKG_ROOT} AND NOT DEFINED MIXXX_VCPKG_ROOT)
 endif()
 
 if(DEFINED MIXXX_VCPKG_ROOT)
+  # Validate MIXXX_VCPKG_ROOT points to a vcpkg root to avoid confusing follow-up errors.
+  set(_vcpkg_toolchain "${MIXXX_VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+  file(TO_NATIVE_PATH "${_vcpkg_toolchain}" _vcpkg_toolchain_native)
+  if(NOT EXISTS "${_vcpkg_toolchain}")
+    message(STATUS
+      "MIXXX_VCPKG_ROOT was set to \"${MIXXX_VCPKG_ROOT}\", but this is not a valid vcpkg root.\n"
+      "Expected to find: ${_vcpkg_toolchain_native}\n"
+      "Please set MIXXX_VCPKG_ROOT to the vcpkg root directory, the folder containing the vcpkg tool (vcpkg.exe on Windows)."
+    )
+    fatal_error_missing_env()
+  endif()
+
   if(
     EXISTS "${MIXXX_VCPKG_ROOT}/overlay/ports"
     OR NOT EXISTS "${MIXXX_VCPKG_ROOT}/ports"
@@ -257,16 +269,6 @@ if(DEFINED MIXXX_VCPKG_ROOT)
       "MIXXX_VCPKG_ROOT not correct (missing ${MIXXX_VCPKG_ROOT}/overlay/ports)"
     )
     fatal_error_missing_env()
-  endif()
-
-  # Validate MIXXX_VCPKG_ROOT points to a vcpkg root to avoid confusing follow-up errors.
-  set(_vcpkg_toolchain "${MIXXX_VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
-  if(NOT EXISTS "${_vcpkg_toolchain}")
-    message(FATAL_ERROR
-      "MIXXX_VCPKG_ROOT was set to \"${MIXXX_VCPKG_ROOT}\", but this is not a valid vcpkg root\n"
-      "Expected to find: ${_vcpkg_toolchain}\n"
-      "Please set MIXXX_VCPKG_ROOT to the vcpkg root directory (the folder containing vcpkg.exe)"
-    )
   endif()
 
   if(NOT DEFINED VCPKG_OVERLAY_PORTS)


### PR DESCRIPTION
Fixes #15016

### Summary
Add an early CMake validation for `MIXXX_VCPKG_ROOT` to avoid confusing follow-up errors when contributors select an incorrect vcpkg root directory.

When `MIXXX_VCPKG_ROOT` is set but `${MIXXX_VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake` is missing, configuration now fails immediately with a clear message explaining what is wrong and how to fix it.

### Testing
- Windows 11 / Visual Studio 2022
- Repro command:
```bat
cmake -S . -B build15016 -DMIXXX_VCPKG_ROOT="C:\Windows"
```

### Output

```text
-- CMAKE_VERSION: 3.31.6-msvc6
-- MIXXX_VCPKG_ROOT was set to "C:\Windows", but this is not a valid vcpkg root.
Expected to find: C:\Windows\scripts\buildsystems\vcpkg.cmake
Please set MIXXX_VCPKG_ROOT to the vcpkg root directory, the folder containing the vcpkg tool (vcpkg.exe on Windows).
CMake Error at CMakeLists.txt:205 (message):
  Did you download the Mixxx build environment using
  `C:/Users/sanja/mixxx/tools/windows_release_buildenv.bat` or
  `C:/Users/sanja/mixxx/tools/windows_buildenv.bat`(includes Debug)?
Call Stack (most recent call first):
  CMakeLists.txt:309 (fatal_error_missing_env)


-- Configuring incomplete, errors occurred!
```