### PR TITLE
make beatjump moving active loop optional

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -9,6 +9,7 @@
 #include "engine/controls/ratecontrol.h"
 #include "engine/enginebuffer.h"
 #include "moc_loopingcontrol.cpp"
+#include "preferences/dialog/dlgprefdeck.h"
 #include "preferences/usersettings.h"
 #include "track/track.h"
 #include "util/compatibility/qatomic.h"
@@ -1769,7 +1770,11 @@ void LoopingControl::slotBeatJump(double beats) {
     LoopInfo loopInfo = m_loopInfo.getValue();
     const auto currentPosition = m_currentPosition.getValue();
 
-    if (m_bLoopingEnabled && !m_bAdjustingLoopIn && !m_bAdjustingLoopOut &&
+    bool beatjumpDoesLoopmove = m_pConfig->getValue(
+            ConfigKey(QStringLiteral("[Controls]"), QStringLiteral("BeatjumpDoesLoopmove")),
+            kDefaultBeatjumpDoesLoopmove);
+    if (m_bLoopingEnabled && beatjumpDoesLoopmove &&
+            !m_bAdjustingLoopIn && !m_bAdjustingLoopOut &&
             loopInfo.startPosition <= currentPosition &&
             loopInfo.endPosition >= currentPosition) {
         // If inside an active loop, move loop

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -215,6 +215,28 @@ LoopingControl::LoopingControl(const QString& group,
     connect(m_pCOLoopMove, &ControlObject::valueChanged,
             this, &LoopingControl::slotLoopMove, Qt::DirectConnection);
 
+    m_pCOLoopMoveSize = new ControlObject(ConfigKey(group, "loopmove_size"),
+            true,
+            false,
+            false,
+            4.0);
+    m_pCOLoopMoveSize->connectValueChangeRequest(this,
+            &LoopingControl::slotLoopMoveSizeChangeRequest,
+            Qt::DirectConnection);
+
+    m_pCOLoopMoveForward = new ControlPushButton(ConfigKey(group, "loopmove_forward"));
+    m_pCOLoopMoveForward->setKbdRepeatable(true);
+    connect(m_pCOLoopMoveForward,
+            &ControlObject::valueChanged,
+            this,
+            &LoopingControl::slotLoopMoveForward);
+    m_pCOLoopMoveBackward = new ControlPushButton(ConfigKey(group, "loopmove_backward"));
+    m_pCOLoopMoveBackward->setKbdRepeatable(true);
+    connect(m_pCOLoopMoveBackward,
+            &ControlObject::valueChanged,
+            this,
+            &LoopingControl::slotLoopMoveBackward);
+
     // Create loop_move_(SIZE) CO's which all call loop_move, but with a set
     // value.
     for (unsigned int i = 0; i < (sizeof(s_dBeatSizes) / sizeof(s_dBeatSizes[0])); ++i) {
@@ -288,6 +310,9 @@ LoopingControl::~LoopingControl() {
     }
 
     delete m_pCOLoopMove;
+    delete m_pCOLoopMoveSize;
+    delete m_pCOLoopMoveForward;
+    delete m_pCOLoopMoveBackward;
     while (!m_loopMoves.isEmpty()) {
         LoopMoveControl* pLoopMove = m_loopMoves.takeLast();
         delete pLoopMove;
@@ -1801,6 +1826,19 @@ void LoopingControl::slotBeatJumpSizeChangeRequest(double beats) {
     m_pCOBeatJumpSize->setAndConfirm(beats);
 }
 
+void LoopingControl::slotLoopMoveSizeChangeRequest(double beats) {
+    // Use same limits as for beat loop size
+    double maxBeatJumpSize = s_dBeatSizes[sizeof(s_dBeatSizes) / sizeof(s_dBeatSizes[0]) - 1];
+    double minBeatJumpSize = s_dBeatSizes[0];
+
+    if ((beats < minBeatJumpSize) || (beats > maxBeatJumpSize)) {
+        // Don't clamp the value here to not fall out of a measure
+        return;
+    }
+
+    m_pCOLoopMoveSize->setAndConfirm(beats);
+}
+
 void LoopingControl::slotBeatJumpSizeHalve(double pressed) {
     if (pressed > 0) {
         m_pCOBeatJumpSize->set(m_pCOBeatJumpSize->get() / 2);
@@ -1822,6 +1860,18 @@ void LoopingControl::slotBeatJumpForward(double pressed) {
 void LoopingControl::slotBeatJumpBackward(double pressed) {
     if (pressed > 0) {
         slotBeatJump(-1.0 * m_pCOBeatJumpSize->get());
+    }
+}
+
+void LoopingControl::slotLoopMoveForward(double pressed) {
+    if (pressed > 0) {
+        slotLoopMove(m_pCOBeatJumpSize->get());
+    }
+}
+
+void LoopingControl::slotLoopMoveBackward(double pressed) {
+    if (pressed > 0) {
+        slotLoopMove(-1.0 * m_pCOBeatJumpSize->get());
     }
 }
 

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -150,6 +150,9 @@ class LoopingControl : public EngineControl {
 
     // Move the loop by beats.
     void slotLoopMove(double beats);
+    void slotLoopMoveSizeChangeRequest(double beats);
+    void slotLoopMoveForward(double pressed);
+    void slotLoopMoveBackward(double pressed);
 
     void slotLoopScale(double scaleFactor);
     void slotLoopDouble(double pressed);
@@ -258,6 +261,9 @@ class LoopingControl : public EngineControl {
     QList<BeatJumpControl*> m_beatJumps;
 
     ControlObject* m_pCOLoopMove;
+    ControlObject* m_pCOLoopMoveSize;
+    ControlPushButton* m_pCOLoopMoveForward;
+    ControlPushButton* m_pCOLoopMoveBackward;
     QList<LoopMoveControl*> m_loopMoves;
 
     // objects below are written from an engine worker thread

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -220,12 +220,22 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
 
     // Double-tap Load to clone a deck via keyboard or controller ([ChannelN],LoadSelectedTrack)
     m_bCloneDeckOnLoadDoubleTap = m_pConfig->getValue(
-            ConfigKey(kControlsGroup, QStringLiteral("CloneDeckOnLoadDoubleTap")), true);
+            ConfigKey(kControlsGroup, QStringLiteral("CloneDeckOnLoadDoubleTap")),
+            kDefaultCloneDeckOnLoad);
     checkBoxCloneDeckOnLoadDoubleTap->setChecked(m_bCloneDeckOnLoadDoubleTap);
     connect(checkBoxCloneDeckOnLoadDoubleTap,
             &QCheckBox::toggled,
             this,
             &DlgPrefDeck::slotCloneDeckOnLoadDoubleTapCheckbox);
+
+    m_bBeatjumpLoopmove = m_pConfig->getValue(
+            ConfigKey(kControlsGroup, QStringLiteral("BeatjumpDoesLoopmove")),
+            kDefaultBeatjumpDoesLoopmove);
+    checkboxBeatjumpLoopmove->setChecked(m_bBeatjumpLoopmove);
+    connect(checkboxBeatjumpLoopmove,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefDeck::slotBeatjumpLoopmove);
 
     m_bRateDownIncreasesSpeed = m_pConfig->getValue(
             ConfigKey(kControlsGroup, QStringLiteral("RateDir")), kDefaultRateDirectionInverted);
@@ -448,7 +458,12 @@ void DlgPrefDeck::slotUpdate() {
     slotSetTrackTimeDisplay(m_pControlTrackTimeDisplay->get());
 
     checkBoxCloneDeckOnLoadDoubleTap->setChecked(m_pConfig->getValue(
-            ConfigKey(kControlsGroup, QStringLiteral("CloneDeckOnLoadDoubleTap")), true));
+            ConfigKey(kControlsGroup, QStringLiteral("CloneDeckOnLoadDoubleTap")),
+            kDefaultCloneDeckOnLoad));
+
+    checkboxBeatjumpLoopmove->setChecked(m_pConfig->getValue(
+            ConfigKey(kControlsGroup, QStringLiteral("BeatjumpDoesLoopmove")),
+            kDefaultBeatjumpDoesLoopmove));
 
     double rateRange = m_rateRangeControls[0]->get();
     int index = ComboBoxRateRange->findData(static_cast<int>(rateRange * 100.0));
@@ -535,6 +550,8 @@ void DlgPrefDeck::slotResetToDefaults() {
 
     // Clone decks by double-tapping Load button.
     checkBoxCloneDeckOnLoadDoubleTap->setChecked(kDefaultCloneDeckOnLoad);
+
+    checkboxBeatjumpLoopmove->setChecked(kDefaultBeatjumpDoesLoopmove);
 
     // Mixxx cue mode
     ComboBoxCueMode->setCurrentIndex(0);
@@ -694,6 +711,10 @@ void DlgPrefDeck::slotLoadWhenDeckPlayingIndexChanged(int comboboxIndex) {
             comboBoxLoadWhenDeckPlaying->itemData(comboboxIndex).toInt());
 }
 
+void DlgPrefDeck::slotBeatjumpLoopmove(bool checked) {
+    m_bBeatjumpLoopmove = checked;
+}
+
 void DlgPrefDeck::slotApply() {
     m_pConfig->set(ConfigKey(kControlsGroup, QStringLiteral("SetIntroStartAtMainCue")),
             ConfigValue(m_bSetIntroStartAtMainCue));
@@ -719,6 +740,9 @@ void DlgPrefDeck::slotApply() {
     m_pConfig->setValue(ConfigKey(kControlsGroup, QStringLiteral("CueRecall")), m_seekOnLoadMode);
     m_pConfig->setValue(ConfigKey(kControlsGroup, QStringLiteral("CloneDeckOnLoadDoubleTap")),
             m_bCloneDeckOnLoadDoubleTap);
+
+    m_pConfig->setValue(ConfigKey(kControlsGroup, QStringLiteral("BeatjumpDoesLoopmove")),
+            m_bBeatjumpLoopmove);
 
     // Set rate range
     // Set the config value before setting the CO values in setRateRangeForAllDecks()

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -16,6 +16,7 @@ class QWidget;
 
 namespace {
 constexpr bool kDefaultCloneDeckOnLoad = true;
+constexpr bool kDefaultBeatjumpDoesLoopmove = true;
 } // namespace
 
 namespace {
@@ -52,6 +53,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotSetTrackLoadMode(int comboboxIndex);
     void slotLoadWhenDeckPlayingIndexChanged(int comboboxIndex);
     void slotCloneDeckOnLoadDoubleTapCheckbox(bool);
+    void slotBeatjumpLoopmove(bool checked);
     void slotRateRampingModeLinearButton(bool);
     void slotRateRampSensitivitySlider(int);
 
@@ -97,6 +99,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
 
     bool m_bSetIntroStartAtMainCue;
     bool m_bCloneDeckOnLoadDoubleTap;
+    bool m_bBeatjumpLoopmove;
 
     int m_iRateRangePercent;
     bool m_bRateDownIncreasesSpeed;

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -192,6 +192,35 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
         </property>
        </widget>
       </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="labelBeatjumpLoopmove">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="text">
+         <string>Beatjump</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+        <property name="buddy">
+         <cstring>checkboxBeatjumpLoopmove</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkboxBeatjumpLoopmove">
+        <property name="toolTip">
+         <string>When checked the beatjump controls move the active loop</string>
+        </property>
+        <property name="text">
+         <string>Beatjump moves the active loop</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -669,6 +698,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
   <tabstop>comboBoxLoadPoint</tabstop>
   <tabstop>comboBoxLoadWhenDeckPlaying</tabstop>
   <tabstop>checkBoxCloneDeckOnLoadDoubleTap</tabstop>
+  <tabstop>checkboxBeatjumpLoopmove</tabstop>
   <tabstop>ComboBoxRateRange</tabstop>
   <tabstop>checkBoxInvertSpeedSlider</tabstop>
   <tabstop>checkBoxResetPitch</tabstop>


### PR DESCRIPTION
Previously beatjump did always move the active loop.
I'm aware this is by design (#1187) to simplify handling and save screen  space -- but it has been bugging me for years, admittedly only rarely, but still: to move inside a loop I'd have to disable it, beatjump quickly, an re-enable it. Cumbersome and stressing, especially with short loops.
(also mentioned in #10811, but that's mainly about beatgrids)

Now at least controller mappings can use both beatjump and loopmove controls independently.

_Further details are in #16150_

I'd be okay with making this a draft until we come to conclusion wrt the skins UX.