### PR TITLE
Traktor S4MK3: fix wheel mode not getting set correctly on deck switch

### DIFF
--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -585,7 +585,11 @@ class Deck extends ComponentContainer {
             this.color = colors[0];
         }
         this.settings = settings;
-        this.secondDeckModes = null;
+        this.secondDeckModes = {
+            moveMode: this.moveMode,
+            wheelMode: this.wheelMode,
+        };
+
         this.selectedHotcue = null;
 
         updateRuntimeData({
@@ -610,6 +614,11 @@ class Deck extends ComponentContainer {
     switchDeck(newDeck) {
         const newGroup = Deck.groupForNumber(newDeck);
 
+        const currentModes = {
+            wheelMode: this.wheelMode,
+            moveMode: this.moveMode,
+        };
+
         switch (this.moveMode) {
         case moveModes.beat:
         case moveModes.bpm:
@@ -626,11 +635,6 @@ class Deck extends ComponentContainer {
             });
             break;
         }
-
-        const currentModes = {
-            wheelMode: this.wheelMode,
-            moveMode: this.moveMode,
-        };
 
         this.selectedStem.fill(false);
 


### PR DESCRIPTION
wheelmode was getting cleared before being saved