### PR TITLE
Flatpak: use Flathub as the runtime repo for bundle builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -560,6 +560,7 @@ jobs:
         run: |
           flatpak build-bundle repo \
             --arch=${{ matrix.variant.arch }} \
+            --runtime-repo=https://dl.flathub.org/repo/flathub.flatpakrepo \
             Mixxx-${GIT_DESC}-${{ matrix.variant.arch }}.flatpak org.mixxx.Mixxx
 
       - name: "Create Debug extension"

--- a/packaging/flatpak/flatpak_build.sh
+++ b/packaging/flatpak/flatpak_build.sh
@@ -235,7 +235,9 @@ case "$COMMAND" in
     bundle | debug)
         echo ""
         echo "Creating single-file Flatpak bundle..."
-        flatpak build-bundle "$REPO_DIR" Mixxx.flatpak org.mixxx.Mixxx
+        flatpak build-bundle "$REPO_DIR" \
+            --runtime-repo=https://dl.flathub.org/repo/flathub.flatpakrepo \
+            Mixxx.flatpak org.mixxx.Mixxx
         if [[ -f "Mixxx.flatpak" ]]; then
             echo ""
             echo "To install the single-file bundle, run:"


### PR DESCRIPTION
This PR adds `--runtime-repo` flag to main Flatpak bundle creation, defining Flathub as the runtime repo. 

Currently we do not specify a runtime repo and installs will fail if the user does not have Flathub configured as a remote. Remotes and runtimes can also be deleted later, possibly leading to a non-working install.

```
djantti@debian-vm:~$ flatpak install --user ./Mixxx.flatpak
error: The application org.mixxx.Mixxx/x86_64/master requires the runtime org.kde.Platform/x86_64/6.10 which was not found
```

Here's the same with the fix applied:

```
djantti@debian-vm:~$ flatpak install --user ./Mixxx_runtime_repo.flatpak
The application org.mixxx.Mixxx depends on runtimes from:
  https://dl.flathub.org/repo/
Configure this as new remote 'flathub' [Y/n]: y
Required runtime for org.mixxx.Mixxx/x86_64/master (runtime/org.kde.Platform/x86_64/6.10) found in remote flathub
Do you want to install it? [Y/n]: y
```

I added the flag to the build workflow and the manual build script. The build script configures Flathub automatically, which is likely why this was missed earlier. :pensive: