### PR TITLE
build: Add pre-commit hook to detect invalid QLabel buddy properties

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -189,3 +189,10 @@ repos:
         additional_dependencies:
           - lxml==5.3.0
         files: ^(res/translations/.*\.ts)$
+      - id: check-ui-buddies
+        name: check-ui-buddies
+        description: "Detect invalid or self-referential QLabel buddies in Qt UI files"
+        entry: python tools/check_ui_buddies.py
+        language: python
+        types: [text]
+        files: ^.*\.ui$

--- a/tools/check_ui_buddies.py
+++ b/tools/check_ui_buddies.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import sys
+import xml.etree.ElementTree as ET
+
+
+def check_file(filepath):
+    try:
+        tree = ET.parse(filepath)
+    except ET.ParseError:
+        # Let check-xml pre-commit hook handle malformed XML
+        return False
+
+    root = tree.getroot()
+    has_error = False
+
+    # Collect all widget names in the UI file
+    all_widgets = set()
+    for widget in root.iter("widget"):
+        if "name" in widget.attrib:
+            all_widgets.add(widget.attrib["name"])
+
+    # Check QLabel buddies
+    for widget in root.iter("widget"):
+        if widget.attrib.get("class") == "QLabel":
+            label_name = widget.attrib.get("name", "<unnamed>")
+
+            for prop in widget.findall("property"):
+                if prop.attrib.get("name") == "buddy":
+                    cstring = prop.find("cstring")
+                    if cstring is not None and cstring.text:
+                        buddy_name = cstring.text
+
+                        if buddy_name == label_name:
+                            msg = (
+                                f"{filepath}: Error: "
+                                f"QLabel '{label_name}' is its own buddy!"
+                            )
+                            print(msg, file=sys.stderr)
+                            has_error = True
+                        elif buddy_name not in all_widgets:
+                            msg = (
+                                f"{filepath}: Error: Buddy '{buddy_name}' "
+                                f"for QLabel '{label_name}' does not exist!"
+                            )
+                            print(msg, file=sys.stderr)
+                            has_error = True
+
+    return has_error
+
+
+if __name__ == "__main__":
+    sys.exit(int(any(check_file(arg) for arg in sys.argv[1:])))


### PR DESCRIPTION
# Add pre-commit hook to detect invalid QLabel buddy properties

## Bug / Issue Summary

Qt's `uic` does not strictly validate `QLabel` `buddy` properties in `.ui` files. An incorrect assignment (such as a label assigning itself as its own buddy) results in a circular destruction dependency. In strict Debug builds or more recent versions of Qt 6, this triggers an `ASSERT` failure (`qobjectdefs_impl.h:131`) when the application shuts down or the widget is destroyed.

This PR adds a static Python check to our `pre-commit` hooks that parses all `.ui` files and ensures that no `QLabel` assigns itself as its own buddy, and that any buddy referenced actually exists in the file.

_(This prevents the crash identified in #16112 from ever happening again.)_

## Describe the changes you have made

1. Added `tools/check_ui_buddies.py` which parses `.ui` xml elements.
2. Registered `check-ui-buddies` inside `.pre-commit-config.yaml` to run automatically on `*.ui` diffs.

## Testing

Running the hook locally before the crash fix is merged:

```bash
$ pre-commit run check-ui-buddies --all-files
```

It successfully blocks the commit and flags the broken file correctly:

> `src/preferences/dialog/dlgprefwaveformdlg.ui: Error: QLabel 'stemOpacityMainLabel' is its own buddy!`
