### PR TITLE
(fix) Search Not operator

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -224,7 +224,7 @@ QString TextFilterNode::toSql() const {
     }
     QStringList searchClauses;
     for (const auto& sqlColumn : m_sqlColumns) {
-        searchClauses << QString("%1 LIKE %2").arg(sqlColumn, escapedArgument);
+        searchClauses << QString("%1 IS NOT NULL AND %1 LIKE %2").arg(sqlColumn, escapedArgument);
     }
     return concatSqlClauses(searchClauses, "OR");
 }

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -67,8 +67,8 @@ TEST_F(SearchQueryParserTest, OneTermOneColumn) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("artist LIKE '%asdf%'")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("artist IS NOT NULL AND artist LIKE '%asdf%'")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, OneTermMultipleColumns) {
@@ -82,9 +82,10 @@ TEST_F(SearchQueryParserTest, OneTermMultipleColumns) {
     pTrack->setAlbum("testASDFtest");
     EXPECT_TRUE(pQuery->match(pTrack));
 
-    EXPECT_STREQ(
-        qPrintable(QString("(artist LIKE '%asdf%') OR (album LIKE '%asdf%')")),
-        qPrintable(pQuery->toSql()));
+    EXPECT_STREQ(qPrintable(QString(
+                         "(artist IS NOT NULL AND artist LIKE '%asdf%') OR "
+                         "(album IS NOT NULL AND album LIKE '%asdf%')")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, OneTermMultipleColumnsNegation) {
@@ -98,9 +99,10 @@ TEST_F(SearchQueryParserTest, OneTermMultipleColumnsNegation) {
     pTrack->setAlbum("testASDFtest");
     EXPECT_FALSE(pQuery->match(pTrack));
 
-    EXPECT_STREQ(
-        qPrintable(QString("NOT ((artist LIKE '%asdf%') OR (album LIKE '%asdf%'))")),
-        qPrintable(pQuery->toSql()));
+    EXPECT_STREQ(qPrintable(QString(
+                         "NOT ((artist IS NOT NULL AND artist LIKE '%asdf%') "
+                         "OR (album IS NOT NULL AND album LIKE '%asdf%'))")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, MultipleTermsOneColumn) {
@@ -114,9 +116,10 @@ TEST_F(SearchQueryParserTest, MultipleTermsOneColumn) {
     pTrack->setArtist("test zXcV test asDf");
     EXPECT_TRUE(pQuery->match(pTrack));
 
-    EXPECT_STREQ(
-        qPrintable(QString("(artist LIKE '%asdf%') AND (artist LIKE '%zxcv%')")),
-        qPrintable(pQuery->toSql()));
+    EXPECT_STREQ(qPrintable(QString(
+                         "(artist IS NOT NULL AND artist LIKE '%asdf%') AND "
+                         "(artist IS NOT NULL AND artist LIKE '%zxcv%')")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, MultipleTermsMultipleColumns) {
@@ -134,11 +137,12 @@ TEST_F(SearchQueryParserTest, MultipleTermsMultipleColumns) {
     pTrack->setAlbum("ASDF ZXCV");
     EXPECT_TRUE(pQuery->match(pTrack));
 
-    EXPECT_STREQ(
-        qPrintable(QString(
-            "((artist LIKE '%asdf%') OR (album LIKE '%asdf%')) "
-            "AND ((artist LIKE '%zxcv%') OR (album LIKE '%zxcv%'))")),
-        qPrintable(pQuery->toSql()));
+    EXPECT_STREQ(qPrintable(QString(
+                         "((artist IS NOT NULL AND artist LIKE '%asdf%') OR "
+                         "(album IS NOT NULL AND album LIKE '%asdf%')) "
+                         "AND ((artist IS NOT NULL AND artist LIKE '%zxcv%') "
+                         "OR (album IS NOT NULL AND album LIKE '%zxcv%'))")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, MultipleTermsMultipleColumnsNegation) {
@@ -158,10 +162,12 @@ TEST_F(SearchQueryParserTest, MultipleTermsMultipleColumnsNegation) {
     EXPECT_FALSE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString(
-            "((artist LIKE '%asdf%') OR (album LIKE '%asdf%')) "
-            "AND (NOT ((artist LIKE '%zxcv%') OR (album LIKE '%zxcv%')))")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString(
+                    "((artist IS NOT NULL AND artist LIKE '%asdf%') OR (album "
+                    "IS NOT NULL AND album LIKE '%asdf%')) "
+                    "AND (NOT ((artist IS NOT NULL AND artist LIKE '%zxcv%') "
+                    "OR (album IS NOT NULL AND album LIKE '%zxcv%')))")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, TextFilter) {
@@ -176,8 +182,8 @@ TEST_F(SearchQueryParserTest, TextFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("comment LIKE '%asdf%'")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("comment IS NOT NULL AND comment LIKE '%asdf%'")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, TextFilterEquals) {
@@ -191,7 +197,7 @@ TEST_F(SearchQueryParserTest, TextFilterEquals) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-            qPrintable(QString("comment LIKE 'asdf'")),
+            qPrintable(QString("comment IS NOT NULL AND comment LIKE 'asdf'")),
             qPrintable(pQuery->toSql()));
 
     // Incomplete quoting should use StringMatch::Contains,
@@ -202,7 +208,7 @@ TEST_F(SearchQueryParserTest, TextFilterEquals) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-            qPrintable(QString("comment LIKE '%asdf%'")),
+            qPrintable(QString("comment IS NOT NULL AND comment LIKE '%asdf%'")),
             qPrintable(pQuery->toSql()));
 }
 
@@ -233,8 +239,8 @@ TEST_F(SearchQueryParserTest, TextFilterQuote) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("comment LIKE '%asdf zxcv%'")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("comment IS NOT NULL AND comment LIKE '%asdf zxcv%'")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, TextFilterQuote_NoEndQuoteTakesWholeQuery) {
@@ -249,8 +255,8 @@ TEST_F(SearchQueryParserTest, TextFilterQuote_NoEndQuoteTakesWholeQuery) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("comment LIKE '%asdf zxcv qwer%'")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("comment IS NOT NULL AND comment LIKE '%asdf zxcv qwer%'")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, TextFilterAllowsSpace) {
@@ -265,8 +271,8 @@ TEST_F(SearchQueryParserTest, TextFilterAllowsSpace) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("comment LIKE '%asdf%'")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("comment IS NOT NULL AND comment LIKE '%asdf%'")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, TextFilterQuotes) {
@@ -281,8 +287,8 @@ TEST_F(SearchQueryParserTest, TextFilterQuotes) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("comment LIKE '%asdf ewe%'")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("comment IS NOT NULL AND comment LIKE '%asdf ewe%'")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, TextFilterDecoration) {
@@ -302,9 +308,9 @@ TEST_F(SearchQueryParserTest, TextFilterDecoration) {
 
     qDebug() << pQuery->toSql();
 
-    EXPECT_STREQ(
-        qPrintable(QString::fromUtf8("comment LIKE '%asdf\xC2\xB0 ewe%'")),
-        qPrintable(pQuery->toSql()));
+    EXPECT_STREQ(qPrintable(QString::fromUtf8("comment IS NOT NULL AND comment "
+                                              "LIKE '%asdf\xC2\xB0 ewe%'")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, TextFilterTrailingSpace) {
@@ -319,8 +325,8 @@ TEST_F(SearchQueryParserTest, TextFilterTrailingSpace) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("comment LIKE '%asdf _%'")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("comment IS NOT NULL AND comment LIKE '%asdf _%'")),
+            qPrintable(pQuery->toSql()));
 
     // We allow to search for two consequitve spaces
     auto pQuery2(
@@ -329,8 +335,8 @@ TEST_F(SearchQueryParserTest, TextFilterTrailingSpace) {
     EXPECT_FALSE(pQuery2->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("comment LIKE '%  _%'")),
-        qPrintable(pQuery2->toSql()));
+            qPrintable(QString("comment IS NOT NULL AND comment LIKE '%  _%'")),
+            qPrintable(pQuery2->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, TextFilterNegation) {
@@ -345,8 +351,8 @@ TEST_F(SearchQueryParserTest, TextFilterNegation) {
     EXPECT_FALSE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("NOT (comment LIKE '%asdf%')")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("NOT (comment IS NOT NULL AND comment LIKE '%asdf%')")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, NumericFilter) {
@@ -627,11 +633,14 @@ TEST_F(SearchQueryParserTest, MultipleFilters) {
     pTrack->setTitle("Colorvision");
     EXPECT_TRUE(pQuery->match(pTrack));
 
-    EXPECT_STREQ(qPrintable(QString("(bpm BETWEEN 127.12 AND 129) AND "
-                                    "((artist LIKE '%com truise%') OR "
-                                    "(album_artist LIKE '%com truise%')) AND "
-                                    "((artist LIKE '%colorvision%') OR (title "
-                                    "LIKE '%colorvision%'))")),
+    EXPECT_STREQ(
+            qPrintable(QString(
+                    "(bpm BETWEEN 127.12 AND 129) AND "
+                    "((artist IS NOT NULL AND artist LIKE '%com truise%') OR "
+                    "(album_artist IS NOT NULL AND album_artist LIKE '%com "
+                    "truise%')) AND "
+                    "((artist IS NOT NULL AND artist LIKE '%colorvision%') OR "
+                    "(title IS NOT NULL AND title LIKE '%colorvision%'))")),
             qPrintable(pQuery->toSql()));
 }
 
@@ -647,8 +656,8 @@ TEST_F(SearchQueryParserTest, ExtraFilterAppended) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("(1 > 2) AND (artist LIKE '%asdf%')")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("(1 > 2) AND (artist IS NOT NULL AND artist LIKE '%asdf%')")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
@@ -1015,10 +1024,11 @@ TEST_F(SearchQueryParserTest, CrateFilterWithOther){
     EXPECT_TRUE(pQuery->match(pTrackA));
     EXPECT_FALSE(pQuery->match(pTrackB));
 
-    EXPECT_STREQ(
-                 qPrintable("(" + m_crateFilterQuery.arg(searchTerm) +
-                            ") AND ((artist LIKE '%asdf%') OR (album_artist LIKE '%asdf%'))"),
-                 qPrintable(pQuery->toSql()));
+    EXPECT_STREQ(qPrintable("(" + m_crateFilterQuery.arg(searchTerm) +
+                         ") AND ((artist IS NOT NULL AND artist LIKE '%asdf%') "
+                         "OR (album_artist IS NOT NULL AND album_artist LIKE "
+                         "'%asdf%'))"),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, CrateFilterWithCrateFilterAndNegation){


### PR DESCRIPTION
Fixes #15918

### The issue
was apparently that NULL values in any of the search columns cause trouble with the true/false/NULL logic in SQL.
I only know little about SQL and _just_ learned about that ^, so after starring at SQL debug for some hours, scratching my head, and before going to sleep and digest -- here's my attempt to explain the issue (feel free to correct me):

When doing an untagged search like `xxxy`, all text columns are searched (artist, title, genre, grouping, comment, ..)

Relevant part of an untagged text query is
`WHERE ((artist LIKE '%xxxy%') OR (album LIKE '%xxxy%') OR ..)`
-> the outer WHERE keeps rows where ((.. LIKE ..) OR ..) is true (NULL and false are removed)
-> mismatches and NULL are removed

The **NOT** text query (`-xxxy`) would be
`WHERE NOT ((artist LIKE '%xxxy%') OR (album LIKE '%xxxy%'))`
-> the WHERE NOT keeps only rows that are **false** (-> NULL is not false <-)
-> matches and NULL are removed
-> less results than expected

 and apparently many of my tracks had NULL in one of these columns, so these tracks were also not shown.

### Fix
is also checking for `IS NOT NULL` in the TextFilterNode:
`[column] IS NOT NULL AND [column] LIKE '%[searchterm]%'`

Note: for testing you can cherry-pick 81741b792f6772796b255dddb1789e4095f80ef2 from #14552 (main) to get the track count on the Tracks item label