### PR TITLE
DlgTrackInfo: add BPM lock toggle to BPM tab

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -144,6 +144,11 @@ void DlgTrackInfo::init() {
             this,
             &DlgTrackInfo::slotBpmClear);
 
+    connect(bpmLock,
+            &QPushButton::clicked,
+            this,
+            &DlgTrackInfo::slotBpmLockClicked);
+
     connect(bpmConst,
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
             &QCheckBox::checkStateChanged,
@@ -464,20 +469,33 @@ void DlgTrackInfo::updateSpinBpmFromBeats() {
     spinBpm->setValue(bpmValue);
 }
 
+/// Updates Lock button text and enables/disables all BPM editing controls based on m_bpmLocked.
+void DlgTrackInfo::updateBpmEditControls() {
+    bpmLock->setText(m_bpmLocked ? tr("Unlock BPM") : tr("Lock BPM"));
+
+    bpmConst->setEnabled(!m_bpmLocked && m_trackHasBeatMap);
+    spinBpm->setEnabled(!m_bpmLocked && !m_trackHasBeatMap);
+    bpmTap->setEnabled(!m_bpmLocked && !m_trackHasBeatMap);
+    bpmDouble->setEnabled(!m_bpmLocked);
+    bpmHalve->setEnabled(!m_bpmLocked);
+    bpmTwoThirds->setEnabled(!m_bpmLocked);
+    bpmThreeFourth->setEnabled(!m_bpmLocked);
+    bpmFourThirds->setEnabled(!m_bpmLocked);
+    bpmThreeHalves->setEnabled(!m_bpmLocked);
+    bpmClear->setEnabled(!m_bpmLocked);
+}
+
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
     m_pBeatsClone = track.getBeats();
     updateSpinBpmFromBeats();
     m_trackHasBeatMap = m_pBeatsClone && !m_pBeatsClone->hasConstantTempo();
     bpmConst->setChecked(!m_trackHasBeatMap);
-    bpmConst->setEnabled(m_trackHasBeatMap); // We cannot turn a BeatGrid to a BeatMap
-    spinBpm->setEnabled(!m_trackHasBeatMap); // We cannot change bpm continuously or tap them
-    bpmTap->setEnabled(!m_trackHasBeatMap);  // when we have a beatmap
 
-    if (track.isBpmLocked()) {
-        tabBPM->setEnabled(false);
-    } else {
-        tabBPM->setEnabled(true);
-    }
+    // Store the lock state from the track into the local staging variable.
+    // This will only be written back to the track on Apply/OK.
+    m_bpmLocked = track.isBpmLocked();
+
+    updateBpmEditControls();
 }
 
 void DlgTrackInfo::loadTrackInternal(const TrackPointer& pTrack) {
@@ -637,6 +655,8 @@ void DlgTrackInfo::saveTrack() {
     slotSpinBpmValueChanged(spinBpm->value());
     updateKeyText();
 
+    m_trackRecord.setBpmLocked(m_bpmLocked);
+
     // Update the cached track
     //
     // If replaceRecord() returns true then both m_trackRecord and m_pBeatsClone
@@ -663,6 +683,7 @@ void DlgTrackInfo::clear() {
     resetTrackRecord();
 
     m_pBeatsClone.reset();
+    m_bpmLocked = false;
     updateSpinBpmFromBeats();
 
     txtLocation->setText("");
@@ -689,6 +710,14 @@ void DlgTrackInfo::slotBpmClear() {
     bpmConst->setEnabled(m_trackHasBeatMap);
     spinBpm->setEnabled(true);
     bpmTap->setEnabled(true);
+}
+
+void DlgTrackInfo::slotBpmLockClicked() {
+    if (!m_pLoadedTrack) {
+        return;
+    }
+    m_bpmLocked = !m_bpmLocked;
+    updateBpmEditControls();
 }
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -60,6 +60,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     void slotBpmScale(mixxx::Beats::BpmScale bpmScale);
     void slotBpmClear();
+    void slotBpmLockClicked();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     void slotBpmConstChanged(Qt::CheckState state);
 #else
@@ -110,6 +111,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     void updateTrackMetadataFields();
     void updateSpinBpmFromBeats();
+    void updateBpmEditControls();
 
     const UserSettingsPointer m_pUserSettings;
 
@@ -124,6 +126,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     mixxx::BeatsPointer m_pBeatsClone;
     bool m_trackHasBeatMap;
 
+    bool m_bpmLocked;
     TapFilter m_tapFilter;
     mixxx::Bpm m_lastTapedBpm;
 

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -733,6 +733,13 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
+        <widget class="QPushButton" name="bpmLock">
+         <property name="toolTip">
+          <string>Lock or unlock the BPM and beatgrid for this track.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
           <layout class="QGridLayout" name="gridLayout">


### PR DESCRIPTION
## Summary
Adds a Lock/Unlock BPM button to the BPM tab in the Track Editor dialog (DlgTrackInfo).

## Problem
When BPM is locked, the entire BPM tab is disabled with no way to unlock it from within the Track Editor. Users must close the dialog and use the track context menu to unlock BPM.

## Changes
- Added a `QPushButton` (bpmLock) to the BPM tab in `dlgtrackinfo.ui`
- Added `slotBpmLockClicked()` slot to handle button clicks
- Modified `reloadTrackBeats()` to individually disable editing controls instead of the whole tab
- Lock button text dynamically updates to "Lock BPM" / "Unlock BPM"

## How to test
1. Open Mixxx and load a track into the library
2. Right-click the track → Properties → BPM tab
3. Click "Lock BPM" → all editing controls should become disabled
4. Click "Unlock BPM" → all editing controls should become enabled again
5. Verify the button state persists when navigating between tracks

### Before Screenshot
<img width="1470" height="850" alt="Before Screnshot" src="https://github.com/user-attachments/assets/06982762-4a55-474e-a2a9-558bf4049f15" />

### After Video
https://github.com/user-attachments/assets/04ec1ef1-d34a-4c8d-9ead-9dd75644991f

