### PR TITLE
Fix false positive "First sound has been moved!" warnings

### DIFF
--- a/src/engine/cachingreader/cachingreaderworker.cpp
+++ b/src/engine/cachingreader/cachingreaderworker.cpp
@@ -274,6 +274,8 @@ void CachingReaderWorker::verifyFirstSound(const CachingReaderChunk* pChunk) {
                             .value()));
     if (pChunk->getIndex() == firstSoundIndex) {
         CSAMPLE sampleBuffer[kNumSoundFrameToVerify * mixxx::kEngineChannelCount];
+        // We read two frames, the last silence frame and the first non-silence frame from
+        // m_firstSoundFrameToVerify. end points to one position after them.
         SINT end = static_cast<SINT>(m_firstSoundFrameToVerify.toLowerFrameBoundary().value()) + 1;
         mixxx::IndexRange probeFrameIndexRange =
                 mixxx::IndexRange::between(end - kNumSoundFrameToVerify, end);
@@ -281,6 +283,7 @@ void CachingReaderWorker::verifyFirstSound(const CachingReaderChunk* pChunk) {
                 pChunk->readBufferedSampleFrames(
                         sampleBuffer, probeFrameIndexRange);
         VERIFY_OR_DEBUG_ASSERT(bufferedFrameIndexRange == probeFrameIndexRange) {
+            qWarning() << "skipping verifyFirstSound()";
             return;
         }
         if (AnalyzerSilence::verifyFirstSound(std::span<const CSAMPLE>(sampleBuffer),

--- a/src/engine/cachingreader/cachingreaderworker.cpp
+++ b/src/engine/cachingreader/cachingreaderworker.cpp
@@ -272,9 +272,10 @@ void CachingReaderWorker::verifyFirstSound(const CachingReaderChunk* pChunk) {
                             .value()));
     if (pChunk->getIndex() == firstSoundIndex) {
         CSAMPLE sampleBuffer[kNumSoundFrameToVerify * mixxx::kEngineChannelCount];
-        SINT end = static_cast<SINT>(m_firstSoundFrameToVerify.toLowerFrameBoundary().value());
-        pChunk->readBufferedSampleFrames(sampleBuffer,
-                mixxx::IndexRange::forward(end - 1, kNumSoundFrameToVerify));
+        SINT end = static_cast<SINT>(m_firstSoundFrameToVerify.toLowerFrameBoundary().value()) + 1;
+        mixxx::IndexRange probeFrameIndexRange =
+                mixxx::IndexRange::between(end - kNumSoundFrameToVerify, end);
+        pChunk->readBufferedSampleFrames(sampleBuffer, probeFrameIndexRange);
         if (AnalyzerSilence::verifyFirstSound(std::span<const CSAMPLE>(sampleBuffer),
                     mixxx::audio::FramePos(1))) {
             qDebug() << "First sound found at the previously stored position";


### PR DESCRIPTION
This may happen in case of cache misses. The issue was cough by valgrind: 

```
==9950== Thread 22 CachingReaderWor:
==9950== Conditional jump or move depends on uninitialised value(s)
==9950==    at 0x4D49B12: __find_if<__gnu_cxx::__normal_iterator<float const*, std::span<float const> >, __gnu_cxx::__ops::_Iter_pred<(anonymous namespace)::first_sound<__gnu_cxx::__normal_iterator<float const*, std::span<float const> > >(__gnu_cxx::__normal_iterator<float const*, std::span<float const> >, __gnu_cxx::__normal_iterator<float const*, std::span<float const> >)::<lambda(auto:53)> > > (stl_algobase.h:2094)
==9950==    by 0x4D49B12: __find_if<__gnu_cxx::__normal_iterator<float const*, std::span<float const> >, __gnu_cxx::__ops::_Iter_pred<(anonymous namespace)::first_sound<__gnu_cxx::__normal_iterator<float const*, std::span<float const> > >(__gnu_cxx::__normal_iterator<float const*, std::span<float const> >, __gnu_cxx::__normal_iterator<float const*, std::span<float const> >)::<lambda(auto:53)> > > (stl_algobase.h:2114)
==9950==    by 0x4D49B12: find_if<__gnu_cxx::__normal_iterator<float const*, std::span<float const> >, (anonymous namespace)::first_sound<__gnu_cxx::__normal_iterator<float const*, std::span<float const> > >(__gnu_cxx::__normal_iterator<float const*, std::span<float const> >, __gnu_cxx::__normal_iterator<float const*, std::span<float const> >)::<lambda(auto:53)> > (stl_algo.h:3910)
==9950==    by 0x4D49B12: first_sound<__gnu_cxx::__normal_iterator<float const*, std::span<float const> > > (analyzersilence.cpp:28)
==9950==    by 0x4D49B12: AnalyzerSilence::findFirstSoundInChunk(std::span<float const, 18446744073709551615ul>) (analyzersilence.cpp:63)
==9950==    by 0x4D4A00B: AnalyzerSilence::verifyFirstSound(std::span<float const, 18446744073709551615ul>, mixxx::audio::FramePos, mixxx::audio::ChannelCount) (analyzersilence.cpp:78)
==9950==    by 0x4DFB328: _firstCachingReaderWorker::verifyFirstSound(CachingReaderChunk const*, mixxx::audio::ChannelCount) (cachingreaderworker.cpp:326)
==9950==    by 0x4DFBA9A: CachingReaderWorker::processReadRequest(CachingReaderChunkReadRequest const&) (cachingreaderworker.cpp:87)
==9950==    by 0x4DFE980: CachingReaderWorker::run() (cachingreaderworker.cpp:151)
==9950==    by 0xB0CCFCE: operator() (qthread_unix.cpp:356)
==9950==    by 0xB0CCFCE: terminate_on_exception<QThreadPrivate::start(void*)::<lambda()> > (qthread_unix.cpp:292)
==9950==    by 0xB0CCFCE: QThreadPrivate::start(void*) (qthread_unix.cpp:315)
==9950==    by 0xB800AC2: start_thread (pthread_create.c:442)
==9950==    by 0xB891A83: clone (clone.S:100)
==9950== 
``

