### PR TITLE
make file size displays consistent: use SI units (kB, MB, GB), 1 decimal

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -397,7 +397,7 @@ void DlgTrackInfo::replaceTrackRecord(
     QFileInfo info(trackLocation);
     if (info.exists() && info.isFile()) {
         int size = info.size();
-        QString sizeStr = QLocale().formattedDataSize(size);
+        QString sizeStr = QLocale().formattedDataSize(size, 1, QLocale::DataSizeSIFormat);
         txtFileSize->setText(sizeStr);
     }
 

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -148,8 +148,8 @@ void DlgRecording::slotRecordingStateChanged(bool isRecording) {
 
 // gets number of recorded bytes and update label
 void DlgRecording::slotBytesRecorded(int bytes) {
-    double megabytes = bytes / 1048576.0;
-    m_bytesRecordedStr = QString::number(megabytes,'f',2);
+    m_bytesRecordedStr =
+            QLocale().formattedDataSize(bytes, 1, QLocale::DataSizeSIFormat);
     refreshLabels();
 }
 
@@ -162,7 +162,7 @@ void DlgRecording::slotDurationRecorded(const QString& durationRecorded) {
 // update label besides start/stop button
 void DlgRecording::refreshLabels() {
     QString recFile = m_pRecordingManager->getRecordingFile();
-    QString recData = QString(QStringLiteral("(") + tr("%1 MiB written in %2") +
+    QString recData = QString(QStringLiteral("(") + tr("%1 written in %2") +
             QStringLiteral(")"))
                               .arg(m_bytesRecordedStr, m_durationRecordedStr);
     labelRecFilename->setText(recFile);


### PR DESCRIPTION
follow-up for #15578

Adjusts file size strings in
* Recording
* Track Info

My reasoning was
> IMO we only need a precision of 1, and --personally-- I'd prefer the old format with SI prefixes (kB, MB, GB), see https://doc.qt.io/qt-6/qlocale.html#DataSizeFormat-enum
just because it's used on all (major) marketplaces and even in Mixxx conversations I never encountered the new IEC prefixes (kiB, MiB, GiB)