### PR TITLE
Add Flatpak build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -563,14 +563,6 @@ jobs:
           build-bundle: false
           upload-artifact: false
 
-      - name: "Sign repo commit"
-        if: env.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY
-        run: |
-          gpg --import <(echo "${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}")
-          flatpak build-sign --gpg-sign="rryan@mixxx.org" repo org.mixxx.Mixxx
-        env:
-          RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY: ${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}
-
       - name: "Create Flatpak bundle"
         run: |
           flatpak build-bundle repo \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -549,10 +549,29 @@ jobs:
       - name: "Build Flatpak"
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
-          bundle: Mixxx_${{ matrix.variant.arch }}.flatpak
+          bundle: Mixxx-${{ matrix.variant.arch }}.flatpak
           manifest-path: packaging/flatpak/org.mixxx.Mixxx.yaml
           arch: ${{ matrix.variant.arch }}
-          upload-artifact: true
+          upload-artifact: false
+
+      - name: "Create Flatpak Debug extension"
+        run: |
+          /app/bin/flatpak build-bundle repo \
+            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
+            --arch=${{ matrix.variant.arch }} \
+            --runtime Mixxx-${{ matrix.variant.arch }}.Debug.flatpak org.mixxx.Mixxx.Debug
+
+      - name: "Upload Flatpak"
+        uses: actions/upload-artifact@v6
+        with:
+          name: Flatpak ${{ matrix.variant.arch }}
+          path: Mixxx-${{ matrix.variant.arch }}.flatpak
+
+      - name: "Upload Flatpak Debug extension"
+        uses: actions/upload-artifact@v6
+        with:
+          name: Flatpak Debug ${{ matrix.variant.arch }}
+          path: Mixxx-${{ matrix.variant.arch }}.Debug.flatpak
 
   update_manifest:
     name: "Update manifest file on download server"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -514,6 +514,46 @@ jobs:
           name: ${{ matrix.artifacts_name }}
           path: ${{ matrix.artifacts_path }}
 
+  build-flatpak:
+    name: "Flatpak"
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.10
+      options: --privileged
+      volumes:
+        - /usr:/host/usr
+        - /opt:/host/opt
+    strategy:
+      matrix:
+        variant:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.variant.runner }}
+    steps:
+      - name: "Recover host disk space"
+        run: |
+          rm -rf /host/opt/hostedtoolcache/CodeQL
+          rm -rf /host/opt/hostedtoolcache/go
+          rm -rf /host/usr/local/lib/android
+          rm -rf /host/usr/local/.ghcup
+          rm -rf /host/usr/local/share/powershell
+          rm -rf /host/usr/share/swift
+          rm -rf /host/usr/share/dotnet
+
+      - name: "Check out repository"
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: "Build Flatpak"
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: Mixxx_${{ matrix.variant.arch }}.flatpak
+          manifest-path: packaging/flatpak/org.mixxx.Mixxx.yaml
+          arch: ${{ matrix.variant.arch }}
+          upload-artifact: true
+
   update_manifest:
     name: "Update manifest file on download server"
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -592,7 +592,7 @@ jobs:
       - name: "Upload Debug extension"
         uses: actions/upload-artifact@v6
         with:
-          name: Flatpak Debug ${{ matrix.variant.arch }}
+          name: Flatpak Debug Extension ${{ matrix.variant.arch }}
           path: Mixxx-${{ env.GIT_DESC }}-${{ matrix.variant.arch }}.Debug.flatpak
 
   update_manifest:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -546,32 +546,54 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: "Store Git version"
+        run: |
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          GIT_DESC=$(git describe --always --first-parent --dirty=-modified)
+          if [ -z "$GIT_DESC" ]; then
+            GIT_DESC="unknown"
+          fi
+          echo "GIT_DESC=$GIT_DESC" >> $GITHUB_ENV
+
       - name: "Build Flatpak"
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
-          bundle: Mixxx-${{ matrix.variant.arch }}.flatpak
           manifest-path: packaging/flatpak/org.mixxx.Mixxx.yaml
           arch: ${{ matrix.variant.arch }}
+          build-bundle: false
           upload-artifact: false
 
-      - name: "Create Flatpak Debug extension"
+      - name: "Sign repo commit"
+        if: env.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY
         run: |
-          /app/bin/flatpak build-bundle repo \
-            --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
-            --arch=${{ matrix.variant.arch }} \
-            --runtime Mixxx-${{ matrix.variant.arch }}.Debug.flatpak org.mixxx.Mixxx.Debug
+          gpg --import <(echo "${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}")
+          flatpak build-sign --gpg-sign="rryan@mixxx.org" repo org.mixxx.Mixxx
+        env:
+          RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY: ${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}
 
-      - name: "Upload Flatpak"
+      - name: "Create Flatpak bundle"
+        run: |
+          flatpak build-bundle repo \
+            --arch=${{ matrix.variant.arch }} \
+            Mixxx-${GIT_DESC}-${{ matrix.variant.arch }}.flatpak org.mixxx.Mixxx
+
+      - name: "Create Debug extension"
+        run: |
+          flatpak build-bundle repo \
+            --arch=${{ matrix.variant.arch }} \
+            --runtime Mixxx-${GIT_DESC}-${{ matrix.variant.arch }}.Debug.flatpak org.mixxx.Mixxx.Debug
+
+      - name: "Upload Flatpak bundle"
         uses: actions/upload-artifact@v6
         with:
           name: Flatpak ${{ matrix.variant.arch }}
-          path: Mixxx-${{ matrix.variant.arch }}.flatpak
+          path: Mixxx-${{ env.GIT_DESC }}-${{ matrix.variant.arch }}.flatpak
 
-      - name: "Upload Flatpak Debug extension"
+      - name: "Upload Debug extension"
         uses: actions/upload-artifact@v6
         with:
           name: Flatpak Debug ${{ matrix.variant.arch }}
-          path: Mixxx-${{ matrix.variant.arch }}.Debug.flatpak
+          path: Mixxx-${{ env.GIT_DESC }}-${{ matrix.variant.arch }}.Debug.flatpak
 
   update_manifest:
     name: "Update manifest file on download server"


### PR DESCRIPTION
We have Flatpak manifests in the tree now, so let's put them to good use! :building_construction:

Right now this PR has the basics for creating single-file Mixxx bundles and uploading them as build artifacts. It's using the official Flatpak actions and containers from Flathub. The container images have all the necessary tools and SDKs included, saving on download time.

https://github.com/flatpak/flatpak-github-actions
https://github.com/flathub-infra/actions-images

These can be used for many things - verifying manifests and metadata, creating a package on other events, building Mixxx releases, uploading to repositories and even to Flathub.

There's a lot to do and my GitHub workflow experience is limited, so help is very much appreciated. :pray: 