### PR TITLE
Clamp user offset values to less than 1 beat

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -553,7 +553,11 @@ double BpmControl::calcSyncAdjustment(bool userTweakingSync) {
         adjustment = 1.0;
         // When updating the user offset, make sure to remove the existing offset or else it
         // will get double-applied.
-        m_dUserOffset.setValue(error + curUserOffset);
+        double offset = error + curUserOffset;
+        while (std::abs(offset) > 1.0f) {
+            offset -= std::copysign(1.0f, offset);
+        }
+        m_dUserOffset.setValue(offset);
     } else {
         // Threshold above which we do sync adjustment.
         const double kErrorThreshold = 0.01;

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -553,10 +553,7 @@ double BpmControl::calcSyncAdjustment(bool userTweakingSync) {
         adjustment = 1.0;
         // When updating the user offset, make sure to remove the existing offset or else it
         // will get double-applied.
-        double offset = error + curUserOffset;
-        while (std::abs(offset) > 1.0f) {
-            offset -= std::copysign(1.0f, offset);
-        }
+        double offset = std::fmod(error + curUserOffset, 1.0f);
         m_dUserOffset.setValue(offset);
     } else {
         // Threshold above which we do sync adjustment.


### PR DESCRIPTION
Occasionally seek operations can cause the user offset value to go quite high -- it never makes sense for the user offset to be more than 1 beat by definition, so reduce it to below that value like a mod operation.