### PR TITLE
(fix) FX units not working on all samplers

### DIFF
--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -72,6 +72,7 @@ class EngineEffectChain final : public EffectsRequestHandler {
     QList<EngineEffect*> m_effects;
     mixxx::SampleBuffer m_buffer1;
     mixxx::SampleBuffer m_buffer2;
+    ChannelHandleMap<ChannelStatus> m_outputChannelMap;
     ChannelHandleMap<ChannelHandleMap<ChannelStatus>> m_chainStatusForChannelMatrix;
     EngineEffectsDelay m_effectsDelay;
 


### PR DESCRIPTION
Fixes #15799

* new profile (or just no effects.xml and effects dir)
* load a track into sampler 5, play
* assign FX1, load Echo etc., turn all on and turn Meta so there's some good feedback/filter effect
* close, restart
* enable Echo, press Play on sampler 5
-> this PR: enjoy the noise : )
-> 2.5: no echo. toggle Fx1 Off and On before engaging Echo & Co, then it works.

The root cause:
short: the fx I/O routing table is not updated instantly when additional samplers are added to the engine (or any inputs actually).

long:
* CoreServices adds the default inputs (4 decks, 4 samplers, mics, aux etc.) and upon creation they are registered in `EffectsManager`
* CoreServices then calls `m_pEffectsManager->setup()` which initializes all EngineEffectChains with the registred inputs/outputs
* then samplers.xml is parsed and maybe more samplers are created -- same when a sampler bank is loaded manually or when we switch to a skin with more samplers
* new inputs are registered in `EffectsManager`, then [in each (standard) effect chain](https://github.com/mixxxdj/mixxx/blob/1bd3c4306269c79cafc62f90a824a5ce10fdbe04/src/engine/effects/engineeffectchain.cpp#L143) and the Fx routing CO states are also restored correctly (see GUI, FX1 on sampler 5)
-> BUT the I/O maps used by `EngineEffectChain`s are not updated, hence engaging an effect has no ..effect for those new inputs
-> the I/O maps _are_ extended for the new key, but `ChannelHandleMap::maybeExpand` abviously can't initialize the outputs map

The fix:
* store the outputs map when creating EngineEffectChain(it won't change as no new outputs are added after `EffectsManager::setup()`-- afaict)
* when registering and [enabling a new input](https://github.com/mixxxdj/mixxx/blob/1bd3c4306269c79cafc62f90a824a5ce10fdbe04/src/engine/effects/engineeffectchain.cpp#L143), use `ChannelHandleMap[input]` as before but then assign the stored output map

____
Maybe alternatively we could add a method `EngineEffectChain::registerInputChannel` and use a new `EffectsRequest::MessageType` to send the request via the message pipe.
But I doubt it has any benefits over the current fix. Does it?