### PR TITLE
Fix updating cues in WOverwiew

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -983,15 +983,14 @@ void CueControl::hotcueSet(HotcueControl* pControl, double value, HotcueSetMode 
         }
     }
 
-    CuePointer pCue = m_pLoadedTrack->createAndAddCue(
+    CuePointer pCue(new Cue(
             cueType,
             hotcueIndex,
             cueStartPosition,
             cueEndPosition,
-            color);
-
-    // TODO(XXX) deal with spurious signals
+            color));
     attachCue(pCue, pControl);
+    m_pLoadedTrack->addCue(pCue);
 
     if (cueType == mixxx::CueType::Loop) {
         setCurrentSavedLoopControlAndActivate(pControl);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1089,6 +1089,11 @@ CuePointer Track::createAndAddCue(
             startPosition,
             endPosition,
             color));
+    addCue(pCue);
+    return pCue;
+}
+
+CuePointer Track::addCue(CuePointer pCue) {
     // While this method could be called from any thread,
     // associated Cue objects should always live on the
     // same thread as their host, namely this->thread().

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -313,6 +313,8 @@ class Track : public QObject {
     // Call when analysis is done.
     void analysisFinished();
 
+    CuePointer addCue(CuePointer pCue);
+
     // Calls for managing the track's cue points
     CuePointer createAndAddCue(
             mixxx::CueType type,


### PR DESCRIPTION
This aims to fix #16075 and maybe #12620
However this is not yet fully tested and probably incomplete. That why draft state.

The issue is that WOverview is acting on changes of the loaded track and on various Cue related COs. 
It assumes that every CO updates happens after all other cue related data is also updated which is wrong and the root cause of the iuse here. 

Since that's is not the case we see MANY invalid update calls using incomplete data only if a single cue is set. 

The problem problematic function is 
WOverview::updateCues() that updates marked from Track data while other date is used from the CO interface. 

There is also an issue with a recursive call into the HotCueConteol class. Updating a Hotcue cause updating the track which in turn updates ALL HotCueControls. The order of these updates causes the indifferent test results we have seen. 

This is however currently needed, because a single track might be loaded into two decks and that's why a signal is required to update the cues if the other track.

Who has interest helping to look into this? 












