### PR TITLE
Fix memory leak WTrackTableView column delegates not deleted on exit

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -85,6 +85,14 @@ WTrackTableView::~WTrackTableView() {
     if (pHeader) {
         pHeader->saveHeaderState();
     }
+    // QAbstractItemView::setItemDelegateForColumn() does not take ownership of
+    // delegates, so we must delete them explicitly. The final set of delegates
+    // (from the last loadTrackModel() call) is never replaced, so they would
+    // otherwise be leaked on exit. See https://github.com/mixxxdj/mixxx/issues/16055
+    const int numColumns = model() ? model()->columnCount() : 0;
+    for (int i = 0; i < numColumns; ++i) {
+        delete itemDelegateForColumn(i);
+    }
 }
 #ifdef __LINUX__
 void WTrackTableView::currentChanged(


### PR DESCRIPTION
 Description
Fixes #16055 

When Mixxx exits, the column delegates set during the last loadTrackModel()
call were never freed. loadTrackModel() correctly deletes old delegates
whenever a new model is loaded, but the final set has no subsequent model
swap to trigger cleanup, so they leak. Valgrind flags these as definitely
lost allocations originating in delegateForColumn().

Changes proposed

Added a cleanup loop in ~WTrackTableView() that iterates over all columns
and explicitly deletes each column-specific delegate before the view is
destroyed. QAbstractItemView does not take ownership of delegates set via
setItemDelegateForColumn(), so this has to be done manually.

 How to test it

Run Mixxx under Valgrind and check that BPMDelegate and other column
delegates no longer appear in the leak report on exit.

valgrind --leak-check=full --track-origins=yes ./mixxx 2>&1 | grep -A5 "BPMDelegate\|delegateForColumn"

Open the library, switch between a few views (playlists, crates, library),
then quit. With the fix the delegates should not appear as leaked.

Next steps

None.

Deploy notes

None.