### PR TITLE
ControlPickerMenu: fix deck offset for Quick Effects

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -998,7 +998,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     QMenu* pEffectsMenu = addSubmenu(tr("Effects"));
     // Deck Quick Effects
     for (int i = 1; i <= iNumDecks; ++i) {
-        const QString deckGroup = PlayerManager::groupForDeck(i);
+        const QString deckGroup = PlayerManager::groupForDeck(i - 1);
         const QString quickEffectGroup = QuickEffectChain::formatEffectChainGroup(deckGroup);
         QMenu* pQuickEffectMenu = addSubmenu(tr("Quick Effects Deck %1").arg(i), pEffectsMenu);
         addControl(quickEffectGroup,


### PR DESCRIPTION
Fixes #16017 

I wonder why the `metainfo` hook is run on push?