### PR TITLE
Fix out of bounds read in echoeffect

### DIFF
--- a/src/effects/backends/builtin/echoeffect.cpp
+++ b/src/effects/backends/builtin/echoeffect.cpp
@@ -152,8 +152,10 @@ void EchoEffect::processChannel(
         delay_seconds = 1 / engineParameters.sampleRate();
     }
 
-    int delay_samples = static_cast<int>(delay_seconds *
-            engineParameters.channelCount() * engineParameters.sampleRate());
+    int delay_frames = static_cast<int>(delay_seconds *
+            engineParameters.sampleRate());
+
+    int delay_samples = delay_frames * engineParameters.channelCount();
     VERIFY_OR_DEBUG_ASSERT(delay_samples <= pGroupState->delay_buf.size()) {
         delay_samples = pGroupState->delay_buf.size();
     }


### PR DESCRIPTION
The echoeffect had an out of bounds read in the line:
`CSAMPLE bufferedSampleRight = pGroupState->delay_buf[read_position + 1];`

This happened, when the calculated delay_samples was not a multiple of the channel count.
I fixed it by first calculating the number of frames as an integer and then multiply the number with the channel count,
so that the delay_samples value is a multiple of the channel count.

This pull request will partially fix the issue: https://github.com/mixxxdj/mixxx/issues/15835