### PR TITLE
fix uninitialized variable in DateAddedFilterNode();

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -814,6 +814,7 @@ QString YearFilterNode::toSql() const {
 // TODO Convert to DateFilterNode and allow searching for "last_played"
 DateAddedFilterNode::DateAddedFilterNode(const QString& argument)
         : m_operatorQuery(false),
+          m_equalsQuery(false),
           m_operator("=") {
     QDateTime date;
     QRegularExpressionMatch opMatch = kNumericOperatorRegex.match(argument);


### PR DESCRIPTION
this is a valgrind finding 

``` 
==37336== Conditional jump or move depends on uninitialised value(s)
==37336==    at 0x499023A: DateAddedFilterNode::toSql() const (searchquery.cpp:916)
==37336==    by 0x4993CD4: AndNode::toSql() const (searchquery.cpp:123)
==37336==    by 0x499393C: OrNode::toSql() const (searchquery.cpp:147)
==37336==    by 0x4993CD4: AndNode::toSql() const (searchquery.cpp:123)
==37336==    by 0x48AA1ED: BaseTrackCache::filterAndSort(QSet<TrackId> const&, QString const&, QString const&, QString const&, QList<SortColumn> const&, int, QHash<TrackId, int>*) (basetrackcache.cpp:491)
==37336==    by 0x489448D: BaseSqlTableModel::select() (basesqltablemodel.cpp:287)
==37336==    by 0x46763E9: WTrackTableView::doSortByColumn(int, Qt::SortOrder) (wtracktableview.cpp:1658)
==37336==    by 0x4676DCC: WTrackTableView::loadTrackModel(QAbstractItemModel*, bool) (wtracktableview.cpp:339)
==37336==    by 0x4853094: DlgAnalysis::DlgAnalysis(WLibrary*, QSharedPointer<ConfigObject<ConfigValue> >, Library*) (dlganalysis.cpp:52)
==37336==    by 0x484D501: AnalysisFeature::bindLibraryWidget(WLibrary*, KeyboardEventFilter*) (analysisfeature.cpp:75)
==37336==    by 0x4377A18: Library::bindLibraryWidget(WLibrary*, KeyboardEventFilter*) (library.cpp:459)
==37336==    by 0x4A10D80: LegacySkinParser::parseLibrary(QDomElement const&) (legacyskinparser.cpp:1596)
==37336== 
``` 