### PR TITLE
Add exponential spin-up and spin-down ramping for smoother playback.

### DIFF
--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -36,7 +36,8 @@ public:
 
   enum class RampMode {
       Stepping = 0, // pitch takes a temporary step up/down a certain amount
-      Linear = 1    // pitch moves up/down in a progressively linear fashion
+      Linear = 1,   // pitch moves up/down in a progressively linear fashion
+      Exponential = 2 // vinyl style spin-up / spin-down curve
   };
 
   void setBpmControl(BpmControl* bpmcontrol);
@@ -174,4 +175,8 @@ private:
   double m_tempRateRatio;
   // Speed for temporary rate change
   double m_dRateTempRampChange;
+
+  // Vinyl-style brake & spin-up timing
+  double m_brakeTime = 0.8;
+  double m_spinTime = 0.5;
 };

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1,4 +1,4 @@
-#include "engine/enginebuffer.h"
+﻿#include "engine/enginebuffer.h"
 
 #include <QtDebug>
 
@@ -810,6 +810,9 @@ void EngineBuffer::slotControlPlayRequest(double v) {
     bool verifiedPlay = updateIndicatorsAndModifyPlay(v > 0.0, oldPlay);
 
     if (!oldPlay && verifiedPlay) {
+        // trigger spin-up here
+    
+        m_pRateControl->setRateRampMode(RateControl::RampMode::Exponential);
         if (m_quantize.toBool()
 #ifdef __VINYLCONTROL__
                 && m_pVinylControlControl && !m_pVinylControlControl->isEnabled()
@@ -817,6 +820,12 @@ void EngineBuffer::slotControlPlayRequest(double v) {
         ) {
             requestSyncPhase();
         }
+    }
+
+    // Spin-DOWN: playing ? stopped
+    if (oldPlay && !verifiedPlay) {
+        //  trigger spin-down here
+        m_pRateControl->setRateRampMode(RateControl::RampMode::Exponential);
     }
 
     // set and confirm must be called here in any case to update the widget toggle state
@@ -855,7 +864,9 @@ void EngineBuffer::slotControlJumpToStartAndStop(double v)
 
 void EngineBuffer::slotControlStop(double v)
 {
+  //Exponential added here for Switch to vinyl brake mode → slow natural stop
     if (v > 0.0) {
+        m_pRateControl->setRateRampMode(RateControl::RampMode::Exponential);
         m_playButton->set(0);
     }
 }


### PR DESCRIPTION

This PR introduces an exponential ramping mode for playback start and stop,
providing smoother and more natural spin-up and spin-down behavior.

The implementation avoids sudden pitch or speed changes and produces a more
vinyl-like playback experience.

I tested the behavior with multiple tracks, including vocal-heavy and
electronic tracks, to ensure smooth transitions without audible artifacts.