### PR TITLE
chore: auto cancel previous branch or PR runs

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -18,6 +18,10 @@ permissions:
   contents: read #  to fetch code (actions/checkout)
   checks: write #  to create new checks (coverallsapp/github-action)
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stop-build:
     name: Check if build should be stopped

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -19,7 +19,7 @@ permissions:
   checks: write #  to create new checks (coverallsapp/github-action)
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This changes automatically cancel the previous CI run on branch and PR. This is useful when quickly pushes after a previous wrong or incomplete one,