### PR TITLE
Fix send ramping in reverb effect

### DIFF
--- a/lib/reverb/Reverb.cc
+++ b/lib/reverb/Reverb.cc
@@ -450,7 +450,7 @@ void MixxxPlateX2::processBuffer(const sample_t* in, sample_t* out, const uint f
     double damp = exp(-M_PI * (.0005+.9995*dampingParam));
     tank.damping[0].set(damp);
     tank.damping[1].set(damp);
-    RampingValue<sample_t> send(pow(currentSend, 1.53), previousSend, frames);
+    RampingValue<sample_t> send(pow(previousSend, 1.53), pow(currentSend, 1.53), frames);
 
     // the modulated lattices interpolate, which needs truncated float
     DSP::FPTruncateMode _truncate;


### PR DESCRIPTION
In the reverb effect the ramping of the send parameter was done incorrectly.
The arguments for the current and previous value passed to the RampingValue constructor was in the wrong order and only the first parameter has been processed with the pow function causing additional noise.
I recorded the reverb effect with a 1000 Hz sine wave before and after my fix.
Then i screenshotted the spectrogram in Tenacity to make the noise visible.
Before my fix:
<img width="152" height="129" alt="sine_reverb_before_fix" src="https://github.com/user-attachments/assets/5510391c-f78c-4892-ae6f-ea7e122a0eca" />

After my fix:
<img width="121" height="144" alt="sine_reverb_after_fix" src="https://github.com/user-attachments/assets/4996a784-af0f-4f43-9037-da450f2e3ac1" />
