### PR TITLE
libdjinterop version bump to fix regression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3076,7 +3076,7 @@ option(ENGINEPRIME "Support for library export to Denon Engine Prime" ON)
 if(ENGINEPRIME)
   # libdjinterop does not currently have a stable ABI, so we fetch sources for a specific tag, build here, and link
   # statically.  This situation should be reviewed once libdjinterop hits version 1.x.
-  set(LIBDJINTEROP_VERSION 0.27.0)
+  set(LIBDJINTEROP_VERSION 0.27.1)
   # Look whether an existing installation of libdjinterop matches the required version.
   find_package(DjInterop ${LIBDJINTEROP_VERSION} EXACT CONFIG)
   if(NOT DjInterop_FOUND)
@@ -3139,7 +3139,7 @@ if(ENGINEPRIME)
         "https://github.com/xsco/libdjinterop/archive/refs/tags/${LIBDJINTEROP_VERSION}.tar.gz"
         "https://launchpad.net/~xsco/+archive/ubuntu/djinterop/+sourcefiles/libdjinterop/${LIBDJINTEROP_VERSION}-0ubuntu1/libdjinterop_${LIBDJINTEROP_VERSION}.orig.tar.gz"
       URL_HASH
-        SHA256=c4e73bf3907fd45be1c9767bcd9f367cbb7c279b4fe047bf2216bc92ae3d1668
+        SHA256=4c7393ab70b7c92374557e72c86f650bea73ba50e59f6e5a683c69038cc7ea48
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/downloads"
       DOWNLOAD_NAME "libdjinterop-${LIBDJINTEROP_VERSION}.tar.gz"
       PREFIX "libdjinterop-${LIBDJINTEROP_VERSION}"

--- a/packaging/flatpak/modules/libdjinterop.yaml
+++ b/packaging/flatpak/modules/libdjinterop.yaml
@@ -4,8 +4,8 @@ config-opts:
   - -DCMAKE_BUILD_TYPE=RelWithDebInfo
 sources:
   - type: archive
-    url: https://github.com/xsco/libdjinterop/archive/refs/tags/0.27.0.tar.gz
-    sha256: c4e73bf3907fd45be1c9767bcd9f367cbb7c279b4fe047bf2216bc92ae3d1668
+    url: https://github.com/xsco/libdjinterop/archive/refs/tags/0.27.1.tar.gz
+    sha256: 4c7393ab70b7c92374557e72c86f650bea73ba50e59f6e5a683c69038cc7ea48
     x-checker-data:
       type: anitya
       project-id: 374896


### PR DESCRIPTION
This PR deliberately targets the 2.6 branch, even though the window has closed, as it fixes a regression that would otherwise result in a degraded user experience for those who use the Engine DJ export functionality.

This PR bumps libdjinterop from 0.27.0 to 0.27.1.  Looking at the [diff between these two tags](https://github.com/xsco/libdjinterop/compare/f499a25..a3daec8), there is only one functional change: https://github.com/xsco/libdjinterop/commit/45565d99b3a25da7d0b13d5792daccc615b5fb3c

That commit fixes a bug whereby the schema version for 3.0.1 databases was mistakenly written as 3.1.0.  This meant that after a user exported a database as version 3.0.1, they would not be able to update it, as the library would then think it was of some unknown/unsupported future version 3.1.0.

I think this is sensible to get in now, so that Mixxx 2.6 does not get released with degraded functionality.  Happy to hear feedback on the proposed approach.

As a new version of an external library, I assume it will need the usual copying to the Mixxx PPA (I'll dput the new version to my PPA if we're in agreement on this approach), as well as vcpkg.