### PR TITLE
Implement Playlist and Crate Sorting Options

### DIFF
--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -1,5 +1,6 @@
 #include "library/trackset/crate/cratefeature.h"
 
+#include <QActionGroup>
 #include <QInputDialog>
 #include <QLineEdit>
 #include <QMenu>
@@ -56,6 +57,7 @@ CrateFeature::CrateFeature(Library* pLibrary,
 
     // construct child model
     m_pSidebarModel->setRootItem(TreeItem::newRoot(this));
+    loadCrateSortSettings();
     rebuildChildModel();
 
     connectLibrary(pLibrary);
@@ -360,10 +362,40 @@ bool CrateFeature::isChildIndexSelectedInSidebar(const QModelIndex& index) {
 }
 
 void CrateFeature::onRightClick(const QPoint& globalPos) {
+    qDebug() << "onRightClick called";
     m_lastRightClickedIndex = QModelIndex();
     QMenu menu(m_pSidebarWidget);
     menu.addAction(m_pCreateCrateAction.get());
     menu.addSeparator();
+
+    auto pSortMenu = make_parented<QMenu>(tr("Sort crates"), &menu);
+
+    auto pSortOrderGroup = make_parented<QActionGroup>(pSortMenu.get());
+    pSortOrderGroup->setExclusive(true);
+
+    QAction* pSortAscending = pSortMenu->addAction(tr("Ascending (A-Z)"));
+    pSortAscending->setCheckable(true);
+    pSortAscending->setChecked(m_sortOrder == CrateSortOrder::Ascending);
+    pSortAscending->setActionGroup(pSortOrderGroup.get());
+    connect(pSortAscending, &QAction::triggered, this, [this]() {
+        m_sortOrder = CrateSortOrder::Ascending;
+        saveCrateSortSettings();
+        rebuildChildModel();
+    });
+
+    QAction* pSortDescending = pSortMenu->addAction(tr("Descending (Z-A)"));
+    pSortDescending->setCheckable(true);
+    pSortDescending->setChecked(m_sortOrder == CrateSortOrder::Descending);
+    pSortDescending->setActionGroup(pSortOrderGroup.get());
+    connect(pSortDescending, &QAction::triggered, this, [this]() {
+        m_sortOrder = CrateSortOrder::Descending;
+        saveCrateSortSettings();
+        rebuildChildModel();
+    });
+
+    menu.addMenu(pSortMenu.get());
+    menu.addSeparator();
+
     menu.addAction(m_pCreateImportPlaylistAction.get());
 #ifdef __ENGINEPRIME__
     menu.addSeparator();
@@ -567,9 +599,25 @@ QModelIndex CrateFeature::rebuildChildModel(CrateId selectedCrateId) {
     CrateSummary crateSummary;
     while (crateSummaries.populateNext(&crateSummary)) {
         modelRows.push_back(newTreeItemForCrateSummary(crateSummary));
-        if (selectedCrateId == crateSummary.getId()) {
-            // save index for selection
-            selectedRow = static_cast<int>(modelRows.size()) - 1;
+    }
+    // Sort the crates by name based on user preference
+    if (m_sortOrder == CrateSortOrder::Descending) {
+        std::sort(modelRows.begin(),
+                modelRows.end(),
+                [](const std::unique_ptr<TreeItem>& a,
+                        const std::unique_ptr<TreeItem>& b) {
+                    return a->getLabel().compare(
+                                   b->getLabel(), Qt::CaseInsensitive) > 0;
+                });
+    }
+    // Ascending is already default from selectCrateSummaries()
+    // Find selected row after sorting
+    for (size_t i = 0; i < modelRows.size(); ++i) {
+        TreeItem* item = modelRows[i].get();
+        if (item && selectedCrateId.isValid() &&
+                CrateId(item->getData()) == selectedCrateId) {
+            selectedRow = static_cast<int>(i);
+            break;
         }
     }
 
@@ -955,4 +1003,17 @@ void CrateFeature::slotTrackSelected(TrackId trackId) {
 
 void CrateFeature::slotResetSelectedTrack() {
     slotTrackSelected(TrackId{});
+}
+
+void CrateFeature::loadCrateSortSettings() {
+    int sortOrderInt = m_pConfig->getValue(
+            ConfigKey("[Library]", "CrateSortOrder"),
+            static_cast<int>(CrateSortOrder::Ascending));
+    m_sortOrder = static_cast<CrateSortOrder>(sortOrderInt);
+}
+
+void CrateFeature::saveCrateSortSettings() {
+    m_pConfig->setValue(
+            ConfigKey("[Library]", "CrateSortOrder"),
+            static_cast<int>(m_sortOrder));
 }

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -20,6 +20,11 @@ class QAction;
 class QPoint;
 class CrateSummary;
 
+enum class CrateSortOrder {
+    Ascending,
+    Descending
+};
+
 class CrateFeature : public BaseTrackSetFeature {
     Q_OBJECT
 
@@ -114,6 +119,11 @@ class CrateFeature : public BaseTrackSetFeature {
     QModelIndex m_lastClickedIndex;
     QModelIndex m_lastRightClickedIndex;
     TrackId m_selectedTrackId;
+
+    CrateSortOrder m_sortOrder;
+
+    void saveCrateSortSettings();
+    void loadCrateSortSettings();
 
     parented_ptr<QAction> m_pCreateCrateAction;
     parented_ptr<QAction> m_pDeleteCrateAction;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -88,7 +88,7 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     pSortByName->setCheckable(true);
     pSortByName->setChecked(m_sortColumn == PlaylistSortColumn::Name);
     pSortByName->setActionGroup(pSortByGroup);
-    connect(pSortByName, &QAction::triggered, [this]() {
+    connect(pSortByName, &QAction::triggered, this, [this]() {
         qDebug() << "Clicked: Name";
         m_sortColumn = PlaylistSortColumn::Name;
         saveSortSettings();
@@ -100,7 +100,7 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     pSortByDateCreated->setCheckable(true);
     pSortByDateCreated->setChecked(m_sortColumn == PlaylistSortColumn::DateCreated);
     pSortByDateCreated->setActionGroup(pSortByGroup);
-    connect(pSortByDateCreated, &QAction::triggered, [this]() {
+    connect(pSortByDateCreated, &QAction::triggered, this, [this]() {
         qDebug() << "Clicked: Date Created";
         m_sortColumn = PlaylistSortColumn::DateCreated;
         saveSortSettings();
@@ -119,7 +119,7 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     pSortAscending->setCheckable(true);
     pSortAscending->setChecked(m_sortOrder == PlaylistSortOrder::Ascending);
     pSortAscending->setActionGroup(pSortOrderGroup);
-    connect(pSortAscending, &QAction::triggered, [this]() {
+    connect(pSortAscending, &QAction::triggered, this, [this]() {
         qDebug() << "Clicked: sort ascending";
         m_sortOrder = PlaylistSortOrder::Ascending;
         saveSortSettings();
@@ -131,7 +131,7 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     pSortDescending->setCheckable(true);
     pSortDescending->setChecked(m_sortOrder == PlaylistSortOrder::Descending);
     pSortDescending->setActionGroup(pSortOrderGroup);
-    connect(pSortDescending, &QAction::triggered, [this]() {
+    connect(pSortDescending, &QAction::triggered, this, [this]() {
         qDebug() << "Clicked: sort descending";
         m_sortOrder = PlaylistSortOrder::Descending;
         saveSortSettings();

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -69,7 +69,6 @@ QVariant PlaylistFeature::title() {
 }
 
 void PlaylistFeature::onRightClick(const QPoint& globalPos) {
-    qDebug() << "onRightClick called";
     m_lastRightClickedIndex = QModelIndex();
     QMenu menu(m_pSidebarWidget);
     menu.addAction(m_pCreatePlaylistAction);
@@ -89,7 +88,6 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     pSortByName->setChecked(m_sortColumn == PlaylistSortColumn::Name);
     pSortByName->setActionGroup(pSortByGroup.get());
     connect(pSortByName, &QAction::triggered, this, [this]() {
-        qDebug() << "Clicked: Name";
         m_sortColumn = PlaylistSortColumn::Name;
         saveSidebarSortSettings();
         clearChildModel();
@@ -101,7 +99,6 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     pSortByDateCreated->setChecked(m_sortColumn == PlaylistSortColumn::DateCreated);
     pSortByDateCreated->setActionGroup(pSortByGroup.get());
     connect(pSortByDateCreated, &QAction::triggered, this, [this]() {
-        qDebug() << "Clicked: Date Created";
         m_sortColumn = PlaylistSortColumn::DateCreated;
         saveSidebarSortSettings();
         clearChildModel();
@@ -120,7 +117,6 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     pSortAscending->setChecked(m_sortOrder == PlaylistSortOrder::Ascending);
     pSortAscending->setActionGroup(pSortOrderGroup.get());
     connect(pSortAscending, &QAction::triggered, this, [this]() {
-        qDebug() << "Clicked: sort ascending";
         m_sortOrder = PlaylistSortOrder::Ascending;
         saveSidebarSortSettings();
         clearChildModel();
@@ -132,7 +128,6 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     pSortDescending->setChecked(m_sortOrder == PlaylistSortOrder::Descending);
     pSortDescending->setActionGroup(pSortOrderGroup.get());
     connect(pSortDescending, &QAction::triggered, this, [this]() {
-        qDebug() << "Clicked: sort descending";
         m_sortOrder = PlaylistSortOrder::Descending;
         saveSidebarSortSettings();
         clearChildModel();
@@ -275,8 +270,6 @@ QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
     QString selectQuery = QStringLiteral("SELECT * FROM %1").arg(m_countsDurationTableName);
     selectQuery.append(getSortOrderClause()); // Add ORDER BY to SELECT, not CREATE VIEW
 
-    qDebug() << "Select query with sorting:" << selectQuery;
-
     QSqlQuery selectQueryExec(database);
     if (!selectQueryExec.exec(selectQuery)) {
         LOG_FAILED_QUERY(selectQueryExec);
@@ -306,8 +299,6 @@ void PlaylistFeature::slotShufflePlaylist() {
     }
 
     if (m_playlistDao.isPlaylistLocked(playlistId)) {
-        qDebug() << "Can't shuffle locked playlist" << playlistId
-                 << m_playlistDao.getPlaylistName(playlistId);
         return;
     }
 
@@ -349,8 +340,6 @@ void PlaylistFeature::slotOrderTracksByCurrentPosition() {
     }
 
     if (m_playlistDao.isPlaylistLocked(playlistId)) {
-        qDebug() << "Can't adopt current sorting for locked playlist" << playlistId
-                 << m_playlistDao.getPlaylistName(playlistId);
         return;
     }
     // Note(ronso0) I propose to proceed only if the playlist is selected and loaded.
@@ -406,7 +395,6 @@ void PlaylistFeature::slotDeleteAllUnlockedPlaylists() {
 /// This method queries the database and does dynamic insertion
 /// @param selectedId entry which should be selected
 QModelIndex PlaylistFeature::constructChildModel(int selectedId) {
-    // qDebug() << "PlaylistFeature::constructChildModel() id:" << selectedId;
     std::vector<std::unique_ptr<TreeItem>> childrenToAdd;
     int selectedRow = -1;
 
@@ -449,7 +437,6 @@ void PlaylistFeature::decorateChild(TreeItem* item, int playlistId) {
 }
 
 void PlaylistFeature::slotPlaylistTableChanged(int playlistId) {
-    // qDebug() << "PlaylistFeature::slotPlaylistTableChanged() playlistId:" << playlistId;
     enum PlaylistDAO::HiddenType type = m_playlistDao.getHiddenType(playlistId);
     if (type != PlaylistDAO::PLHT_NOT_HIDDEN &&  // not a regular playlist
             type != PlaylistDAO::PLHT_UNKNOWN) { // not a deleted playlist
@@ -481,7 +468,6 @@ void PlaylistFeature::slotPlaylistTableChanged(int playlistId) {
 }
 
 void PlaylistFeature::slotPlaylistContentOrLockChanged(const QSet<int>& playlistIds) {
-    // qDebug() << "PlaylistFeature::slotPlaylistContentOrLockChanged() playlistId:" << playlistIds;
     QSet<int> idsToBeUpdated;
     for (const auto playlistId : std::as_const(playlistIds)) {
         if (m_playlistDao.getHiddenType(playlistId) == PlaylistDAO::PLHT_NOT_HIDDEN) {
@@ -496,7 +482,6 @@ void PlaylistFeature::slotPlaylistContentOrLockChanged(const QSet<int>& playlist
 
 void PlaylistFeature::slotPlaylistTableRenamed(int playlistId, const QString& newName) {
     Q_UNUSED(newName);
-    // qDebug() << "PlaylistFeature::slotPlaylistTableRenamed() playlistId:" << playlistId;
     if (m_playlistDao.getHiddenType(playlistId) == PlaylistDAO::PLHT_NOT_HIDDEN) {
         // Maybe we need to re-sort the sidebar items, so call slotPlaylistTableChanged()
         // in order to rebuild the model, not just updateChildModel()
@@ -544,8 +529,6 @@ void PlaylistFeature::loadSidebarSortSettings() {
             ConfigKey("[Library]", "PlaylistSortOrder"),
             static_cast<int>(PlaylistSortOrder::Ascending));
     m_sortOrder = static_cast<PlaylistSortOrder>(sortOrderInt);
-    qDebug() << "Loaded playlist sort settings - Column:" << sortColumnInt
-             << "Order:" << sortOrderInt;
 }
 
 void PlaylistFeature::saveSidebarSortSettings() {
@@ -568,8 +551,8 @@ QString PlaylistFeature::getSortColumnName() const {
 }
 
 QString PlaylistFeature::getSortOrderClause() const {
-    QString columnName = getSortColumnName();
-    QString order = (m_sortOrder == PlaylistSortOrder::Descending)
+    const QString columnName = getSortColumnName();
+    const QString order = (m_sortOrder == PlaylistSortOrder::Descending)
             ? QStringLiteral(" DESC")
             : QStringLiteral(" ASC"); // ← Explicitly add ASC
 
@@ -586,7 +569,5 @@ QString PlaylistFeature::getSortOrderClause() const {
         result = QStringLiteral(" ORDER BY ") + columnName + order;
     }
 
-    qDebug() << "PlaylistFeature sort - Column:" << columnName
-             << "Order:" << order << "Full clause:" << result;
     return result;
 }

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -1,6 +1,6 @@
 #include "library/trackset/playlistfeature.h"
 
-#include <QActionGroup> //added to help create sort menu
+#include <QActionGroup>
 #include <QMenu>
 #include <QSqlTableModel>
 #include <QtDebug>
@@ -34,7 +34,7 @@ PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
     std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
     m_pSidebarModel->setRootItem(std::move(pRootItem));
 
-    loadSortSettings(); // To load Sorting settings for Playlists in the sidebar
+    loadSidebarSortSettings();
     constructChildModel(kInvalidPlaylistId);
 
     m_pShufflePlaylistAction = make_parented<QAction>(tr("Shuffle Playlist"), this);
@@ -69,29 +69,29 @@ QVariant PlaylistFeature::title() {
 }
 
 void PlaylistFeature::onRightClick(const QPoint& globalPos) {
+    qDebug() << "onRightClick called";
     m_lastRightClickedIndex = QModelIndex();
     QMenu menu(m_pSidebarWidget);
     menu.addAction(m_pCreatePlaylistAction);
     menu.addSeparator();
 
-    // adding sort menu items
-    QMenu* pSortMenu = new QMenu(tr("Sort playlists"), &menu);
+    auto pSortMenu = make_parented<QMenu>(tr("Sort playlists"), &menu);
 
     // Sort by submenu
-    QMenu* pSortByMenu = new QMenu(tr("Sort by"), pSortMenu);
+    auto pSortByMenu = make_parented<QMenu>(tr("Sort by"), pSortMenu.get());
 
     // Create action group for exclusive selection
-    QActionGroup* pSortByGroup = new QActionGroup(pSortByMenu);
+    auto pSortByGroup = make_parented<QActionGroup>(pSortByMenu.get());
     pSortByGroup->setExclusive(true);
 
     QAction* pSortByName = pSortByMenu->addAction(tr("Name"));
     pSortByName->setCheckable(true);
     pSortByName->setChecked(m_sortColumn == PlaylistSortColumn::Name);
-    pSortByName->setActionGroup(pSortByGroup);
+    pSortByName->setActionGroup(pSortByGroup.get());
     connect(pSortByName, &QAction::triggered, this, [this]() {
         qDebug() << "Clicked: Name";
         m_sortColumn = PlaylistSortColumn::Name;
-        saveSortSettings();
+        saveSidebarSortSettings();
         clearChildModel();
         constructChildModel(kInvalidPlaylistId);
     });
@@ -99,30 +99,30 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     QAction* pSortByDateCreated = pSortByMenu->addAction(tr("Date created"));
     pSortByDateCreated->setCheckable(true);
     pSortByDateCreated->setChecked(m_sortColumn == PlaylistSortColumn::DateCreated);
-    pSortByDateCreated->setActionGroup(pSortByGroup);
+    pSortByDateCreated->setActionGroup(pSortByGroup.get());
     connect(pSortByDateCreated, &QAction::triggered, this, [this]() {
         qDebug() << "Clicked: Date Created";
         m_sortColumn = PlaylistSortColumn::DateCreated;
-        saveSortSettings();
+        saveSidebarSortSettings();
         clearChildModel();
         constructChildModel(kInvalidPlaylistId);
     });
 
-    pSortMenu->addMenu(pSortByMenu);
+    pSortMenu->addMenu(pSortByMenu.get());
     pSortMenu->addSeparator();
 
     // Sort order (Ascending/Descending)
-    QActionGroup* pSortOrderGroup = new QActionGroup(pSortMenu);
+    auto pSortOrderGroup = make_parented<QActionGroup>(pSortMenu.get());
     pSortOrderGroup->setExclusive(true);
 
     QAction* pSortAscending = pSortMenu->addAction(tr("Ascending"));
     pSortAscending->setCheckable(true);
     pSortAscending->setChecked(m_sortOrder == PlaylistSortOrder::Ascending);
-    pSortAscending->setActionGroup(pSortOrderGroup);
+    pSortAscending->setActionGroup(pSortOrderGroup.get());
     connect(pSortAscending, &QAction::triggered, this, [this]() {
         qDebug() << "Clicked: sort ascending";
         m_sortOrder = PlaylistSortOrder::Ascending;
-        saveSortSettings();
+        saveSidebarSortSettings();
         clearChildModel();
         constructChildModel(kInvalidPlaylistId);
     });
@@ -130,16 +130,16 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     QAction* pSortDescending = pSortMenu->addAction(tr("Descending"));
     pSortDescending->setCheckable(true);
     pSortDescending->setChecked(m_sortOrder == PlaylistSortOrder::Descending);
-    pSortDescending->setActionGroup(pSortOrderGroup);
+    pSortDescending->setActionGroup(pSortOrderGroup.get());
     connect(pSortDescending, &QAction::triggered, this, [this]() {
         qDebug() << "Clicked: sort descending";
         m_sortOrder = PlaylistSortOrder::Descending;
-        saveSortSettings();
+        saveSidebarSortSettings();
         clearChildModel();
         constructChildModel(kInvalidPlaylistId);
     });
 
-    menu.addMenu(pSortMenu);
+    menu.addMenu(pSortMenu.get());
     menu.addSeparator();
 
     menu.addAction(m_pUnlockPlaylistsAction);
@@ -532,7 +532,7 @@ QString PlaylistFeature::getRootViewHtml() const {
     return html;
 }
 
-void PlaylistFeature::loadSortSettings() {
+void PlaylistFeature::loadSidebarSortSettings() {
     // Load sort column (default: Name)
     int sortColumnInt = m_pConfig->getValue(
             ConfigKey("[Library]", "PlaylistSortColumn"),
@@ -548,7 +548,7 @@ void PlaylistFeature::loadSortSettings() {
              << "Order:" << sortOrderInt;
 }
 
-void PlaylistFeature::saveSortSettings() {
+void PlaylistFeature::saveSidebarSortSettings() {
     m_pConfig->setValue(
             ConfigKey("[Library]", "PlaylistSortColumn"),
             static_cast<int>(m_sortColumn));

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -12,6 +12,17 @@
 class TreeItem;
 class QPoint;
 
+enum class PlaylistSortColumn { // adding enum classes for Sorting Playlists by
+                                // different columns in the playlist sidebar
+    Name,
+    DateCreated,
+};
+
+enum class PlaylistSortOrder {
+    Ascending,
+    Descending
+};
+
 class PlaylistFeature : public BasePlaylistFeature {
     Q_OBJECT
 
@@ -53,4 +64,14 @@ class PlaylistFeature : public BasePlaylistFeature {
     parented_ptr<QAction> m_pOrderByCurrentPosAction;
     parented_ptr<QAction> m_pUnlockPlaylistsAction;
     parented_ptr<QAction> m_pDeleteAllUnlockedPlaylistsAction;
+
+    // Sort settings
+    PlaylistSortColumn m_sortColumn;
+    PlaylistSortOrder m_sortOrder;
+
+    // Helper methods for sorting
+    QString getSortColumnName() const;
+    QString getSortOrderClause() const;
+    void saveSortSettings();
+    void loadSortSettings();
 };

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -12,8 +12,7 @@
 class TreeItem;
 class QPoint;
 
-enum class PlaylistSortColumn { // adding enum classes for Sorting Playlists by
-                                // different columns in the playlist sidebar
+enum class PlaylistSortColumn {
     Name,
     DateCreated,
 };
@@ -72,6 +71,6 @@ class PlaylistFeature : public BasePlaylistFeature {
     // Helper methods for sorting
     QString getSortColumnName() const;
     QString getSortOrderClause() const;
-    void saveSortSettings();
-    void loadSortSettings();
+    void saveSidebarSortSettings();
+    void loadSidebarSortSettings();
 };


### PR DESCRIPTION
Adds ability to sort playlists in the sidebar by name and date created.

**Playlists** can be sorted by:
- Name (ascending/descending)
- Date created (ascending/descending)

Sort preferences persist across sessions in user config.

**Status:** Work in progress - crate sorting not yet implemented.

Partial implementation for #15909 

UI Changes:
Added this to the right menu on Playlist.
<img width="425" height="191" alt="image" src="https://github.com/user-attachments/assets/c5156ca3-81c6-4e10-a85d-ece228ffd130" />
