### PR TITLE
feat: add auto recording from command line

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -993,11 +993,15 @@ void MixxxMainWindow::connectMenuBar() {
                 Qt::UniqueConnection);
     }
 
-    auto pRecordingManager = m_pCoreServices->getRecordingManager();
-    auto startRecord = CmdlineArgs::Instance().getStartRecording();
-    if (pRecordingManager && startRecord.has_value()) {
-        pRecordingManager->startRecording(startRecord.value());
-        qInfo() << "Auto start recording to" << pRecordingManager->getRecordingLocation();
+    QString startRecord = CmdlineArgs::Instance().getStartRecording();
+    if (!startRecord.isNull()) {
+        auto pRecordingManager = m_pCoreServices->getRecordingManager();
+        if (pRecordingManager) {
+            pRecordingManager->startRecording(startRecord);
+            qInfo() << "Auto start recording to" << pRecordingManager->getRecordingLocation();
+        } else {
+            DEBUG_ASSERT(!"No RecordManager is available");
+        }
     }
 
 #ifdef __ENGINEPRIME__

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -993,6 +993,13 @@ void MixxxMainWindow::connectMenuBar() {
                 Qt::UniqueConnection);
     }
 
+    auto pRecordingManager = m_pCoreServices->getRecordingManager();
+    auto startRecord = CmdlineArgs::Instance().getStartRecording();
+    if (pRecordingManager && startRecord.has_value()) {
+        pRecordingManager->startRecording(startRecord.value());
+        qInfo() << "Auto start recording to" << pRecordingManager->getRecordingLocation();
+    }
+
 #ifdef __ENGINEPRIME__
     DEBUG_ASSERT(m_pLibraryExporter);
     connect(m_pMenuBar,

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -2,6 +2,7 @@
 
 #include <QDateTime>
 #include <QDir>
+#include <QFileInfo>
 #include <QMessageBox>
 #include <QMutex>
 #include <QStorageInfo>
@@ -98,7 +99,7 @@ qint64 RecordingManager::getFreeSpace() {
     return rv;
 }
 
-void RecordingManager::startRecording() {
+void RecordingManager::startRecording(const QString& recordingLocation) {
     QString encodingType = m_pConfig->getValueString(
             ConfigKey(RECORDING_PREF_KEY, "Encoding"));
     QString fileExtension = EncoderFactory::getFactory()
@@ -121,14 +122,33 @@ void RecordingManager::startRecording() {
     }
 
     m_iNumberSplits = 1;
-    // Append file extension.
-    QString date_time_str = formatDateTimeForFilename(QDateTime::currentDateTime());
-    m_recordingFile = QString("%1.%2")
-                              .arg(date_time_str, fileExtension);
 
-    // Storing the absolutePath of the recording file without file extension.
-    m_recording_base_file = getRecordingDir();
-    m_recording_base_file.append("/").append(date_time_str);
+    if (recordingLocation.isEmpty()) {
+        // Append file extension.
+        QString date_time_str = formatDateTimeForFilename(QDateTime::currentDateTime());
+        m_recordingFile = QStringLiteral("%1.%2")
+                                  .arg(date_time_str, fileExtension);
+
+        // Storing the absolutePath of the recording file without file extension.
+        m_recording_base_file = getRecordingDir();
+        m_recording_base_file.append("/").append(date_time_str);
+    } else {
+        auto fileInfo = QFileInfo(recordingLocation);
+
+        if (!fileInfo.absoluteDir().exists()) {
+            qWarning() << "Recoding directory is not found. Aborting.";
+            return;
+        }
+        m_recordingFile = QStringLiteral("%1.%2")
+                                  .arg(fileInfo.baseName(), fileExtension);
+        if (m_recordingFile != fileInfo.fileName()) {
+            qWarning() << "Requested filename doesn't match with the "
+                          "configured recording encoder. Using"
+                       << m_recordingFile << "instead";
+        }
+        m_recording_base_file = fileInfo.absoluteDir().filePath(fileInfo.baseName());
+    }
+
     // Appending file extension to get the filelocation.
     m_recordingLocation = m_recording_base_file + QChar('.') + fileExtension;
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "Path"), m_recordingLocation);

--- a/src/recording/recordingmanager.h
+++ b/src/recording/recordingmanager.h
@@ -29,7 +29,7 @@ class RecordingManager : public QObject {
     // This will try to start recording. If successful, slotIsRecording will be
     // called and a signal isRecording will be emitted.
     // The method computes the filename based on date/time information.
-    void startRecording();
+    void startRecording(const QString& recordingLocation = {});
     void stopRecording();
     bool isRecordingActive() const;
     void setRecordingDir();

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -51,7 +51,7 @@ bool calcUseColorsAuto() {
 CmdlineArgs::CmdlineArgs()
         : m_startInFullscreen(false), // Initialize vars
           m_startAutoDJ(false),
-          m_startRecording(std::nullopt),
+          m_startRecordingTo(),
           m_rescanLibrary(false),
           m_controllerDebug(false),
           m_controllerAbortOnWarning(false),
@@ -197,12 +197,22 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     QCommandLineOption startRecording(QStringLiteral("start-recording"),
             forUserFeedback
                     ? QCoreApplication::translate("CmdlineArgs",
-                              "Starts recording when Mixxx is launched. If no "
-                              "path is passed, used the recording folder and "
-                              "automatic file name")
+                              "Starts recording when Mixxx is launched.")
+                    : QString());
+    parser.addOption(startRecording);
+
+    QCommandLineOption startRecordingTo(QStringLiteral("start-recording-to"),
+            forUserFeedback
+                    ? QCoreApplication::translate("CmdlineArgs",
+                              "Starts recording to a give file when Mixxx is "
+                              "launched. If the file exists, it will be "
+                              "overwritten. The parent directory must exist or "
+                              "the recording won't start. If the file "
+                              "extension doesn't match with the configured "
+                              "encoder, it will be updated to the right one")
                     : QString(),
             QStringLiteral("path"));
-    parser.addOption(startRecording);
+    parser.addOption(startRecordingTo);
 
     const QCommandLineOption rescanLibrary(QStringLiteral("rescan-library"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -453,8 +463,10 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
         m_startAutoDJ = true;
     }
 
-    if (parser.isSet(startRecording)) {
-        m_startRecording = parser.value(startRecording);
+    if (parser.isSet(startRecordingTo)) {
+        m_startRecordingTo = parser.value(startRecording);
+    } else if (parser.isSet(startRecording)) {
+        m_startRecordingTo = QString("");
     }
 
     if (parser.isSet(rescanLibrary)) {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -51,6 +51,7 @@ bool calcUseColorsAuto() {
 CmdlineArgs::CmdlineArgs()
         : m_startInFullscreen(false), // Initialize vars
           m_startAutoDJ(false),
+          m_startRecording(std::nullopt),
           m_rescanLibrary(false),
           m_controllerDebug(false),
           m_controllerAbortOnWarning(false),
@@ -192,6 +193,16 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                                       "Starts Auto DJ when Mixxx is launched.")
                             : QString());
     parser.addOption(startAutoDJ);
+
+    QCommandLineOption startRecording(QStringLiteral("start-recording"),
+            forUserFeedback
+                    ? QCoreApplication::translate("CmdlineArgs",
+                              "Starts recording when Mixxx is launched. If no "
+                              "path is passed, used the recording folder and "
+                              "automatic file name")
+                    : QString(),
+            QStringLiteral("path"));
+    parser.addOption(startRecording);
 
     const QCommandLineOption rescanLibrary(QStringLiteral("rescan-library"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -440,6 +451,10 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
 
     if (parser.isSet(startAutoDJ)) {
         m_startAutoDJ = true;
+    }
+
+    if (parser.isSet(startRecording)) {
+        m_startRecording = parser.value(startRecording);
     }
 
     if (parser.isSet(rescanLibrary)) {

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -33,8 +33,8 @@ class CmdlineArgs final {
     bool getStartAutoDJ() const {
         return m_startAutoDJ;
     }
-    std::optional<QString> getStartRecording() const {
-        return m_startRecording;
+    QString getStartRecording() const {
+        return m_startRecordingTo;
     }
     bool getRescanLibrary() const {
         return m_rescanLibrary;
@@ -105,7 +105,9 @@ class CmdlineArgs final {
     QList<QString> m_musicFiles;    // List of files to load into players at startup
     bool m_startInFullscreen;       // Start in fullscreen mode
     bool m_startAutoDJ;
-    std::optional<QString> m_startRecording;
+    QString m_startRecordingTo; // Path to auto recording file. Null means none,
+                                // empty means auto (default recoding path, as
+                                // if used manually)
     bool m_rescanLibrary;
     bool m_controllerDebug;
     bool m_controllerPreviewScreens;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -33,6 +33,9 @@ class CmdlineArgs final {
     bool getStartAutoDJ() const {
         return m_startAutoDJ;
     }
+    std::optional<QString> getStartRecording() const {
+        return m_startRecording;
+    }
     bool getRescanLibrary() const {
         return m_rescanLibrary;
     }
@@ -102,6 +105,7 @@ class CmdlineArgs final {
     QList<QString> m_musicFiles;    // List of files to load into players at startup
     bool m_startInFullscreen;       // Start in fullscreen mode
     bool m_startAutoDJ;
+    std::optional<QString> m_startRecording;
     bool m_rescanLibrary;
     bool m_controllerDebug;
     bool m_controllerPreviewScreens;


### PR DESCRIPTION
This feature is inspired by #14455, partially supersede #15735 and #15734 and partially fixes #15569

That feature occurred to me to be quite nice to always have a recorded set that you can decide to save after the session, for example

```sh
mixxx --start-recording /tmp/mixxx.mp3
```

This appears useful as I went to play some new records recently acquired and after having some nice findings, I regretted not being able to listen back to it help to help fine tuning the set, thus why the usefully option to always save the set

A future iteration could be to have this in the settings and allow always recording the set into some temp files, but this might require further work on the engine.