### PR TITLE
Avoid conditional jump that depends on uninitialized memory

### DIFF
--- a/src/library/columncache.cpp
+++ b/src/library/columncache.cpp
@@ -189,8 +189,9 @@ ColumnCache::ColumnCache() {
     m_pKeyNotationCP = new ControlProxy(mixxx::library::prefs::kKeyNotationConfigKey, this);
     m_pKeyNotationCP->connectValueChanged(this, &ColumnCache::slotSetKeySortOrder);
 
+    // Used in BaseTrackTableModel() along with a later setColumns() call.
     // ColumnCache is initialized before the preferences, so slotSetKeySortOrder is called
-    // for again if DlgPrefKey sets the [Library]. key_notation CO to a value other than
+    // again if DlgPrefKey sets the [Library]. key_notation CO to a value other than
     // KeyUtils::CUSTOM as Mixxx is starting.
 }
 
@@ -240,6 +241,10 @@ void ColumnCache::setColumns(QStringList columns) {
 }
 
 void ColumnCache::slotSetKeySortOrder(double notationValue) {
+    if (m_columnsByIndex.isEmpty()) {
+        // we are not caching columns yet
+        return;
+    }
     const int keyColumnIndex = m_columnIndexByEnum[COLUMN_LIBRARYTABLE_KEY];
     if (keyColumnIndex < 0) {
         return;


### PR DESCRIPTION
This fixes this Valgrind finding:
```
==9950== Conditional jump or move depends on uninitialised value(s)
==9950==    at 0x49CE957: ColumnCache::slotSetKeySortOrder(double) (columncache.cpp:254)
==9950==    by 0xAFBB022: call (qobjectdefs_impl.h:375)
==9950==    by 0xAFBB022: void doActivate<false>(QObject*, int, void**) (qobject.cpp:3912)
==9950==    by 0x481E223: ControlProxy::valueChanged(double) (moc_controlproxy.cpp:167)
==9950==    by 0xAFBB022: call (qobjectdefs_impl.h:375)
==9950==    by 0xAFBB022: void doActivate<false>(QObject*, int, void**) (qobject.cpp:3912)
==9950==    by 0x4808779: valueChanged (moc_control.cpp:148)
==9950==    by 0x4808779: ControlDoublePrivate::setInner(double, QObject*) (control.cpp:291)
==9950==    by 0x4807382: ControlDoublePrivate::set(double, QObject*) (control.cpp:278)
==9950==    by 0x45774CB: set (controlproxy.h:139)
==9950==    by 0x45774CB: DlgPrefKey::loadSettings() (dlgprefkey.cpp:154)
==9950==    by 0x457AA37: DlgPrefKey::DlgPrefKey(QWidget*, QSharedPointer<ConfigObject<ConfigValue> >) (dlgprefkey.cpp:51)
==9950==    by 0x4566B4F: DlgPreferences::DlgPreferences(std::shared_ptr<mixxx::ScreensaverManager>, std::shared_ptr<mixxx::skin::SkinLoader>, std::shared_ptr<SoundManager>, std::shared_ptr<ControllerManager>, std::shared_ptr<VinylControlManager>, std::shared_ptr<EffectsManager>, std::shared_ptr<SettingsManager>, std::shared_ptr<Library>) (dlgpreferences.cpp:222)
==9950==    by 0x4549E12: MixxxMainWindow::initialize() (mixxxmainwindow.cpp:314)
==9950==    by 0xAFBB022: call (qobjectdefs_impl.h:375)
==9950==    by 0xAFBB022: void doActivate<false>(QObject*, int, void**) (qobject.cpp:3912)
==9950==    by 0xA5F0AD9: QOpenGLWindow::resizeEvent(QResizeEvent*) (qopenglwindow.cpp:665)
``