### PR TITLE
Bypass denormals-to-zero assertion when running under Valgrind

### DIFF
--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -2,6 +2,10 @@
 
 #include <QtDebug>
 
+#if __has_include(<valgrind/valgrind.h>)
+#include <valgrind/valgrind.h>
+#endif
+
 #include "control/controlobject.h"
 #include "engine/sidechain/enginenetworkstream.h"
 #include "float.h"
@@ -488,10 +492,15 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
         // verify if flush to zero or denormals to zero works
         // test passes if one of the two flag is set.
         volatile double doubleMin = DBL_MIN; // the smallest normalized double
-        VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
-            qWarning() << "Network Sound: Denormals to zero mode is not working. "
-                          "EQs and effects may suffer high CPU load";
-        }
+#if __has_include(<valgrind/valgrind.h>)
+        if (RUNNING_ON_VALGRIND) {
+            qDebug() << "Network Sound: Skipping denormals to zero check: running under Valgrind";
+        } else
+#endif
+            VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
+                qWarning() << "Network Sound: Denormals to zero mode is not working. "
+                              "EQs and effects may suffer high CPU load";
+            }
         else {
             qDebug() << "Network Sound: Denormals to zero mode is working";
         }

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -2,6 +2,10 @@
 
 #include <float.h>
 
+#if __has_include(<valgrind/valgrind.h>)
+#include <valgrind/valgrind.h>
+#endif
+
 #include <QRegularExpression>
 #include <QThread>
 #include <QtDebug>
@@ -1032,9 +1036,16 @@ int SoundDevicePortAudio::callbackProcessClkRef(
         // verify if flush to zero or denormals to zero works
         // test passes if one of the two flag is set.
         volatile double doubleMin = DBL_MIN; // the smallest normalized double
-        VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
-            qWarning() << "Denormals to zero mode is not working. EQs and effects may suffer high CPU load";
-        } else {
+#if __has_include(<valgrind/valgrind.h>)
+        if (RUNNING_ON_VALGRIND) {
+            qDebug() << "Skipping denormals to zero check: running under Valgrind";
+        } else
+#endif
+            VERIFY_OR_DEBUG_ASSERT(doubleMin / 2 == 0.0) {
+                qWarning() << "Denormals to zero mode is not working. EQs and "
+                              "effects may suffer high CPU load";
+            }
+        else {
             qDebug() << "Denormals to zero mode is working";
         }
     }


### PR DESCRIPTION
When running Mixxx under Valgrind, the denormals-to-zero verification assertion fails:

```
DEBUG ASSERT: "doubleMin / 2 == 0.0" in function callbackProcessClkRef()
Denormals to zero mode is not working. EQs and effects may suffer high CPU load
```

This happens because Valgrind intentionally does not emulate SSE DAZ/FTZ modes and instead uses standard IEEE 754 floating-point behavior, so `DBL_MIN / 2` produces a subnormal value rather than `0.0`.

This patch detects Valgrind at runtime using the `RUNNING_ON_VALGRIND` macro from `<valgrind/valgrind.h>` and skips the assertion in that case. The include is guarded with `__has_include` so it compiles cleanly on systems without `valgrind-dev` installed.

Both `sounddeviceportaudio.cpp` and `sounddevicenetwork.cpp` are patched since they share the same assertion.

Fixes #16053