### PR TITLE
MK2 LUT fixes

### DIFF
--- a/lib/xwax/lut_mk2.c
+++ b/lib/xwax/lut_mk2.c
@@ -69,8 +69,14 @@ int lut_init_mk2(struct lut_mk2 *lut, int nslots)
 
 void lut_clear_mk2(struct lut_mk2 *lut)
 {
-    free(lut->table);
-    free(lut->slot);
+    if (!lut)
+        return;
+
+    if (lut->table)
+        free(lut->table);
+
+    if (lut->slot)
+        free(lut->slot);
 }
 
 /*

--- a/lib/xwax/lut_mk2.c
+++ b/lib/xwax/lut_mk2.c
@@ -47,6 +47,16 @@ int lut_init_mk2(struct lut_mk2 *lut, int nslots)
             " (%d slots per hash, %zuKb)\n",
             hashes, nslots, nslots / hashes, bytes / 1024);
 
+    lut->hdr = malloc(sizeof(struct lut_mk2_header));
+    if (lut->hdr == NULL) {
+        perror("malloc");
+        return -1;
+    }
+
+    lut->hdr->magic = MIXXX_LUT_MAGIC;
+    lut->hdr->major = MIXXX_LUT_MAJOR;
+    lut->hdr->minor = MIXXX_LUT_MINOR;
+
     lut->slot = malloc(sizeof(struct slot_mk2) * nslots);
     if (lut->slot == NULL) {
         perror("malloc");
@@ -71,6 +81,9 @@ void lut_clear_mk2(struct lut_mk2 *lut)
 {
     if (!lut)
         return;
+
+    if (lut->hdr)
+        free(lut->hdr);
 
     if (lut->table)
         free(lut->table);

--- a/lib/xwax/lut_mk2.h
+++ b/lib/xwax/lut_mk2.h
@@ -4,7 +4,24 @@
 
 #include "lut.h"
 
+#include <stdint.h>
+
+#define MIXXX_LUT_MAGIC 0x54554c585858494duLL /* MIXXXLUT */
+#define MIXXX_LUT_MAJOR 1
+#define MIXXX_LUT_MINOR 0
+
 typedef u128 mk2bits_t;
+
+/*
+ * NOTE: Should the member order of any of these structs ever be changed,
+ * it is imperative that the MIXXX_LUT_MINOR gets incremented !!!
+ */
+
+struct lut_mk2_header {
+    uint64_t magic;
+    uint16_t major;
+    uint16_t minor;
+};
 
 struct slot_mk2 {
     mk2bits_t timecode;
@@ -12,6 +29,7 @@ struct slot_mk2 {
 };
 
 struct lut_mk2 {
+    struct lut_mk2_header *hdr;
     struct slot_mk2 *slot;
     slot_no_t *table, /* hash -> slot lookup */
         avail; /* next available slot */

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -129,10 +129,10 @@ static struct timecode_def timecodes[] = {
          .high = 0x400000000040,
          .low = 0x0000010800000001
      },
-     .length = 1820000,
-     .safe = 1800000,
+     .length = 1845000,
+     .safe = 1795000,
      .threshold = (128 << 16),
-     },    
+     },
     {
      .name = "traktor_mk2_b",
      .desc = "Traktor Scratch MK2, side B",
@@ -147,10 +147,10 @@ static struct timecode_def timecodes[] = {
          .high = 0x400000000040,
          .low = 0x0000010800000001
      },
-     .length = 2570000,
-     .safe = 2550000,
+     .length = 2590000,
+     .safe = 2540000,
      .threshold = (128 << 16),
-     },    
+     },
     {
      .name = "traktor_mk2_cd",
      .desc = "Traktor Scratch MK2, CD",
@@ -166,7 +166,7 @@ static struct timecode_def timecodes[] = {
          .low = 0x1000010800000001
      },
      .length = 4500000,
-     .safe = 4495000,
+     .safe = 4450000,
      .threshold = (128 << 16),
      },
     {


### PR DESCRIPTION
This adds better checks for mismatches of the expected LUT and what's actually found on disk. 

Also corrects MK2 LUT limits.

Todo:

- [x] Make sure version check triggers before file size check
- [x] Use a different file ending for the versioned LUTs and clean up the old ones. This way downgrading Mixxx won't lead to a crash.
- [x] Add note close to the LUT structs to increment the version if the member order should ever be changed