### PR TITLE
Preferences: reorder waveform type menu items

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -71,8 +71,6 @@ DlgPrefWaveform::DlgPrefWaveform(
         }
         waveformTypeComboBox->addItem(types[i].getDisplayName(), types[i].getType());
     }
-    // Sort the combobox items alphabetically
-    waveformTypeComboBox->model()->sort(0);
 
     // Populate zoom options.
     for (int i = static_cast<int>(WaveformWidgetRenderer::s_waveformMinZoom);

--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -25,9 +25,9 @@ class WaveformWidgetType {
             WaveformWidgetType::Simple,
             WaveformWidgetType::Filtered,
             WaveformWidgetType::HSV,
-            WaveformWidgetType::VSyncTest,
             WaveformWidgetType::RGB,
             WaveformWidgetType::Stacked,
+            WaveformWidgetType::VSyncTest,
     };
 };
 


### PR DESCRIPTION
Addresses mixxxdj/mixxx#16020.

Reorders the Waveform type combobox items in Preferences so the common types appear in a more intuitive order (Simple, Filtered, HSV, RGB, Stacked, VSyncTest).