### PR TITLE
Fix crash in AudioUnit backend due to off-by-one error in parameter syncing

### DIFF
--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -185,7 +185,7 @@ void AudioUnitEffectProcessor::syncParameters() {
 
     int i = 0;
     for (auto parameter : m_parameters) {
-        if (m_lastValues.size() < i) {
+        if (m_lastValues.size() <= i) {
             static_assert(sizeof(AudioUnitParameterValue) == sizeof(float));
             m_lastValues.push_back(util_float_nan());
         }


### PR DESCRIPTION
### Bug Description
Fixes a crash on macOS when using AudioUnit effects in a Debug build.
The `syncParameters()` method had an off-by-one error when growing the `m_lastValues` list.
When `i=0` and the list is empty:
- The check `if (m_lastValues.size() < i)` (0 < 0) evaluated to false.
- The list did not grow.
- Accessing `m_lastValues[i]` caused an index-out-of-bounds assertion failure.
### Reproduction Steps
1. Build Mixxx on macOS in **Debug** mode (`-DCMAKE_BUILD_TYPE=Debug`).
   * *Note: The crash relies on Qt's container bounds assertions, which are often disabled in Release builds.*
2. Start Mixxx with a fresh configuration (or ensure an AudioUnit effect is instantiated).
3. Load an AudioUnit effect into an effect chain (or trigger any action that instantiates `AudioUnitEffectProcessor`).
4. **Result:** Mixxx crashes immediately with `ASSERT failure in QList::operator[]: "index out of range"`.
### The Fix
Changed the condition to `if (m_lastValues.size() <= i)` to ensure the list grows correctly when `size == index`.

### Verification
Run this command on a Mac to verify the crash (before the fix) and the solution (after the fix):
```bash
# 1. Setup Debug Build
cmake -S . -B build_debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=...

# 2. Build
cmake --build build_debug -j10

# 3. Run (This will crash without the fix)
./build_debug/mixxx
```