### PR TITLE
DlgTrackInfo: add editable tuning field

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -3,6 +3,7 @@
 #include <QSignalBlocker>
 #include <QStyleFactory>
 #include <QtDebug>
+#include <cmath>
 
 #include "defs_urls.h"
 #include "library/coverartcache.h"
@@ -33,6 +34,9 @@ constexpr int kMinBpm = 30;
 const mixxx::Duration kMaxInterval = mixxx::Duration::fromMillis(
         static_cast<qint64>(1000.0 * (60.0 / kMinBpm)));
 const QString kBpmPropertyName = QStringLiteral("bpm");
+
+constexpr double kStandardTuningHz = 440.0;
+constexpr double kCentsPerOctave = 1200.0;
 
 } // namespace
 
@@ -167,6 +171,11 @@ void DlgTrackInfo::init() {
             &QLineEdit::editingFinished,
             this,
             &DlgTrackInfo::slotKeyTextChanged);
+
+    connect(spinTuning,
+            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgTrackInfo::slotTuningValueChanged);
 
     connect(bpmTap,
             &QPushButton::pressed,
@@ -434,6 +443,7 @@ void DlgTrackInfo::updateTrackMetadataFields() {
     txtBpm->setText(
             m_trackRecord.getMetadata().getTrackInfo().getBpmText());
     displayKeyText();
+    displayTuningFields();
 
     // Non-editable fields
     txtDuration->setText(
@@ -655,6 +665,7 @@ void DlgTrackInfo::saveTrack() {
     slotSpinBpmValueChanged(spinBpm->value());
     updateKeyText();
 
+    slotTuningValueChanged(spinTuning->value());
     m_trackRecord.setBpmLocked(m_bpmLocked);
 
     // Update the cached track
@@ -795,6 +806,53 @@ void DlgTrackInfo::updateKeyText() {
 void DlgTrackInfo::displayKeyText() {
     const QString keyText = KeyUtils::keyToString(m_trackRecord.getKeys().getGlobalKey());
     txtKey->setText(keyText);
+}
+
+void DlgTrackInfo::displayTuningFields() {
+    const double tuningHz =
+            m_trackRecord.getKeys().getGlobalTuningFrequencyHz();
+    const QSignalBlocker blocker(spinTuning);
+    if (tuningHz > 0.0) {
+        // Block signals to avoid triggering slotTuningValueChanged
+        // while we are just loading data into the widget.
+        spinTuning->setValue(tuningHz);
+
+        const double cents = kCentsPerOctave *
+                std::log2(tuningHz / kStandardTuningHz);
+        const int centsRounded = static_cast<int>(std::lround(cents));
+        const QString offsetText = centsRounded >= 0
+                ? QStringLiteral("+%1 ct").arg(centsRounded)
+                : QStringLiteral("%1 ct").arg(centsRounded);
+        txtTuningCents->setText(offsetText);
+    } else {
+        // No tuning data: set to minimum (triggers specialValueText = blank)
+        spinTuning->setValue(spinTuning->minimum());
+        txtTuningCents->clear();
+    }
+}
+
+void DlgTrackInfo::slotTuningValueChanged(double value) {
+    // Store the user-entered Hz value in the Keys protobuf
+    Keys keys = m_trackRecord.getKeys();
+    if (value <= spinTuning->minimum()) {
+        // Special value (minimum) means "no tuning set" — store 0 Hz
+        keys.setGlobalTuningFrequencyHz(0.0);
+        m_trackRecord.setKeys(std::move(keys));
+        txtTuningCents->clear();
+        return;
+    }
+
+    keys.setGlobalTuningFrequencyHz(value);
+    m_trackRecord.setKeys(std::move(keys));
+
+    // Update the cents offset label so the user gets immediate feedback
+    const double cents = kCentsPerOctave *
+            std::log2(value / kStandardTuningHz);
+    const int centsRounded = static_cast<int>(std::lround(cents));
+    const QString offsetText = centsRounded >= 0
+            ? QStringLiteral("+%1 ct").arg(centsRounded)
+            : QStringLiteral("%1 ct").arg(centsRounded);
+    txtTuningCents->setText(offsetText);
 }
 
 void DlgTrackInfo::slotKeyTextChanged() {

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -70,6 +70,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotSpinBpmValueChanged(double value);
 
     void slotKeyTextChanged();
+    void slotTuningValueChanged(double value);
     void slotRatingChanged(int rating);
     void slotImportMetadataFromFile();
     void slotImportMetadataFromMusicBrainz();
@@ -97,6 +98,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     void updateKeyText();
     void displayKeyText();
+    void displayTuningFields();
 
     void updateFromTrack(const Track& track);
 

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -303,9 +303,9 @@
           </item>
 
           <item row="5" column="2">
-           <widget class="QLabel" name="lblKey">
+           <widget class="QLabel" name="lblTrackNumber">
             <property name="text">
-             <string>Key</string>
+             <string>Track #</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -313,7 +313,7 @@
            </widget>
           </item>
           <item row="5" column="3">
-           <widget class="QLineEdit" name="txtKey">
+           <widget class="QLineEdit" name="txtTrackNumber">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -356,34 +356,125 @@
            </widget>
           </item>
 
-          <item row="6" column="2">
-           <widget class="QLabel" name="lblTrackNumber">
+          <item row="7" column="0">
+           <widget class="QLabel" name="lblKey">
             <property name="text">
-             <string>Track #</string>
+             <string>Key</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
            </widget>
           </item>
-          <item row="6" column="3">
-           <widget class="QLineEdit" name="txtTrackNumber">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+          <item row="7" column="1">
+           <widget class="QWidget">
+            <layout class="QHBoxLayout" name="key_layout">
+
+             <item>
+              <widget class="QLineEdit" name="txtKey">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="keyTuningSpacerItem">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>25</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="lblTuning">
+               <property name="text">
+                <string>Tuning</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignRight|Qt::AlignVCenter</set>
+               </property>
+              </widget>
+             </item>
+
+             <item>
+              <widget class="QDoubleSpinBox" name="spinTuning">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>A4 tuning frequency in Hz. Standard tuning is 440 Hz.</string>
+               </property>
+               <property name="suffix">
+                <string> Hz</string>
+               </property>
+               <property name="decimals">
+                <number>1</number>
+               </property>
+               <property name="minimum">
+                <double>400.000000000000000</double>
+               </property>
+               <property name="maximum">
+                <double>480.000000000000000</double>
+               </property>
+               <property name="singleStep">
+                <double>0.100000000000000</double>
+               </property>
+               <property name="value">
+                <double>400.000000000000000</double>
+               </property>
+               <property name="specialValueText">
+                <string/>
+               </property>
+              </widget>
+             </item>
+
+            </layout>
+           </widget>
+          </item>
+
+          <item row="7" column="2">
+           <widget class="QLabel" name="lblTuningCents">
+            <property name="text">
+             <string>Offset:</string>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="3">
+           <widget class="QLabel" name="txtTuningCents">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="toolTip">
+             <string>Offset from A440 standard tuning in cents.</string>
             </property>
            </widget>
           </item>
 
-          <item row="7" column="0">
+
+          <item row="8" column="0">
            <widget class="QLabel" name="lblTrackComment">
             <property name="text">
              <string>Comments</string>
@@ -393,7 +484,7 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="1" colspan="3">
+          <item row="8" column="1" colspan="3">
            <widget class="QPlainTextEdit" name="txtComment">
             <property name="tabChangesFocus">
              <bool>true</bool>
@@ -401,7 +492,7 @@
            </widget>
           </item>
 
-          <item row="8" column="0">
+          <item row="9" column="0">
            <widget class="QLabel" name="lblTrackColor">
             <property name="text">
              <string>Color</string>
@@ -411,7 +502,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="1" colspan="3">
+          <item row="9" column="1" colspan="3">
            <widget class="QPushButton" name="btnColorPicker">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -421,7 +512,8 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
+
+          <item row="10" column="0">
            <spacer name="horizontalSpacer_5">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -434,7 +526,8 @@
             </property>
            </spacer>
           </item>
-          <item row="10" column="0" colspan="4">
+
+          <item row="11" column="0" colspan="4">
            <layout class="QHBoxLayout" name="meatdata_buttons_layout">
             <item>
              <widget class="QPushButton" name="btnImportMetadataFromMusicBrainz">
@@ -1063,12 +1156,13 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>txtAlbum</tabstop>
   <tabstop>txtAlbumArtist</tabstop>
   <tabstop>txtComposer</tabstop>
-  <tabstop>txtGenre</tabstop>
-  <tabstop>txtGrouping</tabstop>
-  <tabstop>txtComment</tabstop>
   <tabstop>txtYear</tabstop>
-  <tabstop>txtKey</tabstop>
+  <tabstop>txtGenre</tabstop>
   <tabstop>txtTrackNumber</tabstop>
+  <tabstop>txtGrouping</tabstop>
+  <tabstop>txtKey</tabstop>
+  <tabstop>spinTuning</tabstop>
+  <tabstop>txtComment</tabstop>
   <tabstop>btnColorPicker</tabstop>
   <tabstop>btnImportMetadataFromMusicBrainz</tabstop>
   <tabstop>btnImportMetadataFromFile</tabstop>


### PR DESCRIPTION
## Summary

Adds an editable tuning frequency field to the Track Editor (Properties) dialog.

Daniel suggested this on Zulip to complement the tuning detection in PR #15817.

## What it does

- Adds a `QDoubleSpinBox` (range 400-480 Hz) for A4 tuning frequency
- Auto-computes and displays the cents offset from A440 standard tuning
- Placed in the tags section next to the Key field (tuning is related to key)
- User-entered values are saved to the existing `tuning_frequency_hz` DB column
- Shows empty when no tuning data is available

## Screenshots

### Before
<img width="1470" height="850" alt="Before Screenshot" src="https://github.com/user-attachments/assets/84b1d58d-445a-470d-a336-9035a64fcca2" />

### After
<img width="1470" height="850" alt="After Screenshot" src="https://github.com/user-attachments/assets/690b7a9f-5192-462e-84c1-c5163b4e9efe" />


https://github.com/user-attachments/assets/6d5f99bc-ed3a-4056-9182-3933e7687d2b


## Testing

- Opened Track Properties for unanalyzed track → field shows empty
- Entered 442 Hz → cents label shows "+8 ct"
- Entered 432 Hz → cents label shows "-32 ct"
- Applied, closed, reopened → value persists

Related: #15817