### PR TITLE
midi: guard against null script engine in makeInputHandler

### DIFF
--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -623,7 +623,11 @@ void MidiController::processInputMapping(const MidiInputMapping& mapping,
 QJSValue MidiController::makeInputHandler(unsigned char status,
         unsigned char control,
         const QJSValue& scriptCode) {
-    auto pJsEngine = getScriptEngine()->jsEngine();
+    auto* pEngine = getScriptEngine();
+    if (pEngine == nullptr) {
+        return QJSValue();
+    }
+    auto pJsEngine = pEngine->jsEngine();
     VERIFY_OR_DEBUG_ASSERT(pJsEngine) {
         return QJSValue();
     }


### PR DESCRIPTION
during controller shutdown, the script engine can be destroyed before the js shutdown function finishes executing. if the shutdown script calls makeinputhandler, getscriptengine() returns nullptr, causing a null dereference segfault.

adds the same null check already used in the two other getscriptengine() call sites in the same function.