### PR TITLE
(fix) Search related menu: search click trigger

### DIFF
--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -376,7 +376,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             &WSearchRelatedTracksMenu::combineQueriesTriggerSearch);
     // This is for click and Space key
     connect(pCheckBox.get(),
-            &QCheckBox::clicked,
+            &QCheckBox::toggled,
             this,
             &WSearchRelatedTracksMenu::combineQueriesTriggerSearch);
 }
@@ -419,7 +419,7 @@ bool WSearchRelatedTracksMenu::eventFilter(QObject* pObj, QEvent* e) {
 }
 
 void WSearchRelatedTracksMenu::updateSearchButton() {
-    // Enable the Search button if at least opChildbox is checked.
+    // Enable the Search button if at least one checkbox is ticked
     VERIFY_OR_DEBUG_ASSERT(m_pSearchAction) {
         return;
     }


### PR DESCRIPTION
Fixes a regression from https://github.com/mixxxdj/mixxx/commit/62cc6c5c78d3c219e0499eb2843c0d8572a18549 which kind of prevents the 'clicked' signal. ("Search selected" can only be triggered with spcaebar/Enter)
Using `QCheckBox::toggled` fixes it.