### PR TITLE
Add Bandpass Reverb effect with selectable filter order and pre/post filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,10 @@ src/mixxx.rc.include
 src/mixxx.res
 src/test/**/*.actual
 res/qrc_mixxx.cc
+
+
+.vs/
+build/
+install/
+*.db
+*.sqlite

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1363,7 +1363,9 @@ add_library(
   src/engine/filters/enginefilterbessel4.cpp
   src/engine/filters/enginefilterbessel8.cpp
   src/engine/filters/enginefilterbiquad1.cpp
+  src/engine/filters/enginefilterbutterworth2.cpp
   src/engine/filters/enginefilterbutterworth4.cpp
+  src/engine/filters/enginefilterbutterworth6.cpp
   src/engine/filters/enginefilterbutterworth8.cpp
   src/engine/filters/enginefilterlinkwitzriley2.cpp
   src/engine/filters/enginefilterlinkwitzriley4.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1287,6 +1287,7 @@ add_library(
   src/effects/backends/builtin/parametriceqeffect.cpp
   src/effects/backends/builtin/phasereffect.cpp
   src/effects/backends/builtin/reverbeffect.cpp
+  src/effects/backends/builtin/bandpassreverbeffect.cpp
   src/effects/backends/builtin/threebandbiquadeqeffect.cpp
   src/effects/backends/builtin/tremoloeffect.cpp
   src/effects/backends/builtin/whitenoiseeffect.cpp

--- a/src/effects/backends/builtin/bandpassreverbeffect.cpp
+++ b/src/effects/backends/builtin/bandpassreverbeffect.cpp
@@ -1,5 +1,5 @@
 // EXPERIMENT: learning Mixxx reverb code flow
-#include "effects/backends/builtin/reverbeffect.h"
+#include "effects/backends/builtin/bandpassreverbeffect.h"
 
 #include "effects/backends/effectmanifest.h"
 #include "engine/effects/engineeffectparameter.h"
@@ -14,22 +14,22 @@
 // ================================
 
 // static
-QString ReverbEffect::getId() {
-    return "org.mixxx.effects.reverb";
+QString BandpassReverbEffect::getId() {
+    return "org.mixxx.effects.bandpassreverb";
 }
 
 // static
-EffectManifestPointer ReverbEffect::getManifest() {
+EffectManifestPointer BandpassReverbEffect::getManifest() {
     EffectManifestPointer pManifest(new EffectManifest());
     pManifest->setAddDryToWet(true);
     pManifest->setEffectRampsFromDry(true);
 
     pManifest->setId(getId());
-    pManifest->setName(QObject::tr("Reverb"));
+    pManifest->setName(QObject::tr("Bandpass Reverb"));
     pManifest->setAuthor("The Mixxx Team, CAPS Plugins");
     pManifest->setVersion("1.0");
     pManifest->setDescription(QObject::tr(
-            "Emulates the sound of the signal bouncing off the walls of a room"));
+            "Reverb effect followed by a band-pass filter for shaping the reverberated signal."));
 
     EffectManifestParameterPointer decay = pManifest->addParameter();
     decay->setId("decay");
@@ -75,26 +75,47 @@ EffectManifestPointer ReverbEffect::getManifest() {
     send->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::NotInverted);
     send->setRange(0, 0, 1);
 
+    EffectManifestParameterPointer bpFreq = pManifest->addParameter();
+    bpFreq->setId("bp_freq");
+    bpFreq->setName(QObject::tr("BP Frequency"));
+    bpFreq->setShortName(QObject::tr("BPFreq"));
+    bpFreq->setDescription(QObject::tr("Center frequency of band-pass filter"));
+    bpFreq->setValueScaler(EffectManifestParameter::ValueScaler::Logarithmic);
+    bpFreq->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    bpFreq->setRange(200, 1000, 5000);
+
+    EffectManifestParameterPointer bpQ = pManifest->addParameter();
+    bpQ->setId("bp_q");
+    bpQ->setName(QObject::tr("BP Q"));
+    bpQ->setShortName(QObject::tr("BPQ"));
+    bpQ->setDescription(QObject::tr("Q factor of band-pass filter"));
+    bpQ->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    bpQ->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    bpQ->setRange(0.1, 0.707, 5);
+
     return pManifest;
 }
 
-void ReverbEffect::loadEngineEffectParameters(
+void BandpassReverbEffect::loadEngineEffectParameters(
         const QMap<QString, EngineEffectParameterPointer>& parameters) {
     m_pDecayParameter = parameters.value("decay");
     m_pBandWidthParameter = parameters.value("bandwidth");
     m_pDampingParameter = parameters.value("damping");
     m_pSendParameter = parameters.value("send_amount");
+    m_pBPFreqParameter = parameters.value("bp_freq");
+    m_pBPQParameter = parameters.value("bp_q");
 }
 
 
-void ReverbEffect::processChannel(
-        ReverbGroupState* pState,
+void BandpassReverbEffect::processChannel(
+        BandpassReverbGroupState* pState,
         const CSAMPLE* pInput,
         CSAMPLE* pOutput,
         const mixxx::EngineParameters& engineParameters,
         const EffectEnableState enableState,
         const GroupFeatureState& groupFeatures) {
             
+    
     Q_UNUSED(groupFeatures);
 
     const auto decay = static_cast<sample_t>(m_pDecayParameter->value());
@@ -121,6 +142,16 @@ void ReverbEffect::processChannel(
             damping,
             sendCurrent,
             pState->sendPrevious);
+
+    sample_t freq = static_cast<sample_t>(m_pBPFreqParameter->value());
+    sample_t q = static_cast<sample_t>(m_pBPQParameter->value());
+
+    pState->bandPass.setParameters(freq, q);
+    qDebug() << "BP Filter freq:" << freq << " Q:" << q;
+
+    for (int i = 0; i < engineParameters.samplesPerBuffer(); ++i) {
+        pOutput[i] = pState->bandPass.process(pOutput[i]);
+    }
 
     // The ramping of the send parameter handles ramping when enabling, so
     // this effect must handle ramping to dry when disabling itself (instead

--- a/src/effects/backends/builtin/bandpassreverbeffect.cpp
+++ b/src/effects/backends/builtin/bandpassreverbeffect.cpp
@@ -33,17 +33,6 @@ EffectManifestPointer BandpassReverbEffect::getManifest() {
     decay->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
     decay->setRange(0, 0.5, 1);
 
-    EffectManifestParameterPointer bandwidth = pManifest->addParameter();
-    bandwidth->setId("bandwidth");
-    bandwidth->setName(QObject::tr("Bandwidth"));
-    bandwidth->setShortName(QObject::tr("BW"));
-    bandwidth->setDescription(QObject::tr(
-            "Bandwidth of the low pass filter at the input.\n"
-            "Higher values result in less attenuation of high frequencies."));
-    bandwidth->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
-    bandwidth->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
-    bandwidth->setRange(0, 1, 1);
-
     EffectManifestParameterPointer damping = pManifest->addParameter();
     damping->setId("damping");
     damping->setName(QObject::tr("Damping"));
@@ -122,7 +111,6 @@ EffectManifestPointer BandpassReverbEffect::getManifest() {
 void BandpassReverbEffect::loadEngineEffectParameters(
         const QMap<QString, EngineEffectParameterPointer>& parameters) {
     m_pDecayParameter = parameters.value("decay");
-    m_pBandWidthParameter = parameters.value("bandwidth");
     m_pDampingParameter = parameters.value("damping");
     m_pSendParameter = parameters.value("send_amount");
     m_pHPCutoffParameter = parameters.value("hp_cutoff");
@@ -143,7 +131,6 @@ void BandpassReverbEffect::processChannel(
     Q_UNUSED(groupFeatures);
 
     const auto decay = static_cast<sample_t>(m_pDecayParameter->value());
-    const auto bandwidth = static_cast<sample_t>(m_pBandWidthParameter->value());
     const auto damping = static_cast<sample_t>(m_pDampingParameter->value());
     const auto sendCurrent = static_cast<sample_t>(m_pSendParameter->value());
     const bool postFilter = m_pPostFilterParameter->toBool();
@@ -236,7 +223,7 @@ if (!postFilter) {
             filteredBuffer.data(),
             pOutput,
             engineParameters.samplesPerBuffer(),
-            bandwidth,
+            1.0f,
             decay,
             damping,
             sendCurrent,
@@ -251,7 +238,7 @@ if (!postFilter) {
             pInput,
             reverbBuffer.data(),
             engineParameters.samplesPerBuffer(),
-            bandwidth,
+            1.0f,
             decay,
             damping,
             sendCurrent,

--- a/src/effects/backends/builtin/bandpassreverbeffect.cpp
+++ b/src/effects/backends/builtin/bandpassreverbeffect.cpp
@@ -1,4 +1,4 @@
-// EXPERIMENT: learning Mixxx reverb code flow
+
 #include "effects/backends/builtin/bandpassreverbeffect.h"
 
 #include "effects/backends/effectmanifest.h"
@@ -16,7 +16,7 @@ QString BandpassReverbEffect::getId() {
 EffectManifestPointer BandpassReverbEffect::getManifest() {
     EffectManifestPointer pManifest(new EffectManifest());
     pManifest->setAddDryToWet(false);
-    pManifest->setEffectRampsFromDry(true);
+    pManifest->setEffectRampsFromDry(false);
 
     pManifest->setId(getId());
     pManifest->setName(QObject::tr("Bandpass Reverb"));
@@ -80,12 +80,14 @@ EffectManifestPointer BandpassReverbEffect::getManifest() {
 
     EffectManifestParameterPointer bpQ = pManifest->addParameter();
     bpQ->setId("bp_q");
-    bpQ->setName(QObject::tr("BP Q"));
-    bpQ->setShortName(QObject::tr("BPQ"));
-    bpQ->setDescription(QObject::tr("Q factor of band-pass filter"));
+    bpQ->setName(QObject::tr("Bandwidth"));
+    bpQ->setShortName(QObject::tr("Width"));
+    bpQ->setDescription(QObject::tr("Controls width of the band-pass filter"));
     bpQ->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
     bpQ->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
     bpQ->setRange(0.1, 0.707, 10);
+
+    
 
     return pManifest;
 }
@@ -98,6 +100,7 @@ void BandpassReverbEffect::loadEngineEffectParameters(
     m_pSendParameter = parameters.value("send_amount");
     m_pBPFreqParameter = parameters.value("bp_freq");
     m_pBPQParameter = parameters.value("bp_q");
+    
 }
 
 
@@ -107,7 +110,8 @@ void BandpassReverbEffect::processChannel(
         CSAMPLE* pOutput,
         const mixxx::EngineParameters& engineParameters,
         const EffectEnableState enableState,
-        const GroupFeatureState& groupFeatures) {
+        const GroupFeatureState& groupFeatures){
+    
             
     
     Q_UNUSED(groupFeatures);
@@ -120,7 +124,6 @@ void BandpassReverbEffect::processChannel(
     if (pState->sampleRate != engineParameters.sampleRate()) {
         pState->reverb.setSamplerate(engineParameters.sampleRate());
         pState->sampleRate = engineParameters.sampleRate();
-        pState->bandPass.init(engineParameters.sampleRate());
     }
 
 
@@ -128,20 +131,37 @@ void BandpassReverbEffect::processChannel(
         pState->reverb.activate();
     }
 
-    // --- Bandpass parameters ---
+ 
     sample_t freq = static_cast<sample_t>(m_pBPFreqParameter->value());
     sample_t q = static_cast<sample_t>(m_pBPQParameter->value());
-    pState->bandPass.setParameters(freq, q);
 
-    // --- Temporary buffer for filtered signal ---
-    std::vector<CSAMPLE> filteredBuffer(engineParameters.samplesPerBuffer());
+    sample_t bandwidthHz = freq / q;
 
-    // --- Apply bandpass to input ---
-    for (int i = 0; i < engineParameters.samplesPerBuffer(); ++i) {
-        filteredBuffer[i] = pState->bandPass.process(pInput[i]);
+    sample_t lowFreq = freq - bandwidthHz * 0.5;
+    sample_t highFreq = freq + bandwidthHz * 0.5;
+
+    if (lowFreq < 20.0) {
+        lowFreq = 20.0;
     }
 
-    // --- Send filtered signal into reverb ---
+    if (highFreq > engineParameters.sampleRate() / 2.0 - 100.0) {
+        highFreq = engineParameters.sampleRate() / 2.0 - 100.0;
+    }
+
+    pState->butterworthBP.setFrequencyCorners(
+            engineParameters.sampleRate(),
+            lowFreq,
+            highFreq);
+
+
+    std::vector<CSAMPLE> filteredBuffer(engineParameters.samplesPerBuffer());
+
+
+pState->butterworthBP.process(
+        pInput,
+        filteredBuffer.data(),
+        engineParameters.samplesPerBuffer());
+
     pState->reverb.processBuffer(
             filteredBuffer.data(),
             pOutput,
@@ -152,9 +172,7 @@ void BandpassReverbEffect::processChannel(
             sendCurrent,
             pState->sendPrevious);
 
-    // The ramping of the send parameter handles ramping when enabling, so
-    // this effect must handle ramping to dry when disabling itself (instead
-    // of being handled by EngineEffect::process).
+
     if (enableState == EffectEnableState::Disabling) {
         SampleUtil::applyRampingGain(pOutput, 1.0, 0.0, engineParameters.samplesPerBuffer());
         pState->sendPrevious = 0;

--- a/src/effects/backends/builtin/bandpassreverbeffect.cpp
+++ b/src/effects/backends/builtin/bandpassreverbeffect.cpp
@@ -5,15 +5,9 @@
 #include "engine/effects/engineeffectparameter.h"
 #include "util/sample.h"
 #include <QDebug>
+#include <vector>
 
-// ================================
-// Reverb Band-Pass Experiment
-// Author: Tanu
-// Goal: Understand where and how a band-pass filter
-// can be integrated into the reverb signal path.
-// ================================
 
-// static
 QString BandpassReverbEffect::getId() {
     return "org.mixxx.effects.bandpassreverb";
 }
@@ -21,7 +15,7 @@ QString BandpassReverbEffect::getId() {
 // static
 EffectManifestPointer BandpassReverbEffect::getManifest() {
     EffectManifestPointer pManifest(new EffectManifest());
-    pManifest->setAddDryToWet(true);
+    pManifest->setAddDryToWet(false);
     pManifest->setEffectRampsFromDry(true);
 
     pManifest->setId(getId());
@@ -91,7 +85,7 @@ EffectManifestPointer BandpassReverbEffect::getManifest() {
     bpQ->setDescription(QObject::tr("Q factor of band-pass filter"));
     bpQ->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
     bpQ->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
-    bpQ->setRange(0.1, 0.707, 5);
+    bpQ->setRange(0.1, 0.707, 10);
 
     return pManifest;
 }
@@ -126,15 +120,30 @@ void BandpassReverbEffect::processChannel(
     if (pState->sampleRate != engineParameters.sampleRate()) {
         pState->reverb.setSamplerate(engineParameters.sampleRate());
         pState->sampleRate = engineParameters.sampleRate();
+        pState->bandPass.init(engineParameters.sampleRate());
     }
 
-    // Reinitialize the effect when turning it on to prevent replaying the old buffer
-    // from the last time the effect was enabled..
+
     if (enableState == EffectEnableState::Enabling) {
         pState->reverb.activate();
     }
 
-    pState->reverb.processBuffer(pInput,
+    // --- Bandpass parameters ---
+    sample_t freq = static_cast<sample_t>(m_pBPFreqParameter->value());
+    sample_t q = static_cast<sample_t>(m_pBPQParameter->value());
+    pState->bandPass.setParameters(freq, q);
+
+    // --- Temporary buffer for filtered signal ---
+    std::vector<CSAMPLE> filteredBuffer(engineParameters.samplesPerBuffer());
+
+    // --- Apply bandpass to input ---
+    for (int i = 0; i < engineParameters.samplesPerBuffer(); ++i) {
+        filteredBuffer[i] = pState->bandPass.process(pInput[i]);
+    }
+
+    // --- Send filtered signal into reverb ---
+    pState->reverb.processBuffer(
+            filteredBuffer.data(),
             pOutput,
             engineParameters.samplesPerBuffer(),
             bandwidth,
@@ -142,16 +151,6 @@ void BandpassReverbEffect::processChannel(
             damping,
             sendCurrent,
             pState->sendPrevious);
-
-    sample_t freq = static_cast<sample_t>(m_pBPFreqParameter->value());
-    sample_t q = static_cast<sample_t>(m_pBPQParameter->value());
-
-    pState->bandPass.setParameters(freq, q);
-    qDebug() << "BP Filter freq:" << freq << " Q:" << q;
-
-    for (int i = 0; i < engineParameters.samplesPerBuffer(); ++i) {
-        pOutput[i] = pState->bandPass.process(pOutput[i]);
-    }
 
     // The ramping of the send parameter handles ramping when enabling, so
     // this effect must handle ramping to dry when disabling itself (instead

--- a/src/effects/backends/builtin/bandpassreverbeffect.cpp
+++ b/src/effects/backends/builtin/bandpassreverbeffect.cpp
@@ -1,4 +1,3 @@
-
 #include "effects/backends/builtin/bandpassreverbeffect.h"
 
 #include "effects/backends/effectmanifest.h"
@@ -7,8 +6,6 @@
 #include <QDebug>
 #include <vector>
 
-
-
 QString BandpassReverbEffect::getId() {
     return "org.mixxx.effects.bandpassreverb";
 }
@@ -16,7 +13,7 @@ QString BandpassReverbEffect::getId() {
 // static
 EffectManifestPointer BandpassReverbEffect::getManifest() {
     EffectManifestPointer pManifest(new EffectManifest());
-    pManifest->setAddDryToWet(false);
+    pManifest->setAddDryToWet(true);
     pManifest->setEffectRampsFromDry(true);
 
     pManifest->setId(getId());
@@ -70,25 +67,54 @@ EffectManifestPointer BandpassReverbEffect::getManifest() {
     send->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::NotInverted);
     send->setRange(0, 0, 1);
 
-    EffectManifestParameterPointer bpFreq = pManifest->addParameter();
-    bpFreq->setId("bp_freq");
-    bpFreq->setName(QObject::tr("BP Frequency"));
-    bpFreq->setShortName(QObject::tr("BPFreq"));
-    bpFreq->setDescription(QObject::tr("Center frequency of band-pass filter"));
-    bpFreq->setValueScaler(EffectManifestParameter::ValueScaler::Logarithmic);
-    bpFreq->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
-    bpFreq->setRange(200, 1000, 5000);
+    EffectManifestParameterPointer hpCutoff = pManifest->addParameter();
+    hpCutoff->setId("hp_cutoff");
+    hpCutoff->setName(QObject::tr("HP Cutoff"));
+    hpCutoff->setShortName(QObject::tr("HP"));
+    hpCutoff->setDescription(
+            QObject::tr("High-pass cutoff frequency"));
+    hpCutoff->setValueScaler(
+            EffectManifestParameter::ValueScaler::Logarithmic);
+    hpCutoff->setUnitsHint(
+            EffectManifestParameter::UnitsHint::Unknown);
+    hpCutoff->setRange(20, 200, 18000);
 
-    EffectManifestParameterPointer bpQ = pManifest->addParameter();
-    bpQ->setId("bp_q");
-    bpQ->setName(QObject::tr("Bandwidth"));
-    bpQ->setShortName(QObject::tr("Width"));
-    bpQ->setDescription(QObject::tr("Controls width of the band-pass filter"));
-    bpQ->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
-    bpQ->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
-    bpQ->setRange(0.1, 0.707, 10);
+    EffectManifestParameterPointer lpCutoff = pManifest->addParameter();
+    lpCutoff->setId("lp_cutoff");
+    lpCutoff->setName(QObject::tr("LP Cutoff"));
+    lpCutoff->setShortName(QObject::tr("LP"));
+    lpCutoff->setDescription(
+            QObject::tr("Low-pass cutoff frequency"));
+    lpCutoff->setValueScaler(
+            EffectManifestParameter::ValueScaler::Logarithmic);
+    lpCutoff->setUnitsHint(
+            EffectManifestParameter::UnitsHint::Unknown);
+    lpCutoff->setRange(20, 5000, 20000);
 
-    
+    EffectManifestParameterPointer postFilter = pManifest->addParameter();
+    postFilter->setId("post_filter");
+    postFilter->setName(QObject::tr("Post Filter"));
+    postFilter->setShortName(QObject::tr("Post Filter"));
+    postFilter->setDescription(
+            QObject::tr("Apply band-pass filter after the reverb"));
+    postFilter->setValueScaler(
+            EffectManifestParameter::ValueScaler::Toggle);
+    postFilter->setUnitsHint(
+            EffectManifestParameter::UnitsHint::Unknown);
+    postFilter->setRange(0, 0, 1);
+
+    EffectManifestParameterPointer filterOrder = pManifest->addParameter();
+    filterOrder->setId("filter_order");
+    filterOrder->setName(QObject::tr("Filter Order"));
+    filterOrder->setShortName(QObject::tr("Order"));
+    filterOrder->setDescription(QObject::tr(
+        "Selects Butterworth filter steepness (2/4/6/8)."));
+    filterOrder->setValueScaler(EffectManifestParameter::ValueScaler::Integral);
+    //filterOrder->appendStep(qMakePair(QObject::tr("2"), 2));
+    //filterOrder->appendStep(qMakePair(QObject::tr("4"), 4));
+    //filterOrder->appendStep(qMakePair(QObject::tr("6"), 6));
+    //filterOrder->appendStep(qMakePair(QObject::tr("8"), 8));
+    filterOrder->setRange(1, 4, 4);
 
     return pManifest;
 }
@@ -99,11 +125,12 @@ void BandpassReverbEffect::loadEngineEffectParameters(
     m_pBandWidthParameter = parameters.value("bandwidth");
     m_pDampingParameter = parameters.value("damping");
     m_pSendParameter = parameters.value("send_amount");
-    m_pBPFreqParameter = parameters.value("bp_freq");
-    m_pBPQParameter = parameters.value("bp_q");
-   
+    m_pHPCutoffParameter = parameters.value("hp_cutoff");
+    m_pLPCutoffParameter = parameters.value("lp_cutoff");
+    m_pPostFilterParameter = parameters.value("post_filter");
+    m_pFilterOrderParameter = parameters.value("filter_order");
+    
 }
-
 
 void BandpassReverbEffect::processChannel(
         BandpassReverbGroupState* pState,
@@ -112,59 +139,98 @@ void BandpassReverbEffect::processChannel(
         const mixxx::EngineParameters& engineParameters,
         const EffectEnableState enableState,
         const GroupFeatureState& groupFeatures){
-    
-            
-    
+  
     Q_UNUSED(groupFeatures);
 
     const auto decay = static_cast<sample_t>(m_pDecayParameter->value());
     const auto bandwidth = static_cast<sample_t>(m_pBandWidthParameter->value());
     const auto damping = static_cast<sample_t>(m_pDampingParameter->value());
     const auto sendCurrent = static_cast<sample_t>(m_pSendParameter->value());
+    const bool postFilter = m_pPostFilterParameter->toBool();
+    const int filterOrder = static_cast<int>(m_pFilterOrderParameter->value());
 
     if (pState->sampleRate != engineParameters.sampleRate()) {
         pState->reverb.setSamplerate(engineParameters.sampleRate());
         pState->sampleRate = engineParameters.sampleRate();
     }
 
-
     if (enableState == EffectEnableState::Enabling) {
         pState->reverb.activate();
     }
 
- 
-    sample_t freq = static_cast<sample_t>(m_pBPFreqParameter->value());
-    sample_t q = static_cast<sample_t>(m_pBPQParameter->value());
+    const sample_t nyquist = static_cast<sample_t>(engineParameters.sampleRate() * 0.5);
 
-    sample_t bandwidthHz = freq / q;
+    sample_t lowFreq = static_cast<sample_t>(m_pHPCutoffParameter->value());
 
-    sample_t lowFreq = freq - bandwidthHz * 0.5;
-    sample_t highFreq = freq + bandwidthHz * 0.5;
+    sample_t highFreq = static_cast<sample_t>(m_pLPCutoffParameter->value());
 
-    if (lowFreq < 20.0) {
-        lowFreq = 20.0;
+    lowFreq = std::clamp(lowFreq, static_cast<sample_t>(20.0), nyquist - static_cast<sample_t>(100.0));
+
+    highFreq = std::clamp(highFreq, static_cast<sample_t>(20.0), nyquist - static_cast<sample_t>(100.0));
+
+    if (highFreq <= lowFreq) { highFreq = std::min(lowFreq + static_cast<sample_t>(50.0), nyquist - static_cast<sample_t>(1.0));
     }
 
-    if (highFreq > engineParameters.sampleRate() / 2.0 - 100.0) {
-        highFreq = engineParameters.sampleRate() / 2.0 - 100.0;
+    switch (filterOrder) {
+        case 1:
+        pState->butter2.setFrequencyCorners(
+                engineParameters.sampleRate(),
+                lowFreq,
+                highFreq);
+        break;
+        case 2:
+        pState->butter4.setFrequencyCorners(
+                engineParameters.sampleRate(),
+                lowFreq,
+                highFreq);
+        break;
+        case 3:
+        pState->butter6.setFrequencyCorners(
+                engineParameters.sampleRate(),
+                lowFreq,
+                highFreq);
+        break;
+        default:
+        pState->butter8.setFrequencyCorners(
+                engineParameters.sampleRate(),
+                lowFreq,
+                highFreq);
+        break;
+        }
+
+auto processFilter = [&](const CSAMPLE* in, CSAMPLE* out) {
+    switch (filterOrder) {
+    case 1:
+        pState->butter2.process(
+                in, out,
+                engineParameters.samplesPerBuffer());
+        break;
+    case 2:
+        pState->butter4.process(
+                in, out,
+                engineParameters.samplesPerBuffer());
+        break;
+    case 3:
+        pState->butter6.process(
+                in, out,
+                engineParameters.samplesPerBuffer());
+        break;
+    default:
+        pState->butter8.process(
+                in, out,
+                engineParameters.samplesPerBuffer());
+        break;
     }
+};
 
-    pState->butterworthBP.setFrequencyCorners(
-            engineParameters.sampleRate(),
-            lowFreq,
-            highFreq);
+if (!postFilter) {
+    // PRE FILTER
+    std::vector<CSAMPLE> filteredBuffer(
+            engineParameters.samplesPerBuffer());
 
-
- std::vector<CSAMPLE> filteredBuffer(engineParameters.samplesPerBuffer());
-
-
-
-
-pState->butterworthBP.process(
+    processFilter(
         pInput,
-        filteredBuffer.data(),
-        engineParameters.samplesPerBuffer());
-
+        filteredBuffer.data());
 
     pState->reverb.processBuffer(
             filteredBuffer.data(),
@@ -176,10 +242,34 @@ pState->butterworthBP.process(
             sendCurrent,
             pState->sendPrevious);
 
+} else {
+    // POST FILTER
+    std::vector<CSAMPLE> reverbBuffer(
+            engineParameters.samplesPerBuffer());
+
+    pState->reverb.processBuffer(
+            pInput,
+            reverbBuffer.data(),
+            engineParameters.samplesPerBuffer(),
+            bandwidth,
+            decay,
+            damping,
+            sendCurrent,
+            pState->sendPrevious);
+
+    processFilter(
+    reverbBuffer.data(),
+    pOutput);
+}
 
     if (enableState == EffectEnableState::Disabling) {
-        SampleUtil::applyRampingGain(pOutput, 1.0, 0.0, engineParameters.samplesPerBuffer());
-        pState->sendPrevious = 0;
+        SampleUtil::applyRampingGain(
+            pOutput,
+            static_cast<sample_t>(1.0),
+            static_cast<sample_t>(0.0),
+            engineParameters.samplesPerBuffer()
+        );
+        pState->sendPrevious = static_cast<sample_t>(0.0);
     } else {
         pState->sendPrevious = sendCurrent;
     }

--- a/src/effects/backends/builtin/bandpassreverbeffect.cpp
+++ b/src/effects/backends/builtin/bandpassreverbeffect.cpp
@@ -88,14 +88,7 @@ EffectManifestPointer BandpassReverbEffect::getManifest() {
     bpQ->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
     bpQ->setRange(0.1, 0.707, 10);
 
-    EffectManifestParameterPointer order = pManifest->addParameter();
-    order->setId("filter_order");
-    order->setName(QObject::tr("Filter Order"));
-    order->setShortName(QObject::tr("Order"));
-    order->setDescription(QObject::tr("Controls steepness of band-pass filter"));
-    order->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
-    order->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
-    order->setRange(1, 1, 4);
+    
 
     return pManifest;
 }
@@ -108,7 +101,7 @@ void BandpassReverbEffect::loadEngineEffectParameters(
     m_pSendParameter = parameters.value("send_amount");
     m_pBPFreqParameter = parameters.value("bp_freq");
     m_pBPQParameter = parameters.value("bp_q");
-    m_pOrderParameter = parameters.value("filter_order");
+   
 }
 
 
@@ -163,27 +156,14 @@ void BandpassReverbEffect::processChannel(
 
 
  std::vector<CSAMPLE> filteredBuffer(engineParameters.samplesPerBuffer());
-std::vector<CSAMPLE> tempBuffer(engineParameters.samplesPerBuffer());
 
-const int order = static_cast<int>(m_pOrderParameter->value());
+
+
 
 pState->butterworthBP.process(
         pInput,
         filteredBuffer.data(),
         engineParameters.samplesPerBuffer());
-
-for (int stage = 1; stage < order; ++stage) {
-
-    pState->butterworthBP.process(
-            filteredBuffer.data(),
-            tempBuffer.data(),
-            engineParameters.samplesPerBuffer());
-
-    filteredBuffer.swap(tempBuffer);
-}
-
-
-
 
 
     pState->reverb.processBuffer(

--- a/src/effects/backends/builtin/bandpassreverbeffect.cpp
+++ b/src/effects/backends/builtin/bandpassreverbeffect.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 
+
 QString BandpassReverbEffect::getId() {
     return "org.mixxx.effects.bandpassreverb";
 }
@@ -16,7 +17,7 @@ QString BandpassReverbEffect::getId() {
 EffectManifestPointer BandpassReverbEffect::getManifest() {
     EffectManifestPointer pManifest(new EffectManifest());
     pManifest->setAddDryToWet(false);
-    pManifest->setEffectRampsFromDry(false);
+    pManifest->setEffectRampsFromDry(true);
 
     pManifest->setId(getId());
     pManifest->setName(QObject::tr("Bandpass Reverb"));
@@ -87,7 +88,14 @@ EffectManifestPointer BandpassReverbEffect::getManifest() {
     bpQ->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
     bpQ->setRange(0.1, 0.707, 10);
 
-    
+    EffectManifestParameterPointer order = pManifest->addParameter();
+    order->setId("filter_order");
+    order->setName(QObject::tr("Filter Order"));
+    order->setShortName(QObject::tr("Order"));
+    order->setDescription(QObject::tr("Controls steepness of band-pass filter"));
+    order->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    order->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    order->setRange(1, 1, 4);
 
     return pManifest;
 }
@@ -100,7 +108,7 @@ void BandpassReverbEffect::loadEngineEffectParameters(
     m_pSendParameter = parameters.value("send_amount");
     m_pBPFreqParameter = parameters.value("bp_freq");
     m_pBPQParameter = parameters.value("bp_q");
-    
+    m_pOrderParameter = parameters.value("filter_order");
 }
 
 
@@ -154,13 +162,29 @@ void BandpassReverbEffect::processChannel(
             highFreq);
 
 
-    std::vector<CSAMPLE> filteredBuffer(engineParameters.samplesPerBuffer());
+ std::vector<CSAMPLE> filteredBuffer(engineParameters.samplesPerBuffer());
+std::vector<CSAMPLE> tempBuffer(engineParameters.samplesPerBuffer());
 
+const int order = static_cast<int>(m_pOrderParameter->value());
 
 pState->butterworthBP.process(
         pInput,
         filteredBuffer.data(),
         engineParameters.samplesPerBuffer());
+
+for (int stage = 1; stage < order; ++stage) {
+
+    pState->butterworthBP.process(
+            filteredBuffer.data(),
+            tempBuffer.data(),
+            engineParameters.samplesPerBuffer());
+
+    filteredBuffer.swap(tempBuffer);
+}
+
+
+
+
 
     pState->reverb.processBuffer(
             filteredBuffer.data(),

--- a/src/effects/backends/builtin/bandpassreverbeffect.h
+++ b/src/effects/backends/builtin/bandpassreverbeffect.h
@@ -10,27 +10,29 @@
 #include "effects/backends/effectprocessor.h"
 #include "util/class.h"
 #include "util/types.h"
+#include "engine/filters/simplebandpass.h"
 
-class ReverbGroupState : public EffectState {
+class BandpassReverbGroupState : public EffectState {
   public:
-    ReverbGroupState(const mixxx::EngineParameters& engineParameters)
+    BandpassReverbGroupState(const mixxx::EngineParameters& engineParameters)
             : EffectState(engineParameters),
               sampleRate(engineParameters.sampleRate()),
               sendPrevious(0) {
         reverb.init(sampleRate);
     }
     
-    ~ReverbGroupState() override = default;
+    ~BandpassReverbGroupState() override = default;
 
     float sampleRate;
     float sendPrevious;
     MixxxPlateX2 reverb;
+    SimpleBandPass bandPass;
 };
 
-class ReverbEffect : public EffectProcessorImpl<ReverbGroupState> {
+class BandpassReverbEffect : public EffectProcessorImpl<BandpassReverbGroupState> {
   public:
-    ReverbEffect() = default;
-    ~ReverbEffect() override = default;
+    BandpassReverbEffect() = default;
+    ~BandpassReverbEffect() override = default;
 
     static QString getId();
     static EffectManifestPointer getManifest();
@@ -39,7 +41,7 @@ class ReverbEffect : public EffectProcessorImpl<ReverbGroupState> {
             const QMap<QString, EngineEffectParameterPointer>& parameters) override;
 
     void processChannel(
-            ReverbGroupState* pState,
+            BandpassReverbGroupState* pState,
             const CSAMPLE* pInput,
             CSAMPLE* pOutput,
             const mixxx::EngineParameters& engineParameters,
@@ -55,7 +57,8 @@ class ReverbEffect : public EffectProcessorImpl<ReverbGroupState> {
     EngineEffectParameterPointer m_pBandWidthParameter;
     EngineEffectParameterPointer m_pDampingParameter;
     EngineEffectParameterPointer m_pSendParameter;
-  
+    EngineEffectParameterPointer m_pBPFreqParameter;
+    EngineEffectParameterPointer m_pBPQParameter;
 
-    DISALLOW_COPY_AND_ASSIGN(ReverbEffect);
+    DISALLOW_COPY_AND_ASSIGN(BandpassReverbEffect);
 };

--- a/src/effects/backends/builtin/bandpassreverbeffect.h
+++ b/src/effects/backends/builtin/bandpassreverbeffect.h
@@ -63,7 +63,7 @@ class BandpassReverbEffect : public EffectProcessorImpl<BandpassReverbGroupState
     EngineEffectParameterPointer m_pSendParameter;
     EngineEffectParameterPointer m_pBPFreqParameter;
     EngineEffectParameterPointer m_pBPQParameter;
-    EngineEffectParameterPointer m_pOrderParameter;
+    
   
 
 

--- a/src/effects/backends/builtin/bandpassreverbeffect.h
+++ b/src/effects/backends/builtin/bandpassreverbeffect.h
@@ -64,7 +64,6 @@ class BandpassReverbEffect : public EffectProcessorImpl<BandpassReverbGroupState
     }
 
     EngineEffectParameterPointer m_pDecayParameter;
-    EngineEffectParameterPointer m_pBandWidthParameter;
     EngineEffectParameterPointer m_pDampingParameter;
     EngineEffectParameterPointer m_pSendParameter;
     EngineEffectParameterPointer m_pHPCutoffParameter;

--- a/src/effects/backends/builtin/bandpassreverbeffect.h
+++ b/src/effects/backends/builtin/bandpassreverbeffect.h
@@ -10,14 +10,17 @@
 #include "effects/backends/effectprocessor.h"
 #include "util/class.h"
 #include "util/types.h"
-#include "engine/filters/simplebandpass.h"
+#include "engine/filters/enginefilterbutterworth4.h"
+
+
 
 class BandpassReverbGroupState : public EffectState {
   public:
     BandpassReverbGroupState(const mixxx::EngineParameters& engineParameters)
             : EffectState(engineParameters),
               sampleRate(engineParameters.sampleRate()),
-              sendPrevious(0) {
+              sendPrevious(0),
+               butterworthBP(engineParameters.sampleRate(), 200.0, 2000.0) {
         reverb.init(sampleRate);
     }
     
@@ -26,7 +29,8 @@ class BandpassReverbGroupState : public EffectState {
     float sampleRate;
     float sendPrevious;
     MixxxPlateX2 reverb;
-    SimpleBandPass bandPass;
+
+    EngineFilterButterworth4Band butterworthBP;
 };
 
 class BandpassReverbEffect : public EffectProcessorImpl<BandpassReverbGroupState> {
@@ -59,6 +63,8 @@ class BandpassReverbEffect : public EffectProcessorImpl<BandpassReverbGroupState
     EngineEffectParameterPointer m_pSendParameter;
     EngineEffectParameterPointer m_pBPFreqParameter;
     EngineEffectParameterPointer m_pBPQParameter;
+  
+
 
     DISALLOW_COPY_AND_ASSIGN(BandpassReverbEffect);
 };

--- a/src/effects/backends/builtin/bandpassreverbeffect.h
+++ b/src/effects/backends/builtin/bandpassreverbeffect.h
@@ -63,6 +63,7 @@ class BandpassReverbEffect : public EffectProcessorImpl<BandpassReverbGroupState
     EngineEffectParameterPointer m_pSendParameter;
     EngineEffectParameterPointer m_pBPFreqParameter;
     EngineEffectParameterPointer m_pBPQParameter;
+    EngineEffectParameterPointer m_pOrderParameter;
   
 
 

--- a/src/effects/backends/builtin/bandpassreverbeffect.h
+++ b/src/effects/backends/builtin/bandpassreverbeffect.h
@@ -10,9 +10,10 @@
 #include "effects/backends/effectprocessor.h"
 #include "util/class.h"
 #include "util/types.h"
+#include "engine/filters/enginefilterbutterworth2.h"
 #include "engine/filters/enginefilterbutterworth4.h"
-
-
+#include "engine/filters/enginefilterbutterworth6.h"
+#include "engine/filters/enginefilterbutterworth8.h"
 
 class BandpassReverbGroupState : public EffectState {
   public:
@@ -20,7 +21,10 @@ class BandpassReverbGroupState : public EffectState {
             : EffectState(engineParameters),
               sampleRate(engineParameters.sampleRate()),
               sendPrevious(0),
-               butterworthBP(engineParameters.sampleRate(), 200.0, 2000.0) {
+               butter2(engineParameters.sampleRate(), 200.0, 2000.0),
+                butter4(engineParameters.sampleRate(), 200.0, 2000.0),
+                butter6(engineParameters.sampleRate(), 200.0, 2000.0),
+                butter8(engineParameters.sampleRate(), 200.0, 2000.0) {
         reverb.init(sampleRate);
     }
     
@@ -30,9 +34,11 @@ class BandpassReverbGroupState : public EffectState {
     float sendPrevious;
     MixxxPlateX2 reverb;
 
-    EngineFilterButterworth4Band butterworthBP;
+    EngineFilterButterworth2Band butter2;
+    EngineFilterButterworth4Band butter4;
+    EngineFilterButterworth6Band butter6;
+    EngineFilterButterworth8Band butter8;
 };
-
 class BandpassReverbEffect : public EffectProcessorImpl<BandpassReverbGroupState> {
   public:
     BandpassReverbEffect() = default;
@@ -61,11 +67,10 @@ class BandpassReverbEffect : public EffectProcessorImpl<BandpassReverbGroupState
     EngineEffectParameterPointer m_pBandWidthParameter;
     EngineEffectParameterPointer m_pDampingParameter;
     EngineEffectParameterPointer m_pSendParameter;
-    EngineEffectParameterPointer m_pBPFreqParameter;
-    EngineEffectParameterPointer m_pBPQParameter;
+    EngineEffectParameterPointer m_pHPCutoffParameter;
+    EngineEffectParameterPointer m_pLPCutoffParameter;
+    EngineEffectParameterPointer m_pPostFilterParameter;
+    EngineEffectParameterPointer m_pFilterOrderParameter;
     
-  
-
-
     DISALLOW_COPY_AND_ASSIGN(BandpassReverbEffect);
 };

--- a/src/effects/backends/builtin/builtinbackend.cpp
+++ b/src/effects/backends/builtin/builtinbackend.cpp
@@ -32,6 +32,7 @@
 #include "effects/backends/builtin/gaineffect.h"
 #include "effects/backends/builtin/tremoloeffect.h"
 #include "effects/backends/builtin/whitenoiseeffect.h"
+#include "effects/backends/builtin/bandpassreverbeffect.h"
 
 BuiltInBackend::BuiltInBackend() {
     // Keep this list in a reasonable order
@@ -57,6 +58,7 @@ BuiltInBackend::BuiltInBackend() {
     registerEffect<AutoPanEffect>();
 #ifndef __MACAPPSTORE__
     registerEffect<ReverbEffect>();
+    registerEffect<BandpassReverbEffect>();
 #endif
     registerEffect<PhaserEffect>();
     registerEffect<MetronomeEffect>();

--- a/src/effects/backends/builtin/reverbeffect.cpp
+++ b/src/effects/backends/builtin/reverbeffect.cpp
@@ -1,8 +1,17 @@
+// EXPERIMENT: learning Mixxx reverb code flow
 #include "effects/backends/builtin/reverbeffect.h"
 
 #include "effects/backends/effectmanifest.h"
 #include "engine/effects/engineeffectparameter.h"
 #include "util/sample.h"
+#include <QDebug>
+
+// ================================
+// Reverb Band-Pass Experiment
+// Author: Tanu
+// Goal: Understand where and how a band-pass filter
+// can be integrated into the reverb signal path.
+// ================================
 
 // static
 QString ReverbEffect::getId() {
@@ -66,6 +75,24 @@ EffectManifestPointer ReverbEffect::getManifest() {
     send->setDefaultLinkInversion(EffectManifestParameter::LinkInversion::NotInverted);
     send->setRange(0, 0, 1);
 
+    EffectManifestParameterPointer bpFreq = pManifest->addParameter();
+    bpFreq->setId("bp_freq");
+    bpFreq->setName(QObject::tr("BP Frequency"));
+    bpFreq->setShortName(QObject::tr("BPFreq"));
+    bpFreq->setDescription(QObject::tr("Center frequency of band-pass filter"));
+    bpFreq->setValueScaler(EffectManifestParameter::ValueScaler::Logarithmic);
+    bpFreq->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    bpFreq->setRange(200, 1000, 5000);
+
+    EffectManifestParameterPointer bpQ = pManifest->addParameter();
+    bpQ->setId("bp_q");
+    bpQ->setName(QObject::tr("BP Q"));
+    bpQ->setShortName(QObject::tr("BPQ"));
+    bpQ->setDescription(QObject::tr("Q factor of band-pass filter"));
+    bpQ->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    bpQ->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    bpQ->setRange(0.1, 0.707, 5);
+
     return pManifest;
 }
 
@@ -75,7 +102,10 @@ void ReverbEffect::loadEngineEffectParameters(
     m_pBandWidthParameter = parameters.value("bandwidth");
     m_pDampingParameter = parameters.value("damping");
     m_pSendParameter = parameters.value("send_amount");
+    m_pBPFreqParameter = parameters.value("bp_freq");
+    m_pBPQParameter = parameters.value("bp_q");
 }
+
 
 void ReverbEffect::processChannel(
         ReverbGroupState* pState,
@@ -84,6 +114,9 @@ void ReverbEffect::processChannel(
         const mixxx::EngineParameters& engineParameters,
         const EffectEnableState enableState,
         const GroupFeatureState& groupFeatures) {
+            
+    printf("REVERB PROCESS RUNNING\n");
+    qDebug() << "REVERB CODE IS RUNNING";
     Q_UNUSED(groupFeatures);
 
     const auto decay = static_cast<sample_t>(m_pDecayParameter->value());
@@ -110,6 +143,16 @@ void ReverbEffect::processChannel(
             damping,
             sendCurrent,
             pState->sendPrevious);
+
+    sample_t freq = static_cast<sample_t>(m_pBPFreqParameter->value());
+    sample_t q = static_cast<sample_t>(m_pBPQParameter->value());
+
+    pState->bandPass.setParameters(freq, q);
+    qDebug() << "BP Filter freq:" << freq << " Q:" << q;
+
+    for (int i = 0; i < engineParameters.samplesPerBuffer(); ++i) {
+    pOutput[i] = pState->bandPass.process(pOutput[i]);
+    }
 
     // The ramping of the send parameter handles ramping when enabling, so
     // this effect must handle ramping to dry when disabling itself (instead

--- a/src/effects/backends/builtin/reverbeffect.cpp
+++ b/src/effects/backends/builtin/reverbeffect.cpp
@@ -6,12 +6,6 @@
 #include "util/sample.h"
 #include <QDebug>
 
-// ================================
-// Reverb Band-Pass Experiment
-// Author: Tanu
-// Goal: Understand where and how a band-pass filter
-// can be integrated into the reverb signal path.
-// ================================
 
 // static
 QString ReverbEffect::getId() {

--- a/src/effects/backends/builtin/reverbeffect.h
+++ b/src/effects/backends/builtin/reverbeffect.h
@@ -10,6 +10,7 @@
 #include "effects/backends/effectprocessor.h"
 #include "util/class.h"
 #include "util/types.h"
+#include "engine/filters/simplebandpass.h"
 
 class ReverbGroupState : public EffectState {
   public:
@@ -19,11 +20,13 @@ class ReverbGroupState : public EffectState {
               sendPrevious(0) {
         reverb.init(sampleRate);
     }
+    
     ~ReverbGroupState() override = default;
 
     float sampleRate;
     float sendPrevious;
     MixxxPlateX2 reverb;
+    SimpleBandPass bandPass;
 };
 
 class ReverbEffect : public EffectProcessorImpl<ReverbGroupState> {
@@ -54,6 +57,8 @@ class ReverbEffect : public EffectProcessorImpl<ReverbGroupState> {
     EngineEffectParameterPointer m_pBandWidthParameter;
     EngineEffectParameterPointer m_pDampingParameter;
     EngineEffectParameterPointer m_pSendParameter;
+    EngineEffectParameterPointer m_pBPFreqParameter;
+    EngineEffectParameterPointer m_pBPQParameter;
 
     DISALLOW_COPY_AND_ASSIGN(ReverbEffect);
 };

--- a/src/engine/filters/enginefilterbutterworth2.cpp
+++ b/src/engine/filters/enginefilterbutterworth2.cpp
@@ -1,0 +1,53 @@
+#include "engine/filters/enginefilterbutterworth2.h"
+
+#include "moc_enginefilterbutterworth2.cpp"
+
+namespace {
+constexpr char kFidSpecLowPassButterworth2[] = "LpBu2";
+constexpr char kFidSpecBandPassButterworth2[] = "BpBu2";
+constexpr char kFidSpecHighPassButterworth2[] = "HpBu2";
+} // namespace
+
+EngineFilterButterworth2Low::EngineFilterButterworth2Low(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
+    setFrequencyCorners(sampleRate, freqCorner1);
+}
+
+void EngineFilterButterworth2Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
+    // Copy the old coefficients into m_oldCoef
+    setCoefs(kFidSpecLowPassButterworth2,
+            sizeof(kFidSpecLowPassButterworth2),
+            sampleRate,
+            freqCorner1);
+}
+
+EngineFilterButterworth2Band::EngineFilterButterworth2Band(
+        mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
+    setFrequencyCorners(sampleRate, freqCorner1, freqCorner2);
+}
+
+void EngineFilterButterworth2Band::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
+    setCoefs(kFidSpecBandPassButterworth2,
+            sizeof(kFidSpecBandPassButterworth2),
+            sampleRate,
+            freqCorner1,
+            freqCorner2);
+}
+
+EngineFilterButterworth2High::EngineFilterButterworth2High(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
+    setFrequencyCorners(sampleRate, freqCorner1);
+}
+
+void EngineFilterButterworth2High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
+    setCoefs(kFidSpecHighPassButterworth2,
+            sizeof(kFidSpecHighPassButterworth2),
+            sampleRate,
+            freqCorner1);
+}

--- a/src/engine/filters/enginefilterbutterworth2.h
+++ b/src/engine/filters/enginefilterbutterworth2.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "audio/types.h"
+#include "engine/filters/enginefilteriir.h"
+
+class EngineFilterButterworth2Low : public EngineFilterIIR<2, IIR_LP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth2Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+};
+
+class EngineFilterButterworth2Band : public EngineFilterIIR<4, IIR_BP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth2Band(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double freqCorner2);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double freqCorner2);
+};
+
+class EngineFilterButterworth2High : public EngineFilterIIR<2, IIR_HP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth2High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+};

--- a/src/engine/filters/enginefilterbutterworth6.cpp
+++ b/src/engine/filters/enginefilterbutterworth6.cpp
@@ -1,0 +1,53 @@
+#include "engine/filters/enginefilterbutterworth6.h"
+
+#include "moc_enginefilterbutterworth6.cpp"
+
+namespace {
+constexpr char kFidSpecLowPassButterworth6[] = "LpBu6";
+constexpr char kFidSpecBandPassButterworth6[] = "BpBu6";
+constexpr char kFidSpecHighPassButterworth6[] = "HpBu6";
+} // namespace
+
+EngineFilterButterworth6Low::EngineFilterButterworth6Low(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
+    setFrequencyCorners(sampleRate, freqCorner1);
+}
+
+void EngineFilterButterworth6Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
+    // Copy the old coefficients into m_oldCoef
+    setCoefs(kFidSpecLowPassButterworth6,
+            sizeof(kFidSpecLowPassButterworth6),
+            sampleRate,
+            freqCorner1);
+}
+
+EngineFilterButterworth6Band::EngineFilterButterworth6Band(
+        mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
+    setFrequencyCorners(sampleRate, freqCorner1, freqCorner2);
+}
+
+void EngineFilterButterworth6Band::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
+    setCoefs(kFidSpecBandPassButterworth6,
+            sizeof(kFidSpecBandPassButterworth6),
+            sampleRate,
+            freqCorner1,
+            freqCorner2);
+}
+
+EngineFilterButterworth6High::EngineFilterButterworth6High(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
+    setFrequencyCorners(sampleRate, freqCorner1);
+}
+
+void EngineFilterButterworth6High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
+    setCoefs(kFidSpecHighPassButterworth6,
+            sizeof(kFidSpecHighPassButterworth6),
+            sampleRate,
+            freqCorner1);
+}

--- a/src/engine/filters/enginefilterbutterworth6.h
+++ b/src/engine/filters/enginefilterbutterworth6.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "audio/types.h"
+#include "engine/filters/enginefilteriir.h"
+
+class EngineFilterButterworth6Low : public EngineFilterIIR<6, IIR_LP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth6Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+};
+
+class EngineFilterButterworth6Band : public EngineFilterIIR<12, IIR_BP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth6Band(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double freqCorner2);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double freqCorner2);
+};
+
+class EngineFilterButterworth6High : public EngineFilterIIR<6, IIR_HP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth6High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+};

--- a/src/engine/filters/enginefilteriir.h
+++ b/src/engine/filters/enginefilteriir.h
@@ -322,6 +322,7 @@ class EngineFilterIIR : public EngineFilterIIRBase {
     bool m_startFromDry;
 };
 
+// clang-format off
 template<>
 inline double EngineFilterIIR<2, IIR_LP>::processSample(double* coef,
                                                         double* buf,
@@ -347,6 +348,27 @@ inline double EngineFilterIIR<2, IIR_BP>::processSample(double* coef,
     iir -= coef[2] * buf[0];
     fir += iir;
     buf[1] = iir; val = fir;
+    return val;
+}
+
+template<>
+inline double EngineFilterIIR<4, IIR_BP>::processSample(double* coef,
+                                                        double* buf,
+                                                        double val) {
+    double tmp, fir, iir;
+    tmp = buf[0]; buf[0] = buf[1]; buf[1] = buf[2]; buf[2] = buf[3];
+    iir = val * coef[0];
+    iir -= coef[1] * tmp; fir = tmp;
+    iir -= coef[2] * buf[0]; fir += -buf[0] - buf[0];
+    fir += iir;
+    tmp = buf[1];
+    buf[1] = iir;
+    val = fir;
+    iir = val;
+    iir -= coef[3] * tmp; fir = tmp;
+    iir -= coef[4] * buf[2]; fir += buf[2] + buf[2];
+    fir += iir;
+    buf[3] = iir; val = fir;
     return val;
 }
 
@@ -429,6 +451,98 @@ inline double EngineFilterIIR<4, IIR_HP>::processSample(double* coef,
     iir -= coef[4] * buf[2]; fir += -buf[2] - buf[2];
     fir += iir;
     buf[3] = iir; val = fir;
+    return val;
+}
+
+template<>
+inline double EngineFilterIIR<6, IIR_LP>::processSample(double* coef,
+                                                        double* buf,
+                                                        double val) {
+    double tmp, fir, iir;
+    tmp = buf[0]; buf[0] = buf[1]; buf[1] = buf[2]; buf[2] = buf[3];
+    buf[3] = buf[4]; buf[4] = buf[5];
+    iir = val * coef[0];
+    iir -= coef[1] * tmp; fir = tmp;
+    iir -= coef[2] * buf[0]; fir += buf[0] + buf[0];
+    fir += iir;
+    tmp = buf[1]; buf[1] = iir; val = fir;
+    iir = val;
+    iir -= coef[3] * tmp; fir = tmp;
+    iir -= coef[4] * buf[2]; fir += buf[2] + buf[2];
+    fir += iir;
+    tmp = buf[3]; buf[3] = iir; val = fir;
+    iir = val;
+    iir -= coef[5] * tmp; fir = tmp;
+    iir -= coef[6] * buf[4]; fir += buf[4] + buf[4];
+    fir += iir;
+    buf[5] = iir; val = fir;
+    return val;
+}
+
+template<>
+inline double EngineFilterIIR<12, IIR_BP>::processSample(double* coef,
+                                                         double* buf,
+                                                         double val) {
+    double tmp, fir, iir;
+    tmp = buf[0];  buf[0]  = buf[1];  buf[1]  = buf[2];  buf[2]  = buf[3];
+    buf[3]  = buf[4];  buf[4]  = buf[5];  buf[5]  = buf[6];  buf[6]  = buf[7];
+    buf[7]  = buf[8];  buf[8]  = buf[9];  buf[9]  = buf[10]; buf[10] = buf[11];
+    iir = val * coef[0];
+    iir -= coef[1] * tmp; fir = tmp;
+    iir -= coef[2] * buf[0]; fir += -buf[0] - buf[0];
+    fir += iir;
+    tmp = buf[1]; buf[1] = iir; val = fir;
+    iir = val;
+    iir -= coef[3] * tmp; fir = tmp;
+    iir -= coef[4] * buf[2]; fir += -buf[2] - buf[2];
+    fir += iir;
+    tmp = buf[3]; buf[3] = iir; val = fir;
+    iir = val;
+    iir -= coef[5] * tmp; fir = tmp;
+    iir -= coef[6] * buf[4]; fir += -buf[4] - buf[4];
+    fir += iir;
+    tmp = buf[5]; buf[5] = iir; val = fir;
+    iir = val;
+    iir -= coef[7] * tmp; fir = tmp;
+    iir -= coef[8] * buf[6]; fir += buf[6] + buf[6];
+    fir += iir;
+    tmp = buf[7]; buf[7] = iir; val = fir;
+    iir = val;
+    iir -= coef[9] * tmp; fir = tmp;
+    iir -= coef[10] * buf[8]; fir += buf[8] + buf[8];
+    fir += iir;
+    tmp = buf[9]; buf[9] = iir; val = fir;
+    iir = val;
+    iir -= coef[11] * tmp; fir = tmp;
+    iir -= coef[12] * buf[10]; fir += buf[10] + buf[10];
+    fir += iir;
+    buf[11] = iir; val = fir;
+    return val;
+}
+
+template<>
+inline double EngineFilterIIR<6, IIR_HP>::processSample(double* coef,
+                                                        double* buf,
+                                                        double val) {
+    double tmp, fir, iir;
+
+    tmp = buf[0]; buf[0] = buf[1]; buf[1] = buf[2]; buf[2] = buf[3];
+    buf[3] = buf[4]; buf[4] = buf[5];
+    iir = val * coef[0];
+    iir -= coef[1] * tmp; fir = tmp;
+    iir -= coef[2] * buf[0]; fir += -buf[0] - buf[0];
+    fir += iir;
+    tmp = buf[1]; buf[1] = iir; val = fir;
+    iir = val;
+    iir -= coef[3] * tmp; fir = tmp;
+    iir -= coef[4] * buf[2]; fir += -buf[2] - buf[2];
+    fir += iir;
+    tmp = buf[3]; buf[3] = iir; val = fir;
+    iir = val;
+    iir -= coef[5] * tmp; fir = tmp;
+    iir -= coef[6] * buf[4]; fir += -buf[4] - buf[4];
+    fir += iir;
+    buf[5] = iir; val = fir;
     return val;
 }
 

--- a/src/engine/filters/simplebandpass.h
+++ b/src/engine/filters/simplebandpass.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cmath>
+
+class SimpleBandPass {
+  public:
+    SimpleBandPass()
+            : m_sampleRate(44100.0),
+              m_z1(0.0),
+              m_z2(0.0) {}
+
+    void init(double sampleRate) {
+        m_sampleRate = sampleRate;
+        setParameters(1000.0, 0.707);  // 1kHz center, moderate Q
+        reset();
+    }
+
+    void reset() {
+        m_z1 = 0.0;
+        m_z2 = 0.0;
+    }
+
+    void setParameters(double freq, double Q) {
+        const double omega = 2.0 * M_PI * freq / m_sampleRate;
+        const double alpha = sin(omega) / (2.0 * Q);
+
+        const double b0 = alpha;
+        const double b1 = 0.0;
+        const double b2 = -alpha;
+        const double a0 = 1.0 + alpha;
+        const double a1 = -2.0 * cos(omega);
+        const double a2 = 1.0 - alpha;
+
+        m_b0 = b0 / a0;
+        m_b1 = b1 / a0;
+        m_b2 = b2 / a0;
+        m_a1 = a1 / a0;
+        m_a2 = a2 / a0;
+    }
+
+    inline float process(float input) {
+        double output = m_b0 * input + m_z1;
+        m_z1 = m_b1 * input - m_a1 * output + m_z2;
+        m_z2 = m_b2 * input - m_a2 * output;
+        return static_cast<float>(output);
+    }
+
+  private:
+    double m_sampleRate;
+
+    double m_b0, m_b1, m_b2;
+    double m_a1, m_a2;
+
+    double m_z1, m_z2;
+};


### PR DESCRIPTION
This PR has evolved from the initial experiment into a separate Bandpass Reverb effect while restoring the original Reverb implementation.

Current changes

Added a dedicated Bandpass Reverb effect.
Added explicit HP cutoff and LP cutoff controls for selecting the frequency range sent to the reverb.
Added support for Butterworth band-pass filters with selectable orders:
2nd order
4th order
6th order
8th order
Added a Pre/Post Filter option to apply the band-pass either before or after the reverb.
Restored the original Reverb effect unchanged.

Notes
Internally, a minimum 50 Hz separation between HP and LP frequencies is enforced to avoid collapsing the passband.
The UI behavior when the HP and LP knobs cross is still under discussion and will likely be addressed separately after review.
Depends on https://github.com/mixxxdj/mixxx/pull/16570