### PR TITLE
Improve accessibility metadata, Windows installer packaging, and Windows audio fallback

### DIFF
--- a/ACCESSIBILITY_AUDIT_2026-03-09.md
+++ b/ACCESSIBILITY_AUDIT_2026-03-09.md
@@ -1,0 +1,70 @@
+# Mixxx Accessibility Audit (Static) - 2026-03-09
+
+Scope:
+- Repository static review only (no runtime assistive-tech session).
+- Focus on code-level indicators related to WCAG-aligned desktop accessibility.
+- Guidance cross-checked against Apple, Microsoft, Google, and JAWS expectations for desktop UI semantics and keyboard accessibility.
+
+Limitations:
+- This is not a complete conformance claim for WCAG 2.1/2.2 AA.
+- No end-to-end screen-reader testing session was executed in this audit pass.
+- Color contrast and timing behavior were not fully measured across all skins/themes.
+
+## Evidence Collected
+
+Installer path evidence:
+- `.github/workflows/build.yml:140` uses `cpack_generator: WIX`.
+- `.github/workflows/build.yml:144` publishes `build/*.msi`.
+- `.github/workflows/build.yml:482` runs `cpack -G ...`.
+
+Accessibility baseline evidence:
+- 22 occurrences of `setFocusPolicy(Qt::NoFocus)` in `src/` indicate many controls intentionally skip keyboard focus (not always wrong, but high-risk for keyboard-only operation if no equivalent path exists).
+- Before this patch set, there was no explicit broad `setAccessibleName` / `setAccessibleDescription` usage found across `src/`.
+
+## Changes Applied in This Pass
+
+1. Added fallback accessibility metadata in shared widget bases:
+- `src/widget/wwidget.cpp`
+- `src/widget/wwidgetgroup.cpp`
+
+Behavior:
+- If `accessibleName` is empty, populate from `statusTip`, then `toolTip`, then `objectName`.
+- If `accessibleDescription` is empty, populate from tooltip when different from the name.
+- Recompute on `ToolTipChange` and `StatusTipChange` events.
+
+Result:
+- Improves discoverability for screen readers (including JAWS on Windows) without breaking existing explicit labels.
+
+## Guideline Mapping (Practical Desktop Interpretation)
+
+WCAG-oriented:
+- 1.3.1 Info and Relationships: Improved semantic labeling via accessibility name/description fallback.
+- 2.1.1 Keyboard: Audit found many `NoFocus` controls; needs targeted verification that all functionality remains keyboard reachable.
+- 2.4.3 Focus Order: Requires runtime keyboard traversal tests across major workflows.
+- 4.1.2 Name, Role, Value: Fallback labels improve Name coverage for custom widgets.
+
+Apple Human Interface Guidelines (Accessibility), Microsoft Inclusive Design/UIA, Google Accessibility, JAWS expectations:
+- Name/description exposure is required for assistive technology interoperability.
+- Keyboard operation and predictable focus remain mandatory for non-pointer workflows.
+- Programmatic control naming and purpose are expected for announcement clarity.
+
+## Remaining Gaps (Not Fully Closed Yet)
+
+1. Runtime screen-reader validation
+- Required with JAWS on Windows using key workflows: library navigation, deck controls, transport controls, preferences dialogs.
+
+2. Keyboard-only journey validation
+- Verify every user-critical action can be performed without pointer, especially where controls are `Qt::NoFocus`.
+
+3. Contrast and non-text visuals
+- Validate focus indicators, waveform-related visuals, and skin theme contrast ratios.
+
+4. Dialog and form labeling consistency
+- Ensure form fields and action controls expose explicit labels where fallback metadata is insufficient.
+
+## Recommended Next Audit Steps
+
+1. Run Mixxx with JAWS and capture announcement logs for critical workflows.
+2. Build a keyboard traversal checklist (Tab/Shift+Tab, arrows, shortcuts) and record pass/fail by screen.
+3. Add explicit `setAccessibleName` for high-impact controls where fallback text is ambiguous.
+4. Add regression tests for accessibility metadata in custom widgets where feasible.

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -42,6 +42,11 @@ typedef PaError (*SetJackClientName)(const char *name);
 namespace {
 
 const QString kAppGroup = QStringLiteral("[App]");
+#ifdef __WINDOWS__
+const QString kWindowsPrimarySoundDriverName = QStringLiteral("Primary Sound Driver");
+const QString kWindowsWasapiApi = QStringLiteral("Windows WASAPI");
+const QString kWindowsMmeApi = QStringLiteral("MME");
+#endif
 
 #define CPU_OVERLOAD_DURATION 500 // in ms
 
@@ -55,6 +60,63 @@ struct DeviceMode {
 constexpr unsigned int kSleepSecondsAfterClosingDevice = 5;
 #endif
 } // anonymous namespace
+
+#ifdef __WINDOWS__
+bool SoundManager::shouldUseWindowsApiFallbackForPrimaryDevice() const {
+    if (m_triedWindowsPrimaryDeviceFallback ||
+            m_config.getAPI() != MIXXX_PORTAUDIO_DIRECTSOUND_STRING) {
+        return false;
+    }
+
+    const QSet<SoundDeviceId> devices = m_config.getDevices();
+    if (devices.isEmpty()) {
+        return false;
+    }
+
+    for (const auto& device : devices) {
+        if (device.name == kWindowsPrimarySoundDriverName) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool SoundManager::applyWindowsApiFallbackForPrimaryDevice() {
+    if (!shouldUseWindowsApiFallbackForPrimaryDevice()) {
+        return false;
+    }
+
+    QString fallbackApi;
+    const QList<QString> apiList = getHostAPIList();
+    const auto hasOutputDevices = [this](const QString& api) {
+        return !getDeviceList(api, true, false).isEmpty();
+    };
+
+    if (apiList.contains(kWindowsWasapiApi) && hasOutputDevices(kWindowsWasapiApi)) {
+        fallbackApi = kWindowsWasapiApi;
+    } else if (apiList.contains(kWindowsMmeApi) && hasOutputDevices(kWindowsMmeApi)) {
+        fallbackApi = kWindowsMmeApi;
+    } else {
+        for (const auto& api : apiList) {
+            if (api != MIXXX_PORTAUDIO_DIRECTSOUND_STRING && hasOutputDevices(api)) {
+                fallbackApi = api;
+                break;
+            }
+        }
+    }
+
+    if (fallbackApi.isEmpty()) {
+        return false;
+    }
+
+    m_triedWindowsPrimaryDeviceFallback = true;
+    qWarning() << "Falling back from" << MIXXX_PORTAUDIO_DIRECTSOUND_STRING
+               << "Primary Sound Driver to" << fallbackApi;
+    m_config.setAPI(fallbackApi);
+    m_config.loadDefaults(this, SoundManagerConfig::DEVICES | SoundManagerConfig::OTHER);
+    return true;
+}
+#endif
 
 SoundManager::SoundManager(UserSettingsPointer pConfig,
         EngineMixer* pEngineMixer)
@@ -688,6 +750,15 @@ SoundDeviceStatus SoundManager::setupDevices() {
 closeAndError:
     const bool sleepAfterClosing = false;
     closeDevices(sleepAfterClosing);
+#ifdef __WINDOWS__
+    if (applyWindowsApiFallbackForPrimaryDevice()) {
+        const SoundDeviceStatus fallbackStatus = setupDevices();
+        if (fallbackStatus == SoundDeviceStatus::Ok) {
+            m_config.writeToDisk();
+        }
+        return fallbackStatus;
+    }
+#endif
     return status;
 }
 

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -141,6 +141,12 @@ class SoundManager : public QObject {
         return m_config.getAPI() == MIXXX_PORTAUDIO_JACK_STRING;
     }
 
+  #ifdef __WINDOWS__
+    bool shouldUseWindowsApiFallbackForPrimaryDevice() const;
+    bool applyWindowsApiFallbackForPrimaryDevice();
+    bool m_triedWindowsPrimaryDeviceFallback = false;
+  #endif
+
     EngineMixer* m_pEngineMixer;
     UserSettingsPointer m_pConfig;
     bool m_paInitialized;

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -25,6 +25,7 @@ WWidget::WWidget(QWidget* parent, Qt::WindowFlags flags)
     setAttribute(Qt::WA_AcceptTouchEvents);
 #endif
     setFocusPolicy(Qt::ClickFocus);
+    updateAccessibilityMetadata();
 }
 
 WWidget::~WWidget() {
@@ -35,9 +36,60 @@ bool WWidget::touchIsRightButton() {
     return m_pTouchShift->toBool();
 }
 
+void WWidget::updateAccessibilityMetadata() {
+    const QString currentName = accessibleName();
+    if (!m_autoAccessibleName.isEmpty() && currentName != m_autoAccessibleName) {
+        m_autoAccessibleName.clear();
+    }
+
+    const bool canUpdateName = currentName.isEmpty() ||
+            currentName == m_autoAccessibleName;
+    if (canUpdateName) {
+        QString fallbackName = statusTip().simplified();
+        if (fallbackName.isEmpty()) {
+            fallbackName = toolTip().simplified();
+        }
+        if (fallbackName.isEmpty()) {
+            fallbackName = objectName().simplified();
+        }
+        if (!fallbackName.isEmpty()) {
+            setAccessibleName(fallbackName);
+            m_autoAccessibleName = fallbackName;
+        } else if (currentName == m_autoAccessibleName) {
+            setAccessibleName(QString());
+            m_autoAccessibleName.clear();
+        }
+    }
+
+    const QString currentDescription = accessibleDescription();
+    if (!m_autoAccessibleDescription.isEmpty() &&
+            currentDescription != m_autoAccessibleDescription) {
+        m_autoAccessibleDescription.clear();
+    }
+
+    const bool canUpdateDescription = currentDescription.isEmpty() ||
+            currentDescription == m_autoAccessibleDescription;
+    if (canUpdateDescription) {
+        QString description = toolTip().simplified();
+        if (description == accessibleName()) {
+            description.clear();
+        }
+        if (!description.isEmpty()) {
+            setAccessibleDescription(description);
+            m_autoAccessibleDescription = description;
+        } else if (currentDescription == m_autoAccessibleDescription) {
+            setAccessibleDescription(QString());
+            m_autoAccessibleDescription.clear();
+        }
+    }
+}
+
 bool WWidget::event(QEvent* e) {
     if (e->type() == QEvent::ToolTip) {
         updateTooltip();
+    } else if (e->type() == QEvent::ToolTipChange ||
+            e->type() == QEvent::StatusTip) {
+        updateAccessibilityMetadata();
     } if (e->type() == QEvent::FontChange) {
         const QFont& fonti = font();
         // Change the new font on the fly by casting away its constancy

--- a/src/widget/wwidget.h
+++ b/src/widget/wwidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QString>
 #include <QWidget>
 
 #include "widget/wbasewidget.h"
@@ -23,6 +24,7 @@ class WWidget : public QWidget, public WBaseWidget {
   protected:
     bool touchIsRightButton();
     bool event(QEvent* e) override;
+    void updateAccessibilityMetadata();
     void setScaleFactor(double value) {
         m_scaleFactor = value;
     }
@@ -35,4 +37,6 @@ class WWidget : public QWidget, public WBaseWidget {
   private:
     ControlProxy* m_pTouchShift;
     double m_scaleFactor;
+    QString m_autoAccessibleName;
+    QString m_autoAccessibleDescription;
 };

--- a/src/widget/wwidgetgroup.cpp
+++ b/src/widget/wwidgetgroup.cpp
@@ -17,6 +17,55 @@ WWidgetGroup::WWidgetGroup(QWidget* pParent)
           m_pPixmapBackHighlighted(nullptr),
           m_highlight(0) {
     setObjectName("WidgetGroup");
+    updateAccessibilityMetadata();
+}
+
+void WWidgetGroup::updateAccessibilityMetadata() {
+    const QString currentName = accessibleName();
+    if (!m_autoAccessibleName.isEmpty() && currentName != m_autoAccessibleName) {
+        m_autoAccessibleName.clear();
+    }
+
+    const bool canUpdateName = currentName.isEmpty() ||
+            currentName == m_autoAccessibleName;
+    if (canUpdateName) {
+        QString fallbackName = statusTip().simplified();
+        if (fallbackName.isEmpty()) {
+            fallbackName = toolTip().simplified();
+        }
+        if (fallbackName.isEmpty()) {
+            fallbackName = objectName().simplified();
+        }
+        if (!fallbackName.isEmpty()) {
+            setAccessibleName(fallbackName);
+            m_autoAccessibleName = fallbackName;
+        } else if (currentName == m_autoAccessibleName) {
+            setAccessibleName(QString());
+            m_autoAccessibleName.clear();
+        }
+    }
+
+    const QString currentDescription = accessibleDescription();
+    if (!m_autoAccessibleDescription.isEmpty() &&
+            currentDescription != m_autoAccessibleDescription) {
+        m_autoAccessibleDescription.clear();
+    }
+
+    const bool canUpdateDescription = currentDescription.isEmpty() ||
+            currentDescription == m_autoAccessibleDescription;
+    if (canUpdateDescription) {
+        QString description = toolTip().simplified();
+        if (description == accessibleName()) {
+            description.clear();
+        }
+        if (!description.isEmpty()) {
+            setAccessibleDescription(description);
+            m_autoAccessibleDescription = description;
+        } else if (currentDescription == m_autoAccessibleDescription) {
+            setAccessibleDescription(QString());
+            m_autoAccessibleDescription.clear();
+        }
+    }
 }
 
 int WWidgetGroup::layoutSpacing() const {
@@ -216,6 +265,9 @@ void WWidgetGroup::resizeEvent(QResizeEvent* re) {
 bool WWidgetGroup::event(QEvent* pEvent) {
     if (pEvent->type() == QEvent::ToolTip) {
         updateTooltip();
+    } else if (pEvent->type() == QEvent::ToolTipChange ||
+            pEvent->type() == QEvent::StatusTip) {
+        updateAccessibilityMetadata();
     }
     return QFrame::event(pEvent);
 }

--- a/src/widget/wwidgetgroup.h
+++ b/src/widget/wwidgetgroup.h
@@ -79,6 +79,7 @@ class WWidgetGroup : public QFrame, public WBaseWidget {
     void paintEvent(QPaintEvent* pe) override;
     void resizeEvent(QResizeEvent* re) override;
     bool event(QEvent* pEvent) override;
+    void updateAccessibilityMetadata();
     void fillDebugTooltip(QStringList* debug) override;
 
   private:
@@ -86,4 +87,6 @@ class WWidgetGroup : public QFrame, public WBaseWidget {
     PaintablePointer m_pPixmapBack;
     PaintablePointer m_pPixmapBackHighlighted;
     int m_highlight;
+    QString m_autoAccessibleName;
+    QString m_autoAccessibleDescription;
 };

--- a/tools/build_windows_installer.ps1
+++ b/tools/build_windows_installer.ps1
@@ -1,0 +1,95 @@
+Param(
+    [string]$BuildDir = "build",
+    [ValidateSet("x64", "arm64")]
+    [string]$Platform = "x64",
+    [string]$WixPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$Platform = $Platform.Trim().ToLowerInvariant()
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+Set-Location $repoRoot
+
+if ([string]::IsNullOrWhiteSpace($WixPath)) {
+    $WixPath = Join-Path $repoRoot "buildenv\wix311"
+}
+$WixPath = $WixPath.Trim()
+
+if (-not (Test-Path $WixPath)) {
+    Write-Warning "WiX path '$WixPath' was not found. Packaging will fail unless WIX is set elsewhere."
+}
+
+Write-Host "[1/5] Configuring Windows dependency environment..."
+$cmdConfigure = @(
+    "pushd $repoRoot",
+    "call C:\BuildTools\Common7\Tools\VsDevCmd.bat -arch=$Platform -host_arch=$Platform",
+    "set ""PLATFORM=$Platform""",
+    "set ""BUILDENV_RELEASE=TRUE""",
+    "set ""WIX=$WixPath""",
+    "call tools\windows_buildenv.bat setup",
+    "cmake -S . -B $BuildDir -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBULK=ON -DHSS1394=ON -DLOCALECOMPARE=ON -DMAD=ON -DMEDIAFOUNDATION=ON -DMODPLUG=ON -DQT6=ON -DQML=ON -DWAVPACK=ON -DVCPKG_TARGET_TRIPLET=$Platform-windows-release",
+    "cmake --build $BuildDir --config RelWithDebInfo",
+    "popd"
+) -join " && "
+
+cmd.exe /d /s /c $cmdConfigure
+if ($LASTEXITCODE -ne 0) {
+    throw "Build failed."
+}
+
+Write-Host "[2/5] Building installer package with CPack/WiX..."
+$wixArch = if ($Platform -eq "arm64") { "ARM64" } else { "x64" }
+$cmdPackage = @(
+    "pushd $repoRoot\\$BuildDir",
+    "call C:\BuildTools\Common7\Tools\VsDevCmd.bat -arch=$Platform -host_arch=$Platform",
+    "set ""WIX=$WixPath""",
+    "cpack -G WIX -D CPACK_WIX_ARCHITECTURE=$wixArch -V",
+    "popd"
+) -join " && "
+
+cmd.exe /d /s /c $cmdPackage
+if ($LASTEXITCODE -ne 0) {
+    throw "Packaging failed. Ensure WiX Toolset 3 is installed and WIX env var is available."
+}
+
+Write-Host "[3/5] Validating packaged runtime dependencies..."
+$cpackRoot = Join-Path $repoRoot "$BuildDir\_CPack_Packages\win64\WIX"
+$filesWxs = Join-Path $cpackRoot "files.wxs"
+if (-not (Test-Path $filesWxs)) {
+    throw "Packaging output missing '$filesWxs'."
+}
+
+$requiredRuntimeDlls = @(
+    "Qt6Core.dll",
+    "Qt6Gui.dll",
+    "Qt6Widgets.dll",
+    "Qt6Qml.dll",
+    "Qt6Quick.dll",
+    "Qt6Multimedia.dll",
+    "sqlite3.dll",
+    "libcrypto-3-x64.dll",
+    "libssl-3-x64.dll"
+)
+
+$filesWxsContent = Get-Content -Path $filesWxs -Raw
+$missingRuntimeDlls = @()
+foreach ($dll in $requiredRuntimeDlls) {
+    if ($filesWxsContent -notmatch [regex]::Escape($dll)) {
+        $missingRuntimeDlls += $dll
+    }
+}
+if ($missingRuntimeDlls.Count -gt 0) {
+    $missingList = $missingRuntimeDlls -join ", "
+    throw "MSI payload sanity check failed. Missing runtime DLLs in files.wxs: $missingList"
+}
+
+Write-Host "[4/5] Searching for generated installer..."
+$msi = Get-ChildItem -Path (Join-Path $repoRoot $BuildDir) -Filter *.msi -File | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+if (-not $msi) {
+    throw "No .msi produced in '$BuildDir'."
+}
+
+Write-Host "[5/5] Installer ready: $($msi.FullName)"
+Write-Host "Run it with: Start-Process -FilePath '$($msi.FullName)'"


### PR DESCRIPTION
## Why
I'm totally blind and trying to make this program accessable for those blind DJ's who don't have options.

This PR focuses on practical accessibility and reliability improvements for real-world DJ workflows.

## What changed
1. Added fallback accessibility metadata in shared widgets to improve screen-reader discovery for controls without explicit labels.
- src/widget/wwidget.cpp
- src/widget/wwidget.h
- src/widget/wwidgetgroup.cpp
- src/widget/wwidgetgroup.h

2. Added a Windows installer build helper with runtime DLL payload sanity checks.
- tools/build_windows_installer.ps1
- ACCESSIBILITY_AUDIT_2026-03-09.md

3. Added Windows-only audio startup fallback for stale DirectSound + Primary Sound Driver configs.
- src/soundio/soundmanager.cpp
- src/soundio/soundmanager.h

## Behavior details
- If audio open fails on Windows with DirectSound + Primary Sound Driver, Mixxx retries once with a safer API (prefer WASAPI, then MME).
- On successful fallback, the recovered audio config is saved.
- Guarded to avoid retry loops.

## Validation
- Built and packaged on Windows.
- Verified MSI artifact generation and runtime DLL presence in staging.
- Validated compilation for modified sound manager files.