### PR TITLE
libxwax: fix heap leak in timecoder when using non-MK2 timecodes

### DIFF
--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -490,8 +490,10 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
     /* Compute the factor the scale up the derivative to the original level */
     tc->gain_compensation = 1.0 / (M_PI * tc->def->resolution / tc->sample_rate);
 
-    mk2_subcode_init(&tc->upper_bitstream);
-    mk2_subcode_init(&tc->lower_bitstream);
+    if (tc->def->flags & TRAKTOR_MK2) {
+        mk2_subcode_init(&tc->upper_bitstream);
+        mk2_subcode_init(&tc->lower_bitstream);
+    }
 }
 
 /*


### PR DESCRIPTION
PR #15965 swapped the static delayline in xwax out for a heap-allocated ringbuffer. The change was correct, but it left behind a mismatch: `timecoder_init` was calling `mk2_subcode_init` unconditionally for every timecode type, and `mk2_subcode_init` now calls `rb_alloc` to allocate two heap buffers. The problem is that `timecoder_clear` only frees those buffers when the `TRAKTOR_MK2` flag is set. So for every Serato or non-MK2 Traktor session, two ringbuffers get allocated at startup and never freed when the vinyl control is torn down, leading to the heap corruption reported in #16008.

The fix guards the `mk2_subcode_init` calls in `timecoder_init` with the same `TRAKTOR_MK2` check that already exists in `timecoder_clear`, making the two sides symmetric. Before the ringbuffer refactor this didn't matter because `mk2_subcode_init` only zeroed out a fixed array inside the struct with no heap involvement. Now that it allocates memory, init and clear have to agree on when that happens.

Fixes #16008