### PR TITLE
use explicit ShowDirsOnly flag for some file picker dialogs

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -640,7 +640,8 @@ void CoreServices::initialize(QApplication* pApp) {
         QString fd = QFileDialog::getExistingDirectory(nullptr,
                 tr("Choose music library directory"),
                 QStandardPaths::writableLocation(
-                        QStandardPaths::MusicLocation));
+                        QStandardPaths::MusicLocation),
+                QFileDialog::ShowDirsOnly);
 #endif
         // request to add directory to database.
         if (!fd.isEmpty() && m_pLibrary->requestAddDir(fd)) {

--- a/src/library/export/dlglibraryexport.cpp
+++ b/src/library/export/dlglibraryexport.cpp
@@ -222,7 +222,10 @@ void DlgLibraryExport::browseExportDirectory() {
             m_pConfig->getValue(ConfigKey("[Library]", kLastDirConfigItemName),
                     QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
     const auto exportDirectory = QFileDialog::getExistingDirectory(
-            nullptr, tr("Export Library To"), lastExportDirectory);
+            nullptr,
+            tr("Export Library To"),
+            lastExportDirectory,
+            QFileDialog::ShowDirsOnly);
     if (exportDirectory.isEmpty()) {
         return;
     }

--- a/src/library/export/trackexportwizard.cpp
+++ b/src/library/export/trackexportwizard.cpp
@@ -24,7 +24,10 @@ bool TrackExportWizard::selectDestinationDirectory() {
             QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
 
     QString destDir = QFileDialog::getExistingDirectory(
-            nullptr, tr("Export Track Files To"), lastExportDirectory);
+            nullptr,
+            tr("Export Track Files To"),
+            lastExportDirectory,
+            QFileDialog::ShowDirsOnly);
     if (destDir.isEmpty()) {
         return false;
     }

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -404,8 +404,10 @@ void DlgPrefLibrary::resetLibraryFont() {
 
 void DlgPrefLibrary::slotAddDir() {
     QString fd = QFileDialog::getExistingDirectory(
-        this, tr("Choose a music directory"),
-        QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
+            this,
+            tr("Choose a music directory"),
+            QStandardPaths::writableLocation(QStandardPaths::MusicLocation),
+            QFileDialog::ShowDirsOnly);
     if (!fd.isEmpty()) {
         if (m_pLibrary->requestAddDir(fd)) {
             populateDirList();
@@ -487,7 +489,10 @@ void DlgPrefLibrary::slotRelocateDir() {
     }
 
     QString fd = QFileDialog::getExistingDirectory(
-        this, tr("Relink music directory to new location"), startDir);
+            this,
+            tr("Relink music directory to new location"),
+            startDir,
+            QFileDialog::ShowDirsOnly);
 
     if (!fd.isEmpty() && m_pLibrary->requestRelocateDir(currentFd, fd)) {
         populateDirList();

--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -206,9 +206,11 @@ void DlgPrefRecord::slotResetToDefaults() {
 
 void DlgPrefRecord::slotBrowseRecordingsDir() {
     QString fd = QFileDialog::getExistingDirectory(
-            this, tr("Choose recordings directory"),
+            this,
+            tr("Choose recordings directory"),
             m_pConfig->getValueString(
-                    ConfigKey(RECORDING_PREF_KEY,"Directory")));
+                    ConfigKey(RECORDING_PREF_KEY, "Directory")),
+            QFileDialog::ShowDirsOnly);
 
     if (fd != "") {
         // The user has picked a new directory via a file dialog. This means the

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -138,7 +138,11 @@ bool Sandbox::askForAccess(mixxx::FileInfo* pFileInfo) {
         if (pFileInfo->isFile()) {
             result = QFileDialog::getOpenFileName(nullptr, title, location);
         } else if (pFileInfo->isDir()) {
-            result = QFileDialog::getExistingDirectory(nullptr, title, location);
+            result = QFileDialog::getExistingDirectory(
+                    nullptr,
+                    title,
+                    location,
+                    QFileDialog::ShowDirsOnly);
         }
 
         if (result.isNull()) {
@@ -483,7 +487,8 @@ QString Sandbox::migrateOldSettings() {
     QString result = QFileDialog::getExistingDirectory(
             nullptr,
             title,
-            legacySettingsPath);
+            legacySettingsPath,
+            QFileDialog::ShowDirsOnly);
     if (result != legacySettingsPath) {
         qInfo() << "Sandbox::migrateOldSettings: User declined to migrate old settings from"
                 << legacySettingsPath << "User selected" << result;


### PR DESCRIPTION
As recommended in the [docs](https://doc.qt.io/qt-6/qfiledialog.html#getExistingDirectory)
(a bit unexpected as we are calling QFileDialog::getExisting**Directory**)

We use the native OS dialogs to let users pick files and directories, and in the dir case I was wondering why xfce was showing me _ALL_ file types -- which makes picking a dir in crowded dirs a bit of a straining voyage de scroll, if you know what I mean.
Admittedly, my xfce browser ignores this flag, but I'm wondering if it has an effect with other OS / desktops.