### PR TITLE
Fix deck from group detection in JS Component JogWheelBasic

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -755,7 +755,7 @@
         }
 
         const deck = options.deck;
-        const group = script.deckFromGroup(options.group);
+        const deckFromGroup = script.deckFromGroup(options.group);
         delete options.deck;
         delete options.group;
 
@@ -766,7 +766,7 @@
         Object.defineProperties(this, {
             deck: {
                 get: () => this._deck,
-                set: (value) => {
+                set: value => {
                     if (Number.isInteger(value) && value > 0) {
                         this._deck = value;
                         this.reset();
@@ -774,13 +774,9 @@
                 },
             },
             group: {
-                get: () => `[Channel${deck}]`,
+                get: () => `[Channel${this.deck}]`,
                 set: value => {
-                    const deck = script.deckFromGroup(value);
-                    if (deck > 0) {
-                        this._deck = deck;
-                        this.reset();
-                    }
+                    this.deck = script.deckFromGroup(value);
                 },
             }
         });
@@ -788,9 +784,13 @@
         this.deck = deck;
 
         if (!this.deck) {
-            this.group = group;  // try setting deck from group
+            this.deck = deckFromGroup;  // try setting deck from group
         }
 
+        if (!Number.isInteger(this.deck)) {
+            console.warn("missing deck or group");
+            return;
+        }
         if (!Number.isInteger(this.wheelResolution)) {
             console.warn("missing jogwheel resolution");
             return;


### PR DESCRIPTION
This PR fixes behavior of JogWheelBasic when only `group` is given (while `deck` is omitted).

Follow-up for https://github.com/mixxxdj/mixxx/pull/13425

The name `group` was changed because it is [confusing](https://github.com/mixxxdj/mixxx/pull/13425#discussion_r1672395030) for a deck number.

The change was tested on a Reloop Terminal Mix on a custom mapping (using JS Components).

/cc @christophehenry, @Swiftb0y
