### PR TITLE
(fix) History: allow track file export

### DIFF
--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -218,6 +218,7 @@ void SetlogFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
         }
         menu.addSeparator();
         menu.addAction(m_pExportPlaylistAction);
+        menu.addAction(m_pExportTrackFilesAction);
     }
 
     menu.exec(globalPos);


### PR DESCRIPTION
This adds the "Export Track Files" action to History.
(not sure why it hasn't been enabled yet, and I don't see are reason since they're just playlists with a specific type, no extras)