### PR TITLE
Restore common-hid-packet-parser global symbol exceptions for eslint

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -67,7 +67,11 @@ module.exports = tseslint.config(
                 "Controller": "readonly",
                 "Button": "readonly",
                 "Control": "readonly",
-                "Deck": "readonly"
+                "Deck": "readonly",
+                // common-hid-packet-parser globals
+                HIDController: "readonly",
+                HIDDebug: "readonly",
+                HIDPacket: "readonly"
             }
         }
     },


### PR DESCRIPTION
These got lost in https://github.com/mixxxdj/mixxx/pull/13913 and break pre-commit for https://github.com/mixxxdj/mixxx/pull/15897
I set them to `readonly` a the other, before they were writeable.