### PR TITLE
fix "dataChanged() called with an invalid index range" warning

### DIFF
--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -821,13 +821,13 @@ void BaseSqlTableModel::tracksChanged(const QSet<TrackId>& trackIds) {
         qDebug() << this << "trackChanged" << trackIds.size();
     }
 
-    const int numColumns = columnCount();
+    const int lastColumn = columnCount() - 1;
     for (const auto& trackId : trackIds) {
         const auto rows = getTrackRows(trackId);
         for (int row : rows) {
             //qDebug() << "Row in this result set was updated. Signalling update. track:" << trackId << "row:" << row;
             QModelIndex topLeft = index(row, 0);
-            QModelIndex bottomRight = index(row, numColumns);
+            QModelIndex bottomRight = index(row, lastColumn);
             emit dataChanged(topLeft, bottomRight);
         }
     }


### PR DESCRIPTION
Closes #14610 

This is a Qt warning that has been introduced in Qt6.9, see [`QAbstractItemView::dataChanged(topLeft, bottomRight, roles)`](https://github.com/qt/qtbase/blob/40c135de67b93fd9647bcf9df48b55839378ddf8/src/widgets/itemviews/qabstractitemview.cpp#L3420C6-L3420C36).
In earlier versions it just ignored the invalid range.

**Note:** regardless the Qt version it still calls `viewport->update()` which may try to update the entire view, depending on if model cache is enabled / how entensive it is (IIRC)
-> so this may also have been causing GUI issues while Analysis is running, see #15928 / #15930

The only Mixxx implementation that calls this base implementation is `WLibraryTableView::dataChanged`
```
if (!bottomRight.isValid()) {
    qWarning() << "bottomRight invalid, sender:" << sender();
}
```
reveals `LibraryTableModel` and `AnalysisLibraryTableModel` btw.

All `emit dataChanged()` signals we emit look good (topLeft & bottomRight created with reasonable numbers).
Except `BaseSqlTableModel::tracksChanged` where we are +1 outside the valid column range, hence index() returns an invalid index.