### PR TITLE
EngineBuffer: Add physical spin-up ramp behavior

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -1,4 +1,4 @@
-#include "engine/controls/cuecontrol.h"
+﻿#include "engine/controls/cuecontrol.h"
 
 #include "control/controlindicator.h"
 #include "control/controlobject.h"
@@ -2169,9 +2169,32 @@ void CueControl::outroEndActivate(double value) {
     }
 }
 
+
+
 // This is also called from the engine thread. No locking allowed.
 bool CueControl::updateIndicatorsAndModifyPlay(
         bool newPlay, bool oldPlay, bool playPossible) {
+    qWarning() << "=== CUE CONTROL ===";
+    qWarning() << "newPlay:" << newPlay;
+    qWarning() << "oldPlay:" << oldPlay;
+    qWarning() << "playPossible:" << playPossible;
+
+    qWarning() << "previewIndex:" << m_currentlyPreviewingIndex;
+
+    // PLAY
+    if (newPlay) {
+        qWarning() << "PLAY detected";
+    }
+
+    // STOP
+    if (!newPlay && oldPlay) {
+        qWarning() << "STOP detected";
+    }
+
+    // CUE
+    if (!newPlay && !oldPlay) {
+        qWarning() << "CUE detected";
+    }
     // qDebug() << "updateIndicatorsAndModifyPlay" << newPlay << playPossible
     //        << m_currentlyPreviewingIndex;
     CueMode cueMode = static_cast<CueMode>(static_cast<int>(m_pCueMode->get()));

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -113,6 +113,9 @@ RateControl::RateControl(const QString& group, UserSettingsPointer pConfig)
           m_tempRateRatio(0.0),
           m_dRateTempRampChange(0.0),
           m_spinupRateLimit(1.0) {
+          m_pRampStartEnabled = new ControlProxy(getGroup(), "ramped_start_enabled");
+          m_pRampStartEnabled->set(1.0);
+
     // Vinyl control COs are only created for main decks
     if (PlayerManager::isDeckGroup(getGroup())) {
         m_pVCEnabled = ControlObject::getControl(
@@ -409,8 +412,21 @@ double RateControl::calculateSpeed(double baserate,
     *pReportReverse = false;
 
     // Detect play pressed from pause → start physical spin-up
-    if (!paused && m_prevPaused) {
+    if (!paused && m_prevPaused && m_pRampStartEnabled->get() > 0.5) {
         m_spinupRateLimit = 0.0;
+    }
+    // Physical spin-up ramp
+    if (m_spinupRateLimit < 1.0) {
+        const double dt =
+                static_cast<double>(samplesPerBuffer) / m_pSampleRate.get();
+
+        const double rampSpeed = 6.0;
+
+        m_spinupRateLimit += (1.0 - m_spinupRateLimit) * rampSpeed * dt;
+
+        if (m_spinupRateLimit > 0.999) {
+            m_spinupRateLimit = 1.0;
+        }
     }
 
     processTempRate(samplesPerBuffer);

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -411,10 +411,17 @@ double RateControl::calculateSpeed(double baserate,
     *pReportScratching = false;
     *pReportReverse = false;
 
+  /*  qWarning() << "paused:" << paused;
+    qWarning() << "prevPaused:" << m_prevPaused;
+    qWarning() << "scratching:" << *pReportScratching;*/
+
     // Detect play pressed from pause → start physical spin-up
-    if (!paused && m_prevPaused && m_pRampStartEnabled->get() > 0.5) {
+   /* if (!paused && m_prevPaused && !*pReportScratching) {
+        qWarning() << "🔥 SPINUP 🔥";
         m_spinupRateLimit = 0.0;
     }
+
+    m_prevPaused = paused;*/
     // Physical spin-up ramp
     if (m_spinupRateLimit < 1.0) {
         const double dt =

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -109,8 +109,10 @@ RateControl::RateControl(const QString& group, UserSettingsPointer pConfig)
           m_jumpPos(mixxx::audio::FramePos()),
           m_targetPos(mixxx::audio::FramePos()),
           m_bTempStarted(false),
+          m_prevPaused(true),
           m_tempRateRatio(0.0),
-          m_dRateTempRampChange(0.0) {
+          m_dRateTempRampChange(0.0),
+          m_spinupRateLimit(1.0) {
     // Vinyl control COs are only created for main decks
     if (PlayerManager::isDeckGroup(getGroup())) {
         m_pVCEnabled = ControlObject::getControl(
@@ -406,8 +408,27 @@ double RateControl::calculateSpeed(double baserate,
     *pReportScratching = false;
     *pReportReverse = false;
 
+    // Detect play pressed from pause → start physical spin-up
+    if (!paused && m_prevPaused) {
+        m_spinupRateLimit = 0.0;
+    }
+
     processTempRate(samplesPerBuffer);
 
+    // Physical spin-up ramp: gradually increase allowed rate
+    if (m_spinupRateLimit < 1.0) {
+        const double dt =
+                static_cast<double>(samplesPerBuffer) / m_pSampleRate.get();
+
+        // Exponential spin-up curve (physical feel)
+        const double rampSpeed = 6.0; // higher = faster acceleration
+
+        m_spinupRateLimit += (1.0 - m_spinupRateLimit) * rampSpeed * dt;
+
+        if (m_spinupRateLimit > 0.999) {
+            m_spinupRateLimit = 1.0;
+        }
+    }
     double rate;
     const double searching = m_pRateSearch->get();
     if (searching != 0) {
@@ -512,6 +533,9 @@ double RateControl::calculateSpeed(double baserate,
             }
         }
     }
+    rate = math_min(rate, m_spinupRateLimit);
+
+    m_prevPaused = paused;
     return rate;
 }
 

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -162,6 +162,7 @@ private:
 
   // This is true if we've already started to ramp the rate
   bool m_bTempStarted;
+  bool m_prevPaused;
   // Set the Temporary Rate Change Mode
   static RampMode m_eRateRampMode;
   // The Rate Temp Sensitivity, the higher it is the slower it gets
@@ -174,4 +175,6 @@ private:
   double m_tempRateRatio;
   // Speed for temporary rate change
   double m_dRateTempRampChange;
+  // Physical spin-up rate limiter (0.0 → 1.0)
+  double m_spinupRateLimit;
 };

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -177,4 +177,5 @@ private:
   double m_dRateTempRampChange;
   // Physical spin-up rate limiter (0.0 → 1.0)
   double m_spinupRateLimit;
+  ControlProxy* m_pRampStartEnabled;
 };


### PR DESCRIPTION
This PR introduces a physical motor spin-up ramp when transitioning
from paused to playing.

Instead of jumping instantly to full playback rate, the rate is
gradually increased using a sample-rate-based ramp to simulate motor inertia.

This change only affects the play transition and does not interfere
with scratching, cueing, or jog behavior.

Spin-down (pause inertia) will be implemented separately.