### PR TITLE
Fix ramping of the send and feedback parameters in echo effect

### DIFF
--- a/src/effects/backends/builtin/echoeffect.cpp
+++ b/src/effects/backends/builtin/echoeffect.cpp
@@ -167,13 +167,13 @@ void EchoEffect::processChannel(
     int read_position = pGroupState->write_position;
     decrementRing(&read_position, delay_samples, pGroupState->delay_buf.size());
 
-    RampingValue<CSAMPLE_GAIN> send(send_current,
-            pGroupState->prev_send,
+    RampingValue<CSAMPLE_GAIN> send(pGroupState->prev_send,
+            send_current,
             engineParameters.framesPerBuffer());
     // Feedback the delay buffer and then add the new input.
 
-    RampingValue<CSAMPLE_GAIN> feedback(feedback_current,
-            pGroupState->prev_feedback,
+    RampingValue<CSAMPLE_GAIN> feedback(pGroupState->prev_feedback,
+            feedback_current,
             engineParameters.framesPerBuffer());
 
     int rampIndex = 0;


### PR DESCRIPTION
The ramping of the send and feedback parameters was wrong in the echo effect.
The current and previous value was swapped in the RampingValue constructor.

I've tested my fix with a 1000 Hz sine wave and this effect settings:
<img width="552" height="47" alt="echo_settings" src="https://github.com/user-attachments/assets/3bd97308-c6fa-4a23-b75d-f9f7b34a4032" />

This is how the ramping looked like in Tenacity when enabling the effect before my fix:
<img width="294" height="161" alt="echo_before_fix" src="https://github.com/user-attachments/assets/e9967a71-5084-4f52-b57b-dceaabf2df80" />

And after my fix:
<img width="252" height="143" alt="echo_after_fix" src="https://github.com/user-attachments/assets/08551ee1-ce4b-42c0-9645-cb32f27bcf40" />

This bugfix is maybe related to the issue https://github.com/mixxxdj/mixxx/issues/15835