### PR TITLE
Warn when running OpenGL waveforms on Wayland

### DIFF
--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -11,6 +11,7 @@
 #include <QGLShaderProgram>
 #endif
 
+#include <QGuiApplication>
 #include <QOpenGLFunctions>
 #include <QRegularExpression>
 #include <QStringList>
@@ -1390,6 +1391,17 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer pConf
     static const VSyncThread::VSyncMode vsyncMode = pConfig
             ? pConfig->getValue(kVSyncKey, VSyncThread::ST_DEFAULT)
             : VSyncThread::ST_DEFAULT;
+
+#ifdef MIXXX_USE_QOPENGL
+    // QOpenGLWindow inside createWindowContainer causes synchronous Wayland
+    // compositor buffer reallocation on every resize event, making splitter
+    // drag extremely slow. Running under XWayland (QT_QPA_PLATFORM=xcb)
+    // avoids this. See https://github.com/mixxxdj/mixxx/issues/16013
+    if (QGuiApplication::platformName() == QLatin1String("wayland")) {
+        qWarning() << "Wayland detected with OpenGL waveforms: waveform resize"
+                      " may be slow. Set QT_QPA_PLATFORM=xcb to use XWayland.";
+    }
+#endif
 
     QSurfaceFormat format;
     // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0, default is 2.0

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1397,16 +1397,12 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer pConf
     // widgets. Running under XWayland (QT_QPA_PLATFORM=xcb) avoids this issue.
     // See https://github.com/mixxxdj/mixxx/issues/16013 and #14492
     if (QGuiApplication::platformName().startsWith(QLatin1String("wayland"))) {
-        qWarning() << "Wayland detected with OpenGL waveforms and spinny "
-                      "widgets: UI resize"
-                      " will be extremely slow and may cause sticky mouse "
-                      "issues (mouse key not releasing)."
-                      " To fix this, run Mixxx with XWayland by setting "
-                      "QT_QPA_PLATFORM=xcb in your"
-                      " environment or .desktop launcher file."
+        qWarning() << "Wayland detected with OpenGL waveforms: waveforms and "
+                      "spinnies may suffer from rendering issues (slow resize, "
+                      "sticky mouse). Set QT_QPA_PLATFORM=xcb to use XWayland."
                       " See https://github.com/mixxxdj/mixxx/issues/16013 and"
-                      " https://github.com/mixxxdj/mixxx/issues/14492 for "
-                      "details.";
+                      " https://github.com/mixxxdj/mixxx/issues/14492 for"
+                      " details.";
     }
 #endif
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -3,7 +3,6 @@
 #include "waveform/waveform.h"
 
 #ifdef MIXXX_USE_QOPENGL
-#include <QGuiApplication>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLWindow>
 #else
@@ -11,6 +10,7 @@
 #include <QGLShaderProgram>
 #endif
 
+#include <QGuiApplication>
 #include <QOpenGLFunctions>
 #include <QRegularExpression>
 #include <QStringList>
@@ -52,8 +52,8 @@ constexpr bool kOverviewNormalizedDefault = false;
 // Returns true if the given waveform should be rendered.
 bool shouldRenderWaveform(WaveformWidgetAbstract* pWaveformWidget) {
     if (pWaveformWidget == nullptr ||
-        pWaveformWidget->getWidth() == 0 ||
-        pWaveformWidget->getHeight() == 0) {
+            pWaveformWidget->getWidth() == 0 ||
+            pWaveformWidget->getHeight() == 0) {
         return false;
     }
 
@@ -88,7 +88,7 @@ ConfigKey visualGainKey(int index) {
     return ConfigKey(kWaveformGroup, QStringLiteral("VisualGain_") + QString::number(index));
 }
 
-}  // anonymous namespace
+} // anonymous namespace
 
 ///////////////////////////////////////////
 
@@ -105,13 +105,13 @@ WaveformWidgetHolder::WaveformWidgetHolder()
 }
 
 WaveformWidgetHolder::WaveformWidgetHolder(WaveformWidgetAbstract* waveformWidget,
-                                           WWaveformViewer* waveformViewer,
-                                           const QDomNode& node,
-                                           const SkinContext& parentContext)
-    : m_waveformWidget(waveformWidget),
-      m_waveformViewer(waveformViewer),
-      m_skinNodeCache(node.cloneNode()),
-      m_skinContextCache(&parentContext) {
+        WWaveformViewer* waveformViewer,
+        const QDomNode& node,
+        const SkinContext& parentContext)
+        : m_waveformWidget(waveformWidget),
+          m_waveformViewer(waveformViewer),
+          m_skinNodeCache(node.cloneNode()),
+          m_skinContextCache(&parentContext) {
 }
 
 ///////////////////////////////////////////
@@ -335,12 +335,12 @@ WaveformWidgetFactory::WaveformWidgetFactory()
             minorGlesVersion = 0;
         } else {
             m_openGLVersion = QString("Unknown 0x%1")
-                .arg(version, 0, 16);
+                                      .arg(version, 0, 16);
         }
 
         if (majorGlVersion != 0) {
-            m_openGLVersion = QString::number(majorGlVersion) + "."
-                    + QString::number(minorGlVersion);
+            m_openGLVersion = QString::number(majorGlVersion) + "." +
+                    QString::number(minorGlVersion);
 
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
             if (majorGlVersion * 100 + minorGlVersion >= 201) {
@@ -397,7 +397,7 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
     double defaultZoom = m_config->getValueString(kDefaultZoomKey).toDouble(&ok);
     if (ok) {
         setDefaultZoom(defaultZoom);
-    } else{
+    } else {
         m_config->setValue(kDefaultZoomKey, m_defaultZoom);
     }
 
@@ -526,11 +526,11 @@ void WaveformWidgetFactory::slotSkinLoaded() {
 }
 
 bool WaveformWidgetFactory::setWaveformWidget(WWaveformViewer* viewer,
-                                              const QDomElement& node,
-                                              const SkinContext& parentContext) {
+        const QDomElement& node,
+        const SkinContext& parentContext) {
     int index = findIndexOf(viewer);
     if (index != -1) {
-        qDebug() << "WaveformWidgetFactory::setWaveformWidget - "\
+        qDebug() << "WaveformWidgetFactory::setWaveformWidget - "
                     "viewer already have a waveform widget but it's not found by the factory !";
         delete viewer->getWaveformWidget();
     }
@@ -684,11 +684,11 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex, bool force)
 
     m_skipRender = true;
 
-    //re-create/setup all waveform widgets
+    // re-create/setup all waveform widgets
     for (auto& holder : m_waveformWidgetHolders) {
         WaveformWidgetAbstract* previousWidget = holder.m_waveformWidget;
         TrackPointer pTrack = previousWidget->getTrackInfo();
-        //previousWidget->hold();
+        // previousWidget->hold();
         double previousZoom = previousWidget->getZoom();
         double previousPlayMarkerPosition = previousWidget->getPlayMarkerPosition();
         int previousbeatgridAlpha = previousWidget->getBeatGridAlpha();
@@ -703,7 +703,7 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex, bool force)
         viewer->setDisplayBeatGridAlpha(previousbeatgridAlpha);
         // resize() doesn't seem to get called on the widget. I think Qt skips
         // it since the size didn't change.
-        //viewer->resize(viewer->size());
+        // viewer->resize(viewer->size());
         widget->resize(viewer->width(), viewer->height());
         widget->setTrack(pTrack);
         widget->getWidget()->show();
@@ -715,8 +715,9 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex, bool force)
 }
 
 void WaveformWidgetFactory::setDefaultZoom(double zoom) {
-    m_defaultZoom = math_clamp(zoom, WaveformWidgetRenderer::s_waveformMinZoom,
-                               WaveformWidgetRenderer::s_waveformMaxZoom);
+    m_defaultZoom = math_clamp(zoom,
+            WaveformWidgetRenderer::s_waveformMinZoom,
+            WaveformWidgetRenderer::s_waveformMaxZoom);
     if (m_config) {
         m_config->setValue(kDefaultZoomKey, m_defaultZoom);
     }
@@ -822,7 +823,7 @@ void WaveformWidgetFactory::renderSelf() {
             static_cast<int>(m_waveformWidgetHolders.size()));
 
     if (!m_skipRender) {
-        if (m_type) {   // no regular updates for an empty waveform
+        if (m_type) { // no regular updates for an empty waveform
             // next rendered frame is displayed after next buffer swap and than after VSync
             QVarLengthArray<bool, 10> shouldRenderWaveforms(
                     static_cast<int>(m_waveformWidgetHolders.size()));
@@ -840,7 +841,7 @@ void WaveformWidgetFactory::renderSelf() {
                 // Calculate play position for the new Frame in following run
                 pWaveformWidget->preRender(m_vsyncThread);
             }
-            //qDebug() << "prerender" << m_vsyncThread->elapsed();
+            // qDebug() << "prerender" << m_vsyncThread->elapsed();
 
             // It may happen that there is an artificially delayed due to
             // anti tearing driver settings
@@ -853,7 +854,7 @@ void WaveformWidgetFactory::renderSelf() {
                     continue;
                 }
                 pWaveformWidget->render();
-                //qDebug() << "render" << i << m_vsyncThread->elapsed();
+                // qDebug() << "render" << i << m_vsyncThread->elapsed();
             }
         }
 
@@ -866,9 +867,9 @@ void WaveformWidgetFactory::renderSelf() {
 
         // Notify all other waveform-like widgets (e.g. WSpinny's) that they should
         // update.
-        //int t1 = m_vsyncThread->elapsed();
+        // int t1 = m_vsyncThread->elapsed();
         emit waveformUpdateTick();
-        //qDebug() << "emit" << m_vsyncThread->elapsed() - t1;
+        // qDebug() << "emit" << m_vsyncThread->elapsed() - t1;
 
         m_frameCnt += 1.0f;
         mixxx::Duration timeCnt = m_time.elapsed();
@@ -883,7 +884,7 @@ void WaveformWidgetFactory::renderSelf() {
     m_pVisualsManager->process(m_endOfTrackWarningTime);
     m_pGuiTick->process();
 
-    //qDebug() << "refresh end" << m_vsyncThread->elapsed();
+    // qDebug() << "refresh end" << m_vsyncThread->elapsed();
 }
 
 void WaveformWidgetFactory::render() {
@@ -897,9 +898,9 @@ void WaveformWidgetFactory::swapSelf() {
 
     // Do this in an extra slot to be sure to hit the desired interval
     if (!m_skipRender) {
-        if (m_type) {   // no regular updates for an empty waveform
+        if (m_type) { // no regular updates for an empty waveform
             // Show rendered buffer from last render() run
-            //qDebug() << "swap() start" << m_vsyncThread->elapsed();
+            // qDebug() << "swap() start" << m_vsyncThread->elapsed();
             for (const auto& holder : std::as_const(m_waveformWidgetHolders)) {
                 WaveformWidgetAbstract* pWaveformWidget = holder.m_waveformWidget;
 
@@ -916,7 +917,7 @@ void WaveformWidgetFactory::swapSelf() {
                     pGlw->swapBuffers();
                     pGlw->doneCurrent();
                 }
-                //qDebug() << "swap x" << m_vsyncThread->elapsed();
+                // qDebug() << "swap x" << m_vsyncThread->elapsed();
             }
         }
         // WSpinnys are also double-buffered QGLWidgets, like all the waveform
@@ -1390,6 +1391,26 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer pConf
     static const VSyncThread::VSyncMode vsyncMode = pConfig
             ? pConfig->getValue(kVSyncKey, VSyncThread::ST_DEFAULT)
             : VSyncThread::ST_DEFAULT;
+
+    // QOpenGLWindow inside createWindowContainer causes synchronous Wayland
+    // compositor buffer reallocation on every resize event, making splitter
+    // drag and UI resizing extremely slow. This affects both waveforms and spinny
+    // widgets. Running under XWayland (QT_QPA_PLATFORM=xcb) avoids this issue.
+    // See https://github.com/mixxxdj/mixxx/issues/16013,
+    // https://github.com/mixxxdj/mixxx/issues/14492 and
+    // https://github.com/mixxxdj/mixxx/issues/13814
+    // This function is called per OpenGLWindow, so warn only once.
+    static bool waylandWarningShown = false;
+    if (!waylandWarningShown &&
+            QGuiApplication::platformName().startsWith(QLatin1String("wayland"))) {
+        waylandWarningShown = true;
+        qWarning() << "Wayland detected with OpenGL waveforms: waveforms and "
+                      "spinnies may suffer from rendering issues (slow resize, "
+                      "sticky mouse). Set QT_QPA_PLATFORM=xcb to use XWayland."
+                      " See https://github.com/mixxxdj/mixxx/issues/16013 and"
+                      " https://github.com/mixxxdj/mixxx/issues/14492 for"
+                      " details.";
+    }
 
     QSurfaceFormat format;
     // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0, default is 2.0

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -3,7 +3,6 @@
 #include "waveform/waveform.h"
 
 #ifdef MIXXX_USE_QOPENGL
-#include <QGuiApplication>
 #include <QOpenGLShaderProgram>
 #include <QOpenGLWindow>
 #else
@@ -1390,13 +1389,18 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer pConf
             ? pConfig->getValue(kVSyncKey, VSyncThread::ST_DEFAULT)
             : VSyncThread::ST_DEFAULT;
 
-#ifdef MIXXX_USE_QOPENGL
     // QOpenGLWindow inside createWindowContainer causes synchronous Wayland
     // compositor buffer reallocation on every resize event, making splitter
     // drag and UI resizing extremely slow. This affects both waveforms and spinny
     // widgets. Running under XWayland (QT_QPA_PLATFORM=xcb) avoids this issue.
-    // See https://github.com/mixxxdj/mixxx/issues/16013 and #14492
-    if (QGuiApplication::platformName().startsWith(QLatin1String("wayland"))) {
+    // See https://github.com/mixxxdj/mixxx/issues/16013,
+    // https://github.com/mixxxdj/mixxx/issues/14492 and
+    // https://github.com/mixxxdj/mixxx/issues/13814
+    // This function is called per OpenGLWindow, so warn only once.
+    static bool waylandWarningShown = false;
+    if (!waylandWarningShown &&
+            QGuiApplication::platformName().startsWith(QLatin1String("wayland"))) {
+        waylandWarningShown = true;
         qWarning() << "Wayland detected with OpenGL waveforms: waveforms and "
                       "spinnies may suffer from rendering issues (slow resize, "
                       "sticky mouse). Set QT_QPA_PLATFORM=xcb to use XWayland."
@@ -1404,7 +1408,6 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer pConf
                       " https://github.com/mixxxdj/mixxx/issues/14492 for"
                       " details.";
     }
-#endif
 
     QSurfaceFormat format;
     // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0, default is 2.0

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1395,11 +1395,14 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer pConf
 #ifdef MIXXX_USE_QOPENGL
     // QOpenGLWindow inside createWindowContainer causes synchronous Wayland
     // compositor buffer reallocation on every resize event, making splitter
-    // drag extremely slow. Running under XWayland (QT_QPA_PLATFORM=xcb)
-    // avoids this. See https://github.com/mixxxdj/mixxx/issues/16013
+    // drag and UI resizing extremely slow. This affects both waveforms and spinny
+    // widgets. Running under XWayland (QT_QPA_PLATFORM=xcb) avoids this issue.
+    // See https://github.com/mixxxdj/mixxx/issues/16013
     if (QGuiApplication::platformName() == QLatin1String("wayland")) {
-        qWarning() << "Wayland detected with OpenGL waveforms: waveform resize"
-                      " may be slow. Set QT_QPA_PLATFORM=xcb to use XWayland.";
+        qWarning() << "Wayland detected with OpenGL waveforms and spinny widgets: UI resize"
+                      " will be extremely slow. To fix this, run Mixxx with XWayland by setting"
+                      " QT_QPA_PLATFORM=xcb in your environment or .desktop launcher file."
+                      " See https://github.com/mixxxdj/mixxx/issues/16013 for details.";
     }
 #endif
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -53,8 +53,8 @@ constexpr bool kOverviewNormalizedDefault = false;
 // Returns true if the given waveform should be rendered.
 bool shouldRenderWaveform(WaveformWidgetAbstract* pWaveformWidget) {
     if (pWaveformWidget == nullptr ||
-        pWaveformWidget->getWidth() == 0 ||
-        pWaveformWidget->getHeight() == 0) {
+            pWaveformWidget->getWidth() == 0 ||
+            pWaveformWidget->getHeight() == 0) {
         return false;
     }
 
@@ -89,7 +89,7 @@ ConfigKey visualGainKey(int index) {
     return ConfigKey(kWaveformGroup, QStringLiteral("VisualGain_") + QString::number(index));
 }
 
-}  // anonymous namespace
+} // anonymous namespace
 
 ///////////////////////////////////////////
 
@@ -106,13 +106,13 @@ WaveformWidgetHolder::WaveformWidgetHolder()
 }
 
 WaveformWidgetHolder::WaveformWidgetHolder(WaveformWidgetAbstract* waveformWidget,
-                                           WWaveformViewer* waveformViewer,
-                                           const QDomNode& node,
-                                           const SkinContext& parentContext)
-    : m_waveformWidget(waveformWidget),
-      m_waveformViewer(waveformViewer),
-      m_skinNodeCache(node.cloneNode()),
-      m_skinContextCache(&parentContext) {
+        WWaveformViewer* waveformViewer,
+        const QDomNode& node,
+        const SkinContext& parentContext)
+        : m_waveformWidget(waveformWidget),
+          m_waveformViewer(waveformViewer),
+          m_skinNodeCache(node.cloneNode()),
+          m_skinContextCache(&parentContext) {
 }
 
 ///////////////////////////////////////////
@@ -336,12 +336,11 @@ WaveformWidgetFactory::WaveformWidgetFactory()
             minorGlesVersion = 0;
         } else {
             m_openGLVersion = QString("Unknown 0x%1")
-                .arg(version, 0, 16);
+                                      .arg(version, 0, 16);
         }
 
         if (majorGlVersion != 0) {
-            m_openGLVersion = QString::number(majorGlVersion) + "."
-                    + QString::number(minorGlVersion);
+            m_openGLVersion = QString::number(majorGlVersion) + "." + QString::number(minorGlVersion);
 
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
             if (majorGlVersion * 100 + minorGlVersion >= 201) {
@@ -398,7 +397,7 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
     double defaultZoom = m_config->getValueString(kDefaultZoomKey).toDouble(&ok);
     if (ok) {
         setDefaultZoom(defaultZoom);
-    } else{
+    } else {
         m_config->setValue(kDefaultZoomKey, m_defaultZoom);
     }
 
@@ -527,11 +526,11 @@ void WaveformWidgetFactory::slotSkinLoaded() {
 }
 
 bool WaveformWidgetFactory::setWaveformWidget(WWaveformViewer* viewer,
-                                              const QDomElement& node,
-                                              const SkinContext& parentContext) {
+        const QDomElement& node,
+        const SkinContext& parentContext) {
     int index = findIndexOf(viewer);
     if (index != -1) {
-        qDebug() << "WaveformWidgetFactory::setWaveformWidget - "\
+        qDebug() << "WaveformWidgetFactory::setWaveformWidget - "
                     "viewer already have a waveform widget but it's not found by the factory !";
         delete viewer->getWaveformWidget();
     }
@@ -685,11 +684,11 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex, bool force)
 
     m_skipRender = true;
 
-    //re-create/setup all waveform widgets
+    // re-create/setup all waveform widgets
     for (auto& holder : m_waveformWidgetHolders) {
         WaveformWidgetAbstract* previousWidget = holder.m_waveformWidget;
         TrackPointer pTrack = previousWidget->getTrackInfo();
-        //previousWidget->hold();
+        // previousWidget->hold();
         double previousZoom = previousWidget->getZoom();
         double previousPlayMarkerPosition = previousWidget->getPlayMarkerPosition();
         int previousbeatgridAlpha = previousWidget->getBeatGridAlpha();
@@ -704,7 +703,7 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex, bool force)
         viewer->setDisplayBeatGridAlpha(previousbeatgridAlpha);
         // resize() doesn't seem to get called on the widget. I think Qt skips
         // it since the size didn't change.
-        //viewer->resize(viewer->size());
+        // viewer->resize(viewer->size());
         widget->resize(viewer->width(), viewer->height());
         widget->setTrack(pTrack);
         widget->getWidget()->show();
@@ -716,8 +715,7 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex, bool force)
 }
 
 void WaveformWidgetFactory::setDefaultZoom(double zoom) {
-    m_defaultZoom = math_clamp(zoom, WaveformWidgetRenderer::s_waveformMinZoom,
-                               WaveformWidgetRenderer::s_waveformMaxZoom);
+    m_defaultZoom = math_clamp(zoom, WaveformWidgetRenderer::s_waveformMinZoom, WaveformWidgetRenderer::s_waveformMaxZoom);
     if (m_config) {
         m_config->setValue(kDefaultZoomKey, m_defaultZoom);
     }
@@ -823,7 +821,7 @@ void WaveformWidgetFactory::renderSelf() {
             static_cast<int>(m_waveformWidgetHolders.size()));
 
     if (!m_skipRender) {
-        if (m_type) {   // no regular updates for an empty waveform
+        if (m_type) { // no regular updates for an empty waveform
             // next rendered frame is displayed after next buffer swap and than after VSync
             QVarLengthArray<bool, 10> shouldRenderWaveforms(
                     static_cast<int>(m_waveformWidgetHolders.size()));
@@ -841,7 +839,7 @@ void WaveformWidgetFactory::renderSelf() {
                 // Calculate play position for the new Frame in following run
                 pWaveformWidget->preRender(m_vsyncThread);
             }
-            //qDebug() << "prerender" << m_vsyncThread->elapsed();
+            // qDebug() << "prerender" << m_vsyncThread->elapsed();
 
             // It may happen that there is an artificially delayed due to
             // anti tearing driver settings
@@ -854,7 +852,7 @@ void WaveformWidgetFactory::renderSelf() {
                     continue;
                 }
                 pWaveformWidget->render();
-                //qDebug() << "render" << i << m_vsyncThread->elapsed();
+                // qDebug() << "render" << i << m_vsyncThread->elapsed();
             }
         }
 
@@ -867,9 +865,9 @@ void WaveformWidgetFactory::renderSelf() {
 
         // Notify all other waveform-like widgets (e.g. WSpinny's) that they should
         // update.
-        //int t1 = m_vsyncThread->elapsed();
+        // int t1 = m_vsyncThread->elapsed();
         emit waveformUpdateTick();
-        //qDebug() << "emit" << m_vsyncThread->elapsed() - t1;
+        // qDebug() << "emit" << m_vsyncThread->elapsed() - t1;
 
         m_frameCnt += 1.0f;
         mixxx::Duration timeCnt = m_time.elapsed();
@@ -884,7 +882,7 @@ void WaveformWidgetFactory::renderSelf() {
     m_pVisualsManager->process(m_endOfTrackWarningTime);
     m_pGuiTick->process();
 
-    //qDebug() << "refresh end" << m_vsyncThread->elapsed();
+    // qDebug() << "refresh end" << m_vsyncThread->elapsed();
 }
 
 void WaveformWidgetFactory::render() {
@@ -898,9 +896,9 @@ void WaveformWidgetFactory::swapSelf() {
 
     // Do this in an extra slot to be sure to hit the desired interval
     if (!m_skipRender) {
-        if (m_type) {   // no regular updates for an empty waveform
+        if (m_type) { // no regular updates for an empty waveform
             // Show rendered buffer from last render() run
-            //qDebug() << "swap() start" << m_vsyncThread->elapsed();
+            // qDebug() << "swap() start" << m_vsyncThread->elapsed();
             for (const auto& holder : std::as_const(m_waveformWidgetHolders)) {
                 WaveformWidgetAbstract* pWaveformWidget = holder.m_waveformWidget;
 
@@ -917,7 +915,7 @@ void WaveformWidgetFactory::swapSelf() {
                     pGlw->swapBuffers();
                     pGlw->doneCurrent();
                 }
-                //qDebug() << "swap x" << m_vsyncThread->elapsed();
+                // qDebug() << "swap x" << m_vsyncThread->elapsed();
             }
         }
         // WSpinnys are also double-buffered QGLWidgets, like all the waveform
@@ -1397,12 +1395,18 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer pConf
     // compositor buffer reallocation on every resize event, making splitter
     // drag and UI resizing extremely slow. This affects both waveforms and spinny
     // widgets. Running under XWayland (QT_QPA_PLATFORM=xcb) avoids this issue.
-    // See https://github.com/mixxxdj/mixxx/issues/16013
-    if (QGuiApplication::platformName() == QLatin1String("wayland")) {
-        qWarning() << "Wayland detected with OpenGL waveforms and spinny widgets: UI resize"
-                      " will be extremely slow. To fix this, run Mixxx with XWayland by setting"
-                      " QT_QPA_PLATFORM=xcb in your environment or .desktop launcher file."
-                      " See https://github.com/mixxxdj/mixxx/issues/16013 for details.";
+    // See https://github.com/mixxxdj/mixxx/issues/16013 and #14492
+    if (QGuiApplication::platformName().startsWith(QLatin1String("wayland"))) {
+        qWarning() << "Wayland detected with OpenGL waveforms and spinny "
+                      "widgets: UI resize"
+                      " will be extremely slow and may cause sticky mouse "
+                      "issues (mouse key not releasing)."
+                      " To fix this, run Mixxx with XWayland by setting "
+                      "QT_QPA_PLATFORM=xcb in your"
+                      " environment or .desktop launcher file."
+                      " See https://github.com/mixxxdj/mixxx/issues/16013 and"
+                      " https://github.com/mixxxdj/mixxx/issues/14492 for "
+                      "details.";
     }
 #endif
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -339,7 +339,8 @@ WaveformWidgetFactory::WaveformWidgetFactory()
         }
 
         if (majorGlVersion != 0) {
-            m_openGLVersion = QString::number(majorGlVersion) + "." + QString::number(minorGlVersion);
+            m_openGLVersion = QString::number(majorGlVersion) + "." +
+                    QString::number(minorGlVersion);
 
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
             if (majorGlVersion * 100 + minorGlVersion >= 201) {
@@ -714,7 +715,9 @@ bool WaveformWidgetFactory::setWidgetTypeFromHandle(int handleIndex, bool force)
 }
 
 void WaveformWidgetFactory::setDefaultZoom(double zoom) {
-    m_defaultZoom = math_clamp(zoom, WaveformWidgetRenderer::s_waveformMinZoom, WaveformWidgetRenderer::s_waveformMaxZoom);
+    m_defaultZoom = math_clamp(zoom,
+            WaveformWidgetRenderer::s_waveformMinZoom,
+            WaveformWidgetRenderer::s_waveformMaxZoom);
     if (m_config) {
         m_config->setValue(kDefaultZoomKey, m_defaultZoom);
     }


### PR DESCRIPTION
edit: oops didn't think this would be generated but here we are. I thought it was one of my branches causing an issue, but it's repeatable on upstream/main, though this bug needs to be reproduced by someone else still, and I don't think just a warning is a worthy PR

## Problem

When running Mixxx natively on Wayland with allshader (QOpenGLWindow-based) waveforms, dragging the waveform/library splitter is extremely slow.

## Root Cause

`QOpenGLWindow` inside `createWindowContainer` creates a Wayland subsurface. On Wayland, resizing a subsurface triggers a synchronous compositor buffer reallocation for every pixel of movement, blocking the main thread until the compositor acknowledges. This is a Qt/Wayland issue — no application-level deferral can avoid it.

Closes #16013
Related: #13814 (same Wayland resize family, GLSL waveform types)

## Fix

Log a `qWarning` at startup when Wayland is detected with the `QOpenGLWindow`-based waveform path, pointing users to the workaround:

```
QT_QPA_PLATFORM=xcb mixxx
```

## Notes

- Does not affect the legacy QGLWidget path
- Does not affect XWayland (`QT_QPA_PLATFORM=xcb`), which is smooth
- Application-level fixes (deferring paintGL, throttling resize) do not help — the stall is in the Wayland protocol itself
