### PR TITLE
Fix #10209: Show message when rescanning with no library folders

### DIFF
--- a/src/library/library_decl.h
+++ b/src/library/library_decl.h
@@ -21,6 +21,17 @@ enum class FocusWidget {
 };
 
 struct LibraryScanResultSummary {
+    LibraryScanResultSummary()
+            : autoscan(false),
+              numNewTracks(0),
+              numMovedTracks(0),
+              numMissingTracks(0),
+              numNewMissingTracks(0),
+              numRediscoveredTracks(0),
+              tracksTotal(0),
+              noDirectoriesConfigured(false) {
+    }
+
     QString durationString;
     bool autoscan;
     int numNewTracks;
@@ -29,4 +40,5 @@ struct LibraryScanResultSummary {
     int numNewMissingTracks;
     int numRediscoveredTracks;
     int tracksTotal;
+    bool noDirectoriesConfigured;
 };

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -193,15 +193,20 @@ void LibraryScanner::slotStartScan() {
 
     // Recursively scan each directory in the directories table.
     m_libraryRootDirs = m_directoryDao.loadAllDirectories();
-    // If there are no directories then we have nothing to do. Cleanup and
-    // finish the scan immediately.
-    if (m_libraryRootDirs.isEmpty()) {
+    // If there are no directories then we still have to scan independently added tracks.
+    QSet<QString> trackLocations = m_trackDao.getAllTrackLocations();
+
+    if (m_libraryRootDirs.isEmpty() && trackLocations.isEmpty()) {
+        // Nothing to do. noDirectoriesConfigured == true will show the "no dirs" message.
+        LibraryScanResultSummary result;
+        result.autoscan = m_manualScan;
+        result.noDirectoriesConfigured = true;
+
         changeScannerState(IDLE);
+        emit scanSummary(result);
         return;
     }
     changeScannerState(SCANNING);
-
-    QSet<QString> trackLocations = m_trackDao.getAllTrackLocations();
     // Store number of existing tracks so we can calculate the number
     // of missing tracks in slotFinishUnhashedScan().
     m_previouslyMissingTracks = m_trackDao.getAllMissingTrackLocations();

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1248,6 +1248,18 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
         return;
     }
 
+    QMessageBox* pMsg = new QMessageBox();
+    pMsg->setTextFormat(Qt::RichText); // required to get bold text with <b> tags
+    pMsg->setWindowTitle(tr("Library scan finished"));
+
+    if (result.noDirectoriesConfigured) {
+        pMsg->setText(tr("No music directories configured for scanning.") +
+                QStringLiteral("<br>") +
+                tr("Add directories in the library preferences."));
+        pMsg->show();
+        return;
+    }
+
     QString summary =
             tr("Scan took %1").arg(result.durationString) + QStringLiteral("<br><br>");
     if (result.numNewTracks == 0 &&
@@ -1282,9 +1294,7 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
                 tr("%n track(s) in total", nullptr, result.tracksTotal) +
                 QStringLiteral("</b>");
     }
-    QMessageBox* pMsg = new QMessageBox();
-    pMsg->setTextFormat(Qt::RichText); // required to get bold text with <b> tags
-    pMsg->setWindowTitle(tr("Library scan finished"));
+
     pMsg->setText(summary);
     pMsg->show();
 }


### PR DESCRIPTION
Fixes #10209 

## Problem

Previously, when users clicked "Rescan Library" with no music folders configured, nothing happened. The scan would silently complete instantly without any feedback, leaving users confused about whether the feature was working.

## Solution

This PR adds a helpful dialog that appears when users try to rescan with no folders configured. The dialog clearly explains:
- No music directories are currently configured
- Users should add directories in the library preferences

## Screenshot

### After this fix:

<img width="1470" height="889" alt="Screenshot" src="https://github.com/user-attachments/assets/aeda3c53-2b91-4437-9d5e-c8e52afc6265" />


The dialog now provides clear feedback and guidance to users.

## Implementation

- Added `noDirectoriesConfigured` boolean flag to `LibraryScanResultSummary` struct
- Set the flag in `LibraryScanner::slotStartScan()` when no directories are found
- Modified `MixxxMainWindow::slotLibraryScanSummaryDlg()` to display a custom message when the flag is set
- Used explicit flag instead of sentinel values for clarity.

## Testing

Tested on macOS by:
1. Removing all library folders in Preferences → Library
2. Clicking Library → Rescan Library  
3. Verifying the new dialog appears with the helpful message
4. Adding folders back and confirming normal scan behavior still works

Feedback welcome - this is my first contribution to Mixxx and I'm eager to learn!