### PR TITLE
dlgtrackinfo: stretch TAP button and pair inverse BPM scaling buttons

### DIFF
--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -798,6 +798,22 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
             </widget>
            </item>
            <item row="2" column="1">
+            <widget class="QPushButton" name="bpmDouble">
+             <property name="minimumSize">
+              <size>
+               <width>125</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Sets the BPM to 200% of the current value.</string>
+             </property>
+             <property name="text">
+              <string>Double BPM</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
             <widget class="QPushButton" name="bpmTwoThirds">
              <property name="minimumSize">
               <size>
@@ -813,7 +829,23 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="3" column="1">
+            <widget class="QPushButton" name="bpmThreeHalves">
+             <property name="minimumSize">
+              <size>
+               <width>125</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Sets the BPM to 150% of the current value.</string>
+             </property>
+             <property name="text">
+              <string>3/2 BPM</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
             <widget class="QPushButton" name="bpmThreeFourths">
              <property name="minimumSize">
               <size>
@@ -826,38 +858,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
              <property name="text">
               <string>3/4 BPM</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QPushButton" name="bpmFourFifths">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Sets the BPM to 80% of the current value.</string>
-             </property>
-             <property name="text">
-              <string>4/5 BPM</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QPushButton" name="bpmFiveFourths">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Sets the BPM to 125% of the current value.</string>
-             </property>
-             <property name="text">
-              <string>5/4 BPM</string>
              </property>
             </widget>
            </item>
@@ -878,7 +878,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
             </widget>
            </item>
            <item row="5" column="0">
-            <widget class="QPushButton" name="bpmThreeHalves">
+            <widget class="QPushButton" name="bpmFourFifths">
              <property name="minimumSize">
               <size>
                <width>125</width>
@@ -886,15 +886,15 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
               </size>
              </property>
              <property name="toolTip">
-              <string>Sets the BPM to 150% of the current value.</string>
+              <string>Sets the BPM to 80% of the current value.</string>
              </property>
              <property name="text">
-              <string>3/2 BPM</string>
+              <string>4/5 BPM</string>
              </property>
             </widget>
            </item>
            <item row="5" column="1">
-            <widget class="QPushButton" name="bpmDouble">
+            <widget class="QPushButton" name="bpmFiveFourths">
              <property name="minimumSize">
               <size>
                <width>125</width>
@@ -902,14 +902,14 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
               </size>
              </property>
              <property name="toolTip">
-              <string>Sets the BPM to 200% of the current value.</string>
+              <string>Sets the BPM to 125% of the current value.</string>
              </property>
              <property name="text">
-              <string>Double BPM</string>
+              <string>5/4 BPM</string>
              </property>
             </widget>
            </item>
-           <item row="2" column="2" rowspan="3">
+           <item row="2" column="2" rowspan="4">
             <widget class="QPushButton" name="bpmTap">
              <property name="minimumSize">
               <size>
@@ -1109,13 +1109,13 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>bpmConst</tabstop>
   <tabstop>bpmTap</tabstop>
   <tabstop>bpmHalve</tabstop>
+  <tabstop>bpmDouble</tabstop>
   <tabstop>bpmTwoThirds</tabstop>
+  <tabstop>bpmThreeHalves</tabstop>
   <tabstop>bpmThreeFourths</tabstop>
+  <tabstop>bpmFourThirds</tabstop>
   <tabstop>bpmFourFifths</tabstop>
   <tabstop>bpmFiveFourths</tabstop>
-  <tabstop>bpmThreeHalves</tabstop>
-  <tabstop>bpmFourThirds</tabstop>
-  <tabstop>bpmDouble</tabstop>
   <tabstop>bpmClear</tabstop>
   <tabstop>btnPrev</tabstop>
   <tabstop>btnNext</tabstop>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -783,12 +783,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
            </item>
            <item row="2" column="0">
             <widget class="QPushButton" name="bpmHalve">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
              <property name="toolTip">
               <string>Sets the BPM to 50% of the current value.</string>
              </property>
@@ -799,12 +793,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
            </item>
            <item row="2" column="1">
             <widget class="QPushButton" name="bpmDouble">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
              <property name="toolTip">
               <string>Sets the BPM to 200% of the current value.</string>
              </property>
@@ -815,12 +803,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
            </item>
            <item row="3" column="0">
             <widget class="QPushButton" name="bpmTwoThirds">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
              <property name="toolTip">
               <string>Sets the BPM to 66% of the current value.</string>
              </property>
@@ -831,12 +813,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
            </item>
            <item row="3" column="1">
             <widget class="QPushButton" name="bpmThreeHalves">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
              <property name="toolTip">
               <string>Sets the BPM to 150% of the current value.</string>
              </property>
@@ -847,12 +823,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
            </item>
            <item row="4" column="0">
             <widget class="QPushButton" name="bpmThreeFourths">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
              <property name="toolTip">
               <string>Sets the BPM to 75% of the current value.</string>
              </property>
@@ -863,12 +833,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
            </item>
            <item row="4" column="1">
             <widget class="QPushButton" name="bpmFourThirds">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
              <property name="toolTip">
               <string>Sets the BPM to 133% of the current value.</string>
              </property>
@@ -879,12 +843,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
            </item>
            <item row="5" column="0">
             <widget class="QPushButton" name="bpmFourFifths">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
              <property name="toolTip">
               <string>Sets the BPM to 80% of the current value.</string>
              </property>
@@ -895,12 +853,6 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
            </item>
            <item row="5" column="1">
             <widget class="QPushButton" name="bpmFiveFourths">
-             <property name="minimumSize">
-              <size>
-               <width>125</width>
-               <height>0</height>
-              </size>
-             </property>
              <property name="toolTip">
               <string>Sets the BPM to 125% of the current value.</string>
              </property>
@@ -911,17 +863,11 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
            </item>
            <item row="2" column="2" rowspan="4">
             <widget class="QPushButton" name="bpmTap">
-             <property name="minimumSize">
-              <size>
-               <width>121</width>
-               <height>91</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>123</width>
-               <height>128</height>
-              </size>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
              <property name="toolTip">
               <string>Tap with the beat to set the BPM to the speed you are tapping.</string>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -781,7 +781,17 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="2" column="0" colspan="3">
+            <widget class="QLabel" name="labelScaleBpm">
+             <property name="text">
+              <string>Scale BPM:</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignHCenter|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
             <widget class="QPushButton" name="bpmHalve">
              <property name="toolTip">
               <string>Sets the BPM to 50% of the current value.</string>
@@ -791,7 +801,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="3" column="1">
             <widget class="QPushButton" name="bpmDouble">
              <property name="toolTip">
               <string>Sets the BPM to 200% of the current value.</string>
@@ -801,7 +811,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="4" column="0">
             <widget class="QPushButton" name="bpmTwoThirds">
              <property name="toolTip">
               <string>Sets the BPM to 66% of the current value.</string>
@@ -811,7 +821,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
+           <item row="4" column="1">
             <widget class="QPushButton" name="bpmThreeHalves">
              <property name="toolTip">
               <string>Sets the BPM to 150% of the current value.</string>
@@ -821,7 +831,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
+           <item row="5" column="0">
             <widget class="QPushButton" name="bpmThreeFourths">
              <property name="toolTip">
               <string>Sets the BPM to 75% of the current value.</string>
@@ -831,7 +841,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
+           <item row="5" column="1">
             <widget class="QPushButton" name="bpmFourThirds">
              <property name="toolTip">
               <string>Sets the BPM to 133% of the current value.</string>
@@ -841,7 +851,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
+           <item row="6" column="0">
             <widget class="QPushButton" name="bpmFourFifths">
              <property name="toolTip">
               <string>Sets the BPM to 80% of the current value.</string>
@@ -851,7 +861,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="5" column="1">
+           <item row="6" column="1">
             <widget class="QPushButton" name="bpmFiveFourths">
              <property name="toolTip">
               <string>Sets the BPM to 125% of the current value.</string>
@@ -861,7 +871,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
              </property>
             </widget>
            </item>
-           <item row="2" column="2" rowspan="4">
+           <item row="3" column="2" rowspan="4">
             <widget class="QPushButton" name="bpmTap">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -766,15 +766,12 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0" colspan="2">
+           <item row="1" column="1" colspan="2">
             <widget class="QCheckBox" name="bpmConst">
              <property name="toolTip">
               <string>Converts beats detected by the analyzer into a fixed-tempo beatgrid.
 Use this setting if your tracks have a constant tempo (e.g. most electronic music).
 Often results in higher quality beatgrids, but will not do well on tracks that have tempo shifts.</string>
-             </property>
-             <property name="layoutDirection">
-              <enum>Qt::RightToLeft</enum>
              </property>
              <property name="text">
               <string>Assume constant tempo</string>
@@ -787,7 +784,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
               <string>Scale BPM:</string>
              </property>
              <property name="alignment">
-              <set>Qt::AlignHCenter|Qt::AlignVCenter</set>
+              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Follows up on #16026.

Two small layout improvements to the BPM tab:

1. TAP button now spans all four button rows instead of three,
   filling the full height of the scaling buttons section.

2. BPM scaling buttons reordered so inverse pairs sit side by side:
   - Halve / Double
   - 2/3 / 3/2
   - 3/4 / 4/3
   - 4/5 / 5/4

This makes it quicker to recover from an accidental button press
since the inverse is always directly adjacent.

### Screenshots

### Before
<img width="1470" height="855" alt="Before Screenshot" src="https://github.com/user-attachments/assets/b21c1555-edbb-4e43-9d7b-c5a772225e54" />


### After
<img width="1470" height="855" alt="After Screenshot" src="https://github.com/user-attachments/assets/9601dfc8-95be-4524-ac73-df3157a59913" />

