### PR TITLE
dlgtrackinfo: Show resulting BPM on BPM scale buttons

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -496,6 +496,7 @@ void DlgTrackInfo::updateBpmEditControls() {
 void DlgTrackInfo::reloadTrackBeats(const Track& track) {
     m_pBeatsClone = track.getBeats();
     updateSpinBpmFromBeats();
+    updateBpmScaleButtonLabels();
     m_trackHasBeatMap = m_pBeatsClone && !m_pBeatsClone->hasConstantTempo();
     bpmConst->setChecked(!m_trackHasBeatMap);
 
@@ -707,12 +708,44 @@ void DlgTrackInfo::slotBpmScale(mixxx::Beats::BpmScale bpmScale) {
     if (scaledBeats) {
         m_pBeatsClone = *scaledBeats;
         updateSpinBpmFromBeats();
+        updateBpmScaleButtonLabels();
     }
+}
+
+void DlgTrackInfo::updateBpmScaleButtonLabels() {
+    // Get current BPM from the spinbox
+    const double bpm = spinBpm->value();
+
+    auto formatLabel = [bpm](const QString& baseLabel, double scale) -> QString {
+        if (bpm <= 0) {
+            return baseLabel;
+        }
+        const double scaledBpm = bpm * scale;
+        QLocale loc;
+        QString scaledBpmStr = loc.toString(scaledBpm, 'f', 2);
+        while (scaledBpmStr.endsWith('0')) {
+            scaledBpmStr.chop(1);
+        }
+        if (scaledBpmStr.endsWith(loc.decimalPoint())) {
+            scaledBpmStr.chop(1);
+        }
+        return QStringLiteral("%1 | %2 BPM").arg(baseLabel, scaledBpmStr);
+    };
+
+    bpmHalve->setText(formatLabel(tr("1/2 BPM"), 0.5));
+    bpmTwoThirds->setText(formatLabel(tr("2/3 BPM"), 2.0 / 3.0));
+    bpmThreeFourths->setText(formatLabel(tr("3/4 BPM"), 3.0 / 4.0));
+    bpmFourFifths->setText(formatLabel(tr("4/5 BPM"), 4.0 / 5.0));
+    bpmFiveFourths->setText(formatLabel(tr("5/4 BPM"), 5.0 / 4.0));
+    bpmFourThirds->setText(formatLabel(tr("4/3 BPM"), 4.0 / 3.0));
+    bpmThreeHalves->setText(formatLabel(tr("3/2 BPM"), 3.0 / 2.0));
+    bpmDouble->setText(formatLabel(tr("2x BPM"), 2.0));
 }
 
 void DlgTrackInfo::slotBpmClear() {
     m_pBeatsClone.reset();
     updateSpinBpmFromBeats();
+    updateBpmScaleButtonLabels();
 
     bpmConst->setChecked(true);
     bpmConst->setEnabled(m_trackHasBeatMap);
@@ -790,6 +823,7 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
     }
 
     updateSpinBpmFromBeats();
+    updateBpmScaleButtonLabels();
 }
 
 void DlgTrackInfo::updateKeyText() {

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -112,6 +112,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void updateTrackMetadataFields();
     void updateSpinBpmFromBeats();
     void updateBpmEditControls();
+    void updateBpmScaleButtonLabels();
 
     const UserSettingsPointer m_pUserSettings;
 


### PR DESCRIPTION
## Summary
Show resulting BPM on BPM scale buttons in Track Properties dialog.

## Problem
The right-click context menu already shows the resulting BPM next to
each scaling option (e.g. "3/4 BPM | 90 BPM"). This adds the same
behavior to the Track Properties dialog BPM tab buttons, so users
can see what BPM they'll get before clicking.

## Changes
The button labels update dynamically in all code paths:
- When a track is first loaded into the dialog
- When a BPM scale button is clicked
- When the BPM is cleared
- When the BPM spin box is edited manually

The label format and trailing-zero removal logic matches the existing
implementation in wtrackmenu.cpp.

Addresses feedback from @daschuer in #16026.

---

### Before Screenshot
<img width="1470" height="850" alt="Before Screenshot" src="https://github.com/user-attachments/assets/dc00faa2-1304-4c3a-a2ce-8b618d59297f" />

### After Screenshot
<img width="1470" height="850" alt="After Screenshot" src="https://github.com/user-attachments/assets/4d0e388d-f8d9-418a-a547-0492ef980d48" />

### After Video
https://github.com/user-attachments/assets/5bc97c51-b864-4449-8033-03d2479668e1