### PR TITLE
Sound preferences: remove sleep on Apply for non-Pulse APIs

### DIFF
--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -62,7 +62,7 @@ SoundManager::SoundManager(UserSettingsPointer pConfig,
           m_pConfig(pConfig),
           m_paInitialized(false),
           m_config(this),
-          m_prevConfig(this),
+          m_prevAPIWasPulse(false),
           m_pErrorDevice(nullptr),
           m_underflowHappened(0),
           m_underflowUpdateCount(0),
@@ -200,8 +200,7 @@ void SoundManager::closeDevices(
         // And original Pulse bugs
         // https://github.com/mixxxdj/mixxx/issues/770
         // https://github.com/mixxxdj/mixxx/issues/8284
-        const QString prevAPIStr = m_prevConfig.getAPI();
-        if (!prevAPIStr.contains(QStringLiteral("pulse"), Qt::CaseInsensitive)) {
+        if (!m_prevAPIWasPulse) {
             QThread::sleep(kSleepSecondsAfterClosingDevice);
         }
     } else if (!closed)
@@ -749,7 +748,8 @@ void SoundManager::closeActiveConfig(bool async) {
 
 SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& config) {
     SoundDeviceStatus status = SoundDeviceStatus::Ok;
-    m_prevConfig = m_config;
+    const QString prevAPIStr = m_config.getAPI();
+    m_prevAPIWasPulse = prevAPIStr.contains(QStringLiteral("pulse"), Qt::CaseInsensitive);
     m_config = config;
     checkConfig();
 

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -150,6 +150,7 @@ class SoundManager : public QObject {
     QList<CSAMPLE*> m_inputBuffers;
 
     SoundManagerConfig m_config;
+    SoundManagerConfig m_prevConfig;
     SoundDevicePointer m_pErrorDevice;
     QHash<AudioOutput, AudioSource*> m_registeredSources;
     QMultiHash<AudioInput, AudioDestination*> m_registeredDestinations;

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -150,7 +150,7 @@ class SoundManager : public QObject {
     QList<CSAMPLE*> m_inputBuffers;
 
     SoundManagerConfig m_config;
-    SoundManagerConfig m_prevConfig;
+    bool m_prevAPIWasPulse;
     SoundDevicePointer m_pErrorDevice;
     QHash<AudioOutput, AudioSource*> m_registeredSources;
     QMultiHash<AudioInput, AudioDestination*> m_registeredDestinations;


### PR DESCRIPTION
Been using this with **ALSA** (and only that!!) and **legacy UI** for quite some time now without any issues. Mostly with my S4mk3 and maybe my laptop's onboard audio jack.
-> the pause after Apply is now barely noticable and I can safely do this during performance, eg. to adjust the latency.

Note: I read the discussion in #14290 but couldn't figure if there are caveats with other APIs. If there are we could make it
`if (m_config.getAPI() != "ALSA")`
Latest change in this method was #14597 for the QML sound preferences.

Original Pulse bugs:
#770
#8284