### PR TITLE
fixed glitch effect by removing cast to integer

### DIFF
--- a/src/effects/backends/builtin/glitcheffect.cpp
+++ b/src/effects/backends/builtin/glitcheffect.cpp
@@ -89,7 +89,7 @@ void GlitchEffect::processChannel(
             }
         }
         period = std::max(period, 1 / 8.0);
-        delay_seconds = static_cast<int>(period * groupFeatures.beat_length->seconds);
+        delay_seconds = period * groupFeatures.beat_length->seconds;
         min_delay = 1 / 8.0 * groupFeatures.beat_length->seconds;
     } else {
         delay_seconds = period;


### PR DESCRIPTION
The glitch effect doesn't worked when it was used with tracks that have a BPM value because delay_seconds was calculated with an integer cast.

The result was that delay_seconds was 0 (except of tracks with a low BPM value) and in this case the input buffer was just copied to the output buffer.