### PR TITLE
Defer resize-triggered repaint to next vsync paintGL

### DIFF
--- a/src/widget/openglwindow.h
+++ b/src/widget/openglwindow.h
@@ -24,4 +24,5 @@ class OpenGLWindow : public QOpenGLWindow {
 
     WGLWidget* m_pWidget;
     TrackDropTarget* m_pTrackDropTarget;
+    bool m_dirty{};
 };


### PR DESCRIPTION
## Problem

`OpenGLWindow::resizeGL` calls `paintGL()` + `swapBuffers()` synchronously on every resize event. When the user drags the waveform/library splitter, this forces a full GPU render+swap on every pixel of movement, for every waveform widget simultaneously. This causes severe UI stalling during vertical waveform resize.

## History

This was previously fixed in commit e1ec6fb91c ("postpone extra render to avoid flicker until next paintGL") using a `m_dirty` flag, but was reverted in 2bf9ba9387 ("additional paint and swap from resizeGL instead of from paintGL") due to flickering on some systems.

## Fix

Restore the `m_dirty` flag approach: set dirty in `resizeGL`, do the extra render+swap at the start of the next vsync-driven `paintGL`. This reduces GPU blocking from once per pixel of drag to once per vsync frame, while still performing the extra render+swap needed to avoid flickering — just deferred by one frame.