### PR TITLE
Fix textured waveform FBO reallocated on every resize event

### DIFF
--- a/src/waveform/renderers/allshader/waveformrenderertextured.h
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.h
@@ -2,6 +2,8 @@
 
 #ifndef QT_OPENGL_ES_2
 
+#include <QSize>
+
 #include "rendergraph/openglnode.h"
 #include "track/track_decl.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
@@ -69,6 +71,8 @@ class allshader::WaveformRendererTextured final : public allshader::WaveformRend
 
     // Frame buffer for two pass rendering.
     std::unique_ptr<QOpenGLFramebufferObject> m_framebuffer;
+    QSize m_framebufferSize;
+    bool m_pendingResize;
 
     // shaders
     bool m_isSlipRenderer;


### PR DESCRIPTION
## Problem

`WaveformRendererTextured::resizeGL` unconditionally calls `createFrameBuffers()` on every resize event. This allocates a new `QOpenGLFramebufferObject` at 4× oversampling on each pixel of splitter movement. With multiple decks this happens simultaneously, causing severe UI stalling when resizing the waveform/library splitter.

The affected waveform types are those using `WaveformRendererTextured`: Filtered, RGB (HighDetail), and Stacked (HighDetail) — i.e. when `waveform_options` includes the `HighDetail` flag.

## Fix

Guard `createFrameBuffers()` to skip FBO reallocation when the computed buffer dimensions haven't changed. The cached size is reset in `initializeGL()` so the first allocation always occurs and `devicePixelRatio` changes are handled correctly.