### PR TITLE
replaygain: add right click operation to merge replaygain values

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -566,16 +566,14 @@ void WTrackMenu::createActions() {
     // This action is only usable when m_deckGroup is set. That is true only
     // for WTrackmenu instantiated by WTrackProperty and other deck widgets, thus
     // don't create it if a track model is set.
-    if (!m_pTrackModel && featureIsEnabled(Feature::UpdateReplayGainFromPregain)) {
+    if (!m_pTrackModel && featureIsEnabled(Feature::UpdateReplayGain)) {
         m_pUpdateReplayGainAct = make_parented<QAction>(
                 tr("Update ReplayGain from Deck Gain"), m_pClearMetadataMenu);
         connect(m_pUpdateReplayGainAct,
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotUpdateReplayGainFromPregain);
-    }
 
-    if (featureIsEnabled(Feature::Metadata)) {
         m_pNormalizeReplayGainAct = make_parented<QAction>(
                 tr("Normalize ReplayGain Across Selected Tracks"), this);
         connect(m_pNormalizeReplayGainAct,
@@ -747,7 +745,7 @@ void WTrackMenu::setupActions() {
     }
 
     // This action is created only for menus instantiated by deck widgets (e.g.
-    // WTrackProperty) and if UpdateReplayGainFromPregain is supported.
+    // WTrackProperty) and if UpdateReplayGain is supported.
     if (m_pUpdateReplayGainAct) {
         addAction(m_pUpdateReplayGainAct);
     }
@@ -1171,7 +1169,7 @@ void WTrackMenu::updateMenus() {
     }
 
     // This action is created only for menus instantiated by deck widgets (e.g.
-    // WTrackProperty) and if UpdateReplayGainFromPregain is supported.
+    // WTrackProperty) and if UpdateReplayGain is supported.
     // Disable it if no deck group was set.
     if (m_pUpdateReplayGainAct) {
         m_pUpdateReplayGainAct->setEnabled(!m_deckGroup.isEmpty());

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -575,7 +575,7 @@ void WTrackMenu::createActions() {
                 &WTrackMenu::slotUpdateReplayGainFromPregain);
 
         m_pNormalizeReplayGainAct = make_parented<QAction>(
-                tr("Normalize ReplayGain Across Selected Tracks"), this);
+                tr("Apply Average ReplayGain to Selection (e.g. Album)"), this);
         connect(m_pNormalizeReplayGainAct,
                 &QAction::triggered,
                 this,

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -575,6 +575,15 @@ void WTrackMenu::createActions() {
                 &WTrackMenu::slotUpdateReplayGainFromPregain);
     }
 
+    if (featureIsEnabled(Feature::Metadata)) {
+        m_pNormalizeReplayGainAct = make_parented<QAction>(
+                tr("Normalize ReplayGain Across Selected Tracks"), this);
+        connect(m_pNormalizeReplayGainAct,
+                &QAction::triggered,
+                this,
+                &WTrackMenu::slotNormalizeReplayGain);
+    }
+
     if (featureIsEnabled(Feature::Color)) {
         ColorPaletteSettings colorPaletteSettings(m_pConfig);
         m_pColorPickerAction = make_parented<WColorPickerAction>(WColorPicker::Option::AllowNoColor,
@@ -741,6 +750,9 @@ void WTrackMenu::setupActions() {
     // WTrackProperty) and if UpdateReplayGainFromPregain is supported.
     if (m_pUpdateReplayGainAct) {
         addAction(m_pUpdateReplayGainAct);
+    }
+    if (m_pNormalizeReplayGainAct) {
+        addAction(m_pNormalizeReplayGainAct);
     }
 
     addSeparator();
@@ -1165,6 +1177,11 @@ void WTrackMenu::updateMenus() {
         m_pUpdateReplayGainAct->setEnabled(!m_deckGroup.isEmpty());
     }
 
+    // Enable normalize action only when 2+ tracks are selected
+    if (m_pNormalizeReplayGainAct) {
+        m_pNormalizeReplayGainAct->setEnabled(getTrackCount() > 1);
+    }
+
     if (m_pTranslateBeatsHalf) {
         m_pTranslateBeatsHalf->setEnabled(!m_deckGroup.isEmpty());
     }
@@ -1468,6 +1485,48 @@ void WTrackMenu::slotUpdateReplayGainFromPregain() {
         return;
     }
     m_pTrack->adjustReplayGainFromPregain(gain, m_deckGroup);
+}
+
+void WTrackMenu::slotNormalizeReplayGain() {
+    const auto tracks = getTrackPointers();
+    if (tracks.size() < 2) {
+        return;
+    }
+
+    // Compute acoustically correct weighted average ReplayGain.
+    // Weight each track's linear ratio by its duration, then convert back.
+    double totalWeightedRatio = 0.0;
+    double totalDuration = 0.0;
+    int tracksWithGain = 0;
+
+    for (const auto& pTrack : tracks) {
+        const mixxx::ReplayGain rg = pTrack->getReplayGain();
+        const double ratio = rg.getRatio();
+        if (!mixxx::ReplayGain::isValidRatio(ratio)) {
+            continue;
+        }
+        const double duration = pTrack->getDuration();
+        if (duration <= 0.0) {
+            continue;
+        }
+        totalWeightedRatio += duration * ratio;
+        totalDuration += duration;
+        ++tracksWithGain;
+    }
+
+    if (tracksWithGain < 2 || totalDuration <= 0.0) {
+        return;
+    }
+
+    const double averageRatio = totalWeightedRatio / totalDuration;
+
+    // Apply the averaged ratio to all selected tracks, preserving each
+    // track's existing peak value.
+    for (const auto& pTrack : tracks) {
+        mixxx::ReplayGain rg = pTrack->getReplayGain();
+        rg.setRatio(averageRatio);
+        pTrack->setReplayGain(rg);
+    }
 }
 
 void WTrackMenu::slotTranslateBeatsHalf() {

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -55,14 +55,14 @@ class WTrackMenu : public QMenu {
         FileBrowser = 1 << 11,
         Properties = 1 << 12,
         SearchRelated = 1 << 13,
-        UpdateReplayGainFromPregain = 1 << 14,
+        UpdateReplayGain = 1 << 14,
         SelectInLibrary = 1 << 15,
         Analyze = 1 << 16,
         FindOnWeb = 1 << 17,
         TrackModelFeatures = Remove | HideUnhidePurge,
         All = AutoDJ | LoadTo | Playlist | Crate | Remove | Metadata | Reset | Analyze |
                 BPM | Color | HideUnhidePurge | RemoveFromDisk | FileBrowser |
-                Properties | SearchRelated | UpdateReplayGainFromPregain | SelectInLibrary |
+                Properties | SearchRelated | UpdateReplayGain | SelectInLibrary |
                 FindOnWeb
     };
     Q_DECLARE_FLAGS(Features, Feature)
@@ -81,7 +81,7 @@ class WTrackMenu : public QMenu {
             WTrackMenu::Feature::RemoveFromDisk |
             WTrackMenu::Feature::FileBrowser |
             WTrackMenu::Feature::Properties |
-            WTrackMenu::Feature::UpdateReplayGainFromPregain |
+            WTrackMenu::Feature::UpdateReplayGain |
             WTrackMenu::Feature::FindOnWeb |
             WTrackMenu::Feature::SelectInLibrary};
 

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -174,6 +174,7 @@ class WTrackMenu : public QMenu {
 
     // Info and metadata
     void slotUpdateReplayGainFromPregain();
+    void slotNormalizeReplayGain();
     void slotShowDlgTagFetcher();
     void slotImportMetadataFromFileTags();
     void slotExportMetadataIntoFileTags();
@@ -306,6 +307,9 @@ class WTrackMenu : public QMenu {
 
     // Update ReplayGain from Track
     parented_ptr<QAction> m_pUpdateReplayGainAct;
+
+    // Normalize ReplayGain across selected tracks
+    parented_ptr<QAction> m_pNormalizeReplayGainAct;
 
     // Reload Track Metadata Action:
     parented_ptr<QAction> m_pImportMetadataFromFileAct;


### PR DESCRIPTION
This lets the user unify the replaygain value for a set of selected tracks, intended for mixed albums where the replaygain should be the same so there are no volume changes between songs.

It averages out the replaygain values of the individual tracks, proportional to track length, and then updates them all to the new value.  Unanalysized tracks will be ignored for analysis and get the final replaygain value.
