### PR TITLE
Pre-Commit: Run Prettier for d.ts files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,7 +124,7 @@ repos:
     rev: ffb6a759a979008c0e6dff86e39f4745a2d9eac4 # frozen: 3.1.0
     hooks:
       - id: prettier
-        files: \.(d\.ts|ts|tsx|js|yaml)$
+        files: \.(d\.ts|ya?ml)$
   - repo: https://github.com/qarmin/qml_formatter.git
     rev: 37c2513b1b8275a475a160ed2f5b044910335d5f # No release tag yet including #6 fix
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,7 +124,7 @@ repos:
     rev: ffb6a759a979008c0e6dff86e39f4745a2d9eac4 # frozen: 3.1.0
     hooks:
       - id: prettier
-        types: [yaml]
+        files: \.(d\.ts|ts|tsx|js|yaml)$
   - repo: https://github.com/qarmin/qml_formatter.git
     rev: 37c2513b1b8275a475a160ed2f5b044910335d5f # No release tag yet including #6 fix
     hooks:

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,13 @@
 tabWidth: 2
 singleQuote: false
+
+overrides:
+  - files: "*.d.ts"
+    options:
+      printWidth: 180
+      tabWidth: 4
+      semi: true
+      singleQuote: true
+      trailingComma: all
+      bracketSpacing: true
+      useTab: true

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -10,4 +10,4 @@ overrides:
       singleQuote: true
       trailingComma: all
       bracketSpacing: true
-      useTab: true
+      useTabs: false

--- a/res/controllers/color-mapper-api.d.ts
+++ b/res/controllers/color-mapper-api.d.ts
@@ -1,4 +1,3 @@
-
 /** ColorMapperJSProxy */
 
 declare class ColorMapper {
@@ -7,7 +6,7 @@ declare class ColorMapper {
      *
      * @param availableColors List of number pairs (e.g. {0xFF0000: 1, 0x00FF00: 2} )
      */
-    constructor (availableColors: { [rgbColor: number]: number });
+    constructor(availableColors: { [rgbColor: number]: number });
 
     /**
      * For a given RGB color code (e.g. 0xFF0000), this finds the nearest
@@ -16,7 +15,7 @@ declare class ColorMapper {
      *
      * @param colorCode Device specific color code
      */
-    getNearestColor(colorCode: number): {[rgb: number]: number};
+    getNearestColor(colorCode: number): { [rgb: number]: number };
 
     /**
      * For a given RGB color code (e.g. 0xFF0000), this finds the nearest

--- a/res/controllers/console-api.d.ts
+++ b/res/controllers/console-api.d.ts
@@ -1,4 +1,3 @@
-
 /**
      Mixxx installs the QJSEngine::ConsoleExtension for the use in controller mapping scripts.
     See also:
@@ -118,7 +117,7 @@ declare namespace console {
      * @param label measurement label
      * @deprecated Not usable for controller mappings for now [see QTBUG-65419]{@link https://bugreports.qt.io/browse/QTBUG-65419}
      */
-     function profile(label?: string): void;
+    function profile(label?: string): void;
 
     /**
      *  Turns off the JavaScript profiler.
@@ -136,5 +135,4 @@ declare namespace console {
      *    - Or a string containing zero or more substitution strings followed by a list of objects to replace them
      */
     function exception(...data: any[]): void;
-
 }

--- a/res/controllers/engine-api.d.ts
+++ b/res/controllers/engine-api.d.ts
@@ -1,4 +1,3 @@
-
 /** ScriptConnectionJSProxy */
 
 declare interface ScriptConnection {
@@ -30,7 +29,6 @@ declare interface ScriptConnection {
      */
     readonly isConnected: boolean;
 }
-
 
 /** ControllerScriptInterfaceLegacy */
 
@@ -122,7 +120,7 @@ declare namespace engine {
      */
     function getDefaultParameter(group: string, name: string): number;
 
-    type CoCallback = (value: number, group: string, name: string) => void
+    type CoCallback = (value: number, group: string, name: string) => void;
 
     /**
      * Connects a specified Mixxx Control with a callback function, which is executed if the value of the control changes
@@ -162,7 +160,6 @@ declare namespace engine {
      * @deprecated Use {@link engine.makeConnection} instead
      */
     function connectControl(group: string, name: string, callback: CoCallback, disconnect?: boolean): ScriptConnection | boolean | undefined;
-
 
     /**
      * Triggers the execution of all connected callback functions, with the actual value of a control.
@@ -332,6 +329,7 @@ declare namespace engine {
      */
     function isSoftStartActive(deck: number): bool;
 
+    // prettier-ignore
     enum Charset {
         ASCII,          // American Standard Code for Information Interchange (7-Bit)
         UTF_8,          // Unicode Transformation Format (8-Bit)
@@ -368,5 +366,5 @@ declare namespace engine {
      * @param targetCharset The charset to encode the string into.
      * @returns The converted String as an array of bytes. Will return an empty buffer on conversion error or unavailable charset.
      */
-    function convertCharset(targetCharset: Charset, value: string): ArrayBuffer
+    function convertCharset(targetCharset: Charset, value: string): ArrayBuffer;
 }

--- a/res/controllers/hid-controller-api.d.ts
+++ b/res/controllers/hid-controller-api.d.ts
@@ -1,4 +1,3 @@
-
 /** HidControllerJSProxy */
 
 declare namespace controller {

--- a/res/controllers/midi-controller-api.d.ts
+++ b/res/controllers/midi-controller-api.d.ts
@@ -1,4 +1,4 @@
-type MidiInputHandler = (channel: number, control: number, value:number, status:number, group:string) => void;
+type MidiInputHandler = (channel: number, control: number, value: number, status: number, group: string) => void;
 
 declare interface MidiInputHandlerController {
     disconnect(): boolean;
@@ -7,7 +7,6 @@ declare interface MidiInputHandlerController {
 /** MidiControllerJSProxy */
 
 declare namespace midi {
-
     /**
      * Sends a 3 byte MIDI short message
      *
@@ -34,7 +33,7 @@ declare namespace midi {
      */
     function sendSysexMsg(dataList: number[], length?: number): void;
 
-    type InputCallback = (channel: string, control: string, value: number, status: number) => void
+    type InputCallback = (channel: string, control: string, value: number, status: number) => void;
 
     /**
      * Calls the provided callback whenever Mixxx receives a MIDI signal with the first two bytes matching the
@@ -45,5 +44,5 @@ declare namespace midi {
      * @see https://github.com/mixxxdj/mixxx/wiki/midi%20scripting
      * @see https://github.com/mixxxdj/mixxx/wiki/Midi-Crash-Course
      */
-    function makeInputHandler(status: number, midino: number, callback: InputCallback): MidiInputHandlerController
+    function makeInputHandler(status: number, midino: number, callback: InputCallback): MidiInputHandlerController;
 }


### PR DESCRIPTION
Hi,

for the [Mixxx control types generator PR](https://github.com/mixxxdj/manual/pull/840) we need the generated `mixxx-controls.d.ts` file to be formatted in the pre commit. 

At the moment its configured for `yaml` only, but we need it also for `d.ts`.

**Solution:**
Activated prettier for `d.ts` files in pre-commit and applied uniform formatting for all `d.ts` files.