### PR TITLE
Effects: add control to show/hide effect/chain preset popup

### DIFF
--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -123,6 +123,17 @@ EffectChain::EffectChain(const QString& group,
             &EffectChain::slotControlChainPresetSelector);
     m_pControlChainPresetSelector->addAlias(ConfigKey(m_group, QStringLiteral("chain_selector")));
 
+    m_pControlShowPresetList =
+            std::make_unique<ControlPushButton>(ConfigKey(m_group, "show_preset_list"));
+    m_pControlShowPresetList->connectValueChangeRequest(
+            this,
+            [this](double value) {
+                emit presetListShowRequest(value > 0);
+            });
+    // All WEffectChainPresetSelector of this chain receive this. If one of them
+    // is visible, it'll return a 'confirm' signal which we handle in
+    // slotPresetListVisibleChanged and set the control accordingly.
+
     // ControlObjects for skin <-> controller mapping interaction.
     // Refer to comment in header for full explanation.
     m_pControlChainShowFocus = std::make_unique<ControlPushButton>(
@@ -406,6 +417,10 @@ void EffectChain::slotEffectChainPresetRenamed(const QString& oldName, const QSt
 void EffectChain::slotPresetListUpdated() {
     setControlLoadedPresetIndex(presetIndex());
     m_pControlNumChainPresets->forceSet(numPresets());
+}
+
+void EffectChain::slotPresetListVisibleChanged(bool visible) {
+    m_pControlShowPresetList->setAndConfirm(visible ? 1.0 : 0.0);
 }
 
 void EffectChain::enableForInputChannel(const ChannelHandleAndGroup& handleGroup) {

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -81,9 +81,11 @@ class EffectChain : public QObject {
 
   public slots:
     void slotControlClear(double value);
+    void slotPresetListVisibleChanged(bool visible);
 
   signals:
     void chainPresetChanged(const QString& name);
+    void presetListShowRequest(bool show);
 
   protected slots:
     void sendParameterUpdate();
@@ -153,6 +155,7 @@ class EffectChain : public QObject {
     std::unique_ptr<ControlPushButton> m_pControlChainShowFocus;
     std::unique_ptr<ControlPushButton> m_pControlChainHasControllerFocus;
     std::unique_ptr<ControlPushButton> m_pControlChainShowParameters;
+    std::unique_ptr<ControlPushButton> m_pControlShowPresetList;
     std::unique_ptr<ControlPushButton> m_pControlChainFocusedEffect;
 
     SignalProcessingStage m_signalProcessingStage;

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -114,6 +114,17 @@ EffectSlot::EffectSlot(const QString& group,
             this,
             &EffectSlot::slotClear);
 
+    m_pControlShowPresetList =
+            std::make_unique<ControlPushButton>(ConfigKey(m_group, "show_preset_list"));
+    m_pControlShowPresetList->connectValueChangeRequest(
+            this,
+            [this](double value) {
+                emit presetListShowRequest(value > 0);
+            });
+    // All WEffectSelector of this slot receive this. If one of them is visible,
+    // it'll return a 'confirm' signal which we handle in slotPresetListVisibleChanged
+    // and set the control accordingly.
+
     for (unsigned int i = 0; i < kDefaultMaxParameters; ++i) {
         addEffectParameterSlot(EffectParameterType::Knob);
         addEffectParameterSlot(EffectParameterType::Button);
@@ -584,4 +595,8 @@ void EffectSlot::slotEffectMetaParameter(double v, bool force) {
             pParameterSlot->onEffectMetaParameterChanged(v, force);
         }
     }
+}
+
+void EffectSlot::slotPresetListVisibleChanged(bool visible) {
+    m_pControlShowPresetList->setAndConfirm(visible ? 1.0 : 0.0);
 }

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -133,11 +133,13 @@ class EffectSlot : public QObject {
     void slotLoadedEffectRequest(double value);
     void slotClear(double v);
     void slotEffectSelector(double v);
+    void slotPresetListVisibleChanged(bool visible);
     void slotEffectMetaParameter(double v, bool force = false);
 
   signals:
     void effectChanged();
     void parametersChanged();
+    void presetListShowRequest(bool show);
 
   private slots:
     void updateEngineState();
@@ -188,6 +190,7 @@ class EffectSlot : public QObject {
     std::unique_ptr<ControlEncoder> m_pControlEffectSelector;
     std::unique_ptr<ControlObject> m_pControlClear;
     std::unique_ptr<ControlPotmeter> m_pControlMetaParameter;
+    std::unique_ptr<ControlPushButton> m_pControlShowPresetList;
 
     SoftTakeover m_metaknobSoftTakeover;
 

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -67,6 +67,16 @@ void WEffectChainPresetSelector::setup(const QDomNode& node, const SkinContext& 
             QOverload<int>::of(&QComboBox::activated),
             this,
             &WEffectChainPresetSelector::slotEffectChainPresetSelected);
+    // Show/hide the chains list
+    connect(m_pChain.data(),
+            &EffectChain::presetListShowRequest,
+            this,
+            &WEffectChainPresetSelector::slotPresetListShowRequest);
+    // Callback when list is shown/hidden
+    connect(this,
+            &WEffectChainPresetSelector::presetListVisibleChanged,
+            m_pChain.data(),
+            &EffectChain::slotPresetListVisibleChanged);
 
     populate();
 }
@@ -126,6 +136,33 @@ void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
 void WEffectChainPresetSelector::slotChainPresetChanged(const QString& name) {
     setCurrentIndex(findData(name));
     setBaseTooltip(itemData(currentIndex(), Qt::ToolTipRole).toString());
+}
+
+void WEffectChainPresetSelector::slotPresetListShowRequest(bool show) {
+    if (!isVisible()) {
+        return;
+    }
+    if (show) {
+        showPopup();
+    } else {
+        hidePopup();
+    }
+}
+
+/// This opens the popup. Overrides showPopup() so we can set the visibility control,
+/// both when clicking the down arrow and when triggering the control.
+void WEffectChainPresetSelector::showPopup() {
+    if (count() > 0) {
+        QComboBox::showPopup();
+        emit presetListVisibleChanged(true);
+    }
+}
+
+/// Same as showPopup(), override to set the visibility control for both GUI and
+/// control changes
+void WEffectChainPresetSelector::hidePopup() {
+    QComboBox::hidePopup();
+    emit presetListVisibleChanged(false);
 }
 
 bool WEffectChainPresetSelector::event(QEvent* pEvent) {

--- a/src/widget/weffectchainpresetselector.h
+++ b/src/widget/weffectchainpresetselector.h
@@ -16,10 +16,17 @@ class WEffectChainPresetSelector : public QComboBox, public WBaseWidget {
 
     void setup(const QDomNode& node, const SkinContext& context);
 
+    void showPopup() override;
+    void hidePopup() override;
+
+  signals:
+    void presetListVisibleChanged(bool visible);
+
   private slots:
     void populate();
     void slotEffectChainPresetSelected(int index);
     void slotChainPresetChanged(const QString& name);
+    void slotPresetListShowRequest(bool show);
     bool event(QEvent* pEvent) override;
     void paintEvent(QPaintEvent* e) override;
 

--- a/src/widget/weffectselector.h
+++ b/src/widget/weffectselector.h
@@ -16,9 +16,16 @@ class WEffectSelector : public QComboBox, public WBaseWidget {
 
     void setup(const QDomNode& node, const SkinContext& context);
 
+    void showPopup() override;
+    void hidePopup() override;
+
+  signals:
+    void presetListVisibleChanged(bool visible);
+
   private slots:
     void slotEffectUpdated();
     void slotEffectSelected(int newIndex);
+    void slotPresetListShowRequest(bool show);
     void populate();
     bool event(QEvent* pEvent) override;
 


### PR DESCRIPTION
This is a little helper to simplify effect/chain selection with keyboards / controllers.
Instead of blindly going through the preset list with the next/prev controls, you can now bind keys to show the popup and use the arrow keys + Enter to select an effect.

Controls are read+write, meaning they're also updated when the popup is opened with the mouse.

for example
`[EffectRack1_EffectUnit1_Effect3],show_preset_list`
`[QuickEffectRack1_[Channel2]],show_preset_list`

Not sure if you're happy with this targetting the beta branch. If not, I'll rebase onto main.