### PR TITLE
Use libdjinterop 0.27.0 in 2.6 branch Flatpak manifest

### DIFF
--- a/packaging/flatpak/modules/libdjinterop.yaml
+++ b/packaging/flatpak/modules/libdjinterop.yaml
@@ -4,8 +4,8 @@ config-opts:
   - -DCMAKE_BUILD_TYPE=RelWithDebInfo
 sources:
   - type: archive
-    url: https://github.com/xsco/libdjinterop/archive/refs/tags/0.24.3.tar.gz
-    sha256: df41fe39bed9d16d27a3649d237b68edd2cdb6fc71a82cae5cd746d4e4ef6578
+    url: https://github.com/xsco/libdjinterop/archive/refs/tags/0.27.0.tar.gz
+    sha256: c4e73bf3907fd45be1c9767bcd9f367cbb7c279b4fe047bf2216bc92ae3d1668
     x-checker-data:
       type: anitya
       project-id: 374896


### PR DESCRIPTION
This fixes Flatpak builds on 2.6 branch. And main branch uses the same libdjinterop version, so this will work there too.