### PR TITLE
Waveform prefs: move Simple to top of main and overview waveform lists; add Simple overview type

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -36,11 +36,11 @@ DlgPrefWaveform::DlgPrefWaveform(
     setupUi(this);
 
     // Waveform overview init
+    waveformOverviewComboBox->addItem(tr("Simple"), QVariant::fromValue(OverviewType::Simple));
     waveformOverviewComboBox->addItem(
             tr("Filtered"), QVariant::fromValue(OverviewType::Filtered));
     waveformOverviewComboBox->addItem(tr("HSV"), QVariant::fromValue(OverviewType::HSV));
     waveformOverviewComboBox->addItem(tr("RGB"), QVariant::fromValue(OverviewType::RGB));
-    waveformOverviewComboBox->addItem(tr("Simple"), QVariant::fromValue(OverviewType::Simple));
     m_pTypeControl = std::make_unique<ControlPushButton>(kOverviewTypeCfgKey);
     m_pTypeControl->setStates(QMetaEnum::fromType<OverviewType>().keyCount());
     m_pTypeControl->setReadOnly();

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -40,6 +40,7 @@ DlgPrefWaveform::DlgPrefWaveform(
             tr("Filtered"), QVariant::fromValue(OverviewType::Filtered));
     waveformOverviewComboBox->addItem(tr("HSV"), QVariant::fromValue(OverviewType::HSV));
     waveformOverviewComboBox->addItem(tr("RGB"), QVariant::fromValue(OverviewType::RGB));
+    waveformOverviewComboBox->addItem(tr("Simple"), QVariant::fromValue(OverviewType::Simple));
     m_pTypeControl = std::make_unique<ControlPushButton>(kOverviewTypeCfgKey);
     m_pTypeControl->setStates(QMetaEnum::fromType<OverviewType>().keyCount());
     m_pTypeControl->setReadOnly();

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -71,8 +71,15 @@ DlgPrefWaveform::DlgPrefWaveform(
         }
         waveformTypeComboBox->addItem(types[i].getDisplayName(), types[i].getType());
     }
-    // Sort the combobox items alphabetically
+    // Sort the combobox items alphabetically, then move Simple to the top
     waveformTypeComboBox->model()->sort(0);
+    int simpleIdx = waveformTypeComboBox->findData(WaveformWidgetType::Simple);
+    if (simpleIdx > 0) {
+        QString simpleName = waveformTypeComboBox->itemText(simpleIdx);
+        QVariant simpleData = waveformTypeComboBox->itemData(simpleIdx);
+        waveformTypeComboBox->removeItem(simpleIdx);
+        waveformTypeComboBox->insertItem(0, simpleName, simpleData);
+    }
 
     // Populate zoom options.
     for (int i = static_cast<int>(WaveformWidgetRenderer::s_waveformMinZoom);

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -50,15 +50,16 @@ DlgPrefWaveform::DlgPrefWaveform(
     int cfgTypeIndex = waveformOverviewComboBox->findData(QVariant::fromValue(overviewType));
     if (cfgTypeIndex == -1) {
         // Invalid config value, set default type RGB and write it to config
+        overviewType = OverviewType::RGB;
         cfgTypeIndex = waveformOverviewComboBox->findData(
-                QVariant::fromValue(OverviewType::RGB));
+                QVariant::fromValue(overviewType));
         waveformOverviewComboBox->setCurrentIndex(cfgTypeIndex);
-        m_pConfig->setValue(kOverviewTypeCfgKey, cfgTypeIndex);
+        m_pConfig->setValue(kOverviewTypeCfgKey, overviewType);
     } else {
         waveformOverviewComboBox->setCurrentIndex(cfgTypeIndex);
     }
     // Set the control used by WOverview
-    m_pTypeControl->forceSet(cfgTypeIndex);
+    m_pTypeControl->forceSet(static_cast<double>(overviewType));
 
     // Populate waveform options.
     WaveformWidgetFactory* factory = WaveformWidgetFactory::instance();

--- a/src/waveform/overviewtype.h
+++ b/src/waveform/overviewtype.h
@@ -10,6 +10,7 @@ enum class OverviewType {
     Filtered,
     HSV,
     RGB,
+    Simple,
 };
 Q_ENUM_NS(OverviewType);
 

--- a/src/waveform/renderers/waveformoverviewrenderer.cpp
+++ b/src/waveform/renderers/waveformoverviewrenderer.cpp
@@ -38,6 +38,13 @@ QImage render(ConstWaveformPointer pWaveform,
                 dataSize,
                 signalColors,
                 mono);
+    } else if (type == mixxx::OverviewType::Simple) {
+        drawWaveformPartSimple(&painter,
+                pWaveform,
+                nullptr,
+                dataSize,
+                signalColors,
+                mono);
     } else {
         drawWaveformPartRGB(&painter,
                 pWaveform,
@@ -318,6 +325,50 @@ void drawWaveformPartHSV(
             pPainter->setPen(color);
             pPainter->drawLine(QPoint(i / 2, -all[0]),
                     QPoint(i / 2, all[1]));
+        }
+    }
+
+    if (start) {
+        *start = end;
+    }
+}
+
+void drawWaveformPartSimple(
+        QPainter* pPainter,
+        ConstWaveformPointer pWaveform,
+        int* start,
+        int end,
+        const WaveformSignalColors& signalColors,
+        bool mono) {
+    ScopedTimer t(QStringLiteral("waveformOverviewRenderer::drawNextPixmapPartSimple"));
+    int startVal = 0;
+    if (start) {
+        startVal = *start;
+    }
+
+    const QColor color = signalColors.getSignalColor();
+
+    if (mono) {
+        const qreal dy = pPainter->deviceTransform().dy();
+        pPainter->resetTransform();
+        pPainter->translate(0, 2 * dy);
+        pPainter->scale(1, -1);
+
+        pPainter->setPen(color);
+        for (int i = startVal, x = startVal / 2; i < end; i += 2, ++x) {
+            int all = pWaveform->getAll(i) + pWaveform->getAll(i + 1);
+            if (all > 0) {
+                pPainter->drawLine(x, 0, x, all);
+            }
+        }
+    } else {
+        pPainter->setPen(color);
+        for (int i = startVal, x = startVal / 2; i < end; i += 2, ++x) {
+            int allLeft = pWaveform->getAll(i);
+            int allRight = pWaveform->getAll(i + 1);
+            if (allLeft > 0 || allRight > 0) {
+                pPainter->drawLine(x, -allLeft, x, allRight);
+            }
         }
     }
 

--- a/src/waveform/renderers/waveformoverviewrenderer.h
+++ b/src/waveform/renderers/waveformoverviewrenderer.h
@@ -41,4 +41,18 @@ void drawWaveformPartHSV(
         int end,
         const WaveformSignalColors& signalColors,
         bool mono = false);
+void drawWaveformPartSimple(
+        QPainter* pPainter,
+        ConstWaveformPointer pWaveform,
+        int* start,
+        int end,
+        const WaveformSignalColors& signalColors,
+        bool mono = false);
+void drawWaveformPartStackedRGB(
+        QPainter* pPainter,
+        ConstWaveformPointer pWaveform,
+        int* start,
+        int end,
+        const WaveformSignalColors& signalColors,
+        bool mono = false);
 } // namespace waveformOverviewRenderer

--- a/src/waveform/renderers/waveformoverviewrenderer.h
+++ b/src/waveform/renderers/waveformoverviewrenderer.h
@@ -48,11 +48,4 @@ void drawWaveformPartSimple(
         int end,
         const WaveformSignalColors& signalColors,
         bool mono = false);
-void drawWaveformPartStackedRGB(
-        QPainter* pPainter,
-        ConstWaveformPointer pWaveform,
-        int* start,
-        int end,
-        const WaveformSignalColors& signalColors,
-        bool mono = false);
 } // namespace waveformOverviewRenderer

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -1526,6 +1526,14 @@ bool WOverview::drawNextPixmapPart() {
                 nextCompletion,
                 m_signalColors,
                 !m_stereo);
+    } else if (m_type == OverviewType::Simple) {
+        waveformOverviewRenderer::drawWaveformPartSimple(
+                &painter,
+                pWaveform,
+                &m_actualCompletion,
+                nextCompletion,
+                m_signalColors,
+                !m_stereo);
     } else { // OverviewType::RGB:
         waveformOverviewRenderer::drawWaveformPartRGB(
                 &painter,


### PR DESCRIPTION
Closes #16020

Two related changes:

1. Move Simple to the top of the main waveform type combobox (sorted alphabetically otherwise)
2. Add Simple as an overview waveform type, and place it at the top of the overview combobox

The Simple overview renders the amplitude envelope (all channel) using the signal color, mirrored stereo (left upward, right downward) or mono-summed.