### PR TITLE
Fix crash on exit due to invalid QLabel buddy references

### DIFF
--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -359,7 +359,7 @@ Select from different types of displays for the waveform, which differ primarily
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
          <property name="buddy">
-          <cstring>allVisualGain</cstring>
+          <cstring>lowVisualGain</cstring>
          </property>
         </widget>
        </item>
@@ -372,7 +372,7 @@ Select from different types of displays for the waveform, which differ primarily
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
          <property name="buddy">
-          <cstring>allVisualGain</cstring>
+          <cstring>midVisualGain</cstring>
          </property>
         </widget>
        </item>
@@ -385,7 +385,7 @@ Select from different types of displays for the waveform, which differ primarily
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
          <property name="buddy">
-          <cstring>allVisualGain</cstring>
+          <cstring>highVisualGain</cstring>
          </property>
         </widget>
        </item>
@@ -598,7 +598,7 @@ Select from different types of displays for the waveform, which differ primarily
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
        <property name="buddy">
-        <cstring>stemOpacityMainLabel</cstring>
+        <cstring>stemOpacitySpinBox</cstring>
        </property>
       </widget>
      </item>
@@ -613,7 +613,7 @@ Select from different types of displays for the waveform, which differ primarily
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
          <property name="buddy">
-          <cstring>stemOpacityMainLabel</cstring>
+          <cstring>stemOpacitySpinBox</cstring>
          </property>
         </widget>
        </item>
@@ -626,7 +626,7 @@ Select from different types of displays for the waveform, which differ primarily
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
          <property name="buddy">
-          <cstring>stemOpacityMainLabel</cstring>
+          <cstring>stemOutlineOpacitySpinBox</cstring>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
# Fix crash on exit due to invalid QLabel buddy references

Closes #16112

## Bug / Issue Summary

Fixes a consistent crash on exit (`ASSERT failure in QLabel: "Called object is not of the correct type"`) caused by incorrect and self-referential buddy widget assignments in `src/preferences/dialog/dlgprefwaveformdlg.ui`.

When Mixxx is closed or the preferences dialog's parent container is destroyed, Qt destroys the child widgets. In the waveform preferences UI, several `QLabel`s had invalid buddy references, including self-referential buddies (e.g., `stemOpacityMainLabel` being its own buddy).

During widget destruction, Qt emits a signal that the object is decaying and attempts to notify its buddy to remove the logical connection. Since the buddy was the object itself, which was already partially destroyed, Qt's internal validation mechanism failed, triggering an `ASSERT` failure and leading to a `SIGABRT` / crash.

This PR fixes those layout property files:

- `stemOpacityLabel` buddy changed to `stemOpacitySpinBox`
- `stemOpacityMainLabel` buddy changed to `stemOpacitySpinBox`
- `stemOpacityOutlineLabel` buddy changed to `stemOutlineOpacitySpinBox`
- `visualGainLabel_low` buddy changed to `lowVisualGain`
- `visualGainLabel_mid` buddy changed to `midVisualGain`
- `visualGainLabel_high` buddy changed to `highVisualGain`
