### PR TITLE
fixed leveling of whitenoise effect

### DIFF
--- a/src/effects/backends/builtin/whitenoiseeffect.cpp
+++ b/src/effects/backends/builtin/whitenoiseeffect.cpp
@@ -56,7 +56,7 @@ void WhiteNoiseEffect::processChannel(
     RampingValue<CSAMPLE_GAIN> drywet_ramping_value(
             gs.previous_drywet, drywet, engineParameters.samplesPerBuffer());
 
-    std::uniform_real_distribution<> r_distributor(0.0, 1.0);
+    std::uniform_real_distribution<> r_distributor(-1.0, 1.0);
 
     for (SINT i = 0; i < engineParameters.samplesPerBuffer(); i++) {
         CSAMPLE_GAIN drywet_ramped = drywet_ramping_value.getNth(i);


### PR DESCRIPTION
The whitenoise effect adds a DC offset to the audio signal because the generator only adds positive values to the audio signal.
This is how the audio signal looked like before the fix:
<img width="243" height="150" alt="Bildschirmfoto_20260215_094434" src="https://github.com/user-attachments/assets/b4cfae9e-f9cc-43c3-8abb-89db498a785c" />

By changing the range of the random number generator from (0 , 1) to (-1 , 1), the noise is now centered in the output signal:
<img width="210" height="139" alt="Bildschirmfoto_20260215_095713" src="https://github.com/user-attachments/assets/7be3111f-4c34-412e-a8a0-0109aceade94" />
