### PR TITLE
replaygain: add replaygain editing to track properties dialogs

### DIFF
--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -571,18 +571,9 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLabel" name="txtReplayGain">
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+           <widget class="QLineEdit" name="txtReplayGain">
+            <property name="toolTip">
+             <string>ReplayGain value in dB (e.g. -6.0)</string>
             </property>
            </widget>
           </item>
@@ -1062,6 +1053,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>txtYear</tabstop>
   <tabstop>txtKey</tabstop>
   <tabstop>txtTrackNumber</tabstop>
+  <tabstop>txtReplayGain</tabstop>
   <tabstop>btnColorPicker</tabstop>
   <tabstop>btnImportMetadataFromMusicBrainz</tabstop>
   <tabstop>btnImportMetadataFromFile</tabstop>

--- a/src/library/dlgtrackinfomulti.ui
+++ b/src/library/dlgtrackinfomulti.ui
@@ -462,7 +462,7 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QGridLayout" name="properties_layout" rowstretch="0,0,0,0,0,0" columnstretch="0,1,0,1">
+     <layout class="QGridLayout" name="properties_layout" rowstretch="0,0,0,0,0,0,0" columnstretch="0,1,0,1">
 
       <item row="0" column="0">
        <widget class="QLabel" name="lblDuration">
@@ -560,6 +560,35 @@
        </widget>
       </item>
 
+      <item row="2" column="0">
+       <widget class="QLabel" name="lblReplayGain">
+        <property name="text">
+         <string>ReplayGain:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="txtReplayGain">
+        <property name="toolTip">
+         <string>Enter a ReplayGain value in dB (e.g. -6.0 dB) to apply to all selected tracks. Leave empty to make no change.</string>
+        </property>
+        <property name="placeholderText">
+         <string>Enter dB value to apply to all…</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="0" colspan="4">
+       <widget class="QLabel" name="lblReplayGainInfo">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+
       <item row="2" column="2">
        <widget class="QLabel" name="lblSamplerate">
         <property name="text">
@@ -581,7 +610,7 @@
        </widget>
       </item>
 
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="lblLocation">
         <property name="text">
          <string>Location:</string>
@@ -591,7 +620,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1" colspan="3">
+      <item row="4" column="1" colspan="3">
        <widget class="QLabel" name="txtLocation">
         <property name="text">
          <string/>
@@ -605,7 +634,7 @@
        </widget>
       </item>
 
-      <item row="4" column="1" colspan="3">
+      <item row="5" column="1" colspan="3">
        <layout class="QHBoxLayout" name="file_browser_btn_layout">
         <item>
          <widget class="QPushButton" name="btnOpenFileBrowser">
@@ -630,7 +659,7 @@
        </layout>
       </item>
 
-      <item row="5" column="1" colspan="3">
+      <item row="6" column="1" colspan="3">
        <spacer name="properties_bottom_spacer">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -748,6 +777,7 @@
   <tabstop>txtYear</tabstop>
   <tabstop>txtKey</tabstop>
   <tabstop>txtTrackNumber</tabstop>
+  <tabstop>txtReplayGain</tabstop>
   <tabstop>btnColorPicker</tabstop>
   <tabstop>btnImportMetadataFromFile</tabstop>
   <tabstop>btnCancel</tabstop>


### PR DESCRIPTION
in single track edit mode, prefills the dialog with the current replaygain value. blank values will not edit the current value.

For multi track edit mode, prefills the dialog with an empty string.  empty string means no change. An info string shows the current min, max, and average replaygain values.  Users can type in whatever value they want. A filled-in value will be applied to all selected tracks. This is handy for leveling out a mixed album where every track is meant to blend together and should have the same volume.

ai initial draft, hand edited and checked, hand tested.