### PR TITLE
Incoming tracks folder 

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -768,6 +768,7 @@ void CoreServices::initialize(QApplication* pApp) {
     if (rescan || musicDirAdded || m_pSettingsManager->shouldRescanLibrary()) {
         m_pTrackCollectionManager->startLibraryAutoScan();
     }
+    m_pTrackCollectionManager->slotInitalIncomingDirScan();
 
     // This has to be done before m_pSoundManager->setupDevices()
     // https://github.com/mixxxdj/mixxx/issues/9188

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -769,6 +769,7 @@ void CoreServices::initialize(QApplication* pApp) {
     if (rescan || musicDirAdded || m_pSettingsManager->shouldRescanLibrary()) {
         m_pTrackCollectionManager->startLibraryAutoScan();
     }
+    m_pTrackCollectionManager->slotInitalIncomingDirScan();
 
     // This has to be done before m_pSoundManager->setupDevices()
     // https://github.com/mixxxdj/mixxx/issues/9188

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -243,7 +243,10 @@ bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
     if (trackIds.isEmpty()) {
         return false;
     }
+    return appendTracks(trackIds);
+}
 
+bool AutoDJFeature::appendTracks(const QList<TrackId>& trackIds) {
     // Return whether appendTracksToPlaylist succeeded.
     return m_playlistDao.appendTracksToPlaylist(trackIds, m_iAutoDJPlaylistId);
 }

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -49,6 +49,8 @@ class AutoDJFeature : public LibraryFeature {
         return true;
     }
 
+    bool appendTracks(const QList<TrackId>& trackIds);
+
   public slots:
     void activate() override;
 

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -111,6 +111,8 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
         return getTrackByRef(TrackRef::fromUrl(url));
     }
 
+    TrackId getTrackIdByLocation(const QString& location) const;
+
   signals:
     // Forwarded from Track object
     void trackDirty(TrackId trackId);
@@ -148,8 +150,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             const QStringList& pathList,
             ResolveTrackIdFlags flags = ResolveTrackIdFlag::ResolveOnly);
 
-    TrackId getTrackIdByLocation(
-            const QString& location) const;
     TrackPointer getTrackById(
             TrackId trackId) const;
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -784,6 +784,10 @@ void Library::showAutoDJ() {
     m_pSidebarModel->slotFeatureSelect(m_pAutoDJFeature, QModelIndex(), false);
 }
 
+void Library::appendTracksToAutoDJ(const QList<TrackId>& trackIds) {
+    m_pAutoDJFeature->appendTracks(trackIds);
+}
+
 #ifdef __ENGINEPRIME__
 std::unique_ptr<mixxx::LibraryExporter> Library::makeLibraryExporter(
         QWidget* parent) {

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -107,6 +107,7 @@ class Library: public QObject {
     /// and shows the results by switching the view.
     void searchTracksInCollection(const QString& query);
     void showAutoDJ();
+    void appendTracksToAutoDJ(const QList<TrackId>& trackIds);
 
     static const QString kAutoDJViewName;
 

--- a/src/library/library_decl.h
+++ b/src/library/library_decl.h
@@ -42,4 +42,5 @@ struct LibraryScanResultSummary {
     int numRediscoveredTracks;
     int tracksTotal;
     bool noDirectoriesConfigured;
+    QString lastTrackLocation;
 };

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -13,6 +13,11 @@ const ConfigKey mixxx::library::prefs::kLegacyDirectoryConfigKey =
 const QString mixxx::library::prefs::kConfigGroup =
         QStringLiteral("[Library]");
 
+const ConfigKey mixxx::library::prefs::kIncomingTracksDir =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("IncomingTracksDir")};
+
 const ConfigKey mixxx::library::prefs::kRescanOnStartupConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -12,6 +12,8 @@ extern const ConfigKey kLegacyDirectoryConfigKey;
 
 extern const QString kConfigGroup;
 
+extern const ConfigKey kIncomingTracksDir;
+
 extern const ConfigKey kRescanOnStartupConfigKey;
 
 extern const ConfigKey kRepairDatabaseOnNextRestartConfigKey;

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -107,7 +107,8 @@ LibraryScanner::LibraryScanner(
           m_numRelocatedTracks(0),
           m_pProgressDlg(std::make_unique<LibraryScannerDlg>()),
           m_canceled(false),
-          m_manualScan(true) {
+          m_manualScan(true),
+          m_recursive(true) {
     // Move LibraryScanner to its own thread so that our signals/slots will
     // queue to our event loop.
     moveToThread(this);
@@ -203,6 +204,7 @@ void LibraryScanner::slotStartDirScan(const QString& dir) {
     cleanUpDatabase(m_libraryHashDao.database());
 
     m_libraryRootDirs = {mixxx::FileInfo(dir)};
+    m_recursive = false;
     startScanInner();
 }
 
@@ -215,7 +217,7 @@ void LibraryScanner::slotStartScan() {
 
     // Recursively scan each directory in the directories table.
     m_libraryRootDirs = m_directoryDao.loadAllDirectories();
-
+    m_recursive = true;
     startScanInner();
 }
 
@@ -301,8 +303,9 @@ void LibraryScanner::startScanInner() {
         }
         auto dirAccess = mixxx::FileAccess(rootDir);
         if (!m_scannerGlobal->testAndMarkDirectoryScanned(rootDir.toQDir())) {
+            const bool scanUnhashed = false;
             queueTask(new RecursiveScanDirectoryTask(
-                    this, m_scannerGlobal, std::move(dirAccess), false));
+                    this, m_scannerGlobal, std::move(dirAccess), scanUnhashed, m_recursive));
         }
     }
     pWatcher->taskDone();
@@ -340,8 +343,9 @@ void LibraryScanner::slotFinishHashedScan() {
     for (mixxx::FileAccess dirAccess : m_scannerGlobal->unhashedDirs()) {
         // no testAndMarkDirectoryScanned() here, because all unhashedDirs()
         // are already tracked
+        const bool scanUnhashed = true;
         queueTask(new RecursiveScanDirectoryTask(
-                this, m_scannerGlobal, std::move(dirAccess), true));
+                this, m_scannerGlobal, std::move(dirAccess), scanUnhashed, m_recursive));
     }
     pWatcher->taskDone();
 }

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -770,3 +770,7 @@ bool LibraryScanner::changeScannerState(ScannerState newState) {
         return false;
     }
 }
+
+bool LibraryScanner::isIdle() {
+    return m_state == IDLE;
+}

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -121,6 +121,7 @@ LibraryScanner::LibraryScanner(
     // Listen to signals from our public methods (invoked by other threads) and
     // connect them to our slots to run the command on the scanner thread.
     connect(this, &LibraryScanner::startScan, this, &LibraryScanner::slotStartScan);
+    connect(this, &LibraryScanner::startDirScan, this, &LibraryScanner::slotStartDirScan);
 
 #ifdef MIXXX_USE_QML
     if (!CmdlineArgs::Instance().isQml())
@@ -195,6 +196,16 @@ void LibraryScanner::run() {
     kLogger.debug() << "Exiting thread";
 }
 
+void LibraryScanner::slotStartDirScan(const QString& dir) {
+    kLogger.debug() << "slotStartDirScan()";
+    DEBUG_ASSERT(m_state == STARTING);
+
+    cleanUpDatabase(m_libraryHashDao.database());
+
+    m_libraryRootDirs = {mixxx::FileInfo(dir)};
+    startScanInner();
+}
+
 void LibraryScanner::slotStartScan() {
     kLogger.debug() << "slotStartScan()";
     DEBUG_ASSERT(m_state == STARTING);
@@ -204,6 +215,11 @@ void LibraryScanner::slotStartScan() {
 
     // Recursively scan each directory in the directories table.
     m_libraryRootDirs = m_directoryDao.loadAllDirectories();
+
+    startScanInner();
+}
+
+void LibraryScanner::startScanInner() {
     // If there are no directories then we still have to scan independently added tracks.
     QSet<QString> trackLocations = m_trackDao.getAllTrackLocations();
 
@@ -526,6 +542,13 @@ void LibraryScanner::scan(bool autoscan) {
     if (changeScannerState(STARTING)) {
         m_manualScan = autoscan;
         emit startScan();
+    }
+}
+
+void LibraryScanner::scanDir(const QString& dir) {
+    if (changeScannerState(STARTING)) {
+        m_manualScan = true;
+        emit startDirScan(dir);
     }
 }
 

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -256,23 +256,27 @@ void LibraryScanner::startScanInner() {
 
     emit scanStarted();
 
-    // First, we're going to mark all the directories that we've previously
-    // hashed as needing verification. As we search through the directory tree
-    // when we rescan, we'll mark any directory that does still exist as
-    // verified.
-    m_libraryHashDao.invalidateAllDirectories();
+    if (m_recursive) {
+        // First, we're going to mark all the directories that we've previously
+        // hashed as needing verification. As we search through the directory tree
+        // when we rescan, we'll mark any directory that does still exist as
+        // verified.
+        m_libraryHashDao.invalidateAllDirectories();
 
-    // Make sure that `directory` in in track_locations table is indeed a
-    // directory path. This works around / removes residues of a bug where tracks
-    // are falsely marked missing because `directory` == `location`.
-    m_trackDao.cleanupTrackLocationsDirectory();
+        // Make sure that `directory` in in track_locations table is indeed a
+        // directory path. This works around / removes residues of a bug where tracks
+        // are falsely marked missing because `directory` == `location`.
+        m_trackDao.cleanupTrackLocationsDirectory();
 
-    // Mark all the tracks in the library as needing verification of their
-    // existence. (ie. we want to check they're still on your hard drive where
-    // we think they are)
-    m_trackDao.invalidateTrackLocationsInLibrary();
+        // Mark all the tracks in the library as needing verification of their
+        // existence. (ie. we want to check they're still on your hard drive where
+        // we think they are)
+        m_trackDao.invalidateTrackLocationsInLibrary();
 
-    kLogger.debug() << "Recursively scanning library.";
+        kLogger.debug() << "Recursively scanning library.";
+    } else {
+        kLogger.debug() << "Scanning single directory.";
+    }
 
     // Start scanning the library. This prepares insertion queries in TrackDAO
     // (must be called before calling addTracksAdd) and begins a transaction.
@@ -352,6 +356,23 @@ void LibraryScanner::slotFinishHashedScan() {
 
 // Quick hack: return number of relocated tracks
 void LibraryScanner::cleanUpScan() {
+    if (!m_recursive) {
+        // no clean up required in case of single directory scan
+        // only update BaseTrackCache via signals connected to the main TrackDAO.
+        QSet<TrackId> addedTrackIds;
+        for (const QString& trackLocation : m_scannerGlobal->addedTracks()) {
+            TrackId id = m_trackDao.getTrackIdByLocation(trackLocation);
+            VERIFY_OR_DEBUG_ASSERT(id.isValid()) {
+                continue;
+            }
+            addedTrackIds.insert(std::move(id));
+        }
+        if (!addedTrackIds.isEmpty()) {
+            emit tracksChanged(addedTrackIds);
+        }
+        return;
+    }
+
     // At the end of a scan, mark all tracks and directories that weren't
     // "verified" as "deleted" (as long as the scan wasn't canceled half way
     // through). This condition is important because our rescanning algorithm
@@ -376,10 +397,12 @@ void LibraryScanner::cleanUpScan() {
     m_trackDao.markTrackLocationsAsVerified(m_scannerGlobal->verifiedTracks());
 
     kLogger.debug() << "Marking unchanged directories as verified";
+    const bool deleted = false;
+    const bool verified = true;
     m_libraryHashDao.updateDirectoryStatuses(
             m_scannerGlobal->verifiedDirectories(),
-            false,
-            true);
+            deleted,
+            verified);
 
     // After verifying tracks and directories via recursive scanning of the
     // library directories the only unverified tracks will be files that are

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -529,6 +529,9 @@ void LibraryScanner::slotFinishUnhashedScan() {
     result.numRediscoveredTracks = numRediscoveredTracks;
     result.tracksTotal = tracksTotal;
     result.autoscan = m_manualScan;
+    if (result.numNewTracks >= 1) {
+        result.lastTrackLocation = m_scannerGlobal->addedTracks().last();
+    }
 
     m_scannerGlobal.clear();
     changeScannerState(FINISHED);

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -43,6 +43,8 @@ class LibraryScanner : public QThread {
     // Call from any thread to cancel the scan.
     void slotCancel();
 
+    bool isIdle();
+
   signals:
     void scanStarted();
     void scanFinished();

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -32,13 +32,15 @@ class LibraryScanner : public QThread {
             const UserSettingsPointer& pConfig);
     ~LibraryScanner() override;
 
-  public slots:
     // Call from any thread to start a scan. Does nothing if a scan is already
     // in progress.
     // The autoscan flag is used for the summary report. Receivers of scanSummary()
     // can use this to decide whether to show the summary dialog, for example hide
     // it for the automatic scan during startup.
     void scan(bool autoscan = false);
+
+    // Call from any thread to start a scan for a certain directory
+    void scanDir(const QString& dir);
 
     // Call from any thread to cancel the scan.
     void slotCancel();
@@ -59,6 +61,7 @@ class LibraryScanner : public QThread {
     // Emitted by scan() to invoke slotStartScan in the scanner thread's event
     // loop.
     void startScan();
+    void startDirScan(QString dir);
 
   protected:
     void run() override;
@@ -68,6 +71,7 @@ class LibraryScanner : public QThread {
 
   private slots:
     void slotStartScan();
+    void slotStartDirScan(const QString& dir);
     void slotFinishHashedScan();
     void slotFinishUnhashedScan();
 
@@ -87,6 +91,8 @@ class LibraryScanner : public QThread {
         CANCELING,
         FINISHED
     };
+
+    void startScanInner();
 
     void cancelAndQuit();
     void cancel();

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -140,4 +140,5 @@ class LibraryScanner : public QThread {
 
     bool m_canceled;
     bool m_manualScan;
+    bool m_recursive;
 };

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -14,10 +14,12 @@ RecursiveScanDirectoryTask::RecursiveScanDirectoryTask(
         LibraryScanner* pScanner,
         const ScannerGlobalPointer& scannerGlobal,
         const mixxx::FileAccess&& dirAccess,
-        bool scanUnhashed)
+        bool scanUnhashed,
+        bool recursive)
         : ScannerTask(pScanner, scannerGlobal),
           m_dirAccess(std::move(dirAccess)),
-          m_scanUnhashed(scanUnhashed) {
+          m_scanUnhashed(scanUnhashed),
+          m_recursive(recursive) {
 }
 
 void RecursiveScanDirectoryTask::run() {
@@ -78,6 +80,11 @@ void RecursiveScanDirectoryTask::run() {
                 }
             }
         } else {
+            if (!m_recursive) {
+                // We don't want to decent into sub directories
+                // This triggered by the incoming dir file watcher, which is not recursive.
+                continue;
+            }
             // File is a directory
             if (m_scannerGlobal->directoryBlacklisted(currentFile)) {
                 // Skip blacklisted directories like the iTunes Album
@@ -133,7 +140,8 @@ void RecursiveScanDirectoryTask::run() {
                             m_pScanner,
                             m_scannerGlobal,
                             mixxx::FileAccess(dirInfo, m_dirAccess.token()),
-                            m_scanUnhashed));
+                            m_scanUnhashed,
+                            m_recursive));
         }
     }
     setSuccess(true);

--- a/src/library/scanner/recursivescandirectorytask.h
+++ b/src/library/scanner/recursivescandirectorytask.h
@@ -14,7 +14,8 @@ class RecursiveScanDirectoryTask : public ScannerTask {
     RecursiveScanDirectoryTask(LibraryScanner* pScanner,
             const ScannerGlobalPointer& scannerGlobal,
             const mixxx::FileAccess&& dirAccess,
-            bool scanUnhashed);
+            bool scanUnhashed,
+            bool recursive);
     ~RecursiveScanDirectoryTask() override = default;
 
     void run() override;
@@ -22,4 +23,5 @@ class RecursiveScanDirectoryTask : public ScannerTask {
   private:
     const mixxx::FileAccess m_dirAccess;
     const bool m_scanUnhashed;
+    const bool m_recursive;
 };

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -95,16 +95,16 @@ TrackCollectionManager::TrackCollectionManager(QObject* parent,
                 },
                 Qt::DirectConnection);
 
+        connect(m_pScanner.get(),
+                &LibraryScanner::scanFinished,
+                this,
+                &TrackCollectionManager::slotScanFinished);
+
         // Forward signals
         connect(m_pScanner.get(),
                 &LibraryScanner::scanStarted,
                 this,
                 &TrackCollectionManager::libraryScanStarted,
-                /*signal-to-signal*/ Qt::DirectConnection);
-        connect(m_pScanner.get(),
-                &LibraryScanner::scanFinished,
-                this,
-                &TrackCollectionManager::libraryScanFinished,
                 /*signal-to-signal*/ Qt::DirectConnection);
         connect(m_pScanner.get(),
                 &LibraryScanner::scanSummary,
@@ -672,21 +672,26 @@ bool TrackCollectionManager::updateTrackMood(
 }
 #endif // __EXTRA_METADATA__
 
-void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
+void TrackCollectionManager::slotIncomingDirectoryChanged() {
     VERIFY_OR_DEBUG_ASSERT(m_pScanner) {
         return;
     }
 
-    if (path.isEmpty() || !m_pScanner->isIdle()) {
+    QStringList dirs = m_incomingDirWatcher.directories();
+    if (dirs.isEmpty()) {
+        return;
+    }
+    if (!m_pScanner->isIdle()) {
+        m_incomingDirChangePending = true;
         return;
     }
 
-    auto fi = QFileInfo(path);
+    auto fi = QFileInfo(dirs.first());
     const QString absPath = fi.absoluteFilePath();
 
     kLogger.info() << "Incoming directory changed, starting scan for:" << absPath;
 
-    m_pScanner->scanDir(path);
+    m_pScanner->scanDir(absPath);
 }
 
 void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTracksDir) {
@@ -708,10 +713,17 @@ void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTrack
                           << incomingDirPath;
     } else {
         kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
+        m_incomingDirTimer.setSingleShot(true);
+        connect(&m_incomingDirTimer,
+                &QTimer::timeout,
+                this,
+                &TrackCollectionManager::slotIncomingDirectoryChanged);
         connect(&m_incomingDirWatcher,
                 &QFileSystemWatcher::directoryChanged,
                 this,
-                &TrackCollectionManager::slotIncomingDirectoryChanged);
+                [this]() {
+                    m_incomingDirTimer.start(2000);
+                });
     }
 }
 

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -691,7 +691,7 @@ void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
         return;
     }
 
-    if (path.isEmpty()) {
+    if (path.isEmpty() || !m_pScanner->isIdle()) {
         return;
     }
 

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -139,6 +139,10 @@ TrackCollectionManager::TrackCollectionManager(
 }
 
 TrackCollectionManager::~TrackCollectionManager() {
+    QStringList dirs = m_incomingDirWatcher.directories();
+    if (!dirs.isEmpty()) {
+        m_incomingDirWatcher.removePaths(dirs);
+    }
     if (m_pScanner) {
         while (m_pScanner->isRunning()) {
             kLogger.info() << "Stopping library scanner thread";

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -73,16 +73,16 @@ TrackCollectionManager::TrackCollectionManager(QObject* parent,
     } else {
         m_pScanner = std::make_unique<LibraryScanner>(pDbConnectionPool, pConfig);
 
+        connect(m_pScanner.get(),
+                &LibraryScanner::scanFinished,
+                this,
+                &TrackCollectionManager::slotScanFinished);
+
         // Forward signals
         connect(m_pScanner.get(),
                 &LibraryScanner::scanStarted,
                 this,
                 &TrackCollectionManager::libraryScanStarted,
-                /*signal-to-signal*/ Qt::DirectConnection);
-        connect(m_pScanner.get(),
-                &LibraryScanner::scanFinished,
-                this,
-                &TrackCollectionManager::libraryScanFinished,
                 /*signal-to-signal*/ Qt::DirectConnection);
         connect(m_pScanner.get(),
                 &LibraryScanner::scanSummary,
@@ -642,21 +642,26 @@ bool TrackCollectionManager::updateTrackMood(
 }
 #endif // __EXTRA_METADATA__
 
-void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
+void TrackCollectionManager::slotIncomingDirectoryChanged() {
     VERIFY_OR_DEBUG_ASSERT(m_pScanner) {
         return;
     }
 
-    if (path.isEmpty() || !m_pScanner->isIdle()) {
+    QStringList dirs = m_incomingDirWatcher.directories();
+    if (dirs.isEmpty()) {
+        return;
+    }
+    if (!m_pScanner->isIdle()) {
+        m_incomingDirChangePending = true;
         return;
     }
 
-    auto fi = QFileInfo(path);
+    auto fi = QFileInfo(dirs.first());
     const QString absPath = fi.absoluteFilePath();
 
     kLogger.info() << "Incoming directory changed, starting scan for:" << absPath;
 
-    m_pScanner->scanDir(path);
+    m_pScanner->scanDir(absPath);
 }
 
 void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTracksDir) {
@@ -678,10 +683,17 @@ void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTrack
                           << incomingDirPath;
     } else {
         kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
+        m_incomingDirTimer.setSingleShot(true);
+        connect(&m_incomingDirTimer,
+                &QTimer::timeout,
+                this,
+                &TrackCollectionManager::slotIncomingDirectoryChanged);
         connect(&m_incomingDirWatcher,
                 &QFileSystemWatcher::directoryChanged,
                 this,
-                &TrackCollectionManager::slotIncomingDirectoryChanged);
+                [this]() {
+                    m_incomingDirTimer.start(2000);
+                });
     }
 }
 

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -156,26 +156,7 @@ TrackCollectionManager::TrackCollectionManager(
                 m_pConfig->getValue(
                         mixxx::library::prefs::kIncomingTracksDir,
                         QString());
-        if (!incomingTracksDir.isEmpty()) {
-            auto fi = QFileInfo(incomingTracksDir);
-            if (fi.exists() && fi.isDir()) {
-                QString incomingDirPath = fi.absoluteFilePath();
-                if (!m_incomingDirWatcher.addPath(incomingDirPath)) {
-                    kLogger.warning() << "Failed to watch incoming tracks directory"
-                                      << incomingDirPath;
-                } else {
-                    kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
-                    connect(&m_incomingDirWatcher,
-                            &QFileSystemWatcher::directoryChanged,
-                            this,
-                            &TrackCollectionManager::slotIncomingDirectoryChanged);
-                }
-            } else {
-                kLogger.warning()
-                        << "Configured incoming tracks directory is invalid:"
-                        << incomingTracksDir;
-            }
-        }
+        initIncomingDirWatcher(incomingTracksDir);
     }
 }
 
@@ -701,4 +682,30 @@ void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
     kLogger.info() << "Incoming directory changed, starting scan for:" << absPath;
 
     m_pScanner->scanDir(path);
+}
+
+void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTracksDir) {
+    if (incomingTracksDir.isEmpty()) {
+        return;
+    }
+
+    auto fi = QFileInfo(incomingTracksDir);
+    if (!fi.exists() || !fi.isDir()) {
+        kLogger.warning()
+                << "Configured incoming tracks directory is invalid:"
+                << incomingTracksDir;
+        return;
+    }
+
+    QString incomingDirPath = fi.absoluteFilePath();
+    if (!m_incomingDirWatcher.addPath(incomingDirPath)) {
+        kLogger.warning() << "Failed to watch incoming tracks directory"
+                          << incomingDirPath;
+    } else {
+        kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
+        connect(&m_incomingDirWatcher,
+                &QFileSystemWatcher::directoryChanged,
+                this,
+                &TrackCollectionManager::slotIncomingDirectoryChanged);
+    }
 }

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -161,6 +161,10 @@ TrackCollectionManager::TrackCollectionManager(
 }
 
 TrackCollectionManager::~TrackCollectionManager() {
+    QStringList dirs = m_incomingDirWatcher.directories();
+    if (!dirs.isEmpty()) {
+        m_incomingDirWatcher.removePaths(dirs);
+    }
     if (m_pScanner) {
         while (m_pScanner->isRunning()) {
             kLogger.info() << "Stopping library scanner thread";

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -33,14 +33,15 @@ parented_ptr<TrackCollection> createInternalTrackCollection(
 
 } // anonymous namespace
 
-TrackCollectionManager::TrackCollectionManager(
-        QObject* parent,
+TrackCollectionManager::TrackCollectionManager(QObject* parent,
         UserSettingsPointer pConfig,
         mixxx::DbConnectionPoolPtr pDbConnectionPool,
         deleteTrackFn_t /*only-needed-for-testing*/ deleteTrackForTestingFn)
-    : QObject(parent),
-      m_pConfig(pConfig),
-      m_pInternalCollection(createInternalTrackCollection(this, pConfig, deleteTrackForTestingFn)) {
+        : QObject(parent),
+          m_pConfig(pConfig),
+          m_pInternalCollection(createInternalTrackCollection(
+                  this, pConfig, deleteTrackForTestingFn)),
+          m_incomingDirChangePending(false) {
     const QSqlDatabase dbConnection = mixxx::DbConnectionPooled(pDbConnectionPool);
 
     // TODO(XXX): Add a checkbox in the library preferences for checking
@@ -682,4 +683,24 @@ void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTrack
                 this,
                 &TrackCollectionManager::slotIncomingDirectoryChanged);
     }
+}
+
+void TrackCollectionManager::slotScanFinished() {
+    emit libraryScanFinished();
+
+    if (!m_incomingDirChangePending) {
+        return;
+    }
+    m_incomingDirChangePending = false;
+
+    VERIFY_OR_DEBUG_ASSERT(m_pScanner) {
+        return;
+    }
+
+    QStringList dirs = m_incomingDirWatcher.directories();
+    if (dirs.isEmpty()) {
+        return;
+    }
+
+    m_pScanner->scanDir(dirs.first());
 }

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -129,6 +129,31 @@ TrackCollectionManager::TrackCollectionManager(
 
         kLogger.info() << "Starting library scanner thread";
         m_pScanner->start();
+
+        const QString incomingTracksDir =
+                m_pConfig->getValue(
+                        mixxx::library::prefs::kIncomingTracksDir,
+                        QString());
+        if (!incomingTracksDir.isEmpty()) {
+            auto fi = QFileInfo(incomingTracksDir);
+            if (fi.exists() && fi.isDir()) {
+                QString incomingDirPath = fi.absoluteFilePath();
+                if (!m_incomingDirWatcher.addPath(incomingDirPath)) {
+                    kLogger.warning() << "Failed to watch incoming tracks directory"
+                                      << incomingDirPath;
+                } else {
+                    kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
+                    connect(&m_incomingDirWatcher,
+                            &QFileSystemWatcher::directoryChanged,
+                            this,
+                            &TrackCollectionManager::slotIncomingDirectoryChanged);
+                }
+            } else {
+                kLogger.warning()
+                        << "Configured incoming tracks directory is invalid:"
+                        << incomingTracksDir;
+            }
+        }
     }
 }
 
@@ -630,3 +655,18 @@ bool TrackCollectionManager::updateTrackMood(
             mood);
 }
 #endif // __EXTRA_METADATA__
+
+void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
+    VERIFY_OR_DEBUG_ASSERT(m_pScanner) {
+        return;
+    }
+
+    if (path.isEmpty()) {
+        return;
+    }
+
+    auto fi = QFileInfo(path);
+    const QString absPath = fi.absoluteFilePath();
+
+    kLogger.info() << "Incoming tracks directory changed:" << absPath;
+}

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -131,19 +131,12 @@ TrackCollectionManager::TrackCollectionManager(QObject* parent,
         kLogger.info() << "Starting library scanner thread";
         m_pScanner->start();
 
-        const QString incomingTracksDir =
-                m_pConfig->getValue(
-                        mixxx::library::prefs::kIncomingTracksDir,
-                        QString());
-        initIncomingDirWatcher(incomingTracksDir);
+        initIncomingDirWatcher();
     }
 }
 
 TrackCollectionManager::~TrackCollectionManager() {
-    QStringList dirs = m_incomingDirWatcher.directories();
-    if (!dirs.isEmpty()) {
-        m_incomingDirWatcher.removePaths(dirs);
-    }
+    updateIncomingDirWatcher({});
     if (m_pScanner) {
         while (m_pScanner->isRunning()) {
             kLogger.info() << "Stopping library scanner thread";
@@ -664,7 +657,26 @@ void TrackCollectionManager::slotIncomingDirectoryChanged() {
     m_pScanner->scanDir(absPath);
 }
 
-void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTracksDir) {
+void TrackCollectionManager::initIncomingDirWatcher() {
+    m_incomingDirTimer.setSingleShot(true);
+    connect(&m_incomingDirTimer,
+            &QTimer::timeout,
+            this,
+            &TrackCollectionManager::slotIncomingDirectoryChanged);
+    connect(&m_incomingDirWatcher,
+            &QFileSystemWatcher::directoryChanged,
+            this,
+            [this]() {
+                m_incomingDirTimer.start(2000);
+            });
+}
+
+void TrackCollectionManager::updateIncomingDirWatcher(const QString& incomingTracksDir) {
+    QStringList dirs = m_incomingDirWatcher.directories();
+    if (!dirs.isEmpty()) {
+        m_incomingDirWatcher.removePaths(dirs);
+    }
+
     if (incomingTracksDir.isEmpty()) {
         return;
     }
@@ -676,24 +688,12 @@ void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTrack
                 << incomingTracksDir;
         return;
     }
-
     QString incomingDirPath = fi.absoluteFilePath();
     if (!m_incomingDirWatcher.addPath(incomingDirPath)) {
         kLogger.warning() << "Failed to watch incoming tracks directory"
                           << incomingDirPath;
     } else {
         kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
-        m_incomingDirTimer.setSingleShot(true);
-        connect(&m_incomingDirTimer,
-                &QTimer::timeout,
-                this,
-                &TrackCollectionManager::slotIncomingDirectoryChanged);
-        connect(&m_incomingDirWatcher,
-                &QFileSystemWatcher::directoryChanged,
-                this,
-                [this]() {
-                    m_incomingDirTimer.start(2000);
-                });
     }
 }
 
@@ -715,4 +715,13 @@ void TrackCollectionManager::slotScanFinished() {
     }
 
     m_pScanner->scanDir(dirs.first());
+}
+
+void TrackCollectionManager::slotInitalIncomingDirScan() {
+    const QString incomingTracksDir =
+            m_pConfig->getValue(
+                    mixxx::library::prefs::kIncomingTracksDir,
+                    QString());
+    updateIncomingDirWatcher(incomingTracksDir);
+    slotIncomingDirectoryChanged();
 }

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -668,5 +668,7 @@ void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
     auto fi = QFileInfo(path);
     const QString absPath = fi.absoluteFilePath();
 
-    kLogger.info() << "Incoming tracks directory changed:" << absPath;
+    kLogger.info() << "Incoming directory changed, starting scan for:" << absPath;
+
+    m_pScanner->scanDir(path);
 }

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -33,14 +33,15 @@ parented_ptr<TrackCollection> createInternalTrackCollection(
 
 } // anonymous namespace
 
-TrackCollectionManager::TrackCollectionManager(
-        QObject* parent,
+TrackCollectionManager::TrackCollectionManager(QObject* parent,
         UserSettingsPointer pConfig,
         mixxx::DbConnectionPoolPtr pDbConnectionPool,
         deleteTrackFn_t /*only-needed-for-testing*/ deleteTrackForTestingFn)
-    : QObject(parent),
-      m_pConfig(pConfig),
-      m_pInternalCollection(createInternalTrackCollection(this, pConfig, deleteTrackForTestingFn)) {
+        : QObject(parent),
+          m_pConfig(pConfig),
+          m_pInternalCollection(createInternalTrackCollection(
+                  this, pConfig, deleteTrackForTestingFn)),
+          m_incomingDirChangePending(false) {
     const QSqlDatabase dbConnection = mixxx::DbConnectionPooled(pDbConnectionPool);
 
     // TODO(XXX): Add a checkbox in the library preferences for checking
@@ -712,4 +713,24 @@ void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTrack
                 this,
                 &TrackCollectionManager::slotIncomingDirectoryChanged);
     }
+}
+
+void TrackCollectionManager::slotScanFinished() {
+    emit libraryScanFinished();
+
+    if (!m_incomingDirChangePending) {
+        return;
+    }
+    m_incomingDirChangePending = false;
+
+    VERIFY_OR_DEBUG_ASSERT(m_pScanner) {
+        return;
+    }
+
+    QStringList dirs = m_incomingDirWatcher.directories();
+    if (dirs.isEmpty()) {
+        return;
+    }
+
+    m_pScanner->scanDir(dirs.first());
 }

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -151,6 +151,31 @@ TrackCollectionManager::TrackCollectionManager(
 
         kLogger.info() << "Starting library scanner thread";
         m_pScanner->start();
+
+        const QString incomingTracksDir =
+                m_pConfig->getValue(
+                        mixxx::library::prefs::kIncomingTracksDir,
+                        QString());
+        if (!incomingTracksDir.isEmpty()) {
+            auto fi = QFileInfo(incomingTracksDir);
+            if (fi.exists() && fi.isDir()) {
+                QString incomingDirPath = fi.absoluteFilePath();
+                if (!m_incomingDirWatcher.addPath(incomingDirPath)) {
+                    kLogger.warning() << "Failed to watch incoming tracks directory"
+                                      << incomingDirPath;
+                } else {
+                    kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
+                    connect(&m_incomingDirWatcher,
+                            &QFileSystemWatcher::directoryChanged,
+                            this,
+                            &TrackCollectionManager::slotIncomingDirectoryChanged);
+                }
+            } else {
+                kLogger.warning()
+                        << "Configured incoming tracks directory is invalid:"
+                        << incomingTracksDir;
+            }
+        }
     }
 }
 
@@ -660,3 +685,18 @@ bool TrackCollectionManager::updateTrackMood(
             mood);
 }
 #endif // __EXTRA_METADATA__
+
+void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
+    VERIFY_OR_DEBUG_ASSERT(m_pScanner) {
+        return;
+    }
+
+    if (path.isEmpty()) {
+        return;
+    }
+
+    auto fi = QFileInfo(path);
+    const QString absPath = fi.absoluteFilePath();
+
+    kLogger.info() << "Incoming tracks directory changed:" << absPath;
+}

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -661,7 +661,7 @@ void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
         return;
     }
 
-    if (path.isEmpty()) {
+    if (path.isEmpty() || !m_pScanner->isIdle()) {
         return;
     }
 

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -134,26 +134,7 @@ TrackCollectionManager::TrackCollectionManager(
                 m_pConfig->getValue(
                         mixxx::library::prefs::kIncomingTracksDir,
                         QString());
-        if (!incomingTracksDir.isEmpty()) {
-            auto fi = QFileInfo(incomingTracksDir);
-            if (fi.exists() && fi.isDir()) {
-                QString incomingDirPath = fi.absoluteFilePath();
-                if (!m_incomingDirWatcher.addPath(incomingDirPath)) {
-                    kLogger.warning() << "Failed to watch incoming tracks directory"
-                                      << incomingDirPath;
-                } else {
-                    kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
-                    connect(&m_incomingDirWatcher,
-                            &QFileSystemWatcher::directoryChanged,
-                            this,
-                            &TrackCollectionManager::slotIncomingDirectoryChanged);
-                }
-            } else {
-                kLogger.warning()
-                        << "Configured incoming tracks directory is invalid:"
-                        << incomingTracksDir;
-            }
-        }
+        initIncomingDirWatcher(incomingTracksDir);
     }
 }
 
@@ -671,4 +652,30 @@ void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
     kLogger.info() << "Incoming directory changed, starting scan for:" << absPath;
 
     m_pScanner->scanDir(path);
+}
+
+void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTracksDir) {
+    if (incomingTracksDir.isEmpty()) {
+        return;
+    }
+
+    auto fi = QFileInfo(incomingTracksDir);
+    if (!fi.exists() || !fi.isDir()) {
+        kLogger.warning()
+                << "Configured incoming tracks directory is invalid:"
+                << incomingTracksDir;
+        return;
+    }
+
+    QString incomingDirPath = fi.absoluteFilePath();
+    if (!m_incomingDirWatcher.addPath(incomingDirPath)) {
+        kLogger.warning() << "Failed to watch incoming tracks directory"
+                          << incomingDirPath;
+    } else {
+        kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
+        connect(&m_incomingDirWatcher,
+                &QFileSystemWatcher::directoryChanged,
+                this,
+                &TrackCollectionManager::slotIncomingDirectoryChanged);
+    }
 }

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -698,5 +698,7 @@ void TrackCollectionManager::slotIncomingDirectoryChanged(const QString& path) {
     auto fi = QFileInfo(path);
     const QString absPath = fi.absoluteFilePath();
 
-    kLogger.info() << "Incoming tracks directory changed:" << absPath;
+    kLogger.info() << "Incoming directory changed, starting scan for:" << absPath;
+
+    m_pScanner->scanDir(path);
 }

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -153,19 +153,12 @@ TrackCollectionManager::TrackCollectionManager(QObject* parent,
         kLogger.info() << "Starting library scanner thread";
         m_pScanner->start();
 
-        const QString incomingTracksDir =
-                m_pConfig->getValue(
-                        mixxx::library::prefs::kIncomingTracksDir,
-                        QString());
-        initIncomingDirWatcher(incomingTracksDir);
+        initIncomingDirWatcher();
     }
 }
 
 TrackCollectionManager::~TrackCollectionManager() {
-    QStringList dirs = m_incomingDirWatcher.directories();
-    if (!dirs.isEmpty()) {
-        m_incomingDirWatcher.removePaths(dirs);
-    }
+    updateIncomingDirWatcher({});
     if (m_pScanner) {
         while (m_pScanner->isRunning()) {
             kLogger.info() << "Stopping library scanner thread";
@@ -694,7 +687,26 @@ void TrackCollectionManager::slotIncomingDirectoryChanged() {
     m_pScanner->scanDir(absPath);
 }
 
-void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTracksDir) {
+void TrackCollectionManager::initIncomingDirWatcher() {
+    m_incomingDirTimer.setSingleShot(true);
+    connect(&m_incomingDirTimer,
+            &QTimer::timeout,
+            this,
+            &TrackCollectionManager::slotIncomingDirectoryChanged);
+    connect(&m_incomingDirWatcher,
+            &QFileSystemWatcher::directoryChanged,
+            this,
+            [this]() {
+                m_incomingDirTimer.start(2000);
+            });
+}
+
+void TrackCollectionManager::updateIncomingDirWatcher(const QString& incomingTracksDir) {
+    QStringList dirs = m_incomingDirWatcher.directories();
+    if (!dirs.isEmpty()) {
+        m_incomingDirWatcher.removePaths(dirs);
+    }
+
     if (incomingTracksDir.isEmpty()) {
         return;
     }
@@ -706,24 +718,12 @@ void TrackCollectionManager::initIncomingDirWatcher(const QString& incomingTrack
                 << incomingTracksDir;
         return;
     }
-
     QString incomingDirPath = fi.absoluteFilePath();
     if (!m_incomingDirWatcher.addPath(incomingDirPath)) {
         kLogger.warning() << "Failed to watch incoming tracks directory"
                           << incomingDirPath;
     } else {
         kLogger.info() << "Watching incoming tracks directory" << incomingDirPath;
-        m_incomingDirTimer.setSingleShot(true);
-        connect(&m_incomingDirTimer,
-                &QTimer::timeout,
-                this,
-                &TrackCollectionManager::slotIncomingDirectoryChanged);
-        connect(&m_incomingDirWatcher,
-                &QFileSystemWatcher::directoryChanged,
-                this,
-                [this]() {
-                    m_incomingDirTimer.start(2000);
-                });
     }
 }
 
@@ -745,4 +745,13 @@ void TrackCollectionManager::slotScanFinished() {
     }
 
     m_pScanner->scanDir(dirs.first());
+}
+
+void TrackCollectionManager::slotInitalIncomingDirScan() {
+    const QString incomingTracksDir =
+            m_pConfig->getValue(
+                    mixxx::library::prefs::kIncomingTracksDir,
+                    QString());
+    updateIncomingDirWatcher(incomingTracksDir);
+    slotIncomingDirectoryChanged();
 }

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDir>
+#include <QFileSystemWatcher>
 #include <QList>
 #include <QSet>
 #include <atomic>
@@ -118,6 +119,7 @@ class TrackCollectionManager : public QObject,
   public slots:
     void startLibraryScan();
     void stopLibraryScan();
+    void slotIncomingDirectoryChanged(const QString& path);
 
   private:
     void afterTrackAdded(const TrackPointer& pTrack) const;
@@ -150,4 +152,6 @@ class TrackCollectionManager : public QObject,
     std::atomic_bool m_libraryScanActive{false};
     std::mutex m_libraryScanSummaryMutex;
     std::optional<LibraryScanResultSummary> m_pendingLibraryScanSummary;
+
+    QFileSystemWatcher m_incomingDirWatcher;
 };

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -129,6 +129,8 @@ class TrackCollectionManager : public QObject,
     // Callback for GlobalTrackCache
     void saveEvictedTrack(Track* pTrack) noexcept override;
 
+    void initIncomingDirWatcher(const QString& incomingTracksDir);
+
     // Might be called from any thread
     enum class TrackMetadataExportMode {
         Immediate,

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -120,6 +120,7 @@ class TrackCollectionManager : public QObject,
     void startLibraryScan();
     void stopLibraryScan();
     void slotIncomingDirectoryChanged(const QString& path);
+    void slotScanFinished();
 
   private:
     void afterTrackAdded(const TrackPointer& pTrack) const;
@@ -156,4 +157,5 @@ class TrackCollectionManager : public QObject,
     std::optional<LibraryScanResultSummary> m_pendingLibraryScanSummary;
 
     QFileSystemWatcher m_incomingDirWatcher;
+    bool m_incomingDirChangePending;
 };

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDir>
+#include <QFileSystemWatcher>
 #include <QList>
 #include <QSet>
 #include <memory>
@@ -110,6 +111,7 @@ class TrackCollectionManager: public QObject,
   public slots:
     void startLibraryScan();
     void stopLibraryScan();
+    void slotIncomingDirectoryChanged(const QString& path);
 
   private:
     void afterTrackAdded(const TrackPointer& pTrack) const;
@@ -139,4 +141,6 @@ class TrackCollectionManager: public QObject,
 
     // TODO: Extract and decouple LibraryScanner from TrackCollectionManager
     std::unique_ptr<LibraryScanner> m_pScanner;
+
+    QFileSystemWatcher m_incomingDirWatcher;
 };

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -121,6 +121,8 @@ class TrackCollectionManager: public QObject,
     // Callback for GlobalTrackCache
     void saveEvictedTrack(Track* pTrack) noexcept override;
 
+    void initIncomingDirWatcher(const QString& incomingTracksDir);
+
     // Might be called from any thread
     enum class TrackMetadataExportMode {
         Immediate,

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -114,6 +114,7 @@ class TrackCollectionManager: public QObject,
     void stopLibraryScan();
     void slotIncomingDirectoryChanged();
     void slotScanFinished();
+    void slotInitalIncomingDirScan();
 
   private:
     void afterTrackAdded(const TrackPointer& pTrack) const;
@@ -123,7 +124,8 @@ class TrackCollectionManager: public QObject,
     // Callback for GlobalTrackCache
     void saveEvictedTrack(Track* pTrack) noexcept override;
 
-    void initIncomingDirWatcher(const QString& incomingTracksDir);
+    void initIncomingDirWatcher();
+    void updateIncomingDirWatcher(const QString& incomingTracksDir);
 
     // Might be called from any thread
     enum class TrackMetadataExportMode {

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -4,6 +4,7 @@
 #include <QFileSystemWatcher>
 #include <QList>
 #include <QSet>
+#include <QTimer>
 #include <memory>
 
 #include "library/dao/directorydao.h"
@@ -111,7 +112,7 @@ class TrackCollectionManager: public QObject,
   public slots:
     void startLibraryScan();
     void stopLibraryScan();
-    void slotIncomingDirectoryChanged(const QString& path);
+    void slotIncomingDirectoryChanged();
     void slotScanFinished();
 
   private:
@@ -146,5 +147,6 @@ class TrackCollectionManager: public QObject,
     std::unique_ptr<LibraryScanner> m_pScanner;
 
     QFileSystemWatcher m_incomingDirWatcher;
+    QTimer m_incomingDirTimer;
     bool m_incomingDirChangePending;
 };

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -122,6 +122,7 @@ class TrackCollectionManager : public QObject,
     void stopLibraryScan();
     void slotIncomingDirectoryChanged();
     void slotScanFinished();
+    void slotInitalIncomingDirScan();
 
   private:
     void afterTrackAdded(const TrackPointer& pTrack) const;
@@ -131,7 +132,8 @@ class TrackCollectionManager : public QObject,
     // Callback for GlobalTrackCache
     void saveEvictedTrack(Track* pTrack) noexcept override;
 
-    void initIncomingDirWatcher(const QString& incomingTracksDir);
+    void initIncomingDirWatcher();
+    void updateIncomingDirWatcher(const QString& incomingTracksDir);
 
     // Might be called from any thread
     enum class TrackMetadataExportMode {

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -112,6 +112,7 @@ class TrackCollectionManager: public QObject,
     void startLibraryScan();
     void stopLibraryScan();
     void slotIncomingDirectoryChanged(const QString& path);
+    void slotScanFinished();
 
   private:
     void afterTrackAdded(const TrackPointer& pTrack) const;
@@ -145,4 +146,5 @@ class TrackCollectionManager: public QObject,
     std::unique_ptr<LibraryScanner> m_pScanner;
 
     QFileSystemWatcher m_incomingDirWatcher;
+    bool m_incomingDirChangePending;
 };

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -4,6 +4,7 @@
 #include <QFileSystemWatcher>
 #include <QList>
 #include <QSet>
+#include <QTimer>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -119,7 +120,7 @@ class TrackCollectionManager : public QObject,
   public slots:
     void startLibraryScan();
     void stopLibraryScan();
-    void slotIncomingDirectoryChanged(const QString& path);
+    void slotIncomingDirectoryChanged();
     void slotScanFinished();
 
   private:
@@ -157,5 +158,6 @@ class TrackCollectionManager : public QObject,
     std::optional<LibraryScanResultSummary> m_pendingLibraryScanSummary;
 
     QFileSystemWatcher m_incomingDirWatcher;
+    QTimer m_incomingDirTimer;
     bool m_incomingDirChangePending;
 };

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -721,6 +721,10 @@ void PlayerManager::slotLoadToDeck(const QString& location, int deck) {
     slotLoadLocationToPlayer(location, groupForDeck(deck - 1), false);
 }
 
+void PlayerManager::slotPreview(const QString& location) {
+    slotLoadLocationToPlayer(location, groupForPreviewDeck(0), true);
+}
+
 void PlayerManager::slotLoadToPreviewDeck(const QString& location, int previewDeck) {
     slotLoadLocationToPlayer(location, groupForPreviewDeck(previewDeck - 1), false);
 }

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -216,6 +216,8 @@ class PlayerManager : public PlayerManagerInterface {
     // Loads the location to the deck. deckNumber is 1-indexed
     void slotLoadToDeck(const QString& location, int deckNumber);
 
+    void slotPreview(const QString& location);
+
     // Loads the location to the preview deck. previewDeckNumber is 1-indexed
     void slotLoadToPreviewDeck(const QString& location, int previewDeckNumber);
     // Slots for loading tracks to samplers

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1248,12 +1248,11 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
         return;
     }
 
-    QMessageBox* pMsg = new QMessageBox();
-    pMsg->setAttribute(Qt::WA_DeleteOnClose);
-    pMsg->setTextFormat(Qt::RichText); // required to get bold text with <b> tags
-    pMsg->setWindowTitle(tr("Library scan finished"));
-
     if (result.noDirectoriesConfigured) {
+        QMessageBox* pMsg = new QMessageBox();
+        pMsg->setAttribute(Qt::WA_DeleteOnClose);
+        pMsg->setTextFormat(Qt::RichText); // required to get bold text with <b> tags
+        pMsg->setWindowTitle(tr("Library scan finished"));
         pMsg->setText(tr("No music directories configured for scanning.") +
                 QStringLiteral("<br>") +
                 tr("Add directories in the library preferences."));
@@ -1261,6 +1260,14 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
         return;
     }
 
+    if (result.numNewTracks == 1) {
+        showSingleScanSummaryDlg(result);
+    } else {
+        showMassScanSummaryDlg(result);
+    }
+}
+
+void MixxxMainWindow::showMassScanSummaryDlg(const LibraryScanResultSummary& result) {
     QString summary =
             tr("Scan took %1").arg(result.durationString) + QStringLiteral("<br><br>");
     if (result.numNewTracks == 0 &&
@@ -1297,8 +1304,60 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
                 QStringLiteral("</b>");
     }
 
+    QMessageBox* pMsg = new QMessageBox();
+    pMsg->setAttribute(Qt::WA_DeleteOnClose);
     pMsg->setText(summary);
     pMsg->show();
+}
+
+void MixxxMainWindow::showSingleScanSummaryDlg(const LibraryScanResultSummary& result) {
+    const QString location = result.lastTrackLocation;
+
+    // Try to resolve the newly added track to get artist/title.
+    TrackPointer pTrack;
+    auto pTrackCollectionManager = m_pCoreServices->getTrackCollectionManager();
+    if (pTrackCollectionManager) {
+        QList<TrackId> trackIds =
+                pTrackCollectionManager->resolveTrackIdsFromLocations({location});
+        if (!trackIds.isEmpty()) {
+            pTrack = pTrackCollectionManager->getTrackById(trackIds.first());
+        }
+    }
+
+    QString trackLable;
+    if (pTrack) {
+        trackLable = QString("%1 - %2").arg(pTrack->getArtist(), pTrack->getTitle());
+    }
+
+    QMessageBox msgBox;
+    msgBox.setWindowTitle(tr("New track found"));
+    msgBox.setTextFormat(Qt::RichText);
+    // Show the track title in bold and the file path on the next line.
+    msgBox.setText(QString("<b>%1</b><br/><small>%2</small>")
+                    .arg(trackLable.toHtmlEscaped(),
+                            QDir::toNativeSeparators(location)
+                                    .toHtmlEscaped()));
+
+    msgBox.setStandardButtons(QMessageBox::Close);
+
+    QPushButton* pLoadPreviewBtn =
+            msgBox.addButton(tr("Preview"), QMessageBox::ActionRole);
+    QPushButton* pAddAutoDJBtn =
+            msgBox.addButton(tr("Add to Auto DJ"), QMessageBox::ActionRole);
+
+    msgBox.exec();
+
+    if (msgBox.clickedButton() == pLoadPreviewBtn) {
+        // Load into the first preview deck (preview decks are 1-indexed).
+        auto pPlayerManager = m_pCoreServices->getPlayerManager();
+        if (pPlayerManager) {
+            pPlayerManager->slotPreview(location);
+        }
+    } else if (msgBox.clickedButton() == pAddAutoDJBtn) {
+        auto* pLibrary = m_pCoreServices->getLibrary().get();
+        pLibrary->appendTracksToAutoDJ({pTrack->getId()});
+        pLibrary->showAutoDJ();
+    }
 }
 
 void MixxxMainWindow::slotShowKeywheel(bool toggle) {

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1262,12 +1262,11 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
         return;
     }
 
-    QMessageBox* pMsg = new QMessageBox();
-    pMsg->setAttribute(Qt::WA_DeleteOnClose);
-    pMsg->setTextFormat(Qt::RichText); // required to get bold text with <b> tags
-    pMsg->setWindowTitle(tr("Library scan finished"));
-
     if (result.noDirectoriesConfigured) {
+        QMessageBox* pMsg = new QMessageBox();
+        pMsg->setAttribute(Qt::WA_DeleteOnClose);
+        pMsg->setTextFormat(Qt::RichText); // required to get bold text with <b> tags
+        pMsg->setWindowTitle(tr("Library scan finished"));
         pMsg->setText(tr("No music directories configured for scanning.") +
                 QStringLiteral("<br>") +
                 tr("Add directories in the library preferences."));
@@ -1275,6 +1274,14 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
         return;
     }
 
+    if (result.numNewTracks == 1) {
+        showSingleScanSummaryDlg(result);
+    } else {
+        showMassScanSummaryDlg(result);
+    }
+}
+
+void MixxxMainWindow::showMassScanSummaryDlg(const LibraryScanResultSummary& result) {
     QString summary =
             tr("Scan took %1").arg(result.durationString) + QStringLiteral("<br><br>");
     if (result.numNewTracks == 0 &&
@@ -1311,8 +1318,60 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
                 QStringLiteral("</b>");
     }
 
+    QMessageBox* pMsg = new QMessageBox();
+    pMsg->setAttribute(Qt::WA_DeleteOnClose);
     pMsg->setText(summary);
     pMsg->show();
+}
+
+void MixxxMainWindow::showSingleScanSummaryDlg(const LibraryScanResultSummary& result) {
+    const QString location = result.lastTrackLocation;
+
+    // Try to resolve the newly added track to get artist/title.
+    TrackPointer pTrack;
+    auto pTrackCollectionManager = m_pCoreServices->getTrackCollectionManager();
+    if (pTrackCollectionManager) {
+        QList<TrackId> trackIds =
+                pTrackCollectionManager->resolveTrackIdsFromLocations({location});
+        if (!trackIds.isEmpty()) {
+            pTrack = pTrackCollectionManager->getTrackById(trackIds.first());
+        }
+    }
+
+    QString trackLable;
+    if (pTrack) {
+        trackLable = QString("%1 - %2").arg(pTrack->getArtist(), pTrack->getTitle());
+    }
+
+    QMessageBox msgBox;
+    msgBox.setWindowTitle(tr("New track found"));
+    msgBox.setTextFormat(Qt::RichText);
+    // Show the track title in bold and the file path on the next line.
+    msgBox.setText(QString("<b>%1</b><br/><small>%2</small>")
+                    .arg(trackLable.toHtmlEscaped(),
+                            QDir::toNativeSeparators(location)
+                                    .toHtmlEscaped()));
+
+    msgBox.setStandardButtons(QMessageBox::Close);
+
+    QPushButton* pLoadPreviewBtn =
+            msgBox.addButton(tr("Preview"), QMessageBox::ActionRole);
+    QPushButton* pAddAutoDJBtn =
+            msgBox.addButton(tr("Add to Auto DJ"), QMessageBox::ActionRole);
+
+    msgBox.exec();
+
+    if (msgBox.clickedButton() == pLoadPreviewBtn) {
+        // Load into the first preview deck (preview decks are 1-indexed).
+        auto pPlayerManager = m_pCoreServices->getPlayerManager();
+        if (pPlayerManager) {
+            pPlayerManager->slotPreview(location);
+        }
+    } else if (msgBox.clickedButton() == pAddAutoDJBtn) {
+        auto* pLibrary = m_pCoreServices->getLibrary().get();
+        pLibrary->appendTracksToAutoDJ({pTrack->getId()});
+        pLibrary->showAutoDJ();
+    }
 }
 
 void MixxxMainWindow::slotShowKeywheel(bool toggle) {

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -117,6 +117,9 @@ class MixxxMainWindow : public QMainWindow {
     void alwaysHideMenuBarDlg();
 #endif
 
+    void showMassScanSummaryDlg(const LibraryScanResultSummary& result);
+    void showSingleScanSummaryDlg(const LibraryScanResultSummary& result);
+
     QDialog::DialogCode soundDeviceErrorDlg(
             const QString &title, const QString &text, bool* retryClicked);
     QDialog::DialogCode soundDeviceBusyDlg(bool* retryClicked);

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -117,6 +117,10 @@ DlgPreferences::DlgPreferences(
             &DlgPrefLibrary::scanLibrary,
             pLibrary->trackCollectionManager(),
             &TrackCollectionManager::startLibraryScan);
+    connect(plibraryPage,
+            &DlgPrefLibrary::incomingTracksDirChanged,
+            pLibrary->trackCollectionManager(),
+            &TrackCollectionManager::slotInitalIncomingDirScan);
     addPageWidget(PreferencesPage(plibraryPage,
                           new QTreeWidgetItem(contentsTreeWidget, QTreeWidgetItem::Type)),
             tr("Library"),

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -33,7 +33,9 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     Q_OBJECT
   public:
     struct PreferencesPage {
-        PreferencesPage() {
+        PreferencesPage()
+                : pDlg(nullptr),
+                  pTreeItem(nullptr) {
         }
         PreferencesPage(DlgPreferencePage* pDlg, QTreeWidgetItem* pTreeItem)
                 : pDlg(pDlg),

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -55,6 +55,10 @@ DlgPrefLibrary::DlgPrefLibrary(
             &QPushButton::clicked,
             this,
             &DlgPrefLibrary::slotRelocateDir);
+    connect(pushButton_incoming,
+            &QPushButton::clicked,
+            this,
+            &DlgPrefLibrary::slotIncomingDir);
     connect(checkBox_serato_metadata_export,
             &QAbstractButton::clicked,
             this,
@@ -306,6 +310,8 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_itunes->setChecked(true);
     checkBox_show_traktor->setChecked(true);
     checkBox_show_rekordbox->setChecked(true);
+
+    lineEdit_incoming->setText({});
 }
 
 void DlgPrefLibrary::slotUpdate() {
@@ -464,6 +470,12 @@ void DlgPrefLibrary::slotUpdate() {
                     kSidebarHoverExpandDelayConfigKey,
                     kSidebarHoverExpandDelayDefault);
     spinBox_sidebar_hover_expand_delay->setValue(sidebarHoverExpandDelay);
+
+    const QString incomingTracksDir =
+            m_pConfig->getValue(
+                    kIncomingTracksDir,
+                    QString());
+    lineEdit_incoming->setText(incomingTracksDir);
 }
 
 void DlgPrefLibrary::slotCancel() {
@@ -571,6 +583,19 @@ void DlgPrefLibrary::slotRelocateDir() {
     if (!fd.isEmpty() && m_pLibrary->requestRelocateDir(currentFd, fd)) {
         populateDirList();
     }
+}
+
+void DlgPrefLibrary::slotIncomingDir() {
+    QString startDir = lineEdit_incoming->text();
+    QDir dir = startDir;
+    if (startDir.isEmpty() || !dir.exists()) {
+        startDir = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    }
+
+    QString fd = QFileDialog::getExistingDirectory(
+            this, tr("Incoming tracks directory"), startDir);
+
+    lineEdit_incoming->setText(fd);
 }
 
 void DlgPrefLibrary::slotSeratoMetadataExportClicked(bool checked) {
@@ -686,6 +711,8 @@ void DlgPrefLibrary::slotApply() {
     int sidebarHoverExpandDelay = spinBox_sidebar_hover_expand_delay->value();
     m_pConfig->setValue(kSidebarHoverExpandDelayConfigKey, sidebarHoverExpandDelay);
     emit m_pLibrary->setSidebarHoverExpandDelay(sidebarHoverExpandDelay);
+
+    m_pConfig->set(kIncomingTracksDir, lineEdit_incoming->text());
 
     // TODO(rryan): Don't save here.
     m_pConfig->save();

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -713,6 +713,13 @@ void DlgPrefLibrary::slotApply() {
     emit m_pLibrary->setSidebarHoverExpandDelay(sidebarHoverExpandDelay);
 
     m_pConfig->set(kIncomingTracksDir, lineEdit_incoming->text());
+    
+    const QString incomingTracksDir =
+            m_pConfig->getValue(kIncomingTracksDir, QString());
+    if (incomingTracksDir != lineEdit_incoming->text()) {
+        m_pConfig->set(kIncomingTracksDir, lineEdit_incoming->text());
+        emit incomingTracksDirChanged();
+    }
 
     // TODO(rryan): Don't save here.
     m_pConfig->save();

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -595,6 +595,21 @@ void DlgPrefLibrary::slotIncomingDir() {
     QString fd = QFileDialog::getExistingDirectory(
             this, tr("Incoming tracks directory"), startDir);
 
+    if (!fd.isEmpty()) {
+        // Create a security bookmark while we have permission so that we can
+        // access the folder on future runs.
+        QDir directory(fd);
+        Sandbox::createSecurityTokenForDir(directory);
+
+        if (!directory.isReadable()) {
+            QMessageBox::information(nullptr,
+                    tr("Incoming tracks directory"),
+                    tr("Could read: <b>%1</b>.").arg(fd));
+            return;
+        }
+    }
+
+    // Note: Cancel disables the Incoming
     lineEdit_incoming->setText(fd);
 }
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -714,6 +714,13 @@ void DlgPrefLibrary::slotApply() {
 
     m_pConfig->set(kIncomingTracksDir, lineEdit_incoming->text());
 
+    const QString incomingTracksDir =
+            m_pConfig->getValue(kIncomingTracksDir, QString());
+    if (incomingTracksDir != lineEdit_incoming->text()) {
+        m_pConfig->set(kIncomingTracksDir, lineEdit_incoming->text());
+        emit incomingTracksDirChanged();
+    }
+
     // TODO(rryan): Don't save here.
     m_pConfig->save();
 }

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -56,6 +56,8 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg {
   signals:
     void apply();
     void scanLibrary();
+    void incomingTracksDirChanged();
+
     void requestAddDir(const QString& dir);
     void requestRemoveDir(const QString& dir, LibraryRemovalType removalType);
     void requestRelocateDir(const QString& currentDir, const QString& newDir);

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -51,6 +51,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg {
     void slotAddDir();
     void slotRemoveDir();
     void slotRelocateDir();
+    void slotIncomingDir();
 
   signals:
     void apply();

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>661</width>
-    <height>1522</height>
+    <width>667</width>
+    <height>1900</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -96,6 +96,33 @@
         </property>
         <property name="checked">
          <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+
+      <item row="5" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label_incomming">
+          <property name="text">
+           <string>Incoming tracks directory:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_incoming">
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+
+      <item row="5" column="1">
+       <widget class="QPushButton" name="pushButton_incoming">
+        <property name="text">
+         <string>Select</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This PR introduces an incomimg track folder that is watched for new tracks. Once a track appears the user can either preview the track in a preview deck or append it to auto DJ or do nothing: 

<img width="952" height="237" alt="grafik" src="https://github.com/user-attachments/assets/7f17c429-d1a6-4f2d-a4ff-9ebba4143ca0" />

<img width="329" height="128" alt="grafik" src="https://github.com/user-attachments/assets/0ddf4732-1887-4f00-83f8-aa2a88020f2b" />

This covers the use case if you download an audience wish during a performance. 

This shall partially fix https://github.com/mixxxdj/mixxx/issues/13192

