### PR TITLE
Raise fps limit to 144, a common value for gamer displays.

### DIFF
--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -118,7 +118,7 @@ Select from different types of displays for the waveform, which differ primarily
         <number>10</number>
        </property>
        <property name="maximum">
-        <number>60</number>
+        <number>240</number>
        </property>
        <property name="value">
         <number>30</number>
@@ -140,7 +140,7 @@ Select from different types of displays for the waveform, which differ primarily
         <number>10</number>
        </property>
        <property name="maximum">
-        <number>60</number>
+        <number>240</number>
        </property>
        <property name="value">
         <number>30</number>

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -551,7 +551,7 @@ bool WaveformWidgetFactory::setWaveformWidget(WWaveformViewer* viewer,
 }
 
 void WaveformWidgetFactory::setFrameRate(int frameRate) {
-    m_frameRate = math_clamp(frameRate, 1, 120);
+    m_frameRate = math_clamp(frameRate, 1, 240);
     if (m_config) {
         m_config->setValue(kFrameRateKey, m_frameRate);
     }


### PR DESCRIPTION
My new laptop supports 120fps, and we should allow higher numbers if people want to use them.  