### PR TITLE
fix: prevent repeated load operation on QmlPlayerProxy

### DIFF
--- a/src/qml/qmlplayerproxy.cpp
+++ b/src/qml/qmlplayerproxy.cpp
@@ -35,6 +35,9 @@ void QmlPlayerProxy::loadTrack(QmlTrackProxy* track, bool play) {
     if (track == nullptr || track->internal() == nullptr) {
         return;
     }
+    if (m_pCurrentTrack == track->internal()) {
+        return;
+    }
     emit loadTrackRequested(track->internal(),
 #ifdef __STEM__
             mixxx::StemChannel::All,
@@ -43,6 +46,9 @@ void QmlPlayerProxy::loadTrack(QmlTrackProxy* track, bool play) {
 }
 
 void QmlPlayerProxy::loadTrackFromLocation(const QString& trackLocation, bool play) {
+    if (m_pCurrentTrack && m_pCurrentTrack->getLocation() == trackLocation) {
+        return;
+    }
     emit loadTrackFromLocationRequested(trackLocation, play);
 }
 


### PR DESCRIPTION
Add early-return guards to `loadTrack()` and `loadTrackFromLocation()` to skip the load if the requested track is already loaded in the player. This prevents unnecessary unload/reload cycles, avoiding audible glitches and redundant signal emissions.

`loadTrackFromLocationUrl()` is covered implicitly since it delegates to `loadTrackFromLocation()`.

Fixes: #14809