### PR TITLE
[2.5] Fix AudioUnit startup crash by loading out-of-process (macOS)

### DIFF
--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -48,6 +48,7 @@ class AudioUnitManager {
   private:
     QString m_name;
     std::atomic<bool> m_isInstantiated;
+    dispatch_group_t _Nonnull m_instantiationGroup;
     AudioUnit _Nullable m_audioUnit;
 
     AudioUnitManager(AVAudioUnitComponent* _Nullable component);

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -43,7 +43,7 @@ class AudioUnitManager {
     ///
     /// Returns true if the audio unit was instantiated successfully and false if
     /// the timeout was reached instead.
-    bool waitForAudioUnit(int timeoutMs);
+    bool waitForAudioUnit(int timeoutMs) const;
 
   private:
     QString m_name;

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -39,6 +39,12 @@ class AudioUnitManager {
     /// want to e.g. block on a mutex.
     AudioUnit _Nullable getAudioUnit() const;
 
+    /// Blocks until the audio unit has been instantiated.
+    ///
+    /// Returns true if the audio unit was instantiated successfully and false if
+    /// the timeout was reached instead.
+    bool waitForAudioUnit(int timeoutMs);
+
   private:
     QString m_name;
     std::atomic<bool> m_isInstantiated;

--- a/src/effects/backends/audiounit/audiounitmanager.mm
+++ b/src/effects/backends/audiounit/audiounitmanager.mm
@@ -58,7 +58,7 @@ AudioUnit _Nullable AudioUnitManager::getAudioUnit() const {
     return m_audioUnit;
 }
 
-bool AudioUnitManager::waitForAudioUnit(int timeoutMs) {
+bool AudioUnitManager::waitForAudioUnit(int timeoutMs) const {
     // NOTE: We use a sleep loop here since both a QWaitCondition and GCD
     // DispatchGroup-based implementation seem to result in spurious crashes.
     // See https://github.com/mixxxdj/mixxx/pull/13887#issuecomment-2486459443

--- a/src/effects/backends/audiounit/audiounitmanager.mm
+++ b/src/effects/backends/audiounit/audiounitmanager.mm
@@ -94,6 +94,7 @@ void AudioUnitManager::instantiateAudioUnitAsync(
             qWarning() << "Could not instantiate Audio Unit"
                        << pManager->m_name << ":" << error
                        << "(Check https://www.osstatus.com for a description)";
+            dispatch_group_leave(pManager->m_instantiationGroup);
             return;
         }
 

--- a/src/effects/backends/audiounit/audiounitmanifest.mm
+++ b/src/effects/backends/audiounit/audiounitmanifest.mm
@@ -23,7 +23,7 @@ AudioUnitManifest::AudioUnitManifest(
     // Instantiate audio unit (out-of-process) to load parameters
     AudioUnitManagerPointer pManager = AudioUnitManager::create(component);
 
-    const int TIMEOUT_MS = 5000;
+    const int TIMEOUT_MS = 2000;
 
     QElapsedTimer timer;
     timer.start();

--- a/src/effects/backends/audiounit/audiounitmanifest.mm
+++ b/src/effects/backends/audiounit/audiounitmanifest.mm
@@ -24,19 +24,12 @@ AudioUnitManifest::AudioUnitManifest(
     AudioUnitManagerPointer pManager = AudioUnitManager::create(component);
 
     const int TIMEOUT_MS = 2000;
-
-    QElapsedTimer timer;
-    timer.start();
-
-    while (pManager->getAudioUnit() == nil) {
-        if (timer.elapsed() > TIMEOUT_MS) {
-            qWarning() << name() << "took more than" << TIMEOUT_MS
-                       << "ms to initialize, skipping manifest initialization "
-                          "for this effect. This means this effect will not "
-                          "display any parameters and likely not be useful!";
-            return;
-        }
-        QThread::msleep(10);
+    if (!pManager->waitForAudioUnit(TIMEOUT_MS)) {
+        qWarning() << name() << "took more than" << TIMEOUT_MS
+                   << "ms to initialize, skipping manifest initialization "
+                      "for this effect. This means this effect will not "
+                      "display any parameters and likely not be useful!";
+        return;
     }
 
     AudioUnit audioUnit = pManager->getAudioUnit();


### PR DESCRIPTION
## Description

Backport of the Audio Unit out-of-process instantiation fix to the `2.5` branch. (Fixes #16067 and #15187 on `2.5` branch)

`AudioComponentInstanceNew` is the legacy synchronous Apple API. It always loads plugins in-process, meaning any crash in a buggy plugin's static constructor crashes Mixxx immediately (e.g., SIGBUS from writing to read-only memory).

This backport switches to the modern `AudioComponentInstantiate` API with `kAudioComponentInstantiation_LoadOutOfProcess`. This isolates plugin crashes to a separate macOS XPC service:

- The XPC service dies, not Mixxx.
- The callback receives an error code (`OSStatus`), Mixxx skips the buggy plugin gracefully, logs a warning, and continues running correctly.

### Commits Backported from `main`:

1. `6b550f901e` AudioUnitManifest: Instantiate audio units out-of-process
2. `a080f94a43` AudioUnitManifest: Reduce timeout to 2 seconds
3. `a71dd534d9` AudioUnitManager: Factor sleep loop into waitForAudioUnit
4. `7f3bd918c9` AudioUnitManager: Mark waitForAudioUnit const
5. `9176536dc5` AudioUnitManager: Replace sleep loop with dispatch group
6. `27577e5f69` AudioUnitManager: Call dispatch_group_leave on instantiation error (New bugfix on `main` to prevent thread exhaustion when falling back gracefully from errors)

This was manually verified against a customly compiled crashing AU plugin (`CrashingAU.component`, performing `memset()` on read-only memory in `__attribute__((constructor))`). Before this patch, Mixxx 2.5 crashes with a `SIGBUS`. After the patch, Mixxx successfully ignores it with:
`[Main] "CrashingAU" took more than 2000 ms to initialize, skipping manifest initialization for this effect.`
