### PR TITLE
Add Mono recording support for all Encoders

### DIFF
--- a/src/encoder/encoder.h
+++ b/src/encoder/encoder.h
@@ -27,7 +27,8 @@ class Encoder {
     Encoder() {}
     virtual ~Encoder() = default;
 
-    virtual int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) = 0;
+    virtual int initEncoder(mixxx::audio::SampleRate sampleRate,
+            QString* pUserErrorMessage) = 0;
     // encodes the provided buffer of audio.
     virtual void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) = 0;
     // Adds metadata to the encoded audio, i.e., the ID3 tag. Currently only used

--- a/src/encoder/encoderfdkaac.cpp
+++ b/src/encoder/encoderfdkaac.cpp
@@ -247,7 +247,8 @@ void EncoderFdkAac::setEncoderSettings(const EncoderSettings& settings) {
     }
 }
 
-int EncoderFdkAac::initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) {
+int EncoderFdkAac::initEncoder(mixxx::audio::SampleRate sampleRate,
+        QString* pUserErrorMessage) {
     m_sampleRate = sampleRate;
 
     if (!m_pLibrary) {

--- a/src/encoder/encoderfdkaac.h
+++ b/src/encoder/encoderfdkaac.h
@@ -14,7 +14,8 @@ class EncoderFdkAac : public Encoder {
     EncoderFdkAac(EncoderCallback* pCallback);
     virtual ~EncoderFdkAac();
 
-    int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
+    int initEncoder(mixxx::audio::SampleRate sampleRate,
+            QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;

--- a/src/encoder/encoderfdkaacsettings.h
+++ b/src/encoder/encoderfdkaacsettings.h
@@ -33,4 +33,10 @@ class EncoderFdkAacSettings : public EncoderRecordingSettings {
     QList<int> m_qualList;
     UserSettingsPointer m_pConfig;
     QString m_format;
+
+  protected:
+    // Provide config to base class
+    UserSettingsPointer getConfig() const override {
+        return m_pConfig;
+    }
 };

--- a/src/encoder/encoderflacsettings.h
+++ b/src/encoder/encoderflacsettings.h
@@ -39,4 +39,10 @@ class EncoderFlacSettings : public EncoderRecordingSettings {
     QList<OptionsGroup> m_radioList;
     QList<int> m_qualList;
     UserSettingsPointer m_pConfig;
+
+  protected:
+    // Provide config to base class
+    UserSettingsPointer getConfig() const override {
+        return m_pConfig;
+    }
 };

--- a/src/encoder/encodermp3.h
+++ b/src/encoder/encodermp3.h
@@ -14,7 +14,8 @@ class EncoderMp3 final : public Encoder {
     EncoderMp3(EncoderCallback* callback=nullptr);
     ~EncoderMp3() override;
 
-    int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
+    int initEncoder(mixxx::audio::SampleRate sampleRate,
+            QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;

--- a/src/encoder/encodermp3settings.h
+++ b/src/encoder/encodermp3settings.h
@@ -43,4 +43,10 @@ class EncoderMp3Settings : public EncoderRecordingSettings {
     QList<int> m_qualList;
     QList<int> m_qualVBRList;
     UserSettingsPointer m_pConfig;
+
+  protected:
+    // Provide config to base class to read channel mode from recording preferences
+    UserSettingsPointer getConfig() const override {
+        return m_pConfig;
+    }
 };

--- a/src/encoder/encoderopus.cpp
+++ b/src/encoder/encoderopus.cpp
@@ -136,7 +136,8 @@ void EncoderOpus::setEncoderSettings(const EncoderSettings& settings) {
     }
 }
 
-int EncoderOpus::initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) {
+int EncoderOpus::initEncoder(mixxx::audio::SampleRate sampleRate,
+        QString* pUserErrorMessage) {
     Q_UNUSED(pUserErrorMessage);
 
     if (sampleRate != kMainSampleRate) {

--- a/src/encoder/encoderopus.h
+++ b/src/encoder/encoderopus.h
@@ -26,7 +26,8 @@ class EncoderOpus: public Encoder {
     explicit EncoderOpus(EncoderCallback* pCallback = nullptr);
     ~EncoderOpus() override;
 
-    int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
+    int initEncoder(mixxx::audio::SampleRate sampleRate,
+            QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;

--- a/src/encoder/encoderopussettings.h
+++ b/src/encoder/encoderopussettings.h
@@ -46,4 +46,10 @@ class EncoderOpusSettings: public EncoderRecordingSettings {
     UserSettingsPointer m_pConfig;
     QList<int> m_qualList;
     QList<OptionsGroup> m_radioList;
+
+  protected:
+    // Provide config to base class
+    UserSettingsPointer getConfig() const override {
+        return m_pConfig;
+    }
 };

--- a/src/encoder/encodervorbis.cpp
+++ b/src/encoder/encodervorbis.cpp
@@ -204,7 +204,8 @@ void EncoderVorbis::initStream() {
     m_bStreamInitialized = true;
 }
 
-int EncoderVorbis::initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) {
+int EncoderVorbis::initEncoder(mixxx::audio::SampleRate sampleRate,
+        QString* pUserErrorMessage) {
     vorbis_info_init(&m_vinfo);
 
     // initialize VBR quality based mode

--- a/src/encoder/encodervorbis.h
+++ b/src/encoder/encodervorbis.h
@@ -18,7 +18,8 @@ class EncoderVorbis : public Encoder {
     EncoderVorbis(EncoderCallback* pCallback = nullptr);
     ~EncoderVorbis() override;
 
-    int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
+    int initEncoder(mixxx::audio::SampleRate sampleRate,
+            QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;

--- a/src/encoder/encodervorbissettings.h
+++ b/src/encoder/encodervorbissettings.h
@@ -31,4 +31,10 @@ class EncoderVorbisSettings : public EncoderRecordingSettings {
   private:
     QList<int> m_qualList;
     UserSettingsPointer m_pConfig;
+
+  protected:
+    // Provide config to base class to read channel mode from recording preferences
+    UserSettingsPointer getConfig() const override {
+        return m_pConfig;
+    }
 };

--- a/src/encoder/encoderwave.cpp
+++ b/src/encoder/encoderwave.cpp
@@ -62,12 +62,10 @@ static sf_count_t  sf_f_tell (void *user_data)
     return pCallback->tell();
 }
 
-
-
-
 EncoderWave::EncoderWave(EncoderCallback* pCallback)
         : m_pCallback(pCallback),
-          m_pSndfile(nullptr) {
+          m_pSndfile(nullptr),
+          m_channels(2) {
     m_sfInfo.frames = 0;
     m_sfInfo.samplerate = 0;
     m_sfInfo.channels = 0;
@@ -128,6 +126,19 @@ void EncoderWave::setEncoderSettings(const EncoderSettings& settings) {
             qWarning() << " Unexpected radio index on EncoderWave: "
                     << radio << ". reverting to PCM 16bits";
             break;
+    }
+
+    // Read channel mode from settings
+    switch (settings.getChannelMode()) {
+    case EncoderSettings::ChannelMode::MONO:
+        m_channels = 1;
+        break;
+    case EncoderSettings::ChannelMode::STEREO:
+        m_channels = 2;
+        break;
+    case EncoderSettings::ChannelMode::AUTOMATIC:
+        m_channels = 2;
+        break;
     }
 }
 
@@ -193,12 +204,13 @@ void EncoderWave::initStream() {
     }
 }
 
-int EncoderWave::initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) {
+int EncoderWave::initEncoder(mixxx::audio::SampleRate sampleRate,
+        QString* pUserErrorMessage) {
     Q_UNUSED(pUserErrorMessage);
     // set sfInfo.
     // m_sfInfo.format is setup on setEncoderSettings previous to calling initEncoder.
     m_sfInfo.samplerate = sampleRate;
-    m_sfInfo.channels = 2;
+    m_sfInfo.channels = m_channels;
     m_sfInfo.frames = 0;
     m_sfInfo.sections = 0;
     m_sfInfo.seekable = 0;

--- a/src/encoder/encoderwave.h
+++ b/src/encoder/encoderwave.h
@@ -20,7 +20,8 @@ class EncoderWave : public Encoder {
     EncoderWave(EncoderCallback* pCallback = nullptr);
     ~EncoderWave() override;
 
-    int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
+    int initEncoder(mixxx::audio::SampleRate sampleRate,
+            QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;
@@ -36,6 +37,6 @@ class EncoderWave : public Encoder {
 
     SNDFILE* m_pSndfile;
     SF_INFO m_sfInfo;
-
     SF_VIRTUAL_IO m_virtualIo;
+    int m_channels;
 };

--- a/src/encoder/encoderwavesettings.h
+++ b/src/encoder/encoderwavesettings.h
@@ -30,4 +30,10 @@ class EncoderWaveSettings : public EncoderRecordingSettings {
     QList<OptionsGroup> m_radioList;
     UserSettingsPointer m_pConfig;
     QString m_format;
+
+  protected:
+    // Provide config to base class
+    UserSettingsPointer getConfig() const override {
+        return m_pConfig;
+    }
 };

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -8,18 +8,22 @@
 #include "recording/defs_recording.h"
 #include "track/track.h"
 #include "util/event.h"
+#include "util/sample.h" //Using MixMultiChanneltomono function to convert stereo to mono
 
 constexpr int kMetaDataLifeTimeout = 16;
 
 EngineRecord::EngineRecord(UserSettingsPointer pConfig)
         : m_pConfig(pConfig),
-          m_sampleRateControl(QStringLiteral("[App]"), QStringLiteral("samplerate")),
+          m_sampleRateControl(
+                  QStringLiteral("[App]"), QStringLiteral("samplerate")),
           m_frames(0),
           m_recordedDuration(0),
           m_iMetaDataLife(0),
           m_cueTrack(0),
           m_bCueIsEnabled(false),
-          m_bCueUsesFileAnnotation(false) {
+          m_bCueUsesFileAnnotation(
+                  false) { // defaulting to stereo but not picking from config
+                           // in case config is not yet loaded
     m_pRecReady = new ControlProxy(RECORDING_PREF_KEY, "status", this);
     m_sampleRate = mixxx::audio::SampleRate::fromDouble(m_sampleRateControl.get());
 }
@@ -36,6 +40,7 @@ int EngineRecord::updateFromPreferences() {
     m_baAuthor = m_pConfig->getValueString(ConfigKey(RECORDING_PREF_KEY, "Author"));
     m_baAlbum = m_pConfig->getValueString(ConfigKey(RECORDING_PREF_KEY, "Album"));
     m_cueFileName = m_pConfig->getValueString(ConfigKey(RECORDING_PREF_KEY, "CuePath"));
+
     m_bCueIsEnabled = m_pConfig->getValue<bool>(
             ConfigKey(RECORDING_PREF_KEY, QStringLiteral("CueEnabled")));
     m_bCueUsesFileAnnotation = m_pConfig->getValue<bool>(
@@ -202,9 +207,27 @@ void EngineRecord::process(const CSAMPLE* pBuffer, const std::size_t bufferSize)
     // Checking again from m_pRecReady since its status might have changed
     // in the previous "if" blocks.
     if (m_pRecReady->get() == RECORD_ON) {
+        int channelMode = m_pConfig->getValue<int>(
+                ConfigKey(RECORDING_PREF_KEY, "channel_mode"), 0);
+        bool recordMono = (channelMode == 1);
+        /* Downmixing audio to mono if mono recording is enabled.
+        We need to do it before encoding because some encoders don't support mono
+        and we want to be able to record in mono even with these encoders.*/
+        const CSAMPLE* bufferToEncode = pBuffer;
+        std::vector<CSAMPLE> monoBuffer;
+        std::size_t encoderBufferSize = bufferSize;
+
+        if (recordMono) {
+            // Allocate mono buffer (half the size since we're going from 2 channels to 1)
+            monoBuffer.resize(bufferSize / 2);
+            SampleUtil::mixMultichannelToMono(monoBuffer.data(), pBuffer, bufferSize);
+            bufferToEncode = monoBuffer.data();
+            encoderBufferSize = bufferSize / 2;
+        }
+
         // Compress audio. Encoder will call method 'write()' below to
         // write a file stream and emit bytesRecorded.
-        m_pEncoder->encodeBuffer(pBuffer, bufferSize);
+        m_pEncoder->encodeBuffer(bufferToEncode, encoderBufferSize);
 
         //Writing cueLine before updating the time counter since we prefer to be ahead
         //rather than late.
@@ -215,7 +238,7 @@ void EngineRecord::process(const CSAMPLE* pBuffer, const std::size_t bufferSize)
         }
 
         // update frames counting and recorded duration (seconds)
-        m_frames += bufferSize / 2;
+        m_frames += encoderBufferSize / 2;
         unsigned long lastDuration = m_recordedDuration;
         m_recordedDuration = m_frames / m_sampleRate;
 

--- a/src/engine/sidechain/enginerecord.h
+++ b/src/engine/sidechain/enginerecord.h
@@ -7,6 +7,7 @@
 #include "control/pollingcontrolproxy.h"
 #include "encoder/encoder.h"
 #include "encoder/encodercallback.h"
+#include "encoder/encodersettings.h"
 #include "engine/sidechain/sidechainworker.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"

--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -21,6 +21,11 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
           m_selFormat({QString(), QString(), false, QString()}) {
     setupUi(this);
 
+    // Recording audio output mode
+    recordingMainOutputModeComboBox->addItem(tr("Stereo"), 0);
+    recordingMainOutputModeComboBox->addItem(tr("Mono"), 1);
+    loadChannelMode();
+
     // Setting recordings path.
     QString recordingsPath = m_pConfig->getValueString(ConfigKey(RECORDING_PREF_KEY, "Directory"));
     if (recordingsPath.isEmpty()) {
@@ -54,18 +59,21 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
         if (prefformat == format.internalName) {
             m_selFormat = format;
             button->setChecked(true);
-            found=true;
+            found = true;
         }
         m_formatButtons.append(button);
     }
     if (!found) {
         // If no format was available, set to WAVE as default.
         if (!prefformat.isEmpty()) {
-            qWarning() << prefformat <<" format was set in the configuration, but it is not recognized!";
+            qWarning() << prefformat
+                       << " format was set in the configuration, but it is not "
+                          "recognized!";
         }
         m_selFormat = EncoderFactory::getFactory().getFormats().first();
         m_formatButtons.first()->setChecked(true);
-        m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "Encoding"),  ConfigValue(m_selFormat.internalName));
+        m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "Encoding"),
+                ConfigValue(m_selFormat.internalName));
     }
 
     setupEncoderUI();
@@ -98,7 +106,7 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
         // Set file split size
         comboBoxSplitting->setCurrentIndex(index);
     } else {
-        //Use max RIFF size (4GB) as default index, since usually people don't want to split.
+        // Use max RIFF size (4GB) as default index, since usually people don't want to split.
         comboBoxSplitting->setCurrentIndex(4);
         saveSplitSize();
     }
@@ -160,6 +168,16 @@ void DlgPrefRecord::slotApply() {
     saveUseCueFile();
     saveUseCueFileAnnotation();
     saveSplitSize();
+    saveChannelMode(); // saving channel preference (Mono/Stereo) to the config
+}
+// This function is saving the channel mode selection to the config
+void DlgPrefRecord::saveChannelMode() {
+    const int mode =
+            recordingMainOutputModeComboBox->currentData().toInt();
+
+    m_pConfig->set(
+            ConfigKey(RECORDING_PREF_KEY, "channel_mode"),
+            ConfigValue(mode));
 }
 
 // This function updates/refreshes the contents of this dialog.
@@ -167,9 +185,9 @@ void DlgPrefRecord::slotUpdate() {
     // Find out the max width of the labels. This is needed to keep the
     // UI fixed in size when hiding or showing elements.
     // It is not perfect, but it didn't get better than this.
-    int max=0;
-    if (LabelQuality->size().width()> max) {
-        max=LabelQuality->size().width();
+    int max = 0;
+    if (LabelQuality->size().width() > max) {
+        max = LabelQuality->size().width();
     }
     LabelLossless->setMaximumWidth(max);
     LabelLossy->setMaximumWidth(max);
@@ -195,6 +213,8 @@ void DlgPrefRecord::slotUpdate() {
             ConfigKey(RECORDING_PREF_KEY, "CueEnabled"), kDefaultCueEnabled));
 
     slotToggleCueEnabled();
+    loadChannelMode(); // Load recording channel mode (Mono/Stereo) to keep the
+                       // ui updated if reopening preferences
 
     QString fileSizeStr = m_pConfig->getValueString(ConfigKey(RECORDING_PREF_KEY, "FileSize"));
     int index = comboBoxSplitting->findText(fileSizeStr);
@@ -227,10 +247,10 @@ void DlgPrefRecord::slotResetToDefaults() {
 }
 
 void DlgPrefRecord::slotBrowseRecordingsDir() {
-    QString fd = QFileDialog::getExistingDirectory(
-            this, tr("Choose recordings directory"),
+    QString fd = QFileDialog::getExistingDirectory(this,
+            tr("Choose recordings directory"),
             m_pConfig->getValueString(
-                    ConfigKey(RECORDING_PREF_KEY,"Directory")));
+                    ConfigKey(RECORDING_PREF_KEY, "Directory")));
 
     if (fd != "") {
         // The user has picked a new directory via a file dialog. This means the
@@ -245,7 +265,7 @@ void DlgPrefRecord::slotBrowseRecordingsDir() {
 }
 
 void DlgPrefRecord::slotFormatChanged() {
-    QObject *senderObj = sender();
+    QObject* senderObj = sender();
     m_selFormat = EncoderFactory::getFactory().getFormatFor(senderObj->objectName());
     setupEncoderUI();
 }
@@ -257,7 +277,7 @@ void DlgPrefRecord::setupEncoderUI() {
     if (settings->usesQualitySlider()) {
         qualityGroup->setVisible(true);
         SliderQuality->setMinimum(0);
-        SliderQuality->setMaximum(settings->getQualityValues().size()-1);
+        SliderQuality->setMaximum(settings->getQualityValues().size() - 1);
         SliderQuality->setValue(settings->getQualityIndex());
         updateTextQuality();
     } else {
@@ -266,7 +286,7 @@ void DlgPrefRecord::setupEncoderUI() {
     if (settings->usesCompressionSlider()) {
         compressionGroup->setVisible(true);
         SliderCompression->setMinimum(0);
-        SliderCompression->setMaximum(settings->getCompressionValues().size()-1);
+        SliderCompression->setMaximum(settings->getCompressionValues().size() - 1);
         SliderCompression->setValue(settings->getCompression());
         updateTextCompression();
     } else {
@@ -306,7 +326,7 @@ void DlgPrefRecord::setupEncoderUI() {
             OptionGroupsLayout->addWidget(widget);
             optionsgroup.addButton(widget);
             m_optionWidgets.append(widget);
-            if (controlIdx == 0 ) {
+            if (controlIdx == 0) {
                 widget->setChecked(true);
             }
             controlIdx--;
@@ -314,10 +334,23 @@ void DlgPrefRecord::setupEncoderUI() {
     } else {
         labelOptionGroup->setVisible(false);
     }
-        // small hack for VBR
+    // small hack for VBR
     if (m_selFormat.internalName == ENCODING_MP3) {
         updateTextQuality();
     }
+}
+
+// This is to load the recording channel mode (Mono/Stereo) from config
+void DlgPrefRecord::loadChannelMode() {
+    const int mode = m_pConfig->getValue<int>(
+            ConfigKey(RECORDING_PREF_KEY, "channel_mode"),
+            0); // default = Stereo
+
+    const int index =
+            recordingMainOutputModeComboBox->findData(mode);
+
+    recordingMainOutputModeComboBox->setCurrentIndex(
+            index >= 0 ? index : 0);
 }
 
 void DlgPrefRecord::slotSliderQuality() {
@@ -366,8 +399,7 @@ void DlgPrefRecord::updateTextCompression() {
     TextCompression->setText(QString::number(quality));
 }
 
-void DlgPrefRecord::slotGroupChanged()
-{
+void DlgPrefRecord::slotGroupChanged() {
     // On complex scenarios, one could want to enable or disable some controls when changing
     // these, but we don't have these needs now.
     EncoderRecordingSettingsPointer settings =
@@ -425,7 +457,7 @@ void DlgPrefRecord::saveEncoding() {
             EncoderFactory::getFactory().getEncoderRecordingSettings(
                     m_selFormat, m_pConfig);
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "Encoding"),
-        ConfigValue(m_selFormat.internalName));
+            ConfigValue(m_selFormat.internalName));
 
     if (settings->usesQualitySlider()) {
         settings->setQualityByIndex(SliderQuality->value());
@@ -438,7 +470,7 @@ void DlgPrefRecord::saveEncoding() {
         // TODO (XXX): Right now i am supporting just one optiongroup.
         // The concept is already there for multiple groups
         EncoderSettings::OptionsGroup group = settings->getOptionGroups().first();
-        int i=0;
+        int i = 0;
         for (const QAbstractButton* widget : std::as_const(m_optionWidgets)) {
             if (widget->objectName() == group.groupCode) {
                 if (widget->isChecked() != Qt::Unchecked) {
@@ -460,7 +492,7 @@ void DlgPrefRecord::slotToggleCueEnabled() {
 
 void DlgPrefRecord::saveUseCueFile() {
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "CueEnabled"),
-                   ConfigValue(CheckBoxRecordCueFile->isChecked()));
+            ConfigValue(CheckBoxRecordCueFile->isChecked()));
 }
 
 void DlgPrefRecord::saveUseCueFileAnnotation() {
@@ -470,5 +502,5 @@ void DlgPrefRecord::saveUseCueFileAnnotation() {
 
 void DlgPrefRecord::saveSplitSize() {
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "FileSize"),
-                   ConfigValue(comboBoxSplitting->currentText()));
+            ConfigValue(comboBoxSplitting->currentText()));
 }

--- a/src/preferences/dialog/dlgprefrecord.h
+++ b/src/preferences/dialog/dlgprefrecord.h
@@ -49,6 +49,8 @@ class DlgPrefRecord : public DlgPreferencePage, public Ui::DlgPrefRecordDlg  {
     void saveUseCueFile();
     void saveUseCueFileAnnotation();
     void saveSplitSize();
+    void loadChannelMode();
+    void saveChannelMode();
 
     // Pointer to config object
     UserSettingsPointer m_pConfig;

--- a/src/preferences/dialog/dlgprefrecorddlg.ui
+++ b/src/preferences/dialog/dlgprefrecorddlg.ui
@@ -137,7 +137,30 @@ information from filepaths (i.e. username)</string>
     </widget>
    </item>
 
-   <item row="1" column="0" colspan="3">
+	<item row="1" column="0" colspan="3">
+		<widget class="QGroupBox" name="groupBoxAudio">
+			<property name="title">
+				<string>Audio</string>
+			</property>
+			<layout class="QGridLayout" name="gridLayoutAudio">
+				<item row="0" column="0">
+					<widget class="QLabel" name="recordingMainOutputModeLabel">
+						<property name="text">
+							<string>Channels</string>
+						</property>
+						<property name="buddy">
+							<cstring>recordingMainOutputModeComboBox</cstring>
+						</property>
+					</widget>
+				</item>
+				<item row="0" column="1" colspan="2">
+					<widget class="QComboBox" name="recordingMainOutputModeComboBox"/>
+				</item>
+			</layout>
+		</widget>
+	</item>
+
+	<item row="2" column="0" colspan="3">
     <widget class="QGroupBox" name="groupBoxFileformat">
      <property name="title">
       <string>Output File Format</string>
@@ -300,7 +323,7 @@ information from filepaths (i.e. username)</string>
     </widget>
    </item>
 
-   <item row="2" column="0" colspan="3">
+   <item row="3" column="0" colspan="3">
     <widget class="QGroupBox" name="groupBoxTags">
      <property name="title">
       <string>Tags</string>


### PR DESCRIPTION
This PR implements True Mono Recording Support as detailed in Issue #15180 . I have, after discussions with the community and maintainers, implemented an Independent Recording output option. So if the user wants the audio output in stereo but the recording output in Mono, that is possible (or any of the other three permutations).

Also, this is the GUI Change that will take place due to the recording output preference added:

**Before: **
<img width="2392" height="1558" alt="image" src="https://github.com/user-attachments/assets/6989a305-2d1d-459e-adae-9547459f12fd" />

**After: **
<img width="2384" height="1542" alt="image" src="https://github.com/user-attachments/assets/1f126d09-0b6f-45a1-ad79-b0cf49cc549f" />


**Note: This is a clean resubmission of #15947 with properly formatted code and a single commit for easier review trying to pass the code style check as it kept failing on the last pr due to majority of commits being without pre-commit.**