### PR TITLE
Disable GitHub cache for VCPKG buildenv to save buildtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,13 +205,6 @@ jobs:
         if: runner.os != 'Linux'
         run: ${{ matrix.buildenv_script }} name
 
-      - name: "[macOS/Windows] Set up build environment cache"
-        if: runner.os != 'Linux'
-        uses: actions/cache@v5
-        with:
-          path: ${{ matrix.buildenv_basepath }}
-          key: ${{ runner.os }}-buildenv-${{ env.BUILDENV_NAME }}
-
       - name: "[macOS] Import Apple code signing identity"
         id: apple_codesign
         if: runner.os == 'macOS' && env.MACOS_CODESIGN_CERTIFICATE_P12_BASE64 != null && env.MACOS_CODESIGN_CERTIFICATE_PASSWORD != null


### PR DESCRIPTION
Overall the caching of the VCPKG build environments cost a lot of build time and electrical energy, because the available cache space is not enough for compiler cache (ccache on non-Windows) and the buildenv cache (on non-Linux).

- Benefit of buildenv caching in case of cache hit: ~2minutes
- Cost of buildenv caching in case of cache miss: ~4minutes

- Benefit of compiler caching (ccache): ~30minutes