### PR TITLE
feat: make mouse wheel scroll loop size

### DIFF
--- a/res/qml/Deck/Loop.qml
+++ b/res/qml/Deck/Loop.qml
@@ -1,6 +1,6 @@
 import ".." as Skin
 import Mixxx 1.0 as Mixxx
-import QtQuick 2.12
+import QtQuick 2
 import QtQuick.Layouts
 import QtQuick.Shapes
 import QtQuick.Controls 2.12
@@ -104,6 +104,16 @@ Rectangle {
         }
     }
     RowLayout {
+        WheelHandler {
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+            onWheel: event => {
+                if (event.angleDelta.y < 0) {
+                    loopSizeRepeater.adjustSelectedIndex(-1)
+                } else if (event.angleDelta.y > 0) {
+                    loopSizeRepeater.adjustSelectedIndex(1)
+                }
+            }
+        }
         anchors {
             bottom: parent.bottom
             bottomMargin: 6
@@ -160,7 +170,7 @@ Rectangle {
                     if (loopEnabled.value ^ mouse.button == Qt.RightButton) {
                         loopHalve.trigger();
                     }
-                    loopSizeRepeater.selectedIndex = Math.max(0, loopSizeRepeater.selectedIndex - 1);
+                    loopSizeRepeater.adjustSelectedIndex(-1);
                 }
             }
         }
@@ -175,6 +185,11 @@ Rectangle {
                     values.push(values[values.length - 1] * 2);
                 }
                 return values;
+            }
+
+
+            function adjustSelectedIndex(delta){
+                loopSizeRepeater.selectedIndex = Math.min(Math.max(0, loopSizeRepeater.selectedIndex + delta), loopSizeRepeater.values.length - 1)
             }
 
             function update() {
@@ -296,7 +311,7 @@ Rectangle {
                     if (loopEnabled.value ^ mouse.button == Qt.RightButton) {
                         loopDouble.trigger();
                     }
-                    loopSizeRepeater.selectedIndex = Math.min(loopSizeRepeater.values.length - 1, loopSizeRepeater.selectedIndex + 1);
+                    loopSizeRepeater.adjustSelectedIndex(1);
                 }
             }
         }


### PR DESCRIPTION
Right clicks on the half/double button could already be used to scroll the loop size option without changing the current loop size. 

This PR makes the mouse wheel scrolling the loop size button as well.


https://github.com/user-attachments/assets/df71b5b9-f01b-477b-b206-46230b9cbb01

