### PR TITLE
AutoDJ: Reset AutoDJ when deck orientation changes

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -55,6 +55,7 @@ DeckAttributes::DeckAttributes(int index,
     m_outroStartPos.connectValueChanged(this, &DeckAttributes::slotOutroStartPositionChanged);
     m_outroEndPos.connectValueChanged(this, &DeckAttributes::slotOutroEndPositionChanged);
     m_rateRatio.connectValueChanged(this, &DeckAttributes::slotRateChanged);
+    m_orientation.connectValueChanged(this, &DeckAttributes::slotOrientationChanged);
 }
 
 DeckAttributes::~DeckAttributes() {
@@ -100,6 +101,11 @@ void DeckAttributes::slotPlayerEmpty() {
 void DeckAttributes::slotRateChanged(double v) {
     Q_UNUSED(v);
     emit rateChanged(this);
+}
+
+void DeckAttributes::slotOrientationChanged(double v) {
+    Q_UNUSED(v);
+    emit orientationChanged(this);
 }
 
 TrackPointer DeckAttributes::getLoadedTrack() const {
@@ -532,6 +538,16 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
                 &DeckAttributes::rateChanged,
                 this,
                 &AutoDJProcessor::playerRateChanged);
+
+        connect(pLeftDeck,
+                &DeckAttributes::orientationChanged,
+                this,
+                &AutoDJProcessor::playerOrientationChanged);
+        connect(pRightDeck,
+                &DeckAttributes::orientationChanged,
+                this,
+                &AutoDJProcessor::playerOrientationChanged);
+
         connect(m_pAutoDJTableModel,
                 &PlaylistTableModel::firstTrackChanged,
                 this,
@@ -1687,6 +1703,19 @@ void AutoDJProcessor::playerRateChanged(DeckAttributes* pAttributes) {
         return;
     }
     calculateTransition(fromDeck, getOtherDeck(fromDeck), false);
+}
+
+void AutoDJProcessor::playerOrientationChanged(DeckAttributes* pAttributes) {
+    if constexpr (sDebug) {
+        qDebug() << this << "playerOrientationChanged" << pAttributes->group;
+    }
+
+    if (m_eState != ADJ_DISABLED) {
+        // Disable and Enable auto DJ.  We will likely fail to enable auto DJ
+        // but that will pop up an error to explain the situation to the user.
+        toggleAutoDJ(false);
+        toggleAutoDJ(true);
+    }
 }
 
 void AutoDJProcessor::playlistFirstTrackChanged() {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1711,10 +1711,9 @@ void AutoDJProcessor::playerOrientationChanged(DeckAttributes* pAttributes) {
     }
 
     if (m_eState != ADJ_DISABLED) {
-        // Disable and Enable auto DJ.  We will likely fail to enable auto DJ
-        // but that will pop up an error to explain the situation to the user.
+        // Disable auto DJ and emit the error explaining that we no longer have two valid decks.
         toggleAutoDJ(false);
-        toggleAutoDJ(true);
+        emit autoDJError(ADJ_NOT_TWO_DECKS);
     }
 }
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -105,6 +105,7 @@ class DeckAttributes : public QObject {
     void loadingTrack(DeckAttributes* pDeck, TrackPointer pNewTrack, TrackPointer pOldTrack);
     void playerEmpty(DeckAttributes* pDeck);
     void rateChanged(DeckAttributes* pDeck);
+    void orientationChanged(DeckAttributes* pDeck);
 
   private slots:
     void slotPlayPosChanged(double v);
@@ -117,6 +118,7 @@ class DeckAttributes : public QObject {
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void slotPlayerEmpty();
     void slotRateChanged(double v);
+    void slotOrientationChanged(double v);
 
   public:
     int index;
@@ -231,6 +233,7 @@ class AutoDJProcessor : public QObject {
     void playerLoadingTrack(DeckAttributes* pDeck, TrackPointer pNewTrack, TrackPointer pOldTrack);
     void playerEmpty(DeckAttributes* pDeck);
     void playerRateChanged(DeckAttributes* pDeck);
+    void playerOrientationChanged(DeckAttributes* pDeck);
     void playlistFirstTrackChanged();
 
     void controlEnableChangeRequest(double value);


### PR DESCRIPTION
When deck orientation changes, disable and then enable AutoDJ in case the program is now in an invalid state.

Fixes #15962