### PR TITLE
Library: add `stars_up`/`stars_down` and `set_bpmlock` controls

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -392,6 +392,26 @@ LibraryControl::LibraryControl(Library* pLibrary)
             this,
             &LibraryControl::slotTrackColorNext);
 
+    // Track Rating controls
+    m_pStarsUp = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "stars_up"));
+    m_pStarsDown = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "stars_down"));
+    connect(m_pStarsUp.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                if (value > 0) {
+                    slotTrackRatingChangeRequestRelative(1);
+                }
+            });
+    connect(m_pStarsDown.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                if (value > 0) {
+                    slotTrackRatingChangeRequestRelative(-1);
+                }
+            });
+
     // Controls to select saved searchbox queries and to clear the searchbox
     m_pSelectHistoryNext = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "search_history_next"));
@@ -1223,5 +1243,16 @@ void LibraryControl::slotTrackColorNext(double v) {
     WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
     if (pTrackTableView) {
         pTrackTableView->assignNextTrackColor();
+    }
+}
+
+void LibraryControl::slotTrackRatingChangeRequestRelative(int change) {
+    if (!m_pLibraryWidget || change == 0) {
+        return;
+    }
+
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->trackRatingChangeRequestRelative(change);
     }
 }

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -373,6 +373,13 @@ LibraryControl::LibraryControl(Library* pLibrary)
                 &LibraryControl::slotIncrementFontSize);
     }
 
+    // Set BPM lock (button state does not reflect track(s) state)
+    m_pBpmLock = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "set_bpmlock"));
+    connect(m_pBpmLock.get(),
+            &ControlPushButton::valueChanged,
+            this,
+            &LibraryControl::slotToggleBpmLock);
+
     // Track Color controls
     m_pTrackColorPrev = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "track_color_prev"));
     m_pTrackColorNext = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "track_color_next"));
@@ -1183,6 +1190,17 @@ void LibraryControl::slotIncrementFontSize(double v) {
 void LibraryControl::slotDecrementFontSize(double v) {
     if (v > 0.0) {
         slotFontSize(-1);
+    }
+}
+
+void LibraryControl::slotToggleBpmLock(double v) {
+    if (!m_pLibraryWidget || v < 0) {
+        return;
+    }
+
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->toggleBpmLock(v > 0);
     }
 }
 

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -110,6 +110,8 @@ class LibraryControl : public QObject {
     void slotTrackColorPrev(double v);
     void slotTrackColorNext(double v);
 
+    void slotTrackRatingChangeRequestRelative(int change);
+
     // Deprecated navigation slots
     void slotSelectNextTrack(double v);
     void slotSelectPrevTrack(double v);
@@ -193,6 +195,10 @@ class LibraryControl : public QObject {
     // Controls to change track color
     std::unique_ptr<ControlPushButton> m_pTrackColorPrev;
     std::unique_ptr<ControlPushButton> m_pTrackColorNext;
+
+    // Controls to change track rating
+    std::unique_ptr<ControlPushButton> m_pStarsUp;
+    std::unique_ptr<ControlPushButton> m_pStarsDown;
 
     // Control to show/hide the track menu
     std::unique_ptr<ControlPushButton> m_pShowTrackMenu;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -105,6 +105,8 @@ class LibraryControl : public QObject {
     void slotEditItem(double);
     void slotGoToItem(double v);
 
+    void slotToggleBpmLock(double v);
+
     void slotTrackColorPrev(double v);
     void slotTrackColorNext(double v);
 
@@ -185,6 +187,8 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlEncoder> m_pSortColumnToggle;
     std::unique_ptr<ControlPushButton> m_pSortOrder;
     std::unique_ptr<ControlPushButton> m_pSortFocusedColumn;
+
+    std::unique_ptr<ControlPushButton> m_pBpmLock;
 
     // Controls to change track color
     std::unique_ptr<ControlPushButton> m_pTrackColorPrev;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -459,6 +459,21 @@ TrackModel::SortColumnId WTrackTableView::getColumnIdFromCurrentIndex() {
     return pTrackModel->sortColumnIdFromColumnIndex(currentIndex().column());
 }
 
+void WTrackTableView::toggleBpmLock(bool locked) {
+    TrackModel* pTrackModel = getTrackModel();
+    if (!pTrackModel) {
+        return;
+    }
+
+    const QModelIndexList indices = getSelectedRows();
+    for (const auto& index : indices) {
+        TrackPointer pTrack = pTrackModel->getTrack(index);
+        if (pTrack) {
+            pTrack->setBpmLocked(locked);
+        }
+    }
+}
+
 void WTrackTableView::assignPreviousTrackColor() {
     TrackModel* pTrackModel = getTrackModel();
     if (!pTrackModel) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -514,6 +514,27 @@ void WTrackTableView::assignNextTrackColor() {
     }
 }
 
+void WTrackTableView::trackRatingChangeRequestRelative(int change) {
+    TrackModel* pTrackModel = getTrackModel();
+    if (!pTrackModel) {
+        return;
+    }
+    const QModelIndexList indices = getSelectedRows();
+    if (indices.isEmpty()) {
+        return;
+    }
+
+    const QModelIndex index = indices.at(0);
+    TrackPointer pTrack = pTrackModel->getTrack(index);
+    if (pTrack) {
+        int newRating = pTrack->getRating() + change;
+        if (mixxx::TrackRecord::isValidRating(newRating) &&
+                newRating != pTrack->getRating()) {
+            pTrack->setRating(newRating);
+        }
+    }
+}
+
 void WTrackTableView::slotPurge() {
     TrackModel* pTrackModel = getTrackModel();
     if (!pTrackModel) {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -53,6 +53,7 @@ class WTrackTableView : public WLibraryTableView {
     void loadSelectedTrackToGroup(const QString& group,
             bool play);
 #endif
+    void toggleBpmLock(bool locked);
     void assignNextTrackColor() override;
     void assignPreviousTrackColor() override;
     TrackModel::SortColumnId getColumnIdFromCurrentIndex() override;

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -56,6 +56,7 @@ class WTrackTableView : public WLibraryTableView {
     void toggleBpmLock(bool locked);
     void assignNextTrackColor() override;
     void assignPreviousTrackColor() override;
+    void trackRatingChangeRequestRelative(int change);
     TrackModel::SortColumnId getColumnIdFromCurrentIndex() override;
     QList<TrackId> getSelectedTrackIds() const;
     bool isTrackInCurrentView(const TrackId& trackId);


### PR DESCRIPTION
Complements for the existing channel controls.
Just to ease the track preparation workflow a little for keyboard / controllers.
`[Library],set_bpmlock`
`[Library],stars_up`
`[Library],stars_down`

No-risk feature, so targeting 2.6 here.

**Note:**
unlike `[ChannelN],bpmlock`, `[Library],set_bpmlock` is "set-only" = CO state doesn't reflect the lock state of the selected track(s). That is because IMO it's too much effort to a) read `Track::isBpmLocked()` for every selection change in the tracks table, and b) not worth it UX-wise to have a tri-state CO (unlocked, locked, partially locked).
For bulk actions we have the Lock/Unlock actions in the tracks menu.

- [ ] add to manual