### PR TITLE
Add 5/4 and 4/5 BPM scaling controls

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -292,6 +292,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("3/4 BPM"),
             tr("Multiply current BPM by 0.75"),
             pBpmMenu);
+    addDeckAndSamplerControl("beats_set_fivefourths",
+            tr("5/4 BPM"),
+            tr("Multiply current BPM by 1.25"),
+            pBpmMenu);
     addDeckAndSamplerControl("beats_set_fourthirds",
             tr("4/3 BPM"),
             tr("Multiply current BPM by 1.333"),

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -292,6 +292,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("3/4 BPM"),
             tr("Multiply current BPM by 0.75"),
             pBpmMenu);
+    addDeckAndSamplerControl("beats_set_fourfifths",
+            tr("4/5 BPM"),
+            tr("Multiply current BPM by 0.8"),
+            pBpmMenu);
     addDeckAndSamplerControl("beats_set_fivefourths",
             tr("5/4 BPM"),
             tr("Multiply current BPM by 1.25"),

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -154,6 +154,16 @@ BpmControl::BpmControl(const QString& group,
                     slotScaleBpm(mixxx::Beats::BpmScale::ThreeFourths);
                 }
             });
+    m_pBeatsFourFifths = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_set_fourfifths"), false);
+    connect(m_pBeatsFourFifths.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](int value) {
+                if (value > 0) {
+                    slotScaleBpm(mixxx::Beats::BpmScale::FourFifths);
+                }
+            });
     m_pBeatsFiveFourths = std::make_unique<ControlPushButton>(
             ConfigKey(group, "beats_set_fivefourths"), false);
     connect(m_pBeatsFiveFourths.get(),

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -154,6 +154,16 @@ BpmControl::BpmControl(const QString& group,
                     slotScaleBpm(mixxx::Beats::BpmScale::ThreeFourths);
                 }
             });
+    m_pBeatsFiveFourths = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_set_fivefourths"), false);
+    connect(m_pBeatsFiveFourths.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](int value) {
+                if (value > 0) {
+                    slotScaleBpm(mixxx::Beats::BpmScale::FiveFourths);
+                }
+            });
     m_pBeatsFourThirds = std::make_unique<ControlPushButton>(
             ConfigKey(group, "beats_set_fourthirds"), false);
     connect(m_pBeatsFourThirds.get(),

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -158,6 +158,7 @@ class BpmControl : public EngineControl {
     std::unique_ptr<ControlPushButton> m_pBeatsHalve;
     std::unique_ptr<ControlPushButton> m_pBeatsTwoThirds;
     std::unique_ptr<ControlPushButton> m_pBeatsThreeFourths;
+    std::unique_ptr<ControlPushButton> m_pBeatsFiveFourths;
     std::unique_ptr<ControlPushButton> m_pBeatsFourThirds;
     std::unique_ptr<ControlPushButton> m_pBeatsThreeHalves;
     std::unique_ptr<ControlPushButton> m_pBeatsDouble;

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -158,6 +158,7 @@ class BpmControl : public EngineControl {
     std::unique_ptr<ControlPushButton> m_pBeatsHalve;
     std::unique_ptr<ControlPushButton> m_pBeatsTwoThirds;
     std::unique_ptr<ControlPushButton> m_pBeatsThreeFourths;
+    std::unique_ptr<ControlPushButton> m_pBeatsFourFifths;
     std::unique_ptr<ControlPushButton> m_pBeatsFiveFourths;
     std::unique_ptr<ControlPushButton> m_pBeatsFourThirds;
     std::unique_ptr<ControlPushButton> m_pBeatsThreeHalves;

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -130,6 +130,9 @@ void DlgTrackInfo::init() {
     connect(bpmThreeFourths, &QPushButton::clicked, this, [this] {
         slotBpmScale(mixxx::Beats::BpmScale::ThreeFourths);
     });
+    connect(bpmFourFifths, &QPushButton::clicked, this, [this] {
+        slotBpmScale(mixxx::Beats::BpmScale::FourFifths);
+    });
     connect(bpmFiveFourths, &QPushButton::clicked, this, [this] {
         slotBpmScale(mixxx::Beats::BpmScale::FiveFourths);
     });

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -121,23 +121,26 @@ void DlgTrackInfo::init() {
             &DlgTrackInfo::slotCancel);
 
     // BPM edit buttons
-    connect(bpmDouble, &QPushButton::clicked, this, [this] {
-        slotBpmScale(mixxx::Beats::BpmScale::Double);
-    });
     connect(bpmHalve, &QPushButton::clicked, this, [this] {
         slotBpmScale(mixxx::Beats::BpmScale::Halve);
     });
     connect(bpmTwoThirds, &QPushButton::clicked, this, [this] {
         slotBpmScale(mixxx::Beats::BpmScale::TwoThirds);
     });
-    connect(bpmThreeFourth, &QPushButton::clicked, this, [this] {
+    connect(bpmThreeFourths, &QPushButton::clicked, this, [this] {
         slotBpmScale(mixxx::Beats::BpmScale::ThreeFourths);
+    });
+    connect(bpmFiveFourths, &QPushButton::clicked, this, [this] {
+        slotBpmScale(mixxx::Beats::BpmScale::FiveFourths);
     });
     connect(bpmFourThirds, &QPushButton::clicked, this, [this] {
         slotBpmScale(mixxx::Beats::BpmScale::FourThirds);
     });
     connect(bpmThreeHalves, &QPushButton::clicked, this, [this] {
         slotBpmScale(mixxx::Beats::BpmScale::ThreeHalves);
+    });
+    connect(bpmDouble, &QPushButton::clicked, this, [this] {
+        slotBpmScale(mixxx::Beats::BpmScale::Double);
     });
     connect(bpmClear,
             &QPushButton::clicked,

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -482,12 +482,14 @@ void DlgTrackInfo::updateBpmEditControls() {
     bpmConst->setEnabled(!m_bpmLocked && m_trackHasBeatMap);
     spinBpm->setEnabled(!m_bpmLocked && !m_trackHasBeatMap);
     bpmTap->setEnabled(!m_bpmLocked && !m_trackHasBeatMap);
-    bpmDouble->setEnabled(!m_bpmLocked);
     bpmHalve->setEnabled(!m_bpmLocked);
     bpmTwoThirds->setEnabled(!m_bpmLocked);
-    bpmThreeFourth->setEnabled(!m_bpmLocked);
+    bpmThreeFourths->setEnabled(!m_bpmLocked);
+    bpmFourFifths->setEnabled(!m_bpmLocked);
+    bpmFiveFourths->setEnabled(!m_bpmLocked);
     bpmFourThirds->setEnabled(!m_bpmLocked);
     bpmThreeHalves->setEnabled(!m_bpmLocked);
+    bpmDouble->setEnabled(!m_bpmLocked);
     bpmClear->setEnabled(!m_bpmLocked);
 }
 

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -830,6 +830,22 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
             </widget>
            </item>
            <item row="3" column="1">
+            <widget class="QPushButton" name="bpmFourFifths">
+             <property name="minimumSize">
+              <size>
+               <width>125</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Sets the BPM to 80% of the current value.</string>
+             </property>
+             <property name="text">
+              <string>4/5 BPM</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
             <widget class="QPushButton" name="bpmFiveFourths">
              <property name="minimumSize">
               <size>
@@ -845,7 +861,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="4" column="1">
             <widget class="QPushButton" name="bpmFourThirds">
              <property name="minimumSize">
               <size>
@@ -861,7 +877,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
+           <item row="5" column="0">
             <widget class="QPushButton" name="bpmThreeHalves">
              <property name="minimumSize">
               <size>
@@ -877,7 +893,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
+           <item row="5" column="1">
             <widget class="QPushButton" name="bpmDouble">
              <property name="minimumSize">
               <size>
@@ -1095,6 +1111,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>bpmHalve</tabstop>
   <tabstop>bpmTwoThirds</tabstop>
   <tabstop>bpmThreeFourths</tabstop>
+  <tabstop>bpmFourFifths</tabstop>
   <tabstop>bpmFiveFourths</tabstop>
   <tabstop>bpmThreeHalves</tabstop>
   <tabstop>bpmFourThirds</tabstop>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -782,22 +782,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QPushButton" name="bpmDouble">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Sets the BPM to 200% of the current value.</string>
-             </property>
-             <property name="text">
-              <string>Double BPM</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
             <widget class="QPushButton" name="bpmHalve">
              <property name="minimumSize">
               <size>
@@ -813,7 +797,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="2" column="1">
             <widget class="QPushButton" name="bpmTwoThirds">
              <property name="minimumSize">
               <size>
@@ -829,8 +813,8 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
-            <widget class="QPushButton" name="bpmThreeFourth">
+           <item row="3" column="0">
+            <widget class="QPushButton" name="bpmThreeFourths">
              <property name="minimumSize">
               <size>
                <width>125</width>
@@ -845,7 +829,39 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
+           <item row="3" column="1">
+            <widget class="QPushButton" name="bpmFiveFourths">
+             <property name="minimumSize">
+              <size>
+               <width>125</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Sets the BPM to 125% of the current value.</string>
+             </property>
+             <property name="text">
+              <string>5/4 BPM</string>
+             </property>
+            </widget>
+           </item>
            <item row="4" column="0">
+            <widget class="QPushButton" name="bpmFourThirds">
+             <property name="minimumSize">
+              <size>
+               <width>125</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Sets the BPM to 133% of the current value.</string>
+             </property>
+             <property name="text">
+              <string>4/3 BPM</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
             <widget class="QPushButton" name="bpmThreeHalves">
              <property name="minimumSize">
               <size>
@@ -861,8 +877,8 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
-            <widget class="QPushButton" name="bpmFourThirds">
+           <item row="5" column="0">
+            <widget class="QPushButton" name="bpmDouble">
              <property name="minimumSize">
               <size>
                <width>125</width>
@@ -870,10 +886,10 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
               </size>
              </property>
              <property name="toolTip">
-              <string>Sets the BPM to 133% of the current value.</string>
+              <string>Sets the BPM to 200% of the current value.</string>
              </property>
              <property name="text">
-              <string>4/3 BPM</string>
+              <string>Double BPM</string>
              </property>
             </widget>
            </item>
@@ -1076,12 +1092,13 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>spinBpm</tabstop>
   <tabstop>bpmConst</tabstop>
   <tabstop>bpmTap</tabstop>
-  <tabstop>bpmDouble</tabstop>
   <tabstop>bpmHalve</tabstop>
   <tabstop>bpmTwoThirds</tabstop>
-  <tabstop>bpmThreeFourth</tabstop>
+  <tabstop>bpmThreeFourths</tabstop>
+  <tabstop>bpmFiveFourths</tabstop>
   <tabstop>bpmThreeHalves</tabstop>
   <tabstop>bpmFourThirds</tabstop>
+  <tabstop>bpmDouble</tabstop>
   <tabstop>bpmClear</tabstop>
   <tabstop>btnPrev</tabstop>
   <tabstop>btnNext</tabstop>

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -75,33 +75,57 @@ TEST(BeatGridTest, Scale) {
     EXPECT_DOUBLE_EQ(bpm.value(),
             pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
-    pGrid = *pGrid->tryScale(Beats::BpmScale::Double);
-    EXPECT_DOUBLE_EQ(2 * bpm.value(),
-            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
-                    .value());
 
     pGrid = *pGrid->tryScale(Beats::BpmScale::Halve);
-    EXPECT_DOUBLE_EQ(bpm.value(),
+    EXPECT_DOUBLE_EQ(bpm.value() / 2,
             pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
 
+    pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
     pGrid = *pGrid->tryScale(Beats::BpmScale::TwoThirds);
     EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3,
             pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
 
-    pGrid = *pGrid->tryScale(Beats::BpmScale::ThreeHalves);
-    EXPECT_DOUBLE_EQ(bpm.value(),
-            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
-                    .value());
-
+    pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
     pGrid = *pGrid->tryScale(Beats::BpmScale::ThreeFourths);
     EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4,
             pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
 
+    pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
+    pGrid = *pGrid->tryScale(Beats::BpmScale::FiveFourths);
+    EXPECT_DOUBLE_EQ(bpm.value() * 5 / 4,
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
+
+    pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
     pGrid = *pGrid->tryScale(Beats::BpmScale::FourThirds);
-    EXPECT_DOUBLE_EQ(bpm.value(),
+    EXPECT_DOUBLE_EQ(bpm.value() * 4 / 3,
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
+
+    pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
+    pGrid = *pGrid->tryScale(Beats::BpmScale::ThreeHalves);
+    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 2,
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
+
+    pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
+    pGrid = *pGrid->tryScale(Beats::BpmScale::Double);
+    EXPECT_DOUBLE_EQ(bpm.value() * 2,
             pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
 }

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -100,6 +100,14 @@ TEST(BeatGridTest, Scale) {
     pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
             mixxx::audio::kStartFramePos,
             mixxx::Bpm(bpm));
+    pGrid = *pGrid->tryScale(Beats::BpmScale::FourFifths);
+    EXPECT_DOUBLE_EQ(bpm.value() * 4 / 5,
+            pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
+
+    pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
+            mixxx::audio::kStartFramePos,
+            mixxx::Bpm(bpm));
     pGrid = *pGrid->tryScale(Beats::BpmScale::FiveFourths);
     EXPECT_DOUBLE_EQ(bpm.value() * 5 / 4,
             pGrid->getBpmInRange(audio::kStartFramePos, trackEndPosition)

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -57,33 +57,45 @@ TEST_F(BeatMapTest, Scale) {
     EXPECT_DOUBLE_EQ(bpm.value(),
             pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
-    pMap = *pMap->tryScale(Beats::BpmScale::Double);
-    EXPECT_DOUBLE_EQ(2 * bpm.value(),
-            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
-                    .value());
 
     pMap = *pMap->tryScale(Beats::BpmScale::Halve);
-    EXPECT_DOUBLE_EQ(bpm.value(),
+    EXPECT_DOUBLE_EQ(bpm.value() / 2,
             pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
 
+    pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
     pMap = *pMap->tryScale(Beats::BpmScale::TwoThirds);
     EXPECT_DOUBLE_EQ(bpm.value() * 2 / 3,
             pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
 
-    pMap = *pMap->tryScale(Beats::BpmScale::ThreeHalves);
-    EXPECT_DOUBLE_EQ(bpm.value(),
+    pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
+    pMap = *pMap->tryScale(Beats::BpmScale::FourThirds);
+    EXPECT_DOUBLE_EQ(bpm.value() * 4 / 3,
             pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
 
+    pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
     pMap = *pMap->tryScale(Beats::BpmScale::ThreeFourths);
     EXPECT_DOUBLE_EQ(bpm.value() * 3 / 4,
             pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
 
-    pMap = *pMap->tryScale(Beats::BpmScale::FourThirds);
-    EXPECT_DOUBLE_EQ(bpm.value(),
+    pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
+    pMap = *pMap->tryScale(Beats::BpmScale::FiveFourths);
+    EXPECT_DOUBLE_EQ(bpm.value() * 5 / 4,
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
+
+    pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
+    pMap = *pMap->tryScale(Beats::BpmScale::ThreeHalves);
+    EXPECT_DOUBLE_EQ(bpm.value() * 3 / 2,
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
+
+    pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
+    pMap = *pMap->tryScale(Beats::BpmScale::Double);
+    EXPECT_DOUBLE_EQ(bpm.value() * 2,
             pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
                     .value());
 }

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -82,6 +82,12 @@ TEST_F(BeatMapTest, Scale) {
                     .value());
 
     pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
+    pMap = *pMap->tryScale(Beats::BpmScale::FourFifths);
+    EXPECT_DOUBLE_EQ(bpm.value() * 4 / 5,
+            pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)
+                    .value());
+
+    pMap = Beats::fromBeatPositions(m_pTrack->getSampleRate(), beats);
     pMap = *pMap->tryScale(Beats::BpmScale::FiveFourths);
     EXPECT_DOUBLE_EQ(bpm.value() * 5 / 4,
             pMap->getBpmInRange(audio::kStartFramePos, trackEndPosition)

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -669,6 +669,9 @@ std::optional<BeatsPointer> Beats::tryScale(BpmScale scale) const {
     case BpmScale::ThreeFourths:
         scaleFactor *= 3.0 / 4;
         break;
+    case BpmScale::FourFifths:
+        scaleFactor *= 4.0 / 5;
+        break;
     case BpmScale::FiveFourths:
         scaleFactor *= 5.0 / 4;
         break;

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -660,9 +660,6 @@ std::optional<BeatsPointer> Beats::tryTranslateBeats(double xBeats) const {
 std::optional<BeatsPointer> Beats::tryScale(BpmScale scale) const {
     double scaleFactor = 1.0;
     switch (scale) {
-    case BpmScale::Double:
-        scaleFactor = 2.0;
-        break;
     case BpmScale::Halve:
         scaleFactor = 0.5;
         break;
@@ -672,11 +669,17 @@ std::optional<BeatsPointer> Beats::tryScale(BpmScale scale) const {
     case BpmScale::ThreeFourths:
         scaleFactor *= 3.0 / 4;
         break;
+    case BpmScale::FiveFourths:
+        scaleFactor *= 5.0 / 4;
+        break;
     case BpmScale::FourThirds:
         scaleFactor *= 4.0 / 3;
         break;
     case BpmScale::ThreeHalves:
         scaleFactor *= 3.0 / 2;
+        break;
+    case BpmScale::Double:
+        scaleFactor = 2.0;
         break;
     default:
         DEBUG_ASSERT(!"scale value invalid");

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -267,6 +267,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
         Halve,
         TwoThirds,
         ThreeFourths,
+        FourFifths,
         FiveFourths,
         FourThirds,
         ThreeHalves,

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -264,12 +264,13 @@ class Beats : private std::enable_shared_from_this<Beats> {
             const QString& subVersion = QString());
 
     enum class BpmScale {
-        Double,
         Halve,
         TwoThirds,
         ThreeFourths,
+        FiveFourths,
         FourThirds,
         ThreeHalves,
+        Double,
     };
 
     /// Returns false if the beats implementation supports non-const beats.

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -495,6 +495,8 @@ void WTrackMenu::createActions() {
         storeActionTextAndScaleInProperties(m_pBpmTwoThirdsAction, 2.0 / 3.0);
         m_pBpmThreeFourthsAction = make_parented<QAction>(tr("3/4 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmThreeFourthsAction, 3.0 / 4.0);
+        m_pBpmFourFifthsAction = make_parented<QAction>(tr("4/5 BPM"), m_pBPMMenu);
+        storeActionTextAndScaleInProperties(m_pBpmFourFifthsAction, 4.0 / 5.0);
         m_pBpmFiveFourthsAction = make_parented<QAction>(tr("5/4 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmFiveFourthsAction, 5.0 / 4.0);
         m_pBpmFourThirdsAction = make_parented<QAction>(tr("4/3 BPM"), m_pBPMMenu);
@@ -512,6 +514,9 @@ void WTrackMenu::createActions() {
         });
         connect(m_pBpmThreeFourthsAction, &QAction::triggered, this, [this] {
             slotScaleBpm(mixxx::Beats::BpmScale::ThreeFourths);
+        });
+        connect(m_pBpmFourFifthsAction, &QAction::triggered, this, [this] {
+            slotScaleBpm(mixxx::Beats::BpmScale::FourFifths);
         });
         connect(m_pBpmFiveFourthsAction, &QAction::triggered, this, [this] {
             slotScaleBpm(mixxx::Beats::BpmScale::FiveFourths);
@@ -646,6 +651,7 @@ void WTrackMenu::setupActions() {
         m_pBPMMenu->addAction(m_pBpmHalveAction);
         m_pBPMMenu->addAction(m_pBpmTwoThirdsAction);
         m_pBPMMenu->addAction(m_pBpmThreeFourthsAction);
+        m_pBPMMenu->addAction(m_pBpmFourFifthsAction);
         m_pBPMMenu->addAction(m_pBpmFiveFourthsAction);
         m_pBPMMenu->addAction(m_pBpmFourThirdsAction);
         m_pBPMMenu->addAction(m_pBpmThreeHalvesAction);
@@ -1137,6 +1143,7 @@ void WTrackMenu::updateMenus() {
             m_pBpmHalveAction->setEnabled(!anyBpmLocked);
             m_pBpmTwoThirdsAction->setEnabled(!anyBpmLocked);
             m_pBpmThreeFourthsAction->setEnabled(!anyBpmLocked);
+            m_pBpmFourFifthsAction->setEnabled(!anyBpmLocked);
             m_pBpmFiveFourthsAction->setEnabled(!anyBpmLocked);
             m_pBpmFourThirdsAction->setEnabled(!anyBpmLocked);
             m_pBpmThreeHalvesAction->setEnabled(!anyBpmLocked);
@@ -1157,6 +1164,7 @@ void WTrackMenu::updateMenus() {
                     appendBpmPreviewtoBpmAction(m_pBpmHalveAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmTwoThirdsAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmThreeFourthsAction, bpm);
+                    appendBpmPreviewtoBpmAction(m_pBpmFourFifthsAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmFiveFourthsAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmFourThirdsAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmThreeHalvesAction, bpm);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -489,22 +489,21 @@ void WTrackMenu::createActions() {
         connect(m_pBpmUnlockAction, &QAction::triggered, this, &WTrackMenu::slotUnlockBpm);
 
         //BPM edit actions
-        m_pBpmDoubleAction = make_parented<QAction>(tr("Double BPM"), m_pBPMMenu);
-        storeActionTextAndScaleInProperties(m_pBpmDoubleAction, 2.0);
         m_pBpmHalveAction = make_parented<QAction>(tr("Halve BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmHalveAction, 0.5);
         m_pBpmTwoThirdsAction = make_parented<QAction>(tr("2/3 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmTwoThirdsAction, 2.0 / 3.0);
         m_pBpmThreeFourthsAction = make_parented<QAction>(tr("3/4 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmThreeFourthsAction, 3.0 / 4.0);
+        m_pBpmFiveFourthsAction = make_parented<QAction>(tr("5/4 BPM"), m_pBPMMenu);
+        storeActionTextAndScaleInProperties(m_pBpmFiveFourthsAction, 5.0 / 4.0);
         m_pBpmFourThirdsAction = make_parented<QAction>(tr("4/3 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmFourThirdsAction, 4.0 / 3.0);
         m_pBpmThreeHalvesAction = make_parented<QAction>(tr("3/2 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmThreeHalvesAction, 3.0 / 2.0);
+        m_pBpmDoubleAction = make_parented<QAction>(tr("Double BPM"), m_pBPMMenu);
+        storeActionTextAndScaleInProperties(m_pBpmDoubleAction, 2.0);
 
-        connect(m_pBpmDoubleAction, &QAction::triggered, this, [this] {
-            slotScaleBpm(mixxx::Beats::BpmScale::Double);
-        });
         connect(m_pBpmHalveAction, &QAction::triggered, this, [this] {
             slotScaleBpm(mixxx::Beats::BpmScale::Halve);
         });
@@ -514,11 +513,17 @@ void WTrackMenu::createActions() {
         connect(m_pBpmThreeFourthsAction, &QAction::triggered, this, [this] {
             slotScaleBpm(mixxx::Beats::BpmScale::ThreeFourths);
         });
+        connect(m_pBpmFiveFourthsAction, &QAction::triggered, this, [this] {
+            slotScaleBpm(mixxx::Beats::BpmScale::FiveFourths);
+        });
         connect(m_pBpmFourThirdsAction, &QAction::triggered, this, [this] {
             slotScaleBpm(mixxx::Beats::BpmScale::FourThirds);
         });
         connect(m_pBpmThreeHalvesAction, &QAction::triggered, this, [this] {
             slotScaleBpm(mixxx::Beats::BpmScale::ThreeHalves);
+        });
+        connect(m_pBpmDoubleAction, &QAction::triggered, this, [this] {
+            slotScaleBpm(mixxx::Beats::BpmScale::Double);
         });
 
         m_pBpmResetAction = make_parented<QAction>(tr("Clear BPM and Beatgrid"), m_pBPMMenu);
@@ -641,6 +646,7 @@ void WTrackMenu::setupActions() {
         m_pBPMMenu->addAction(m_pBpmHalveAction);
         m_pBPMMenu->addAction(m_pBpmTwoThirdsAction);
         m_pBPMMenu->addAction(m_pBpmThreeFourthsAction);
+        m_pBPMMenu->addAction(m_pBpmFiveFourthsAction);
         m_pBPMMenu->addAction(m_pBpmFourThirdsAction);
         m_pBPMMenu->addAction(m_pBpmThreeHalvesAction);
         m_pBPMMenu->addAction(m_pBpmDoubleAction);
@@ -1128,12 +1134,13 @@ void WTrackMenu::updateMenus() {
         if (featureIsEnabled(Feature::BPM)) {
             m_pBpmUnlockAction->setEnabled(anyBpmLocked);
             m_pBpmLockAction->setEnabled(anyBpmNotLocked);
-            m_pBpmDoubleAction->setEnabled(!anyBpmLocked);
             m_pBpmHalveAction->setEnabled(!anyBpmLocked);
             m_pBpmTwoThirdsAction->setEnabled(!anyBpmLocked);
             m_pBpmThreeFourthsAction->setEnabled(!anyBpmLocked);
+            m_pBpmFiveFourthsAction->setEnabled(!anyBpmLocked);
             m_pBpmFourThirdsAction->setEnabled(!anyBpmLocked);
             m_pBpmThreeHalvesAction->setEnabled(!anyBpmLocked);
+            m_pBpmDoubleAction->setEnabled(!anyBpmLocked);
             m_pBpmResetAction->setEnabled(!anyBpmLocked);
             m_pBpmUndoAction->setEnabled(!anyBpmLocked && canUndoBeatsChange());
 
@@ -1147,12 +1154,13 @@ void WTrackMenu::updateMenus() {
                 }
                 if (pTrack) {
                     const double bpm = pTrack->getBpm();
-                    appendBpmPreviewtoBpmAction(m_pBpmDoubleAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmHalveAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmTwoThirdsAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmThreeFourthsAction, bpm);
+                    appendBpmPreviewtoBpmAction(m_pBpmFiveFourthsAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmFourThirdsAction, bpm);
                     appendBpmPreviewtoBpmAction(m_pBpmThreeHalvesAction, bpm);
+                    appendBpmPreviewtoBpmAction(m_pBpmDoubleAction, bpm);
                 }
             }
         }

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -340,12 +340,13 @@ class WTrackMenu : public QMenu {
     // BPM feature
     parented_ptr<QAction> m_pBpmLockAction;
     parented_ptr<QAction> m_pBpmUnlockAction;
-    parented_ptr<QAction> m_pBpmDoubleAction;
     parented_ptr<QAction> m_pBpmHalveAction;
     parented_ptr<QAction> m_pBpmTwoThirdsAction;
-    parented_ptr<QAction> m_pBpmThreeFourthsAction;
     parented_ptr<QAction> m_pBpmFourThirdsAction;
+    parented_ptr<QAction> m_pBpmThreeFourthsAction;
+    parented_ptr<QAction> m_pBpmFiveFourthsAction;
     parented_ptr<QAction> m_pBpmThreeHalvesAction;
+    parented_ptr<QAction> m_pBpmDoubleAction;
     parented_ptr<QAction> m_pBpmResetAction;
     parented_ptr<QAction> m_pBpmUndoAction;
     parented_ptr<QAction> m_pTranslateBeatsHalf;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -344,6 +344,7 @@ class WTrackMenu : public QMenu {
     parented_ptr<QAction> m_pBpmTwoThirdsAction;
     parented_ptr<QAction> m_pBpmFourThirdsAction;
     parented_ptr<QAction> m_pBpmThreeFourthsAction;
+    parented_ptr<QAction> m_pBpmFourFifthsAction;
     parented_ptr<QAction> m_pBpmFiveFourthsAction;
     parented_ptr<QAction> m_pBpmThreeHalvesAction;
     parented_ptr<QAction> m_pBpmDoubleAction;


### PR DESCRIPTION
Implements both the ×5/4 and ×4/5 BPM scaling options requested in #14686.

## Changes
- Adopts mxmilkiib's FiveFourths (5/4) implementation from #14780 (credit preserved via cherry-pick)
- Adds the missing FourFifths (4/5 = 0.8x) counterpart across all layers:
  - `BpmScale` enum (`src/track/beats.h`)
  - Scale math (`src/track/beats.cpp`)
  - Engine control (`bpmcontrol.cpp/.h`) with key `beats_set_fourfifths`
  - Controller picker menu (`controlpickermenu.cpp`)
  - Right-click track menu (`wtrackmenu.cpp/.h`)
  - Track Properties BPM tab (`dlgtrackinfo.cpp/.ui`)
  - Unit tests (`beatgridtest.cpp`, `beatmaptest.cpp`)

Closes #14686
Based on work from #14780 by @mxmilkiib

## Screenshots

### Before
<img width="1470" height="850" alt="Before" src="https://github.com/user-attachments/assets/3ea305c4-b0a4-4756-9130-bc461b50797b" />

### After
<img width="1470" height="850" alt="After" src="https://github.com/user-attachments/assets/5a65528e-5d4e-4865-9589-d379b46ccc3b" />
