### PR TITLE
feat(preferences): Add unsigned int support to ConfigObject

### DIFF
--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -95,7 +95,8 @@ QString computeResourcePathImpl() {
 #endif
 #endif // !defined(__EMSCRIPTEN__)
     } else {
-        //qDebug() << "Setting qResourcePath from location in resourcePath commandline arg:" << qResourcePath;
+        // qDebug() << "Setting qResourcePath from location in resourcePath
+        // commandline arg:" << qResourcePath;
     }
 
     if (qResourcePath.isEmpty()) {
@@ -122,7 +123,7 @@ QString computeSettingsPath(const QString& configFilename) {
     return QString();
 }
 
-}  // namespace
+} // namespace
 // static
 ConfigKey ConfigKey::parseCommaSeparated(const QString& key) {
     int comma = key.indexOf(",");
@@ -131,11 +132,11 @@ ConfigKey ConfigKey::parseCommaSeparated(const QString& key) {
 }
 
 ConfigValue::ConfigValue(int iValue)
-    : value(QString::number(iValue)) {
+        : value(QString::number(iValue)) {
 }
 
 ConfigValue::ConfigValue(double dValue)
-    : value(QString::number(dValue)) {
+        : value(QString::number(dValue)) {
 }
 
 ConfigValueKbd::ConfigValueKbd(const QKeySequence& keys)
@@ -159,48 +160,50 @@ ConfigObject<ValueType>::ConfigObject(
     reopen(file);
 }
 
-template <class ValueType> ConfigObject<ValueType>::~ConfigObject() {
+template<class ValueType>
+ConfigObject<ValueType>::~ConfigObject() {
 }
 
-template <class ValueType>
+template<class ValueType>
 void ConfigObject<ValueType>::set(const ConfigKey& k, const ValueType& v) {
     QWriteLocker lock(&m_valuesLock);
     m_values.insert(k, v);
 }
 
-template <class ValueType>
+template<class ValueType>
 ValueType ConfigObject<ValueType>::get(const ConfigKey& k) const {
     QReadLocker lock(&m_valuesLock);
     return m_values.value(k);
 }
 
-template <class ValueType>
+template<class ValueType>
 bool ConfigObject<ValueType>::exists(const ConfigKey& k) const {
     QReadLocker lock(&m_valuesLock);
     return m_values.contains(k);
 }
 
-template <class ValueType>
+template<class ValueType>
 bool ConfigObject<ValueType>::remove(const ConfigKey& k) {
     QWriteLocker lock(&m_valuesLock);
     return m_values.remove(k) > 0;
 }
 
-template <class ValueType>
+template<class ValueType>
 QString ConfigObject<ValueType>::getValueString(const ConfigKey& k) const {
     ValueType v = get(k);
     return v.value;
 }
 
-template <class ValueType> bool ConfigObject<ValueType>::parse() {
+template<class ValueType>
+bool ConfigObject<ValueType>::parse() {
     // Open file for reading
     QFile configfile(m_filename);
     if (m_filename.length() < 1 || !configfile.open(QIODevice::ReadOnly)) {
         qDebug() << "ConfigObject: Could not read" << m_filename;
         return false;
     } else {
-        //qDebug() << "ConfigObject: Parse" << m_filename;
-        // Parse the file
+        // qDebug() << "ConfigObject: Parse" << m_filename;
+        //  Parse the file
         int group = 0;
         QString groupStr, line;
         QTextStream text(&configfile);
@@ -216,13 +219,13 @@ template <class ValueType> bool ConfigObject<ValueType>::parse() {
                 if (line.startsWith("[") && line.endsWith("]")) {
                     group++;
                     groupStr = line;
-                    //qDebug() << "Group :" << groupStr;
+                    // qDebug() << "Group :" << groupStr;
                 } else if (group > 0) {
                     QString key;
                     QTextStream(&line) >> key;
                     QString val = line.right(line.length() - key.length()); // finds the value string
                     val = val.trimmed();
-                    //qDebug() << "control:" << key << "value:" << val;
+                    // qDebug() << "control:" << key << "value:" << val;
                     ConfigKey k(groupStr, key);
                     ValueType m(val);
                     set(k, m);
@@ -234,7 +237,8 @@ template <class ValueType> bool ConfigObject<ValueType>::parse() {
     return true;
 }
 
-template <class ValueType> void ConfigObject<ValueType>::reopen(const QString& file) {
+template<class ValueType>
+void ConfigObject<ValueType>::reopen(const QString& file) {
     m_filename = file;
     if (!m_filename.isEmpty()) {
         parse();
@@ -269,7 +273,8 @@ bool ConfigObject<ValueType>::save() {
     // a minimum length as an additional safety check.
     qint64 minLength = 0;
     for (auto i = m_values.constBegin(); i != m_values.constEnd(); ++i) {
-        //qDebug() << "group:" << it.key().group << "item" << it.key().item << "val" << it.value()->value;
+        // qDebug() << "group:" << it.key().group << "item" << it.key().item <<
+        // "val" << it.value()->value;
         if (i.key().group != group) {
             group = i.key().group;
             stream << "\n"
@@ -289,7 +294,7 @@ bool ConfigObject<ValueType>::save() {
 
     tmpFile.close();
     if (tmpFile.error() !=
-            QFile::NoError) { //could be better... should actually say what the error was..
+            QFile::NoError) { // could be better... should actually say what the error was..
         qWarning().nospace() << "Error while writing configuration file: "
                              << tmpFile.fileName() << ": " << tmpFile.errorString();
         return false;
@@ -335,7 +340,8 @@ QList<ConfigKey> ConfigObject<ValueType>::getKeysWithGroup(const QString& group)
     return filteredList;
 }
 
-template <class ValueType> ConfigObject<ValueType>::ConfigObject(const QDomNode& node) {
+template<class ValueType>
+ConfigObject<ValueType>::ConfigObject(const QDomNode& node) {
     if (!node.isNull() && node.isElement()) {
         QDomNode ctrl = node.firstChild();
 
@@ -352,7 +358,7 @@ template <class ValueType> ConfigObject<ValueType>::ConfigObject(const QDomNode&
     }
 }
 
-template <class ValueType>
+template<class ValueType>
 QMultiHash<ValueType, ConfigKey> ConfigObject<ValueType>::transpose() const {
     QReadLocker lock(&m_valuesLock);
 
@@ -366,27 +372,38 @@ QMultiHash<ValueType, ConfigKey> ConfigObject<ValueType>::transpose() const {
 template class ConfigObject<ConfigValue>;
 template class ConfigObject<ConfigValueKbd>;
 
-template <> template <>
+template<>
+template<>
 void ConfigObject<ConfigValue>::setValue(
         const ConfigKey& key, const QString& value) {
     set(key, ConfigValue(value));
 }
 
-template <> template <>
+template<>
+template<>
 void ConfigObject<ConfigValue>::setValue(
         const ConfigKey& key, const bool& value) {
     set(key, value ? ConfigValue("1") : ConfigValue("0"));
 }
 
-template <> template <>
+template<>
+template<>
 void ConfigObject<ConfigValue>::setValue(
         const ConfigKey& key, const int& value) {
     set(key, ConfigValue(QString::number(value)));
 }
 
-template <> template <>
+template<>
+template<>
 void ConfigObject<ConfigValue>::setValue(
         const ConfigKey& key, const double& value) {
+    set(key, ConfigValue(QString::number(value)));
+}
+
+template<>
+template<>
+void ConfigObject<ConfigValue>::setValue(
+        const ConfigKey& key, const unsigned int& value) {
     set(key, ConfigValue(QString::number(value)));
 }
 
@@ -408,7 +425,8 @@ void ConfigObject<ConfigValue>::setValue(
     set(key, ConfigValue(mixxx::RgbColor::toQString(value)));
 }
 
-template <> template <>
+template<>
+template<>
 bool ConfigObject<ConfigValue>::getValue(
         const ConfigKey& key, const bool& default_value) const {
     const ConfigValue value = get(key);
@@ -420,7 +438,8 @@ bool ConfigObject<ConfigValue>::getValue(
     return ok ? result != 0 : default_value;
 }
 
-template <> template <>
+template<>
+template<>
 int ConfigObject<ConfigValue>::getValue(
         const ConfigKey& key, const int& default_value) const {
     const ConfigValue value = get(key);
@@ -432,7 +451,8 @@ int ConfigObject<ConfigValue>::getValue(
     return ok ? result : default_value;
 }
 
-template <> template <>
+template<>
+template<>
 double ConfigObject<ConfigValue>::getValue(
         const ConfigKey& key, const double& default_value) const {
     const ConfigValue value = get(key);
@@ -441,6 +461,19 @@ double ConfigObject<ConfigValue>::getValue(
     }
     bool ok;
     auto result = value.value.toDouble(&ok);
+    return ok ? result : default_value;
+}
+
+template<>
+template<>
+unsigned int ConfigObject<ConfigValue>::getValue(
+        const ConfigKey& key, const unsigned int& default_value) const {
+    const ConfigValue value = get(key);
+    if (value.isNull()) {
+        return default_value;
+    }
+    bool ok;
+    auto result = value.value.toUInt(&ok);
     return ok ? result : default_value;
 }
 
@@ -479,7 +512,7 @@ mixxx::RgbColor ConfigObject<ConfigValue>::getValue(const ConfigKey& key) const 
 }
 
 // For string literal default
-template <>
+template<>
 QString ConfigObject<ConfigValue>::getValue(
         const ConfigKey& key, const char* default_value) const {
     const ConfigValue value = get(key);
@@ -489,7 +522,7 @@ QString ConfigObject<ConfigValue>::getValue(
     return value.value;
 }
 
-template <>
+template<>
 QString ConfigObject<ConfigValueKbd>::getValue(
         const ConfigKey& key, const char* default_value) const {
     const ConfigValueKbd value = get(key);
@@ -499,7 +532,8 @@ QString ConfigObject<ConfigValueKbd>::getValue(
     return value.value;
 }
 
-template <> template <>
+template<>
+template<>
 QString ConfigObject<ConfigValue>::getValue(
         const ConfigKey& key, const QString& default_value) const {
     const ConfigValue value = get(key);
@@ -509,7 +543,8 @@ QString ConfigObject<ConfigValue>::getValue(
     return value.value;
 }
 
-template <> template <>
+template<>
+template<>
 QString ConfigObject<ConfigValueKbd>::getValue(
         const ConfigKey& key, const QString& default_value) const {
     const ConfigValueKbd value = get(key);

--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -86,7 +86,9 @@ class ConfigValue {
     explicit ConfigValue(const QDomNode&) {
         reportFatalErrorAndQuit("ConfigValue from QDomNode not implemented here");
     }
-    bool isNull() const { return value.isNull(); }
+    bool isNull() const {
+        return value.isNull();
+    }
 
     QString value;
 };
@@ -122,7 +124,7 @@ class ConfigValueKbd : public ConfigValue {
         return lhs.m_keys == rhs.m_keys;
     }
 
-   private:
+  private:
     QKeySequence m_keys;
 };
 
@@ -130,7 +132,8 @@ inline bool operator!=(const ConfigValueKbd& lhs, const ConfigValueKbd& rhs) {
     return !(lhs == rhs);
 }
 
-template <class ValueType> class ConfigObject {
+template<class ValueType>
+class ConfigObject {
   public:
     ConfigObject(const QString& file);
     ConfigObject(const QString& file, const QString& resourcePath, const QString& settingsPath);
@@ -156,7 +159,7 @@ template <class ValueType> class ConfigObject {
 
     // Sets the value for key to ValueType(value), over-writing pre-existing
     // values. ResultType is serialized to string on a per-type basis.
-    template <class ResultType>
+    template<class ResultType>
     void setValue(const ConfigKey& key, const ResultType& value);
     template<class EnumType>
         requires std::is_enum_v<EnumType>
@@ -167,7 +170,7 @@ template <class ValueType> class ConfigObject {
 
     // Returns the value for key, converted to ResultType. If key is not present
     // or the value cannot be converted to ResultType, returns ResultType().
-    template <class ResultType>
+    template<class ResultType>
     ResultType getValue(const ConfigKey& key) const {
         return getValue<ResultType>(key, ResultType());
     }
@@ -177,7 +180,7 @@ template <class ValueType> class ConfigObject {
 
     // Returns the value for key, converted to ResultType. If key is not present
     // or the value cannot be converted to ResultType, returns default_value.
-    template <class ResultType>
+    template<class ResultType>
     ResultType getValue(const ConfigKey& key, const ResultType& default_value) const;
     QString getValue(const ConfigKey& key, const char* default_value) const;
     template<typename EnumType>
@@ -239,3 +242,10 @@ void ConfigObject<ConfigValue>::setValue(const ConfigKey& key, const QString& va
 template<>
 template<>
 void ConfigObject<ConfigValue>::setValue(const ConfigKey& key, const bool& value);
+template<>
+template<>
+void ConfigObject<ConfigValue>::setValue(const ConfigKey& key, const unsigned int& value);
+template<>
+template<>
+unsigned int ConfigObject<ConfigValue>::getValue(
+        const ConfigKey& key, const unsigned int& default_value) const;

--- a/src/test/configobject_test.cpp
+++ b/src/test/configobject_test.cpp
@@ -1,7 +1,8 @@
+#include "preferences/configobject.h"
+
 #include <QString>
 
 #include "test/mixxxtest.h"
-#include "preferences/configobject.h"
 
 namespace {
 
@@ -107,6 +108,35 @@ TEST_F(ConfigObjectTest, GetValue_Bool) {
     EXPECT_TRUE(config()->getValue(ck, false));
 }
 
+TEST_F(ConfigObjectTest, SetValue_UnsignedInteger) {
+    auto ck = ConfigKey("[Test]", "test");
+    config()->setValue(ck, 5u);
+    EXPECT_QSTRING_EQ("5", config()->getValue<QString>(ck));
+}
+
+TEST_F(ConfigObjectTest, GetValue_UnsignedInteger) {
+    auto ck = ConfigKey("[Test]", "test");
+
+    // Not present.
+    EXPECT_EQ(5u, config()->getValue(ck, 5u));
+
+    // Empty
+    config()->setValue(ck, QString(""));
+    EXPECT_EQ(5u, config()->getValue(ck, 5u));
+
+    // Malformatted.
+    config()->setValue(ck, QString("asdf"));
+    EXPECT_EQ(5u, config()->getValue(ck, 5u));
+
+    // Negative string (should fallback to default)
+    config()->setValue(ck, QString("-1"));
+    EXPECT_EQ(5u, config()->getValue(ck, 5u));
+
+    // Ok.
+    config()->setValue(ck, QString("4"));
+    EXPECT_EQ(4u, config()->getValue(ck, 5u));
+}
+
 TEST_F(ConfigObjectTest, Exists) {
     auto ck = ConfigKey("[Test]", "test");
     EXPECT_FALSE(config()->exists(ck));
@@ -125,7 +155,8 @@ TEST_F(ConfigObjectTest, GetValueString) {
 TEST_F(ConfigObjectTest, Save) {
     for (int i = 0; i < 10; ++i) {
         config()->setValue(ConfigKey(QString("[Test%1]").arg(i),
-                                     QString("control%1").arg(i)), i);
+                                   QString("control%1").arg(i)),
+                i);
     }
 
     m_pConfig->save();
@@ -133,10 +164,11 @@ TEST_F(ConfigObjectTest, Save) {
             new UserSettings(getTestDataDir().filePath("test.cfg")));
 
     for (int i = 0; i < 10; ++i) {
-        EXPECT_EQ(i, config()->getValue<int>(
-            ConfigKey(QString("[Test%1]").arg(i),
-                      QString("control%1").arg(i)), -1));
+        EXPECT_EQ(i,
+                config()->getValue<int>(ConfigKey(QString("[Test%1]").arg(i),
+                                                QString("control%1").arg(i)),
+                        -1));
     }
 }
 
-}  // namespace
+} // namespace


### PR DESCRIPTION
Add template specializations for [setValue](cci:1://file:///Users/ayushsah/Documents/GitHub/mixxx/src/preferences/configobject.cpp:395:0-400:1) and [getValue](cci:1://file:///Users/ayushsah/Documents/GitHub/mixxx/src/preferences/configobject.cpp:466:0-477:1) with `unsigned int` type in ConfigObject. This enables storing and retrieving unsigned integer values from configuration. This is semantically appropriate for values that should never be negative (e.g., counts, durations in days, etc.). This follows the existing pattern used for `int` and `double` types.
## Changes
- Added `setValue<unsigned int>` template specialization
- Added `getValue<unsigned int>` template specialization
## Testing
- Added unit tests