### PR TITLE
Fix MIDI learning wizard not appearing when opened from prefs button

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -389,6 +389,11 @@ void DlgPrefController::showLearningWizard() {
         showMapping(m_pMapping);
     }
 
+    // Hide the prefs dialog before showing the wizard. The wizard is parented
+    // to this page (a child of the prefs dialog), so hiding the prefs dialog
+    // after show() would cascade-hide the wizard too.
+    emit mappingStarted();
+
     // Note that DlgControllerLearning is set to delete itself on close using
     // the Qt::WA_DeleteOnClose attribute (so this "new" doesn't leak memory)
     m_pDlgControllerLearning =
@@ -413,8 +418,6 @@ void DlgPrefController::showLearningWizard() {
             &DlgControllerLearning::inputMappingsLearned,
             this,
             &DlgPrefController::midiInputMappingsLearned);
-
-    emit mappingStarted();
     connect(m_pDlgControllerLearning,
             &DlgControllerLearning::stopLearning,
             this,


### PR DESCRIPTION
## Description

Clicking the "Learning Wizard" button in the controller preferences page closed the preferences dialog but the learning wizard never appeared.

## Root Cause

`DlgControllerLearning` is parented to `DlgPrefController`, which is a child of `DlgPreferences`. The wizard was created and shown, then `mappingStarted()` was emitted — which calls `DlgPreferences::hide()`. Qt's cascade-hide propagates to all child widgets, immediately hiding the just-shown wizard.

## Fix

Emit `mappingStarted()` before creating and showing the wizard, so the preferences dialog is already hidden when the wizard appears.