### PR TITLE
Instantaneous frequency detector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2940,6 +2940,7 @@ if(BUILD_TESTING)
     src/test/rgbcolor_test.cpp
     src/test/rotary_test.cpp
     src/test/samplebuffertest.cpp
+    src/test/savitzkygolaytest.cpp
     src/test/schemamanager_test.cpp
     src/test/searchqueryparsertest.cpp
     src/test/seratobeatgridtest.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2918,6 +2918,7 @@ if(BUILD_TESTING)
     src/test/looping_control_test.cpp
     src/test/main.cpp
     src/test/mathutiltest.cpp
+    src/test/matrixapitest.cpp
     src/test/metadatatest.cpp
     #TODO: make this build again
     #src/test/metaknob_link_test.cpp
@@ -3022,7 +3023,7 @@ if(BUILD_TESTING)
   set_target_properties(mixxx-test PROPERTIES AUTOMOC ON)
   target_link_libraries(
     mixxx-test
-    PRIVATE mixxx-lib mixxx-gitinfostore GTest::gtest GTest::gmock
+    PRIVATE mixxx-lib mixxx-gitinfostore mixxx-xwax GTest::gtest GTest::gmock
   )
 
   if(BUILD_BENCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5249,6 +5249,7 @@ if(VINYLCONTROL)
       lib/xwax/filters.c
       lib/xwax/ringbuffer.c
       lib/xwax/pitch_kalman.c
+      lib/xwax/fmatrix.c
   )
   target_include_directories(mixxx-xwax SYSTEM PUBLIC lib/xwax)
   target_link_libraries(mixxx-lib PRIVATE mixxx-xwax)

--- a/lib/xwax/complex.h
+++ b/lib/xwax/complex.h
@@ -1,0 +1,78 @@
+#ifndef COMPLEX_H
+
+#define COMPLEX_H
+
+#include <stdint.h>
+
+/*
+ * 32-bit signed fixed point datatype. The fixed point position depends on the usage context
+ * and can be the ARM 1.31 format (Q0.31) and others.
+ */
+
+typedef int32_t q31_t;
+
+/*
+ * 64-bit signed fixed point datatype. The fixed point position depends on the usage context,
+ * and can be the ARM 2.62 format (Q1.62) and others.
+ */
+
+typedef int64_t q63_t;
+
+/*
+ * A complex type in ARM Q format
+ */
+
+struct complex_q63 {
+    q63_t re;
+    q63_t im;
+};
+
+/*
+ * A complex type in ARM Q format
+ */
+
+struct complex_q31 {
+    q31_t re;
+    q31_t im;
+};
+
+/*
+ * Complex multiplication in polar form.
+ *
+ * Takes ARM 1.31 format as z0 and z1 and returns ARM 2.62 format.
+ *
+ * Imaginary number: i = sqrt(-1) --> i * i = -1
+ *
+ * e^(i*x) = cos(x) + i * sin(x)
+ * e^(i*y) = cos(y) + i * sin(y)
+ *
+ * e^(i*x) * e^(i*y) = ( cos(x) + i * sin(x) ) * ( cos(y) + i * sin(y) )
+ * e^(i*x) * e^(i*y) = cos(x) * cos(y) + cos(x) * i * sin(y) + cos(y) * i * sin(x) + i * sin(x) * i * sin(x)
+ * e^(i*x) * e^(i*y) = cos(x) * cos(y) + cos(x) * i * sin(y) + cos(y) * i * sin(x) - sin(x) * sin(y)
+ *
+ * Everything that has an i, belongs to the imaginary part, so we reorder:
+ *
+ * e^(i*x) * e^(i*y) = cos(x) * cos(y) - sin(x) * sin(y) + cos(x) * i * sin(y) + cos(y) * i * sin(x)
+ *                    {              real               } {                 imag                    }
+ */
+
+static inline struct complex_q63 complex_q31_mul(struct complex_q31 z0,
+    struct complex_q31 z1)
+{
+    q63_t re = (q63_t)z0.re * z1.re - (q63_t)z0.im * z1.im;
+    q63_t im = (q63_t)z0.re * z1.im + (q63_t)z1.re * z0.im;
+
+    return (struct complex_q63) { re, im };
+}
+
+/*
+ * Converts a complex_q31 into its complex conjugate
+ */
+
+static inline struct complex_q31 complex_q31_conj(struct complex_q31 z)
+{
+    z.im = -z.im;
+    return z;
+}
+
+#endif /* end of include guard COMPLEX_H */

--- a/lib/xwax/filters.c
+++ b/lib/xwax/filters.c
@@ -7,10 +7,10 @@
 #include "filters.h"
 
 /*
- * Initializes the exponential moving average filter.
+ * Initializes the exponential weighted moving average filter.
  */
 
-void ema_init(struct ema_filter *filter, const double alpha)
+void ewma_init(struct ewma_filter *filter, const double alpha)
 {
     if (!filter) {
         errno = EINVAL;
@@ -23,11 +23,11 @@ void ema_init(struct ema_filter *filter, const double alpha)
 }
 
 /*
- * Computes an exponential moving average with the possibility to weight newly added
+ * Computes an exponential weighted moving average with the possibility to weight newly added
  * values with a factor alpha.
  */
 
-int ema(struct ema_filter *filter, const int x)
+int ewma(struct ewma_filter *filter, const int x)
 {
     if (!filter) {
         errno = EINVAL;

--- a/lib/xwax/filters.c
+++ b/lib/xwax/filters.c
@@ -330,3 +330,46 @@ int savgol(struct savitzky_golay *f, int x)
 
     return (int)lround(y);
 }
+
+/*
+ * Implements a simple highpass as rumble filter
+ */
+
+void rhpf_init(struct rumble_filter *f, unsigned int fs, double fc)
+{
+    if (!f) {
+        errno = EINVAL;
+        perror(__func__);
+        return;
+    }
+
+    f->fs = (double)fs;
+    f->fc = fc;
+
+    double RC = 1.0 / (2.0 * M_PI * fc);
+    double dt = 1.0 / fs;
+    f->alpha = RC / (RC + dt);   /* from standard 1st order HP formula */
+
+    f->x_old = 0.0;
+    f->y_old = 0.0;
+}
+
+/*
+ * Processes a sample in the rumble filter
+ */
+
+int rhpf_process(struct rumble_filter *f, int x)
+{
+    if (!f) {
+        errno = EINVAL;
+        perror(__func__);
+        return 0;
+    }
+
+    double y = f->alpha * (f->y_old + x - f->x_old);
+
+    f->x_old = x;
+    f->y_old = y;
+
+    return (int)lround(y);
+}

--- a/lib/xwax/filters.c
+++ b/lib/xwax/filters.c
@@ -47,6 +47,25 @@ void ewma_init(struct ewma_filter *f, const double alpha)
 }
 
 /*
+ * Initializes the exponential weighted moving average filter.
+ * Takes the carrier frequency and sampling rate into account.
+ */
+
+void ewma_init_adaptive(struct ewma_filter *f, double k, double f_carrier,
+    double fs)
+{
+    if (!f) {
+        errno = EINVAL;
+        perror(__func__);
+        return;
+    }
+
+    double tau = k / f_carrier; /* fraction of carrier frequency */
+    f->alpha = 1.0 - exp(-1.0 / (fs * tau));
+    f->y_old = 0.0;
+}
+
+/*
  * Computes an exponential weighted moving average with the possibility to weight newly added
  * values with a factor alpha.
  */

--- a/lib/xwax/filters.c
+++ b/lib/xwax/filters.c
@@ -1,6 +1,6 @@
 
-#include <limits.h>
 #include <errno.h>
+#include <limits.h>
 #include <math.h>
 #include <stdio.h>
 
@@ -10,16 +10,16 @@
  * Initializes the exponential weighted moving average filter.
  */
 
-void ewma_init(struct ewma_filter *filter, const double alpha)
+void ewma_init(struct ewma_filter *f, const double alpha)
 {
-    if (!filter) {
+    if (!f) {
         errno = EINVAL;
         perror(__func__);
         return;
     }
 
-    filter->alpha = alpha;
-    filter->y_old = 0;
+    f->alpha = alpha;
+    f->y_old = 0;
 }
 
 /*
@@ -27,16 +27,16 @@ void ewma_init(struct ewma_filter *filter, const double alpha)
  * values with a factor alpha.
  */
 
-int ewma(struct ewma_filter *filter, const int x)
+int ewma(struct ewma_filter *f, const int x)
 {
-    if (!filter) {
+    if (!f) {
         errno = EINVAL;
         perror(__func__);
         return -EINVAL;
     }
 
-    int y = filter->alpha * x + (1 - filter->alpha) * filter->y_old;
-    filter->y_old = y;
+    int y = f->alpha * x + (1 - f->alpha) * f->y_old;
+    f->y_old = y;
 
     return y;
 }
@@ -45,25 +45,25 @@ int ewma(struct ewma_filter *filter, const int x)
  * Initializes the derivative filter.
  */
 
-void derivative_init(struct differentiator *filter)
+void derivative_init(struct differentiator *f)
 {
-    if (!filter) {
+    if (!f) {
         errno = EINVAL;
         perror(__func__);
         return;
     }
 
-    filter->x_old = 0;
+    f->x_old = 0;
 }
 
 /*
  * Computes a simple derivative, i.e. the slope of the input signal without gain compensation.
  */
 
-int derivative(struct differentiator *filter, const int x)
+int derivative(struct differentiator *f, const int x)
 {
-    int y = x - filter->x_old;
-    filter->x_old = x;
+    int y = x - f->x_old;
+    f->x_old = x;
 
     return y;
 }
@@ -72,16 +72,16 @@ int derivative(struct differentiator *filter, const int x)
  * Initializes the RMS filter
  */
 
-void rms_init(struct root_mean_square *filter, const float alpha)
+void rms_init(struct root_mean_square *f, const float alpha)
 {
-    if (!filter) {
+    if (!f) {
         errno = EINVAL;
         perror(__func__);
         return;
     }
 
-    filter->squared_old = 0;
-    filter->alpha = alpha;
+    f->squared_old = 0;
+    f->alpha = alpha;
 }
 
 /*
@@ -89,20 +89,20 @@ void rms_init(struct root_mean_square *filter, const float alpha)
  * The 1.0 > alpha > 0 determines the smoothness of the result:
  */
 
-int rms(struct root_mean_square *filter, const int x)
+int rms(struct root_mean_square *f, const int x)
 {
-    if (!filter) {
+    if (!f) {
         errno = EINVAL;
         perror(__func__);
         return -EINVAL;
     }
 
     /* Compute squared value */
-    unsigned long long squared = (unsigned long long)x * (unsigned long long)x;
+    double squared = (double)x * (double)x;
 
     /* Apply EMA filter to squared values */
-    filter->squared_old = (1.0 - filter->alpha) * filter->squared_old + filter->alpha * squared;
+    f->squared_old = (1.0 - f->alpha) * f->squared_old + f->alpha * squared;
 
     /* Take square root at the end */
-    return (int)sqrt(filter->squared_old);
+    return (int)lround(sqrt(f->squared_old));
 }

--- a/lib/xwax/filters.c
+++ b/lib/xwax/filters.c
@@ -1,10 +1,34 @@
+#include "filters.h"
+#include "fmatrix.h"
 
 #include <errno.h>
 #include <limits.h>
+#define _USE_MATH_DEFINES
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-#include "filters.h"
+static inline double clamp_to_int32(double x)
+{
+    if (x > INT_MAX) {
+        x = INT_MAX;
+    } else if (x < INT_MIN) {
+        x = INT_MIN;
+    }
+
+    return x;
+}
+
+static inline void normalize_coeffs(double *coeffs, size_t N)
+{
+    double sum = 0.0;
+
+    for (size_t i = 0; i < N; i++)
+        sum += coeffs[i];
+
+    for (size_t i = 0; i < N; i++)
+        coeffs[i] /= sum;
+}
 
 /*
  * Initializes the exponential weighted moving average filter.
@@ -105,4 +129,204 @@ int rms(struct root_mean_square *f, const int x)
 
     /* Take square root at the end */
     return (int)lround(sqrt(f->squared_old));
+}
+
+/*
+ * Computes the coefficients for a Savitzky-Golay filter at runtime
+ * by using a Vandermonde matrix:
+ *
+ *      | (-M)^0 (-M)^1 (-M)^N |
+ *      |    :      :      :   |
+ *  A = |   0^0    0^1    0^N  |
+ *      |    :      :      :   |
+ *      |   M^0    M^1    M^N  |
+ *
+ * see https://c.mql5.com/forextsd/forum/147/sgfilter.pdf
+ *
+ * where M is the half-width of the sample window
+ * and N is the order of the polynomial
+ *
+ *         N
+ *  p(n) = Σ a_k * n^k
+ *        k=0
+ */
+
+static double *savgol_gen_coeffs(size_t window_size, size_t polyorder)
+{
+    if (window_size % 2 == 0 || polyorder >= window_size) {
+        errno = EINVAL;
+        perror(__func__);
+        return NULL;
+    }
+
+    struct fmatrix *A = NULL;
+    struct fmatrix *AT = NULL;
+    struct fmatrix *B = NULL;
+    struct fmatrix *B_inv = NULL;
+    struct fmatrix *H = NULL;
+
+    size_t M = (window_size - 1) / 2;
+    size_t N = window_size;
+    size_t I = polyorder + 1;
+    double *coeff = NULL;
+
+    /* A: (N x I) */
+
+    A = fmat_alloc(N, I);
+    if (!A)
+        goto out;
+
+    /*
+     * Fill the n x i Vandermonde matrix
+     *
+     *   a_n,i = n^i, -M <= n <= M
+     *                 i = 0, 1, ..., N
+     */
+
+    for (size_t n = 0; n < N; n++) {
+        int base = (int)n - (int)M; // May be negative
+
+        for (size_t i = 0; i < I; i++) {
+            fmat_set(A, n, i, pow((double)base, (double)i));
+        }
+    }
+
+    /* AT = A^T */
+
+    AT = fmat_trans(NULL, A);
+    if (!AT)
+        goto out;
+
+    /* B = A^T x A */
+
+    B = fmat_mul(NULL, AT, A);
+    if (!B)
+        goto out;
+
+    /* B_inv */
+
+    B_inv = fmat_inv(NULL, B);
+    if (!B_inv)
+        goto out;
+
+    /* H = B_inv * AT */
+
+    H = fmat_mul(NULL, B_inv, AT);
+    if (!H)
+        goto out;
+
+    /* Allocate coefficient array */
+
+    coeff = calloc(window_size, sizeof(double));
+    if (!coeff)
+        goto out;
+
+    /* The coefficients can be obtained by extracting row 0 of H. */
+
+    for (size_t i = 0; i < N; i++)
+        coeff[i] = fmat_get(H, 0, i);
+
+    normalize_coeffs(coeff, N);
+
+    /* Cleanup */
+
+out:
+    fmat_free(A);
+    fmat_free(AT);
+    fmat_free(B);
+    fmat_free(B_inv);
+    fmat_free(H);
+
+    return coeff;
+}
+
+/*
+ * Creates a Savitzky-Golay filter at runtime given a windows size N
+ * and filter order. The sample window size determines the delay of the filter.
+ * The delay of the filter equals the half width M of the sample window.
+ */
+
+struct savitzky_golay *savgol_create(size_t window_size, size_t polyorder)
+{
+    if (window_size < 3 || window_size % 2 == 0 || polyorder >= window_size) {
+        errno = EINVAL;
+        if (polyorder >= window_size)
+            fprintf(stderr,
+                "%s: The filter order needs to be less than the window size\n",
+                __func__);
+        if (window_size % 2 == 0)
+            fprintf(stderr, "%s: The window size N must be odd\n", __func__);
+        goto error;
+    }
+
+    struct savitzky_golay *f = malloc(sizeof(*f));
+    if (!f)
+        goto error;
+
+    f->window_size = window_size;
+    f->polyorder = polyorder;
+    f->M = (window_size - 1) / 2; /* Determine the half width */
+
+    f->delayline = rb_alloc(window_size, sizeof(int));
+    if (!f->delayline)
+        goto error_rb_alloc;
+
+    f->coeff = savgol_gen_coeffs(window_size, polyorder);
+    if (!f->coeff)
+        goto error_coeff;
+
+    return f;
+
+error_coeff:
+    rb_free(f->delayline);
+error_rb_alloc:
+    free(f);
+error:
+    perror(__func__);
+
+    return NULL;
+}
+
+/*
+ * Destroys a Savitzky-Golay filter object
+ */
+
+void savgol_destroy(struct savitzky_golay *f)
+{
+    if (!f)
+        return;
+
+    rb_free(f->delayline);
+    free(f->coeff);
+    free(f);
+}
+
+/*
+ * Applies a Savitzky-Golay filter to an input sample. The filter achieves
+ * optimal smoothing of signal using least-squares polynomials.
+ */
+
+int savgol(struct savitzky_golay *f, int x)
+{
+    if (!f) {
+        errno = EINVAL;
+        perror(__func__);
+        return 0;
+    }
+
+    rb_push(f->delayline, &x);
+
+    double y = 0;
+    int *sample = NULL; /* Sample pointer */
+
+    for (size_t i = 0; i < f->window_size; i++) {
+        sample = (int *)rb_at(f->delayline, i);
+        y += f->coeff[i] * *sample;
+    }
+
+    /* Clamp as last security measure */
+
+    y = clamp_to_int32(y);
+
+    return (int)lround(y);
 }

--- a/lib/xwax/filters.h
+++ b/lib/xwax/filters.h
@@ -10,6 +10,8 @@ struct ewma_filter {
 };
 
 void ewma_init(struct ewma_filter *f, const double alpha);
+void ewma_init_adaptive(struct ewma_filter *f, double k, double f_carrier,
+    double fs);
 int ewma(struct ewma_filter *f, const int x);
 
 struct differentiator {

--- a/lib/xwax/filters.h
+++ b/lib/xwax/filters.h
@@ -2,13 +2,13 @@
 
 #define FILTERS_H
 
-struct ema_filter {
+struct ewma_filter {
     double alpha;
     int y_old;
 };
 
-void ema_init(struct ema_filter *, const double alpha);
-int ema(struct ema_filter *, const int x);
+void ewma_init(struct ewma_filter *, const double alpha);
+int ewma(struct ewma_filter *, const int x);
 
 struct differentiator {
     int x_old;

--- a/lib/xwax/filters.h
+++ b/lib/xwax/filters.h
@@ -2,6 +2,10 @@
 
 #define FILTERS_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "ringbuffer.h"
 
 struct ewma_filter {
@@ -51,5 +55,9 @@ struct rumble_filter {
 
 void rhpf_init(struct rumble_filter *f, unsigned int fs, double fc);
 int rhpf_process(struct rumble_filter *f, int x);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* end of include guard FILTERS_H */

--- a/lib/xwax/filters.h
+++ b/lib/xwax/filters.h
@@ -39,4 +39,15 @@ struct savitzky_golay *savgol_create(size_t window_size, size_t polyorder);
 void savgol_destroy(struct savitzky_golay *f);
 int savgol(struct savitzky_golay *f, int x);
 
+struct rumble_filter {
+    double fc;    /* Cutoff frequency */
+    double fs;    /* Sample rate */
+    double alpha; /* Filter coefficient */
+    double x_old; /* x[n-1] */
+    double y_old; /* y[n-1] */
+};
+
+void rhpf_init(struct rumble_filter *f, unsigned int fs, double fc);
+int rhpf_process(struct rumble_filter *f, int x);
+
 #endif /* end of include guard FILTERS_H */

--- a/lib/xwax/filters.h
+++ b/lib/xwax/filters.h
@@ -7,22 +7,22 @@ struct ewma_filter {
     int y_old;
 };
 
-void ewma_init(struct ewma_filter *, const double alpha);
-int ewma(struct ewma_filter *, const int x);
+void ewma_init(struct ewma_filter *f, const double alpha);
+int ewma(struct ewma_filter *f, const int x);
 
 struct differentiator {
     int x_old;
 };
 
-void derivative_init(struct differentiator *filter);
-int derivative(struct differentiator *, const int x);
+void derivative_init(struct differentiator *f);
+int derivative(struct differentiator *f, const int x);
 
 struct root_mean_square {
-    float alpha;
-    unsigned long long squared_old;
+    double alpha;
+    double squared_old;
 };
 
-void rms_init(struct root_mean_square *filter, const float alpha);
-int rms(struct root_mean_square *filter, const int x);
+void rms_init(struct root_mean_square *f, const float alpha);
+int rms(struct root_mean_square *f, const int x);
 
 #endif /* end of include guard FILTERS_H */

--- a/lib/xwax/filters.h
+++ b/lib/xwax/filters.h
@@ -2,6 +2,8 @@
 
 #define FILTERS_H
 
+#include "ringbuffer.h"
+
 struct ewma_filter {
     double alpha;
     int y_old;
@@ -24,5 +26,17 @@ struct root_mean_square {
 
 void rms_init(struct root_mean_square *f, const float alpha);
 int rms(struct root_mean_square *f, const int x);
+
+struct savitzky_golay {
+    size_t window_size;           /* Window size */
+    size_t M;                     /* Half width */
+    size_t polyorder;             /* Polynomial order */
+    double *coeff;                /* Filter coefficients */
+    struct ringbuffer *delayline; /* Sample ringbuffer */
+};
+
+struct savitzky_golay *savgol_create(size_t window_size, size_t polyorder);
+void savgol_destroy(struct savitzky_golay *f);
+int savgol(struct savitzky_golay *f, int x);
 
 #endif /* end of include guard FILTERS_H */

--- a/lib/xwax/fmatrix.c
+++ b/lib/xwax/fmatrix.c
@@ -1,0 +1,409 @@
+#include "fmatrix.h"
+
+#include <errno.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct fmatrix {
+	size_t cols, rows;
+	fval_t *data;
+};
+
+struct fmatrix *fmat_alloc(const size_t rows, const size_t cols)
+{
+	if (!rows || !cols) {
+		errno = EINVAL;
+		perror(__func__);
+		return NULL;
+	}
+
+	/* Allocate the struct */
+	struct fmatrix *m = malloc(sizeof(struct fmatrix));
+	if (!m) {
+		perror(__func__);
+		goto error;
+	}
+
+	m->cols = cols;
+	m->rows = rows;
+	m->data = NULL;
+
+	/* Allocate the rows */
+	m->data = calloc(rows * cols, sizeof(fval_t));
+	if (!m->data) {
+		perror(__func__);
+		goto error_data;
+	}
+
+	return m;
+
+error_data:
+	free(m);
+error:
+	return NULL;
+}
+
+void fmat_free(struct fmatrix *m)
+{
+	if (!m)
+		return;
+
+	if (m->data)
+		free(m->data);
+
+	free(m);
+}
+
+void fmat_set(struct fmatrix *m, size_t row, size_t col, fval_t val)
+{
+	if (!m || row >= m->rows || col >= m->cols) {
+		errno = EINVAL;
+		perror(__func__);
+		return;
+	}
+
+	m->data[m->cols * row + col] = val;
+}
+
+inline void fmat_set_unsafe(struct fmatrix *m, size_t row, size_t col, fval_t val)
+{
+	m->data[m->cols * row + col] = val;
+}
+
+fval_t fmat_get(const struct fmatrix *m, size_t row, size_t col)
+{
+	if (!m || row >= m->rows || col >= m->cols) {
+		errno = EINVAL;
+		perror(__func__);
+		return 0;
+	}
+
+	return m->data[m->cols * row + col];
+}
+
+inline fval_t fmat_get_unsafe(const struct fmatrix *m, size_t row, size_t col)
+{
+	return m->data[m->cols * row + col];
+}
+
+struct fmatrix *fmat_mul(struct fmatrix *dest, const struct fmatrix *a, const struct fmatrix *b)
+{
+	if (!a || !b || a->cols != b->rows) {
+		errno = EINVAL;
+		perror(__func__);
+		return NULL;
+	}
+
+	if (dest) {
+		if (dest->rows != a->rows || dest->cols != b->cols) {
+			errno = EINVAL;
+			perror(__func__);
+			return NULL;
+		}
+	} else {
+		dest = fmat_alloc(a->rows, b->cols);
+		if (!dest)
+			return NULL;
+	}
+
+	for (size_t i = 0; i < a->rows; i++) {
+		for (size_t j = 0; j < b->cols; j++) {
+			fval_t sum = 0;
+
+			for (size_t k = 0; k < a->cols; k++)
+				sum += FMAT_GET(a, i, k) * FMAT_GET(b, k, j);
+
+			FMAT_SET(dest, i, j, sum);
+		}
+	}
+
+	return dest;
+}
+
+struct fmatrix *fmat_trans(struct fmatrix *dest, const struct fmatrix *src)
+{
+	if (!src) {
+		errno = EINVAL;
+		perror(__func__);
+		return NULL;
+	}
+
+	if (dest) {
+		if (dest->rows != src->cols || dest->cols != src->rows) {
+			errno = EINVAL;
+			perror(__func__);
+			return NULL;
+		}
+	} else {
+		dest = fmat_alloc(src->cols, src->rows);
+		if (!dest)
+			return NULL;
+	}
+
+	for (size_t r = 0; r < src->rows; r++)
+		for (size_t c = 0; c < src->cols; c++)
+			FMAT_SET(dest, c, r, FMAT_GET(src, r, c));
+
+	return dest;
+}
+
+static int fmat_lup_decompose(struct fmatrix *a, size_t *perm, double *sign)
+{
+	const size_t n = a->rows;
+	const double eps = 1e-12;
+
+	for (size_t i = 0; i < n; ++i)
+		perm[i] = i;
+
+	*sign = 1.0;
+
+	for (size_t k = 0; k < n; ++k) {
+		size_t pivot_row = k;
+		double max_abs = fabs(a->data[k * n + k]);
+
+		for (size_t i = k + 1; i < n; ++i) {
+			double v = fabs(a->data[i * n + k]);
+			if (v > max_abs) {
+				max_abs = v;
+				pivot_row = i;
+			}
+		}
+
+		if (max_abs < eps)
+			return -1;
+
+		if (pivot_row != k) {
+			for (size_t j = 0; j < n; ++j) {
+				double t = a->data[k * n + j];
+				a->data[k * n + j] = a->data[pivot_row * n + j];
+				a->data[pivot_row * n + j] = t;
+			}
+			size_t tp = perm[k];
+			perm[k] = perm[pivot_row];
+			perm[pivot_row] = tp;
+			*sign = -*sign;
+		}
+
+		double pivot = a->data[k * n + k];
+
+		for (size_t i = k + 1; i < n; ++i) {
+			double *row_i = &a->data[i * n];
+			double *row_k = &a->data[k * n];
+			row_i[k] /= pivot;
+			double lik = row_i[k];
+			for (size_t j = k + 1; j < n; ++j)
+				row_i[j] -= lik * row_k[j];
+		}
+	}
+
+	return 0;
+}
+
+static void fmat_lu_solve(const struct fmatrix *lu, const size_t *perm, const double *b, double *x)
+{
+	const size_t n = lu->rows;
+
+	for (size_t i = 0; i < n; ++i) {
+		double sum = b[perm[i]];
+		for (size_t j = 0; j < i; ++j)
+			sum -= lu->data[i * n + j] * x[j];
+		x[i] = sum;
+	}
+
+	for (size_t i = n; i-- > 0;) {
+		double sum = x[i];
+		for (size_t j = i + 1; j < n; ++j)
+			sum -= lu->data[i * n + j] * x[j];
+		x[i] = sum / lu->data[i * n + i];
+	}
+}
+
+struct fmatrix *fmat_inv_lup(struct fmatrix *dest, const struct fmatrix *src)
+{
+	struct fmatrix *lu = NULL;
+	int dest_allocated = 0;
+	size_t *perm = NULL;
+	double *rhs = NULL;
+	double *sol = NULL;
+	int error = -1;
+	double sign;
+
+	if (!src || src->rows != src->cols) {
+		errno = EINVAL;
+		goto out;
+	}
+
+	size_t n = src->rows;
+
+	if (dest) {
+		if (dest->rows != n || dest->cols != n) {
+			errno = EINVAL;
+			goto out;
+		}
+	} else {
+		dest = fmat_alloc(n, n);
+		if (!dest)
+			goto out;
+		dest_allocated = 1;
+	}
+
+	lu = fmat_alloc(n, n);
+	perm = malloc(n * sizeof(*perm));
+	rhs = malloc(n * sizeof(*rhs));
+	sol = malloc(n * sizeof(*sol));
+	if (!lu || !perm || !rhs || !sol)
+		goto out;
+
+	memcpy(lu->data, src->data, n * n * sizeof(double));
+
+	if (fmat_lup_decompose(lu, perm, &sign) != 0) {
+		errno = EINVAL;
+		goto out;
+	}
+
+	for (size_t col = 0; col < n; ++col) {
+		memset(rhs, 0, n * sizeof(*rhs));
+		rhs[col] = 1.0;
+		fmat_lu_solve(lu, perm, rhs, sol);
+
+		for (size_t row = 0; row < n; ++row)
+			dest->data[row * n + col] = sol[row];
+	}
+
+	error = 0;
+
+out:
+	free(sol);
+	free(rhs);
+	free(perm);
+	fmat_free(lu);
+
+	if (error) {
+		if (dest_allocated)
+			fmat_free(dest);
+		perror(__func__);
+		return NULL;
+	}
+
+	return dest;
+}
+
+static int fmat_inv_2x2(const struct fmatrix *src, struct fmatrix *dest)
+{
+	const double a = src->data[0];
+	const double b = src->data[1];
+	const double c = src->data[2];
+	const double d = src->data[3];
+
+	const double det = a * d - b * c;
+	if (fabs(det) < 1e-12)
+		return -1;
+
+	const double inv_det = 1.0 / det;
+
+	dest->data[0] = d * inv_det;
+	dest->data[1] = -b * inv_det;
+	dest->data[2] = -c * inv_det;
+	dest->data[3] = a * inv_det;
+
+	return 0;
+}
+
+static int fmat_inv_3x3(const struct fmatrix *src, struct fmatrix *dest)
+{
+	const double *m = src->data;
+
+	const double a = m[0], b = m[1], c = m[2];
+	const double d = m[3], e = m[4], f = m[5];
+	const double g = m[6], h = m[7], i = m[8];
+
+	const double A = e * i - f * h;
+	const double B = -(d * i - f * g);
+	const double C = d * h - e * g;
+	const double D = -(b * i - c * h);
+	const double E = a * i - c * g;
+	const double F = -(a * h - b * g);
+	const double G = b * f - c * e;
+	const double H = -(a * f - c * d);
+	const double I = a * e - b * d;
+
+	const double det = a * A + b * B + c * C;
+	if (fabs(det) < 1e-12)
+		return -1;
+
+	const double inv_det = 1.0 / det;
+
+	dest->data[0] = A * inv_det;
+	dest->data[1] = D * inv_det;
+	dest->data[2] = G * inv_det;
+	dest->data[3] = B * inv_det;
+	dest->data[4] = E * inv_det;
+	dest->data[5] = H * inv_det;
+	dest->data[6] = C * inv_det;
+	dest->data[7] = F * inv_det;
+	dest->data[8] = I * inv_det;
+
+	return 0;
+}
+
+struct fmatrix *fmat_inv(struct fmatrix *dest, const struct fmatrix *src)
+{
+	if (!src || src->rows != src->cols) {
+		errno = EINVAL;
+		perror(__func__);
+		return NULL;
+	}
+
+	const size_t n = src->rows;
+
+	if (dest) {
+		if (dest->rows != n || dest->cols != n) {
+			errno = EINVAL;
+			perror(__func__);
+
+			return NULL;
+		}
+	} else {
+		dest = fmat_alloc(n, n);
+
+		if (!dest)
+			return NULL;
+	}
+
+	if (n == 1) {
+		if (fabs(src->data[0]) < 1e-12) {
+			fprintf(stderr, "%s: matrix is singular\n", __func__);
+			goto error;
+		}
+
+		dest->data[0] = 1.0 / src->data[0];
+
+		return dest;
+	}
+
+	if (n == 2) {
+		if (fmat_inv_2x2(src, dest) != 0) {
+			fprintf(stderr, "%s: matrix is singular\n", __func__);
+			goto error;
+		}
+
+		return dest;
+	}
+
+	if (n == 3) {
+		if (fmat_inv_3x3(src, dest) != 0) {
+			fprintf(stderr, "%s: matrix is singular\n", __func__);
+			goto error;
+		}
+
+		return dest;
+	}
+
+	return fmat_inv_lup(dest, src);
+
+error:
+	fmat_free(dest);
+	return NULL;
+}

--- a/lib/xwax/fmatrix.h
+++ b/lib/xwax/fmatrix.h
@@ -1,0 +1,46 @@
+#ifndef FMATRIX_H
+#define FMATRIX_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Scalar type for matrix elements */
+typedef double fval_t;
+
+#ifdef DEBUG
+#define FMAT_SET(m, row, col, val) fmat_set(m, row, col, val)
+#define FMAT_GET(m, row, col) fmat_get(m, row, col)
+#else
+#define FMAT_SET(m, row, col, val) fmat_set_unsafe(m, row, col, val)
+#define FMAT_GET(m, row, col) fmat_get_unsafe(m, row, col)
+#endif
+
+/* Allocate an empty floating-point matrix */
+struct fmatrix *fmat_alloc(const size_t rows, const size_t cols);
+/* Delete a floating-point matrix */
+void fmat_free(struct fmatrix *m);
+
+/* Set a single field of a floating-point matrix (slower safe version for testing) */
+void fmat_set(struct fmatrix *m, size_t row, size_t col, fval_t val);
+/* Set a single field of a floating-point matrix (unsafe inlined version) */
+void fmat_set_unsafe(struct fmatrix *m, size_t row, size_t col, fval_t val);
+/* Get a single field of a floating-point matrix (slower safe version for testing) */
+fval_t fmat_get(const struct fmatrix *m, size_t row, size_t col);
+/* Get a single field of a floating-point matrix (unsafe inlined version) */
+fval_t fmat_get_unsafe(const struct fmatrix *m, size_t row, size_t col);
+
+/* Multiply two floating-point matrices */
+struct fmatrix *fmat_mul(struct fmatrix *dest, const struct fmatrix *a, const struct fmatrix *b);
+/* Transpose a floating-point matrix */
+struct fmatrix *fmat_trans(struct fmatrix *dest, const struct fmatrix *src);
+/* Compute the inverse of a floating-point matrix */
+struct fmatrix *fmat_inv(struct fmatrix *dest, const struct fmatrix *src);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FMATRIX_H */

--- a/lib/xwax/pitch.h
+++ b/lib/xwax/pitch.h
@@ -27,13 +27,13 @@
 
 /* State of the pitch calculation filter */
 
-struct pitch {
+struct pitch_filter {
     double dt, x, v;
 };
 
 /* Prepare the filter for observations every dt seconds */
 
-static inline void pitch_init(struct pitch *p, double dt)
+static inline void pitch_init(struct pitch_filter *p, double dt)
 {
     p->dt = dt;
     p->x = 0.0;
@@ -46,7 +46,7 @@ static inline void pitch_init(struct pitch *p, double dt)
  * Because the vinyl uses timestamps, the values for dx are discrete
  * rather than smooth. */
 
-static inline void pitch_dt_observation(struct pitch *p, double dx)
+static inline void pitch_dt_observation(struct pitch_filter *p, double dx)
 {
     double predicted_x, predicted_v, residual_x;
 
@@ -63,7 +63,7 @@ static inline void pitch_dt_observation(struct pitch *p, double dx)
 
 /* Get the pitch after filtering */
 
-static inline double pitch_current(struct pitch *p)
+static inline double pitch_current(struct pitch_filter *p)
 {
     return p->v;
 }

--- a/lib/xwax/pitch.h
+++ b/lib/xwax/pitch.h
@@ -61,11 +61,4 @@ static inline void pitch_dt_observation(struct pitch_filter *p, double dx)
     p->x -= dx; /* relative to previous */
 }
 
-/* Get the pitch after filtering */
-
-static inline double pitch_current(struct pitch_filter *p)
-{
-    return p->v;
-}
-
 #endif

--- a/lib/xwax/pitch_kalman.c
+++ b/lib/xwax/pitch_kalman.c
@@ -32,7 +32,7 @@ static inline double pow3(double val)
  * r: variance of dx measurement (tune up if observations are noisier)
  */
 
-void pitch_kalman_init(struct pitch_kalman *p, double dt, struct kalman_coeffs stable,
+void pitch_kalman_init(struct pitch_kalman_filter *p, double dt, struct kalman_coeffs stable,
                        struct kalman_coeffs adjust, struct kalman_coeffs reactive,
                        struct kalman_coeffs scratch, double adjust_threshold,
                        double reactive_threshold, double scratch_threshold, bool debug)
@@ -87,7 +87,7 @@ void pitch_kalman_init(struct pitch_kalman *p, double dt, struct kalman_coeffs s
  * Feed one observation: in the last dt seconds, position moved by dx
  */
 
-void pitch_kalman_update(struct pitch_kalman* p, double dx)
+void pitch_kalman_update(struct pitch_kalman_filter* p, double dx)
 {
     if (!p) {
         errno = EINVAL;

--- a/lib/xwax/pitch_kalman.c
+++ b/lib/xwax/pitch_kalman.c
@@ -211,6 +211,10 @@ void pitch_kalman_update(struct pitch_kalman* p, double dx)
 
     const double S = P_pred[x][x] + p->coeffs->R;
 
+    /* Check for division by zero */
+    if (S == 0.0)
+        return;
+
     /*
      * Kalman gain: K = P_pred * H^T * S^-1
      *

--- a/lib/xwax/pitch_kalman.h
+++ b/lib/xwax/pitch_kalman.h
@@ -93,22 +93,4 @@ static inline void kalman_tune_sensitivity(struct pitch_kalman_filter* p, struct
     p->coeffs = coeffs;
 }
 
-
-/*
- * Get the current pitch (velocity estimate)
- */
-
-static inline double pitch_kalman_current(const struct pitch_kalman_filter* p)
-{
-    if (!p) {
-        errno = EINVAL;
-        perror(__func__);
-        return 0.0;
-    }
-
-    /* Return the velocity Xk[v] relative to carrier frequency of the timecode (normalized) */
-
-    return p->Xk[1];
-}
-
 #endif /* PITCH_KALMAN_H */

--- a/lib/xwax/pitch_kalman.h
+++ b/lib/xwax/pitch_kalman.h
@@ -22,8 +22,7 @@
  *
  * Modes:
  *   stable  : Low Q and high R for stable playback
- *   adjust  : Medium values for slight pitch changes
- *   reactive: High Q and low R for high reactivity (scratching)
+ *   scratch : High Q and low R for high reactivity (scratching)
  */
 
 #ifndef PITCH_KALMAN_H
@@ -57,25 +56,22 @@ struct pitch_kalman_filter {
 
     double P[2][2];
 
-    /* Thresholds of the innovation quantity for the mode switches */
+    /* Thresholds of the innovation quantity for the mode switch */
 
-    double scratch_threshold, reactive_threshold, adjust_threshold;
+    double scratch_threshold;
 
     /* Currently used coefficients*/
 
     struct kalman_coeffs* coeffs;
 
-    /* Stable, adjust reactive coefficients for the mode switch */
+    /* Stable and scratch coefficients for the mode switch */
 
     struct kalman_coeffs stable;
-    struct kalman_coeffs adjust;
-    struct kalman_coeffs reactive;
     struct kalman_coeffs scratch;
 };
 
 void pitch_kalman_init(struct pitch_kalman_filter *p, double dt, struct kalman_coeffs stable,
-                       struct kalman_coeffs adjust, struct kalman_coeffs reactive, struct kalman_coeffs scratch,
-                       double adjust_threshold, double reactive_threshold, double scratch_threshold, bool debug);
+                       struct kalman_coeffs scratch, double scratch_threshold, bool debug);
 void pitch_kalman_update(struct pitch_kalman_filter *p, double dx);
 
 /*

--- a/lib/xwax/pitch_kalman.h
+++ b/lib/xwax/pitch_kalman.h
@@ -43,7 +43,7 @@ struct kalman_coeffs {
 #define KALMAN_COEFFS(q_arg, r_arg) \
     (struct kalman_coeffs) {.Q = (q_arg), .R = (r_arg)}
 
-struct pitch_kalman {
+struct pitch_kalman_filter {
     /*
      * NOTE: In discrete time dt is usually denoted as Ts = 1/Fs,
      * but xwax uses the continuous notation.
@@ -73,16 +73,16 @@ struct pitch_kalman {
     struct kalman_coeffs scratch;
 };
 
-void pitch_kalman_init(struct pitch_kalman *p, double dt, struct kalman_coeffs stable,
+void pitch_kalman_init(struct pitch_kalman_filter *p, double dt, struct kalman_coeffs stable,
                        struct kalman_coeffs adjust, struct kalman_coeffs reactive, struct kalman_coeffs scratch,
                        double adjust_threshold, double reactive_threshold, double scratch_threshold, bool debug);
-void pitch_kalman_update(struct pitch_kalman *p, double dx);
+void pitch_kalman_update(struct pitch_kalman_filter *p, double dx);
 
 /*
  * Retune noise sensitivity without resetting state
  */
 
-static inline void kalman_tune_sensitivity(struct pitch_kalman* p, struct kalman_coeffs* coeffs)
+static inline void kalman_tune_sensitivity(struct pitch_kalman_filter* p, struct kalman_coeffs* coeffs)
 {
     if (!p || !coeffs) {
         errno = EINVAL;
@@ -98,7 +98,7 @@ static inline void kalman_tune_sensitivity(struct pitch_kalman* p, struct kalman
  * Get the current pitch (velocity estimate)
  */
 
-static inline double pitch_kalman_current(const struct pitch_kalman* p)
+static inline double pitch_kalman_current(const struct pitch_kalman_filter* p)
 {
     if (!p) {
         errno = EINVAL;

--- a/lib/xwax/ringbuffer.c
+++ b/lib/xwax/ringbuffer.c
@@ -48,13 +48,8 @@ void rb_free(struct ringbuffer *rb)
     if (!rb)
         return;
 
-    if (rb->data) {
-        free(rb->data);
-        rb->data = NULL;
-    }
-
+    free(rb->data);
     free(rb);
-    rb = NULL;
 }
 
 /*

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -422,7 +422,7 @@ static void init_channel(struct timecode_def *def, struct timecoder_channel *ch,
     ch->positive = false;
     ch->zero = 0;
 
-    ch->deriv_scaled = INT_MAX/2;
+    ch->deriv = INT_MAX/2;
     ch->rms = INT_MAX/2;
     ch->rms_deriv = 0;
 
@@ -524,9 +524,6 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
     tc->timecode_ticker = 0;
 
     tc->mon = NULL;
-
-    /* Compute the factor the scale up the derivative to the original level */
-    tc->gain_compensation = 1.0 / (M_PI * tc->def->resolution / tc->sample_rate);
 
     if (tc->def->flags & TRAKTOR_MK2) {
         mk2_subcode_init(&tc->upper_bitstream);
@@ -729,17 +726,10 @@ static inline double phase_difference(const int cos0, const int sin0,
 /*
  * Various processing of the carrier wave needed for pitch detection.
  *
- * Pushes samples into a delayline, computes the derivative, computes RMS
- * values and scales the derivative back up to the original signal's level.
+ * Pushes samples into a delayline, computes the derivative, filters it and
+ * computes RMS values.
  * Afterards the upscaled derivative can by processed by the pitch detection
  * algorithm.
- *
- * NOTE: Ideally the gain compensation should be done in the derivative and lowpass
- * filter structures by determining the amplitude response. I had this
- * implemented previously, but chose gain compensation by using the RMS value,
- * since it is easier to understand for developers not trained in signal
- * processing. Additionally it's nice to have the dB level at hand.
- *
  */
 
 static void process_carrier(struct timecoder *tc, signed int primary,
@@ -784,22 +774,11 @@ static void process_carrier(struct timecoder *tc, signed int primary,
     tc->secondary.rms_deriv =
         rms(&tc->secondary.rms_deriv_filter, tc->secondary.deriv);
 
-    /* Compute the gain compensation for the derivative*/
-    tc->gain_compensation = (double)tc->secondary.rms / tc->secondary.rms_deriv;
-
-    /* Without this limit pitch becomes too sensitive */
-    if (tc->gain_compensation > 25.0)
-        tc->gain_compensation = 25.0;
-
     tc->dB = 20 * log10((double)tc->secondary.rms / INT_MAX);
 
-    /* Compute the scaled derivative */
-    tc->primary.deriv_scaled = tc->primary.deriv * tc->gain_compensation;
-    tc->secondary.deriv_scaled = tc->secondary.deriv * tc->gain_compensation;
-
     /* Push the derivative samples into the ringbuffer */
-    rb_push(tc->primary.delayline_deriv, &tc->primary.deriv_scaled);
-    rb_push(tc->secondary.delayline_deriv, &tc->secondary.deriv_scaled);
+    rb_push(tc->primary.delayline_deriv, &tc->primary.deriv);
+    rb_push(tc->secondary.delayline_deriv, &tc->secondary.deriv);
 }
 
 /*
@@ -948,8 +927,8 @@ void timecoder_submit(struct timecoder *tc, signed short *pcm, size_t npcm)
              * two is necessary.
              */
 
-            update_monitor(tc, tc->primary.deriv_scaled * 2,
-                    tc->secondary.deriv_scaled * 2);
+            update_monitor(tc, tc->primary.deriv * 2,
+                    tc->secondary.deriv * 2);
         } else {
             process_sample(tc, primary, secondary);
             update_monitor(tc, left, right);

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -486,9 +486,9 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
     tc->direction_changed = false;
 
     if (tc->use_legacy_pitch_filter) {
-        pitch_init(&tc->pitch, tc->dt);
+        pitch_init(&tc->pitch_filter, tc->dt);
     } else {
-        pitch_kalman_init(&tc->pitch_kalman,
+        pitch_kalman_init(&tc->pitch_kalman_filter,
                           tc->dt,
                           KALMAN_COEFFS(1e-8, 10.0), /* stable mode */
                           KALMAN_COEFFS(1e-4, 1e-1), /* adjust mode */
@@ -865,9 +865,9 @@ static void process_sample(struct timecoder *tc,
 
     if (!tc->primary.swapped && !tc->secondary.swapped) {
         if (tc->use_legacy_pitch_filter)
-            pitch_dt_observation(&tc->pitch, 0.0);
+            pitch_dt_observation(&tc->pitch_filter, 0.0);
         else
-            pitch_kalman_update(&tc->pitch_kalman, 0.0);
+            pitch_kalman_update(&tc->pitch_kalman_filter, 0.0);
     } else {
         double dx;
 
@@ -882,9 +882,9 @@ static void process_sample(struct timecoder *tc,
             dx = -dx;
 
         if (tc->use_legacy_pitch_filter)
-            pitch_dt_observation(&tc->pitch, dx);
+            pitch_dt_observation(&tc->pitch_filter, dx);
         else
-            pitch_kalman_update(&tc->pitch_kalman, dx);
+            pitch_kalman_update(&tc->pitch_kalman_filter, dx);
     }
 
     /* If we have crossed the primary channel in the right polarity,

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -484,17 +484,25 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
     if (tc->use_legacy_pitch_filter) {
         pitch_init(&tc->pitch_filter, tc->dt);
     } else {
-        pitch_kalman_init(&tc->pitch_kalman_filter,
-                          tc->dt,
-                          KALMAN_COEFFS(1e-8, 10.0), /* stable mode */
-                          KALMAN_COEFFS(1e-4, 1e-1), /* adjust mode */
-                          KALMAN_COEFFS(1e-3, 1e-2), /* reactive mode */
-                          KALMAN_COEFFS(1e-1, 1e-4), /* scratch mode */
-                          6e-4, /* adjust threshold */
-                          25e-4, /* reactive threshold */
-                          40e-4, /* scratch threshold */
-                          false);
+        if (tc->def->flags & TRAKTOR_MK2) {
+            pitch_kalman_init(&tc->pitch_kalman_filter, tc->dt,
+                              KALMAN_COEFFS(1e-16, 1e-2), /* stable mode */
+                              KALMAN_COEFFS(0.0135, 8e-6), /* scratch mode */
+                              15, /* threshold */
+                              false);
+        } else {
+            pitch_kalman_init(&tc->pitch_kalman_filter, tc->dt,
+                              KALMAN_COEFFS(1e-16, 1e-2), /* stable mode */
+                              KALMAN_COEFFS(0.0235, 1e-5), /* scratch mode */
+                              5, /* threshold */
+                              false);
+        }
     }
+
+    tc->ref_level = INT_MAX;
+    tc->bitstream = 0;
+    tc->timecode = 0;
+    tc->valid_counter = 0;
 
     tc->ref_level = INT_MAX;
     tc->bitstream = 0;

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -485,6 +485,10 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
     tc->last_quadrant = 0;
     tc->direction_changed = false;
 
+    tc->dphi = 0.0;
+    tc->freq = 0.0;
+    tc->pitch = 0.0;
+
     if (tc->use_legacy_pitch_filter) {
         pitch_init(&tc->pitch_filter, tc->dt);
     } else {

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -453,6 +453,8 @@ static void init_channel(struct timecode_def *def, struct timecoder_channel *ch,
     if (window % 2 == 0)
         window++;
     ch->savgol_filter = savgol_create(window, 3);
+
+    rhpf_init(&ch->rumble_filter, sample_rate, 50.0 * ((double)def->resolution / 1000.0));
 }
 
 /*
@@ -753,6 +755,9 @@ static void process_carrier(struct timecoder *tc, signed int primary,
 
     rb_push(tc->primary.delayline, &primary);
     rb_push(tc->secondary.delayline, &secondary);
+
+    primary = rhpf_process(&tc->primary.rumble_filter, primary);
+    secondary = rhpf_process(&tc->secondary.rumble_filter, secondary);
 
     /* Compute the discrete derivative */
     tc->primary.deriv = derivative(&tc->primary.differentiator,

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -413,11 +413,14 @@ void mk2_subcode_init(struct mk2_subcode *sc)
 }
 
 /*
- * Initialise filter values for the MK2 demodulation
+ * Initialise filter values for one channel
  */
 
-static void init_mk2_channel(struct timecoder_channel *ch)
+static void init_channel(struct timecode_def *def, struct timecoder_channel *ch)
 {
+    ch->positive = false;
+    ch->zero = 0;
+
     ch->deriv_scaled = INT_MAX/2;
     ch->rms = INT_MAX/2;
     ch->rms_deriv = 0;
@@ -428,24 +431,17 @@ static void init_mk2_channel(struct timecoder_channel *ch)
         return;
     }
 
+    ch->delayline_deriv = rb_alloc(5, sizeof(int));
+    if (!ch->delayline_deriv) {
+        perror(__func__);
+        return;
+    }
+
     ewma_init(&ch->ewma_filter, 3e-1);
     derivative_init(&ch->differentiator);
+
     rms_init(&ch->rms_filter, 1e-3);
     rms_init(&ch->rms_deriv_filter, 1e-3);
-}
-
-
-/*
- * Initialise filter values for one channel
- */
-
-static void init_channel(struct timecode_def *def, struct timecoder_channel *ch)
-{
-    ch->positive = false;
-    ch->zero = 0;
-
-    if (def->flags & TRAKTOR_MK2)
-        init_mk2_channel(ch);
 }
 
 /*
@@ -480,10 +476,6 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
     init_channel(tc->def, &tc->secondary);
 
     tc->use_legacy_pitch_filter = pitch_estimator; /* Switch for pitch filter type */
-
-    tc->quadrant = 0;
-    tc->last_quadrant = 0;
-    tc->direction_changed = false;
 
     tc->dphi = 0.0;
     tc->freq = 0.0;
@@ -688,59 +680,6 @@ static void process_bitstream(struct timecoder *tc, signed int m)
 }
 
 /*
- * Compare the last quadrant we were in to the new one and return the
- * correct displacement for the pitch filter model.
- *
- * A full revolution of the carrier has the length of 1.0 / tc->def->resolution,
- * which is also the sample rate of the timecode (not the audio). One quadrant
- * corresponds to 1/4 * revolution, which is the time between two zero
- * crossings. Hence we multiply this quantity by displacement in quadrants.
- */
-
-static double quantize_phase(struct timecoder *tc)
-{
-    unsigned diff = ((tc->quadrant - tc->last_quadrant) % 4);
-    static unsigned long long direction_change_counter = 0;
-    const unsigned int forwards_diff = (tc->def->flags & SWITCH_PHASE) ? 1 : 3;
-    const unsigned int backwards_diff = (tc->def->flags & SWITCH_PHASE) ? 3 : 1;
-
-    /* Check for a displacement of four quadrants */
-    if (diff == 0 && !tc->direction_changed) {
-        return 1.0 / tc->def->resolution;
-    }
-    
-    /* Check for a displacement of three quadrants */
-    if ((tc->forwards && diff == forwards_diff) || (!tc->forwards && diff == backwards_diff)) {
-        return (3.0 / tc->def->resolution) / 4.0;
-    }
-    
-    /* Check for a displacement of two quadrants  */
-    if (diff == 2) {
-        return (1.0 / tc->def->resolution) / 2.0;
-    }
-    
-    return (1.0 / tc->def->resolution) / 4.0;
-}
-
-/*
- * Track the quadrature phase of the pitch counter on the unit circle
- *
- * There are four zero crossings in a whole cycle. In between are the four
- * quadrants of the sine and cosine, which are in quadrature.
- */
-
-static void track_quadrature_phase(struct timecoder *tc, bool direction_changed)
-{
-    tc->last_quadrant = tc->quadrant;
-    tc->direction_changed = direction_changed;
-
-    bool pos = tc->primary.swapped ? tc->primary.positive : tc->secondary.positive;
-    bool add = tc->secondary.swapped ? 0b1 : 0b0;
-
-    tc->quadrant = (!pos << 1) | add;
-}
-
-/*
  * Computes the phase difference of a given sine-cosine pair using
  * complex number theory in ARM Q1.31 fixed-point format for max efficiency.
  */
@@ -814,6 +753,10 @@ static void process_carrier(struct timecoder *tc, signed int primary,
     /* Compute the scaled derivative */
     tc->primary.deriv_scaled = tc->primary.deriv * tc->gain_compensation;
     tc->secondary.deriv_scaled = tc->secondary.deriv * tc->gain_compensation;
+
+    /* Push the derivative samples into the ringbuffer */
+    rb_push(tc->primary.delayline_deriv, &tc->primary.deriv_scaled);
+    rb_push(tc->secondary.delayline_deriv, &tc->secondary.deriv_scaled);
 }
 
 /*
@@ -827,69 +770,50 @@ static void process_sample(struct timecoder *tc,
 			   signed int primary, signed int secondary)
 {
     if (tc->def->flags & TRAKTOR_MK2) {
-        process_carrier(tc, primary, secondary);
-
         detect_zero_crossing(&tc->primary, tc->primary.deriv_scaled, tc->zero_alpha,
                 tc->threshold);
         detect_zero_crossing(&tc->secondary, tc->secondary.deriv_scaled, tc->zero_alpha,
                 tc->threshold);
-
     } else {
         detect_zero_crossing(&tc->primary, primary, tc->zero_alpha, tc->threshold);
         detect_zero_crossing(&tc->secondary, secondary, tc->zero_alpha, tc->threshold);
     }
 
-    /* If an axis has been crossed, use the direction of the crossing
-     * to work out the direction of the vinyl */
+    if (tc->dB > -45.0) { // Ignore noise
+        tc->dphi =
+            phase_difference(*(int*)rb_at(tc->primary.delayline_deriv, 0),
+                             *(int*)rb_at(tc->secondary.delayline_deriv, 0),
+                             *(int*)rb_at(tc->primary.delayline_deriv, 1),
+                             *(int*)rb_at(tc->secondary.delayline_deriv, 1));
 
-    if (tc->primary.swapped || tc->secondary.swapped) {
-        bool forwards;
+        double ddphi = 0.0; /* Derivative of the phase difference */
 
-        if (tc->primary.swapped) {
-            forwards = (tc->primary.positive != tc->secondary.positive);
+        if (tc->use_legacy_pitch_filter) {
+            pitch_dt_observation(&tc->pitch_filter, tc->dphi);
+            ddphi = tc->pitch_filter.v;
         } else {
-            forwards = (tc->primary.positive == tc->secondary.positive);
+            pitch_kalman_update(&tc->pitch_kalman_filter, tc->dphi);
+            ddphi = tc->pitch_kalman_filter.Xk[1];
         }
 
-        if (tc->def->flags & SWITCH_PHASE)
-	    forwards = !forwards;
-
-        track_quadrature_phase(tc, forwards != tc->forwards);
-
-        if (forwards != tc->forwards) { /* direction has changed */
-            tc->forwards = forwards;
-            tc->valid_counter = 0;
-        }
-    }
-
-    /*
-     * If any axis has been crossed, register movement using the pitch
-     * counters. This occurs four time per cycle of the sinusoid.
-     */
-
-    if (!tc->primary.swapped && !tc->secondary.swapped) {
-        if (tc->use_legacy_pitch_filter)
-            pitch_dt_observation(&tc->pitch_filter, 0.0);
-        else
-            pitch_kalman_update(&tc->pitch_kalman_filter, 0.0);
+        tc->freq = ddphi / (2.0 * M_PI);
+        tc->pitch = (tc->freq / tc->def->resolution);
     } else {
-        double dx;
-
-        /*
-         * Assumption: We usually advance by a quarter rotation,
-         * unless we skip zero crossings. In this case the new quadrature
-         * tracker calculates the correct displacement for the pitch filter.
-         */
-
-        dx = quantize_phase(tc);
-        if (!tc->forwards)
-            dx = -dx;
-
-        if (tc->use_legacy_pitch_filter)
-            pitch_dt_observation(&tc->pitch_filter, dx);
-        else
-            pitch_kalman_update(&tc->pitch_kalman_filter, dx);
+        tc->freq = 0.0;
+        tc->pitch = 0.0;
     }
+
+    bool forwards = tc->forwards;
+    if (tc->freq > 0.0)
+        forwards = true;
+    else if (tc->freq < 0.0)
+        forwards = false;
+
+    if (tc->def->flags & SWITCH_PHASE)
+        forwards = !forwards;
+
+    if (forwards != tc->forwards) /* direction has changed */
+        tc->forwards = forwards;
 
     /* If we have crossed the primary channel in the right polarity,
      * it's time to read off a timecode 0 or 1 value */
@@ -968,6 +892,8 @@ void timecoder_submit(struct timecoder *tc, signed short *pcm, size_t npcm)
             primary = right;
             secondary = left;
         }
+
+        process_carrier(tc, primary, secondary);
 
         if (tc->def->flags & TRAKTOR_MK2) {
             process_sample(tc, primary, secondary);

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -402,10 +402,7 @@ void mk2_subcode_init(struct mk2_subcode *sc)
     sc->bit = U128_ZERO;
 
     sc->readings = rb_alloc(3, sizeof(int));
-    if (!sc->readings) {
-        perror(__func__);
-        return;
-    }
+    assert(sc->readings);
 
     /* Initialise smoothing filters */
     ewma_init(&sc->ewma_reading, 0.01);
@@ -427,16 +424,10 @@ static void init_channel(struct timecode_def *def, struct timecoder_channel *ch,
     ch->rms_deriv = 0;
 
     ch->delayline = rb_alloc(5, sizeof(int));
-    if (!ch->delayline) {
-        perror(__func__);
-        return;
-    }
+    assert(ch->delayline);
 
     ch->delayline_deriv = rb_alloc(5, sizeof(int));
-    if (!ch->delayline_deriv) {
-        perror(__func__);
-        return;
-    }
+    assert(ch->delayline_deriv);
 
     ewma_init_adaptive(&ch->ewma_filter, 5e-2, def->resolution, sample_rate);
     derivative_init(&ch->differentiator);
@@ -452,7 +443,9 @@ static void init_channel(struct timecode_def *def, struct timecoder_channel *ch,
     size_t window = (size_t)ceil(sample_rate / def->resolution)/4;
     if (window % 2 == 0)
         window++;
+
     ch->savgol_filter = savgol_create(window, 3);
+    assert(ch->savgol_filter);
 
     rhpf_init(&ch->rumble_filter, sample_rate, 50.0 * ((double)def->resolution / 1000.0));
 }

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -418,20 +418,20 @@ void mk2_subcode_init(struct mk2_subcode *sc)
 
 static void init_mk2_channel(struct timecoder_channel *ch)
 {
-    ch->mk2.deriv_scaled = INT_MAX/2;
-    ch->mk2.rms = INT_MAX/2;
-    ch->mk2.rms_deriv = 0;
+    ch->deriv_scaled = INT_MAX/2;
+    ch->rms = INT_MAX/2;
+    ch->rms_deriv = 0;
 
-    ch->mk2.delayline = rb_alloc(5, sizeof(int));
-    if (!ch->mk2.delayline) {
+    ch->delayline = rb_alloc(5, sizeof(int));
+    if (!ch->delayline) {
         perror(__func__);
         return;
     }
 
-    ewma_init(&ch->mk2.ewma_filter, 3e-1);
-    derivative_init(&ch->mk2.differentiator);
-    rms_init(&ch->mk2.rms_filter, 1e-3);
-    rms_init(&ch->mk2.rms_deriv_filter, 1e-3);
+    ewma_init(&ch->ewma_filter, 3e-1);
+    derivative_init(&ch->differentiator);
+    rms_init(&ch->rms_filter, 1e-3);
+    rms_init(&ch->rms_deriv_filter, 1e-3);
 }
 
 
@@ -525,9 +525,12 @@ void timecoder_clear(struct timecoder *tc)
 {
     assert(tc->mon == NULL);
 
+    rb_free(tc->primary.delayline);
+    rb_free(tc->secondary.delayline);
+    rb_free(tc->primary.delayline_deriv);
+    rb_free(tc->secondary.delayline_deriv);
+
     if (tc->def->flags & TRAKTOR_MK2) {
-        rb_free(tc->primary.mk2.delayline);
-        rb_free(tc->secondary.mk2.delayline);
         rb_free(tc->upper_bitstream.readings);
         rb_free(tc->lower_bitstream.readings);
     }
@@ -750,6 +753,66 @@ static inline double phase_difference(const int cos0, const int sin0,
 }
 
 /*
+ * Various processing of the carrier wave needed for pitch detection.
+ *
+ * Pushes samples into a delayline, computes the derivative, computes RMS
+ * values and scales the derivative back up to the original signal's level.
+ * Afterards the upscaled derivative can by processed by the pitch detection
+ * algorithm.
+ *
+ * NOTE: Ideally the gain compensation should be done in the derivative and lowpass
+ * filter structures by determining the amplitude response. I had this
+ * implemented previously, but chose gain compensation by using the RMS value,
+ * since it is easier to understand for developers not trained in signal
+ * processing. Additionally it's nice to have the dB level at hand.
+ *
+ */
+
+static void process_carrier(struct timecoder *tc, signed int primary,
+    signed int secondary)
+{
+    if (!tc) {
+        errno = EINVAL;
+        perror(__func__);
+        return;
+    }
+
+    /* Push the samples into the ringbuffer */
+
+    rb_push(tc->primary.delayline, &primary);
+    rb_push(tc->secondary.delayline, &secondary);
+
+    /* Compute the discrete derivative */
+    tc->primary.deriv = derivative(&tc->primary.differentiator,
+        ewma(&tc->primary.ewma_filter, primary));
+    tc->secondary.deriv = derivative(&tc->secondary.differentiator,
+        ewma(&tc->secondary.ewma_filter, secondary));
+
+    /* Compute the smoothed RMS value */
+    tc->primary.rms = rms(&tc->primary.rms_filter, primary);
+    tc->secondary.rms = rms(&tc->secondary.rms_filter, secondary);
+
+    /* Compute the smoothed RMS value for the derivative */
+    tc->primary.rms_deriv =
+        rms(&tc->primary.rms_deriv_filter, tc->primary.deriv);
+    tc->secondary.rms_deriv =
+        rms(&tc->secondary.rms_deriv_filter, tc->secondary.deriv);
+
+    /* Compute the gain compensation for the derivative*/
+    tc->gain_compensation = (double)tc->secondary.rms / tc->secondary.rms_deriv;
+
+    /* Without this limit pitch becomes too sensitive */
+    if (tc->gain_compensation > 25.0)
+        tc->gain_compensation = 25.0;
+
+    tc->dB = 20 * log10((double)tc->secondary.rms / INT_MAX);
+
+    /* Compute the scaled derivative */
+    tc->primary.deriv_scaled = tc->primary.deriv * tc->gain_compensation;
+    tc->secondary.deriv_scaled = tc->secondary.deriv * tc->gain_compensation;
+}
+
+/*
  * Process a single sample from the incoming audio
  *
  * The two input signals (primary and secondary) are in the full range
@@ -760,11 +823,11 @@ static void process_sample(struct timecoder *tc,
 			   signed int primary, signed int secondary)
 {
     if (tc->def->flags & TRAKTOR_MK2) {
-        mk2_process_carrier(tc, primary, secondary);
+        process_carrier(tc, primary, secondary);
 
-        detect_zero_crossing(&tc->primary, tc->primary.mk2.deriv_scaled, tc->zero_alpha,
+        detect_zero_crossing(&tc->primary, tc->primary.deriv_scaled, tc->zero_alpha,
                 tc->threshold);
-        detect_zero_crossing(&tc->secondary, tc->secondary.mk2.deriv_scaled, tc->zero_alpha,
+        detect_zero_crossing(&tc->secondary, tc->secondary.deriv_scaled, tc->zero_alpha,
                 tc->threshold);
 
     } else {
@@ -830,7 +893,7 @@ static void process_sample(struct timecoder *tc,
     if (tc->def->flags & TRAKTOR_MK2) {
         if (tc->secondary.swapped)
         {
-            int reading = *(int*)rb_at(tc->secondary.mk2.delayline, 3);
+            int reading = *(int*)rb_at(tc->secondary.delayline, 3);
             mk2_process_timecode(tc, reading);
         }
     } else {
@@ -912,8 +975,8 @@ void timecoder_submit(struct timecoder *tc, signed short *pcm, size_t npcm)
              * two is necessary.
              */
 
-            update_monitor(tc, tc->primary.mk2.deriv_scaled * 2,
-                    tc->secondary.mk2.deriv_scaled * 2);
+            update_monitor(tc, tc->primary.deriv_scaled * 2,
+                    tc->secondary.deriv_scaled * 2);
         } else {
             process_sample(tc, primary, secondary);
             update_monitor(tc, left, right);

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -401,7 +401,7 @@ void mk2_subcode_init(struct mk2_subcode *sc)
     sc->avg_slope = INT_MAX/2;
     sc->bit = U128_ZERO;
 
-    sc->readings = rb_alloc(5, sizeof(int));
+    sc->readings = rb_alloc(3, sizeof(int));
     if (!sc->readings) {
         perror(__func__);
         return;
@@ -416,7 +416,8 @@ void mk2_subcode_init(struct mk2_subcode *sc)
  * Initialise filter values for one channel
  */
 
-static void init_channel(struct timecode_def *def, struct timecoder_channel *ch)
+static void init_channel(struct timecode_def *def, struct timecoder_channel *ch,
+    unsigned int sample_rate)
 {
     ch->positive = false;
     ch->zero = 0;
@@ -442,6 +443,16 @@ static void init_channel(struct timecode_def *def, struct timecoder_channel *ch)
 
     rms_init(&ch->rms_filter, 1e-3);
     rms_init(&ch->rms_deriv_filter, 1e-3);
+
+    /*
+     * The ratio of the sampling rate and carrier frequency divided by four
+     * make for a good window size. This was concluded empirically.
+     */
+
+    size_t window = (size_t)ceil(sample_rate / def->resolution)/4;
+    if (window % 2 == 0)
+        window++;
+    ch->savgol_filter = savgol_create(window, 3);
 }
 
 /*
@@ -472,8 +483,8 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
         tc->threshold >>= 5; /* approx -36dB */
 
     tc->forwards = 1;
-    init_channel(tc->def, &tc->primary);
-    init_channel(tc->def, &tc->secondary);
+    init_channel(tc->def, &tc->primary, sample_rate);
+    init_channel(tc->def, &tc->secondary, sample_rate);
 
     tc->use_legacy_pitch_filter = pitch_estimator; /* Switch for pitch filter type */
 
@@ -538,6 +549,9 @@ void timecoder_clear(struct timecoder *tc)
         rb_free(tc->upper_bitstream.readings);
         rb_free(tc->lower_bitstream.readings);
     }
+
+    savgol_destroy(tc->primary.savgol_filter);
+    savgol_destroy(tc->secondary.savgol_filter);
 }
 
 /*
@@ -742,9 +756,18 @@ static void process_carrier(struct timecoder *tc, signed int primary,
 
     /* Compute the discrete derivative */
     tc->primary.deriv = derivative(&tc->primary.differentiator,
-        ewma(&tc->primary.ewma_filter, primary));
+        primary);
     tc->secondary.deriv = derivative(&tc->secondary.differentiator,
-        ewma(&tc->secondary.ewma_filter, secondary));
+        secondary);
+
+    tc->primary.deriv = ewma(&tc->primary.ewma_filter, tc->primary.deriv);
+    tc->secondary.deriv = ewma(&tc->secondary.ewma_filter, tc->secondary.deriv);
+
+    tc->primary.deriv_decoder = tc->primary.deriv;
+    tc->secondary.deriv_decoder = tc->secondary.deriv;
+
+    tc->primary.deriv = savgol(tc->primary.savgol_filter, tc->primary.deriv);
+    tc->secondary.deriv = savgol(tc->secondary.savgol_filter, tc->secondary.deriv);
 
     /* Compute the smoothed RMS value */
     tc->primary.rms = rms(&tc->primary.rms_filter, primary);
@@ -785,9 +808,9 @@ static void process_sample(struct timecoder *tc,
 			   signed int primary, signed int secondary)
 {
     if (tc->def->flags & TRAKTOR_MK2) {
-        detect_zero_crossing(&tc->primary, tc->primary.deriv_scaled, tc->zero_alpha,
+        detect_zero_crossing(&tc->primary, tc->primary.deriv_decoder, tc->zero_alpha,
                 tc->threshold);
-        detect_zero_crossing(&tc->secondary, tc->secondary.deriv_scaled, tc->zero_alpha,
+        detect_zero_crossing(&tc->secondary, tc->secondary.deriv_decoder, tc->zero_alpha,
                 tc->threshold);
     } else {
         detect_zero_crossing(&tc->primary, primary, tc->zero_alpha, tc->threshold);
@@ -836,7 +859,7 @@ static void process_sample(struct timecoder *tc,
     if (tc->def->flags & TRAKTOR_MK2) {
         if (tc->secondary.swapped)
         {
-            int reading = *(int*)rb_at(tc->secondary.delayline, 3);
+            int reading = *(int *)rb_at(tc->secondary.delayline, 3);
             mk2_process_timecode(tc, reading);
         }
     } else {

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -30,6 +30,7 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
+#include "complex.h"
 #include "debug.h"
 #include "filters.h"
 #include "timecoder.h"
@@ -730,6 +731,22 @@ static void track_quadrature_phase(struct timecoder *tc, bool direction_changed)
     bool add = tc->secondary.swapped ? 0b1 : 0b0;
 
     tc->quadrant = (!pos << 1) | add;
+}
+
+/*
+ * Computes the phase difference of a given sine-cosine pair using
+ * complex number theory in ARM Q1.31 fixed-point format for max efficiency.
+ */
+
+static inline double phase_difference(const int cos0, const int sin0,
+                                      const int cos1, const int sin1)
+{
+    struct complex_q31 z0 = { .re = cos0, .im = sin0 };
+    struct complex_q31 z1 = { .re = cos1, .im = sin1 };
+    struct complex_q31 z1_conj = complex_q31_conj(z1);
+    struct complex_q63 product = complex_q31_mul(z0, z1_conj);
+
+    return atan2((double)product.im, (double)product.re);
 }
 
 /*

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -408,8 +408,8 @@ void mk2_subcode_init(struct mk2_subcode *sc)
     }
 
     /* Initialise smoothing filters */
-    ema_init(&sc->ema_reading, 0.01);
-    ema_init(&sc->ema_slope, 0.01);
+    ewma_init(&sc->ewma_reading, 0.01);
+    ewma_init(&sc->ewma_slope, 0.01);
 }
 
 /*
@@ -428,7 +428,7 @@ static void init_mk2_channel(struct timecoder_channel *ch)
         return;
     }
 
-    ema_init(&ch->mk2.ema_filter, 3e-1);
+    ewma_init(&ch->mk2.ewma_filter, 3e-1);
     derivative_init(&ch->mk2.differentiator);
     rms_init(&ch->mk2.rms_filter, 1e-3);
     rms_init(&ch->mk2.rms_deriv_filter, 1e-3);

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -438,7 +438,7 @@ static void init_channel(struct timecode_def *def, struct timecoder_channel *ch,
         return;
     }
 
-    ewma_init(&ch->ewma_filter, 3e-1);
+    ewma_init_adaptive(&ch->ewma_filter, 5e-2, def->resolution, sample_rate);
     derivative_init(&ch->differentiator);
 
     rms_init(&ch->rms_filter, 1e-3);
@@ -843,7 +843,7 @@ static void process_sample(struct timecoder *tc,
     if (tc->def->flags & TRAKTOR_MK2) {
         if (tc->secondary.swapped)
         {
-            int reading = *(int *)rb_at(tc->secondary.delayline, 3);
+            int reading = *(int *)rb_at(tc->secondary.delayline, 2);
             mk2_process_timecode(tc, reading);
         }
     } else {

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -609,6 +609,13 @@ static inline void update_monitor(struct timecoder *tc, signed int x, signed int
     if (!tc->mon)
         return;
 
+    /* Only draw the monitor if the signal level is greater -40 dB */
+
+    if (tc->dB < -40.0) {
+        x = 0;
+        y = 0;
+    }
+
     size = tc->mon_size;
     ref = tc->ref_level;
 
@@ -906,7 +913,7 @@ void timecoder_submit(struct timecoder *tc, signed short *pcm, size_t npcm)
         if (tc->def->flags & TRAKTOR_MK2) {
             process_sample(tc, primary, secondary);
 
-            /* 
+            /*
              * Display the derivative in the monitor. Since the signal is not
              * a perfect ring on the x-y-plane, but jumps up and down a bit,
              * it looks to small in the scope. Therefore a multiplication by

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -831,8 +831,11 @@ static void process_sample(struct timecoder *tc,
     else if (tc->freq < 0.0)
         forwards = false;
 
-    if (tc->def->flags & SWITCH_PHASE)
+    if (tc->def->flags & SWITCH_PHASE) {
+        tc->pitch = -tc->pitch;
+        tc->freq = -tc->freq;
         forwards = !forwards;
+    }
 
     if (forwards != tc->forwards) /* direction has changed */
         tc->forwards = forwards;

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -61,14 +61,14 @@ struct timecoder_channel {
     unsigned int crossing_ticker; /* samples since we last crossed zero */
 
     int rms, rms_deriv; /* RMS values for the signal and its derivative */
-    signed int deriv, deriv_scaled; /* Derivative and its scaled version */
+    signed int deriv, deriv_decoder, deriv_scaled; /* Derivative and its scaled version */
 
     struct ringbuffer *delayline; /* needed for the pitch detection*/
     struct ringbuffer *delayline_deriv; /* needed for the pitch detection*/
     struct ewma_filter ewma_filter;
     struct differentiator differentiator;
     struct root_mean_square rms_filter, rms_deriv_filter;
-
+    struct savitzky_golay *savgol_filter;
 };
 
 struct mk2_subcode {

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -101,8 +101,8 @@ struct timecoder {
     struct timecoder_channel primary, secondary;
 
     bool use_legacy_pitch_filter;
-    struct pitch pitch;
-    struct pitch_kalman pitch_kalman;
+    struct pitch_filter pitch_filter;
+    struct pitch_kalman_filter pitch_kalman_filter;
     unsigned quadrant, last_quadrant;
     bool direction_changed;
 
@@ -156,9 +156,9 @@ static inline struct timecode_def* timecoder_get_definition(struct timecoder *tc
 static inline double timecoder_get_pitch(struct timecoder *tc)
 {
     if (tc->use_legacy_pitch_filter)
-        return pitch_current(&tc->pitch) / tc->speed;
+        return pitch_current(&tc->pitch_filter) / tc->speed;
     else
-        return pitch_kalman_current(&tc->pitch_kalman) / tc->speed;
+        return pitch_kalman_current(&tc->pitch_kalman_filter) / tc->speed;
 }
 
 /*

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -59,7 +59,7 @@ struct timecoder_channel_mk2 {
     signed int deriv, deriv_scaled; /* Derivative and its scaled version */
 
     struct ringbuffer *delayline; /* needed for the Traktor MK2 demodulation */
-    struct ema_filter ema_filter;
+    struct ewma_filter ema_filter;
     struct differentiator differentiator;
     struct root_mean_square rms_filter, rms_deriv_filter;
 };
@@ -84,8 +84,8 @@ struct mk2_subcode {
     bool recent_bit_flip;
 
     struct ringbuffer *readings;
-    struct ema_filter ema_reading;
-    struct ema_filter ema_slope;
+    struct ewma_filter ewma_reading;
+    struct ewma_filter ewma_slope;
 };
 
 struct timecoder {

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -61,7 +61,7 @@ struct timecoder_channel {
     unsigned int crossing_ticker; /* samples since we last crossed zero */
 
     int rms, rms_deriv; /* RMS values for the signal and its derivative */
-    signed int deriv, deriv_decoder, deriv_scaled; /* Derivative and its scaled version */
+    signed int deriv, deriv_decoder; /* Derivative */
 
     struct ringbuffer *delayline; /* needed for the pitch detection*/
     struct ringbuffer *delayline_deriv; /* needed for the pitch detection*/
@@ -129,7 +129,6 @@ struct timecoder {
     int mon_size, mon_counter;
 
     struct mk2_subcode upper_bitstream, lower_bitstream;
-    double gain_compensation; /* Scaling factor for the derivative */
 };
 
 struct timecode_def* timecoder_find_definition(const char *name, const char *lut_dir_path);

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -54,23 +54,20 @@ struct timecode_def {
     struct lut_mk2 lut_mk2; /* MK2 version */
 };
 
-struct timecoder_channel_mk2 {
-    int rms, rms_deriv; /* RMS values for the signal and its derivative */
-    signed int deriv, deriv_scaled; /* Derivative and its scaled version */
-
-    struct ringbuffer *delayline; /* needed for the Traktor MK2 demodulation */
-    struct ewma_filter ema_filter;
-    struct differentiator differentiator;
-    struct root_mean_square rms_filter, rms_deriv_filter;
-};
-
 struct timecoder_channel {
     bool positive, /* wave is in positive part of cycle */
 	swapped; /* wave recently swapped polarity */
     signed int zero;
     unsigned int crossing_ticker; /* samples since we last crossed zero */
 
-    struct timecoder_channel_mk2 mk2;
+    int rms, rms_deriv; /* RMS values for the signal and its derivative */
+    signed int deriv, deriv_scaled; /* Derivative and its scaled version */
+
+    struct ringbuffer *delayline; /* needed for the Traktor MK2 demodulation */
+    struct ewma_filter ewma_filter;
+    struct differentiator differentiator;
+    struct root_mean_square rms_filter, rms_deriv_filter;
+
 };
 
 struct mk2_subcode {

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -69,6 +69,7 @@ struct timecoder_channel {
     struct differentiator differentiator;
     struct root_mean_square rms_filter, rms_deriv_filter;
     struct savitzky_golay *savgol_filter;
+    struct rumble_filter rumble_filter;
 };
 
 struct mk2_subcode {

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -63,7 +63,8 @@ struct timecoder_channel {
     int rms, rms_deriv; /* RMS values for the signal and its derivative */
     signed int deriv, deriv_scaled; /* Derivative and its scaled version */
 
-    struct ringbuffer *delayline; /* needed for the Traktor MK2 demodulation */
+    struct ringbuffer *delayline; /* needed for the pitch detection*/
+    struct ringbuffer *delayline_deriv; /* needed for the pitch detection*/
     struct ewma_filter ewma_filter;
     struct differentiator differentiator;
     struct root_mean_square rms_filter, rms_deriv_filter;
@@ -102,8 +103,6 @@ struct timecoder {
     double dphi; /* Phase difference */
     double freq; /* Current carrier frequency */
     double pitch; /* Current pitch */
-
-    unsigned quadrant, last_quadrant;
 
     bool forwards;
     bool use_legacy_pitch_filter;
@@ -161,10 +160,7 @@ static inline struct timecode_def* timecoder_get_definition(struct timecoder *tc
 
 static inline double timecoder_get_pitch(struct timecoder *tc)
 {
-    if (tc->use_legacy_pitch_filter)
-        return pitch_current(&tc->pitch_filter) / tc->speed;
-    else
-        return pitch_kalman_current(&tc->pitch_kalman_filter) / tc->speed;
+        return tc->pitch / tc->speed;
 }
 
 /*

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -86,8 +86,10 @@ struct mk2_subcode {
 };
 
 struct timecoder {
+    struct timecoder_channel primary, secondary;
     struct timecode_def *def;
-    double speed;
+
+    double speed; /* 33 or 45 rpm */
 
     /* Precomputed values */
 
@@ -97,14 +99,18 @@ struct timecoder {
 
     /* Pitch information */
 
-    bool forwards;
-    struct timecoder_channel primary, secondary;
+    double dphi; /* Phase difference */
+    double freq; /* Current carrier frequency */
+    double pitch; /* Current pitch */
 
+    unsigned quadrant, last_quadrant;
+
+    bool forwards;
     bool use_legacy_pitch_filter;
+    bool direction_changed;
+
     struct pitch_filter pitch_filter;
     struct pitch_kalman_filter pitch_kalman_filter;
-    unsigned quadrant, last_quadrant;
-    bool direction_changed;
 
     /* Numerical timecode */
 

--- a/lib/xwax/timecoder_mk2.c
+++ b/lib/xwax/timecoder_mk2.c
@@ -472,7 +472,7 @@ void mk2_process_timecode(struct timecoder *tc, signed int reading)
     tc->timecode_ticker = 0;
 
     tc->ref_level -= tc->ref_level / REF_PEAKS_AVG;
-    tc->ref_level += abs((int)(tc->secondary.rms_deriv * tc->gain_compensation))
+    tc->ref_level += abs((int)(tc->secondary.rms_deriv))
         / REF_PEAKS_AVG;
 
     debug("upper.valid_counter: %d, lower.valid_counter %d, forwards: %b\n", */

--- a/lib/xwax/timecoder_mk2.c
+++ b/lib/xwax/timecoder_mk2.c
@@ -382,9 +382,9 @@ void mk2_process_carrier(struct timecoder *tc, signed int primary, signed int se
 
     /* Compute the discrete derivative */
     tc->primary.mk2.deriv = derivative(&tc->primary.mk2.differentiator,
-            ema(&tc->primary.mk2.ema_filter, primary));
+            ewma(&tc->primary.mk2.ewma_filter, primary));
     tc->secondary.mk2.deriv = derivative(&tc->secondary.mk2.differentiator,
-            ema(&tc->secondary.mk2.ema_filter, secondary));
+            ewma(&tc->secondary.mk2.ewma_filter, secondary));
 
     /* Compute the smoothed RMS value */
     tc->primary.mk2.rms = rms(&tc->primary.mk2.rms_filter, primary);
@@ -473,10 +473,10 @@ inline static void mk2_process_bitstream(struct timecoder *tc, struct mk2_subcod
 
     rb_push(sc->readings, &reading);
 
-    sc->avg_reading = ema(&sc->ema_reading, reading);
+    sc->avg_reading = ewma(&sc->ewma_reading, reading);
 
     /* Calculate absolute of average slope */
-    sc->avg_slope = ema(&sc->ema_slope, abs(reading - *(int*)rb_at(sc->readings, 1)));
+    sc->avg_slope = ewma(&sc->ewma_slope, abs(reading - *(int*)rb_at(sc->readings, 1)));
 
     /* Calculate current and last slope */
     current_slope[0] =  (reading - *(int*)rb_at(sc->readings, 1));

--- a/lib/xwax/timecoder_mk2.c
+++ b/lib/xwax/timecoder_mk2.c
@@ -353,62 +353,6 @@ error_fopen:
 }
 
 /*
- * Do Traktor-MK2-specific processing of the carrier wave
- *
- * Pushes samples into a delayline, computes the derivative, computes RMS
- * values and scales the derivative back up to the original signal's level.
- * Afterards the upscaled derivative can by processed by the pitch detection
- * algorithm.
- *
- * NOTE: Ideally the gain compensation should be done in the derivative and lowpass
- * filter structures by determining the amplitude response. I had this
- * implemented previously, but chose gain compensation by using the RMS value,
- * since it is easier to understand for developers not trained in signal
- * processing. Additionally it's nice to have the dB level at hand.
- *
- */
-
-void mk2_process_carrier(struct timecoder *tc, signed int primary, signed int secondary)
-{
-    if (!tc) {
-        errno = -EINVAL;
-        perror(__func__);
-        return;
-    }
-
-    /* Push the samples into the ringbuffer */
-    rb_push(tc->primary.mk2.delayline, &primary);
-    rb_push(tc->secondary.mk2.delayline, &secondary);
-
-    /* Compute the discrete derivative */
-    tc->primary.mk2.deriv = derivative(&tc->primary.mk2.differentiator,
-            ewma(&tc->primary.mk2.ewma_filter, primary));
-    tc->secondary.mk2.deriv = derivative(&tc->secondary.mk2.differentiator,
-            ewma(&tc->secondary.mk2.ewma_filter, secondary));
-
-    /* Compute the smoothed RMS value */
-    tc->primary.mk2.rms = rms(&tc->primary.mk2.rms_filter, primary);
-    tc->secondary.mk2.rms = rms(&tc->secondary.mk2.rms_filter, secondary);
-
-    /* Compute the smoothed RMS value for the derivative */
-    tc->primary.mk2.rms_deriv = rms(&tc->primary.mk2.rms_deriv_filter, tc->primary.mk2.deriv);
-    tc->secondary.mk2.rms_deriv = rms(&tc->secondary.mk2.rms_deriv_filter, tc->secondary.mk2.deriv);
-
-    /* Compute the gain compensation for the derivative*/
-    tc->gain_compensation = (double)tc->secondary.mk2.rms / tc->secondary.mk2.rms_deriv;
-
-    /* Without this limit pitch becomes too sensitive */
-    if (tc->gain_compensation > 25.0)
-        tc->gain_compensation = 25.0;
-
-    tc->dB = 20 * log10((double)tc->secondary.mk2.rms / INT_MAX);
-
-    /* Compute the scaled derivative */
-    tc->primary.mk2.deriv_scaled = tc->primary.mk2.deriv * tc->gain_compensation;
-    tc->secondary.mk2.deriv_scaled = tc->secondary.mk2.deriv * tc->gain_compensation;
-}
-
-/*
  * Detect if the upward or downward slope hits a threshold.
  * Upwards signifies a one and downwards a zero.
  */
@@ -483,7 +427,7 @@ inline static void mk2_process_bitstream(struct timecoder *tc, struct mk2_subcod
     current_slope[1] =  (reading - *(int*)rb_at(sc->readings, 2));
 
     /* The bits only change when an offset jump occurs. Else the previous bit is taken  */
-    detect_bit_flip(current_slope, tc->secondary.mk2.rms, reading, sc->avg_reading, &sc->bit,
+    detect_bit_flip(current_slope, tc->secondary.rms, reading, sc->avg_reading, &sc->bit,
                     &sc->recent_bit_flip, tc->forwards, U128(0x0, !tc->secondary.positive));
 
     if (lfsr_verify(tc->def, &sc->timecode, &sc->bitstream, sc->bit, tc->forwards)) {
@@ -528,7 +472,7 @@ void mk2_process_timecode(struct timecoder *tc, signed int reading)
     tc->timecode_ticker = 0;
 
     tc->ref_level -= tc->ref_level / REF_PEAKS_AVG;
-    tc->ref_level += abs((int)(tc->secondary.mk2.rms_deriv * tc->gain_compensation))
+    tc->ref_level += abs((int)(tc->secondary.rms_deriv * tc->gain_compensation))
         / REF_PEAKS_AVG;
 
     debug("upper.valid_counter: %d, lower.valid_counter %d, forwards: %b\n", */

--- a/lib/xwax/timecoder_mk2.h
+++ b/lib/xwax/timecoder_mk2.h
@@ -12,7 +12,6 @@ int build_lookup_mk2(struct timecode_def *def);
 int lut_load_mk2(struct timecode_def *def, const char *lut_dir_path);
 int lut_store_mk2(struct timecode_def *def, const char *lut_dir_path);
 
-void mk2_process_carrier(struct timecoder *tc, signed int primary, signed int secondary);
 void mk2_process_timecode(struct timecoder *tc, signed int reading);
 
 #endif /* end of include guard TIMECODER_MK2_H */

--- a/src/test/matrixapitest.cpp
+++ b/src/test/matrixapitest.cpp
@@ -1,0 +1,171 @@
+#include <gtest/gtest.h>
+
+#ifdef _MSC_VER
+#include "fmatrix.h"
+#else
+extern "C" {
+#include "fmatrix.h"
+}
+#endif
+
+namespace {
+
+class MatrixApiTest : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite() {
+    }
+
+    static void TearDownTestSuite() {
+    }
+};
+
+TEST_F(MatrixApiTest, AllocAndSetGet) {
+    struct fmatrix* A = fmat_alloc(2, 3);
+    ASSERT_NE(A, nullptr);
+
+    fmat_set(A, 0, 1, 5.0);
+    fmat_set(A, 1, 2, -3.0);
+
+    EXPECT_DOUBLE_EQ(fmat_get(A, 0, 1), 5.0);
+    EXPECT_DOUBLE_EQ(fmat_get(A, 1, 2), -3.0);
+
+    fmat_free(A);
+}
+
+TEST_F(MatrixApiTest, HeapCreation) {
+    struct fmatrix* A = fmat_alloc(3, 3);
+    ASSERT_NE(A, nullptr);
+
+    fmat_set(A, 0, 0, 1);
+    fmat_set(A, 0, 1, 1);
+    fmat_set(A, 0, 2, 1);
+
+    EXPECT_NEAR(fmat_get(A, 0, 1), 1, 1e-12);
+    EXPECT_NEAR(fmat_get(A, 0, 0), 1, 1e-12);
+    EXPECT_NEAR(fmat_get(A, 0, 2), 1, 1e-12);
+    EXPECT_NEAR(fmat_get(A, 1, 0), 0, 1e-12);
+    EXPECT_NEAR(fmat_get(A, 1, 1), 0, 1e-12);
+    EXPECT_NEAR(fmat_get(A, 1, 2), 0, 1e-12);
+    EXPECT_NEAR(fmat_get(A, 2, 0), 0, 1e-12);
+    EXPECT_NEAR(fmat_get(A, 2, 1), 0, 1e-12);
+    EXPECT_NEAR(fmat_get(A, 2, 2), 0, 1e-12);
+
+    fmat_free(A);
+}
+
+TEST_F(MatrixApiTest, Multiplication) {
+    struct fmatrix* A = fmat_alloc(3, 3);
+    struct fmatrix* B = fmat_alloc(3, 3);
+    ASSERT_NE(A, nullptr);
+    ASSERT_NE(B, nullptr);
+
+    // A = [1 1 1; 0 0 0; 0 0 0]
+    fmat_set(A, 0, 0, 1);
+    fmat_set(A, 0, 1, 1);
+    fmat_set(A, 0, 2, 1);
+
+    // B = column of ones
+    fmat_set(B, 0, 0, 1);
+    fmat_set(B, 1, 0, 1);
+    fmat_set(B, 2, 0, 1);
+
+    struct fmatrix* C = fmat_mul(nullptr, A, B);
+    ASSERT_NE(C, nullptr);
+
+    EXPECT_NEAR(fmat_get(C, 0, 0), 3.0, 1e-12);
+    EXPECT_NEAR(fmat_get(C, 0, 1), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(C, 0, 2), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(C, 1, 0), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(C, 1, 1), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(C, 1, 2), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(C, 2, 0), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(C, 2, 1), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(C, 2, 2), 0.0, 1e-12);
+
+    fmat_free(A);
+    fmat_free(B);
+    fmat_free(C);
+}
+
+TEST_F(MatrixApiTest, Transposition) {
+    struct fmatrix* A = fmat_alloc(2, 3);
+    ASSERT_NE(A, nullptr);
+
+    fmat_set(A, 0, 1, 1);
+    fmat_set(A, 1, 2, 1);
+
+    struct fmatrix* T = fmat_trans(nullptr, A);
+    ASSERT_NE(T, nullptr);
+
+    EXPECT_NEAR(fmat_get(T, 0, 0), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(T, 0, 1), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(T, 1, 0), 1.0, 1e-12);
+    EXPECT_NEAR(fmat_get(T, 1, 1), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(T, 2, 0), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(T, 2, 1), 1.0, 1e-12);
+
+    fmat_free(A);
+    fmat_free(T);
+}
+
+TEST_F(MatrixApiTest, Inverse) {
+    struct fmatrix* A = fmat_alloc(3, 3);
+    ASSERT_NE(A, nullptr);
+
+    fmat_set(A, 0, 0, 2);
+    fmat_set(A, 1, 0, 1);
+    fmat_set(A, 2, 0, 0);
+
+    fmat_set(A, 0, 1, -1);
+    fmat_set(A, 1, 1, 2);
+    fmat_set(A, 2, 1, -1);
+
+    fmat_set(A, 0, 2, 0);
+    fmat_set(A, 1, 2, -2);
+    fmat_set(A, 2, 2, 1);
+
+    struct fmatrix* Ainv = fmat_inv(nullptr, A);
+    ASSERT_NE(Ainv, nullptr);
+
+    EXPECT_NEAR(fmat_get(Ainv, 0, 0), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(Ainv, 0, 1), 1.0, 1e-12);
+    EXPECT_NEAR(fmat_get(Ainv, 0, 2), 2.0, 1e-12);
+
+    EXPECT_NEAR(fmat_get(Ainv, 1, 0), -1.0, 1e-12);
+    EXPECT_NEAR(fmat_get(Ainv, 1, 1), 2.0, 1e-12);
+    EXPECT_NEAR(fmat_get(Ainv, 1, 2), 4.0, 1e-12);
+
+    EXPECT_NEAR(fmat_get(Ainv, 2, 0), -1.0, 1e-12);
+    EXPECT_NEAR(fmat_get(Ainv, 2, 1), 2.0, 1e-12);
+    EXPECT_NEAR(fmat_get(Ainv, 2, 2), 5.0, 1e-12);
+
+    fmat_free(A);
+    fmat_free(Ainv);
+}
+
+TEST_F(MatrixApiTest, InverseProperty) {
+    struct fmatrix* A = fmat_alloc(2, 2);
+    ASSERT_NE(A, nullptr);
+
+    fmat_set(A, 0, 0, 4);
+    fmat_set(A, 0, 1, 7);
+    fmat_set(A, 1, 0, 2);
+    fmat_set(A, 1, 1, 6);
+
+    struct fmatrix* Ainv = fmat_inv(nullptr, A);
+    ASSERT_NE(Ainv, nullptr);
+
+    struct fmatrix* I = fmat_mul(nullptr, A, Ainv);
+    ASSERT_NE(I, nullptr);
+
+    EXPECT_NEAR(fmat_get(I, 0, 0), 1.0, 1e-12);
+    EXPECT_NEAR(fmat_get(I, 0, 1), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(I, 1, 0), 0.0, 1e-12);
+    EXPECT_NEAR(fmat_get(I, 1, 1), 1.0, 1e-12);
+
+    fmat_free(A);
+    fmat_free(Ainv);
+    fmat_free(I);
+}
+
+} // namespace

--- a/src/test/savitzkygolaytest.cpp
+++ b/src/test/savitzkygolaytest.cpp
@@ -1,0 +1,116 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdlib>
+
+#ifdef _MSC_VER
+#include "filters.h"
+#else
+extern "C" {
+#include "filters.h"
+}
+#endif
+
+namespace {
+
+#define Q1_31_SCALE (1LL << 31)
+typedef int32_t q31_t; // 32-bit fractional data type in 1.31 format
+
+static q31_t to_q1_31(double x) {
+    return (q31_t)round(x * Q1_31_SCALE);
+}
+
+class SavitzkyGolayTest : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite() {
+    }
+
+    static void TearDownTestSuite() {
+    }
+};
+
+TEST(SavitzkyGolayTest, LowFrequencySignal) {
+    const double f = 100.0;
+    const double w = 2 * M_PI * f;
+    const double fs = 44100;
+    const double Ts = 1 / fs;
+    const int N = 100;
+    const double atol = 0.2;
+
+    q31_t input[N];
+    q31_t output[N];
+
+    for (int n = 0; n < N; n++) {
+        input[n] = to_q1_31(sin(w * n * Ts));
+    }
+
+    struct savitzky_golay* sg = savgol_create(11, 2);
+
+    for (int n = 0; n < N; n++) {
+        output[n] = savgol(sg, input[n]);
+    }
+
+    for (int n = 10; n < N; n++) { // skip startup
+        EXPECT_NEAR(output[n], input[n], to_q1_31(atol));
+    }
+
+    savgol_destroy(sg);
+}
+
+TEST(SavitzkyGolayTest, PlainSequence) {
+    const int N = 21;
+    const double atol = 1e-6;
+
+    q31_t input[N];
+    q31_t output[N];
+
+    for (int n = 0; n < N; n++) {
+        input[n] = to_q1_31(0.99);
+    }
+
+    struct savitzky_golay* sg = savgol_create(11, 2);
+
+    for (int n = 0; n < N; n++) {
+        output[n] = savgol(sg, input[n]);
+    }
+
+    for (int n = N / 2; n < N; n++) { // skip startup
+        EXPECT_NEAR(output[n], input[n], to_q1_31(atol));
+    }
+
+    savgol_destroy(sg);
+}
+
+TEST(SavitzkyGolayTest, NoiseFiltering) {
+    const double f = 100.0;
+    const double w = 2 * M_PI * f;
+    const double fs = 44100;
+    const double Ts = 1 / fs;
+    const int N = 100;
+    const double atol = 0.2;
+
+    q31_t noise[N];
+    q31_t input[N];
+    q31_t noisy_input[N];
+    q31_t output[N];
+
+    for (int n = 0; n < N; n++) {
+        input[n] = to_q1_31(sin(w * n * Ts));
+        noise[n] = rand() % (10000000);
+        noisy_input[n] = input[n] + noise[n];
+    }
+
+    struct savitzky_golay* sg = savgol_create(11, 2);
+
+    for (int n = 0; n < N; n++) {
+        output[n] = savgol(sg, noisy_input[n]);
+    }
+
+    for (int n = 10; n < N; n++) { // skip startup
+        EXPECT_NEAR(output[n], input[n], to_q1_31(atol));
+    }
+
+    savgol_destroy(sg);
+}
+
+} // namespace

--- a/src/vinylcontrol/defs_vinylcontrol.h
+++ b/src/vinylcontrol/defs_vinylcontrol.h
@@ -75,7 +75,7 @@ constexpr int VINYL_STATUS_ERROR = 3;
 
 #define MIXXX_VC_DEFAULT_LEADINTIME 0
 
-#define MIXXX_VINYL_SCOPE_UPDATE_LATENCY_MS 66
+#define MIXXX_VINYL_SCOPE_UPDATE_LATENCY_MS 33
 #define MIXXX_VINYL_SCOPE_SIZE 100
 
 constexpr int kMaximumVinylControlInputs = 4;


### PR DESCRIPTION
### Rework of the pitch detection logic

**Pitch detection in xwax**

```c
if (zero_crossing == true)
    pitch_filter_update(M_PI/2);
else
    pitch_filter_update(0.0);
```

Every time a zero crossing is detected (which happens four times per cycle of the sinusoid), the filter is updated and else it is not updated at all, because there is no information.

This has the advantage that you can easily mentally abstract movement if not trained in signal processing, but an actual DSP engineer would never do this. If you only do measurements on zero-crossing and otherwise feed 0.0 into the filter, the output is very noisy. Feeding 0.0 into the filter on most samples makes the velocity degrade to then snap back when a zero-crossing is found.

**New approach**

1. Turn the signal into clean sinusoids by e.g taking the derivative
2. Compute the phase difference Δφ from the sine-cosine pair
3. Feed the phase difference into the Kalman filter to obtain a smooth dΔφ/dt
4. Compute the instantaneous frequency by

```math
f = \frac{\frac{d\Delta\Phi}{dt}}{2\pi}
```

From here on computing the pitch is trivial:

```math
pitch = \frac{f}{\mathrm{f}_\mathrm{carrier}}
```


This updates the filter on every sample and achieves faster direction changes. The performance is great and the scratch feeling is way superior!

### Todo

- [x] Tune the Q and R of the Kalman filter to match the new input
- [x] Fix a division by zero bug in the Kalman filter
- [x] Remove the complex mode switching logic, since it added smoothness at the cost of higher sticker drift
- [x] Draw the monitor only when a signal threshold of -40dB is exceeded to not draw noise
- [x] Smooth the needle drops
- [x] Use more readable Q0.31 complex format for the phase difference
- [x] Cleanup


### Tests
- [x] Algoriddim djay ✅
- [x] Mixvibes ✅
- [x] Rekordbox ✅
- [x] Serato ✅
- [x] Traktor MK1 ✅ <-- backspin bug regression present since the old fix doesn't work for the new pitch detector
- [x] Traktor MK2 ✅ <-- same issue
- [x] Test for all sampling frequencies (the Savitzky-Golay filter windows gets adjusted for buffer sizes) ✅
- [x] Test for all buffer sizes betwenn 1.45ms to 92.9 ms ✅
- [x] Add a test  for the Matrix API ✅
- [x] Add a test for the Savitzky-Golay filter ✅
