### PR TITLE
Library: add 'No paths' option for playlist export

### DIFF
--- a/src/library/library_decl.h
+++ b/src/library/library_decl.h
@@ -20,6 +20,12 @@ enum class FocusWidget {
                  // m_pFocusedWidget in librarycontrol.cpp
 };
 
+enum class PlaylistExportFilePathMode {
+    AbsolutePaths,
+    RelativePaths,
+    NoPaths
+};
+
 struct LibraryScanResultSummary {
     QString durationString;
     bool autoscan;

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -66,21 +66,21 @@ QStringList LibraryFeature::getPlaylistFiles(QFileDialog::FileMode mode) const {
 bool LibraryFeature::exportPlaylistItemsIntoFile(
         QString playlistFilePath,
         const QList<QString>& playlistItemLocations,
-        bool useRelativePath)    {
+        PlaylistExportFilePathMode filePathMode) {
     if (playlistFilePath.endsWith(
             QStringLiteral(".pls"),
             Qt::CaseInsensitive)) {
         return ParserPls::writePLSFile(
                 playlistFilePath,
                 playlistItemLocations,
-                useRelativePath);
+                filePathMode);
     } else if (playlistFilePath.endsWith(
             QStringLiteral(".m3u8"),
             Qt::CaseInsensitive)) {
         return ParserM3u::writeM3U8File(
                 playlistFilePath,
                 playlistItemLocations,
-                useRelativePath);
+                filePathMode);
     } else {
         //default export to M3U if file extension is missing
         if (!playlistFilePath.endsWith(
@@ -106,6 +106,6 @@ bool LibraryFeature::exportPlaylistItemsIntoFile(
         return ParserM3u::writeM3UFile(
                 playlistFilePath,
                 playlistItemLocations,
-                useRelativePath);
+                filePathMode);
     }
 }

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -10,6 +10,7 @@
 
 #include "library/coverartcache.h"
 #include "library/dao/trackdao.h"
+#include "library/library_decl.h"
 #include "library/treeitemmodel.h"
 #include "track/track_decl.h"
 #ifdef __STEM__
@@ -176,7 +177,7 @@ class LibraryFeature : public QObject {
     static bool exportPlaylistItemsIntoFile(
             QString playlistFilePath,
             const QList<QString>& playlistItemLocations,
-            bool useRelativePath);
+            PlaylistExportFilePathMode filePathMode);
 
   private:
     QStringList getPlaylistFiles(QFileDialog::FileMode mode) const;

--- a/src/library/parsercsv.cpp
+++ b/src/library/parsercsv.cpp
@@ -147,8 +147,9 @@ QList<QList<QString>> ParserCsv::tokenize(const QByteArray& str, char delimiter)
     return tokens;
 }
 
-bool ParserCsv::writeCSVFile(const QString &file_str, BaseSqlTableModel* pPlaylistTableModel, bool useRelativePath)
-{
+bool ParserCsv::writeCSVFile(const QString& file_str,
+        BaseSqlTableModel* pPlaylistTableModel,
+        PlaylistExportFilePathMode filePathMode) {
     /*
      * Important note:
      * On Windows \n will produce a <CR><CL> (=\r\n)
@@ -223,7 +224,11 @@ bool ParserCsv::writeCSVFile(const QString &file_str, BaseSqlTableModel* pPlayli
                                 ->data(pPlaylistTableModel->index(j, i),
                                         BaseTrackTableModel::kDataExportRole)
                                 .toString();
-                if (useRelativePath) {
+                // FIXME add helper functions for these three types
+                if (filePathMode == PlaylistExportFilePathMode::NoPaths) {
+                    mixxx::FileInfo file(field);
+                    field = file.fileName().prepend(QStringLiteral("./"));
+                } else if (filePathMode == PlaylistExportFilePathMode::RelativePaths) {
                     field = base_dir.relativeFilePath(field);
                 }
             } else {

--- a/src/library/parsercsv.h
+++ b/src/library/parsercsv.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <QByteArray>
 #include <QList>
 #include <QString>
-#include <QByteArray>
 
+#include "library/library_decl.h"
 #include "library/parser.h"
 
 class BaseSqlTableModel;
@@ -14,7 +15,9 @@ class ParserCsv : public Parser {
     static bool isPlaylistFilenameSupported(const QString& playlistFile);
     static QList<QString> parseAllLocations(const QString&);
     // Playlist Export
-    static bool writeCSVFile(const QString &file, BaseSqlTableModel* pPlaylistTableModel, bool useRelativePath);
+    static bool writeCSVFile(const QString& file,
+            BaseSqlTableModel* pPlaylistTableModel,
+            PlaylistExportFilePathMode filePathMode);
     // Readable Text export
     static bool writeReadableTextFile(const QString &file, BaseSqlTableModel* pPlaylistTableModel,  bool writeTimestamp);
 

--- a/src/library/parserm3u.cpp
+++ b/src/library/parserm3u.cpp
@@ -90,16 +90,22 @@ QList<QString> ParserM3u::parseAllLocations(const QString& playlistFile) {
     return paths;
 }
 
-bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &items, bool useRelativePath) {
-    return writeM3UFile(file_str, items, useRelativePath, false);
+bool ParserM3u::writeM3UFile(const QString& file_str,
+        const QList<QString>& items,
+        PlaylistExportFilePathMode filePathMode) {
+    return writeM3UFile(file_str, items, filePathMode, false);
 }
 
-bool ParserM3u::writeM3U8File(const QString &file_str, const QList<QString> &items, bool useRelativePath) {
-    return writeM3UFile(file_str, items, useRelativePath, true);
+bool ParserM3u::writeM3U8File(const QString& file_str,
+        const QList<QString>& items,
+        PlaylistExportFilePathMode filePathMode) {
+    return writeM3UFile(file_str, items, filePathMode, true);
 }
 
-bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &items, bool useRelativePath, bool useUtf8)
-{
+bool ParserM3u::writeM3UFile(const QString& file_str,
+        const QList<QString>& items,
+        PlaylistExportFilePathMode filePathMode,
+        bool useUtf8) {
     // Important note:
     // On Windows \n will produce a <CR><CL> (=\r\n)
     // On Linux and OS X \n is <CR> (which remains \n)
@@ -109,28 +115,30 @@ bool ParserM3u::writeM3UFile(const QString &file_str, const QList<QString> &item
     QString fileContents(QStringLiteral("#EXTM3U\n"));
     for (const QString& item : items) {
         fileContents += QStringLiteral("#EXTINF\n");
-        if (useUtf8) {
-            if (useRelativePath) {
-                fileContents += baseDirectory.relativeFilePath(item) + QStringLiteral("\n");
-            } else {
-                fileContents += item + QStringLiteral("\n");
-            }
-        } else {
+        bool encodeAsUrl = false;
+        if (!useUtf8) {
             QByteArray trackByteArray = codec->fromUnicode(item);
             QString trackName = codec->toUnicode(trackByteArray);
-            if (trackName == item) {
-                if (useRelativePath) { //Issue: URL Location is not working properly for Relative Paths
-                    fileContents += baseDirectory.relativeFilePath(item) + QStringLiteral("\n");
-                } else {
-                    fileContents += item + QStringLiteral("\n");
-                }
-            } else {
-                QUrl itemUrl = QUrl::fromLocalFile(item);
-                QString itemUrlEncoded = itemUrl.toEncoded();
-                fileContents += itemUrlEncoded + QStringLiteral("\n");
-                urlEncodingUsed = true;
+            encodeAsUrl = trackName != item;
+        }
+
+        if (encodeAsUrl) {
+            QUrl itemUrl = QUrl::fromLocalFile(item);
+            const QString itemUrlEncoded = itemUrl.toEncoded();
+            fileContents += itemUrlEncoded;
+            urlEncodingUsed = true;
+        } else {
+            // FIXME add helper functions for these three types
+            if (filePathMode == PlaylistExportFilePathMode::AbsolutePaths) {
+                fileContents += item;
+            } else if (filePathMode == PlaylistExportFilePathMode::RelativePaths) {
+                fileContents += baseDirectory.relativeFilePath(item);
+            } else { // NoPaths
+                mixxx::FileInfo file(item);
+                fileContents += QStringLiteral("./") + file.fileName();
             }
         }
+        fileContents += QStringLiteral("\n");
     }
 
     QByteArray outputByteArray;

--- a/src/library/parserm3u.h
+++ b/src/library/parserm3u.h
@@ -15,6 +15,7 @@
 #include <QList>
 #include <QString>
 
+#include "library/library_decl.h"
 #include "library/parser.h"
 
 class ParserM3u : public Parser {
@@ -22,7 +23,17 @@ class ParserM3u : public Parser {
     static bool isPlaylistFilenameSupported(const QString& fileName);
     static QList<QString> parseAllLocations(const QString& playlistFile);
     /// Playlist Export
-    static bool writeM3UFile(const QString &file_str, const QList<QString> &items, bool useRelativePath, bool useUtf8);
-    static bool writeM3UFile(const QString &file, const QList<QString> &items, bool useRelativePath);
-    static bool writeM3U8File(const QString &file_str, const QList<QString> &items, bool useRelativePath);
+    static bool writeM3UFile(
+            const QString& file_str,
+            const QList<QString>& items,
+            PlaylistExportFilePathMode filePathMode,
+            bool useUtf8);
+    static bool writeM3UFile(
+            const QString& file,
+            const QList<QString>& items,
+            PlaylistExportFilePathMode filePathMode);
+    static bool writeM3U8File(
+            const QString& file_str,
+            const QList<QString>& items,
+            PlaylistExportFilePathMode filePathMode);
 };

--- a/src/library/parserpls.cpp
+++ b/src/library/parserpls.cpp
@@ -76,8 +76,9 @@ QList<QString> ParserPls::parseAllLocations(const QString& playlistFile) {
     return locations;
 }
 
-bool ParserPls::writePLSFile(const QString &file_str, const QList<QString> &items, bool useRelativePath)
-{
+bool ParserPls::writePLSFile(const QString& file_str,
+        const QList<QString>& items,
+        PlaylistExportFilePathMode filePathMode) {
     QFile file(file_str);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         ErrorDialogHandler* pDialogHandler = ErrorDialogHandler::instance();
@@ -97,14 +98,18 @@ bool ParserPls::writePLSFile(const QString &file_str, const QList<QString> &item
     out << "[playlist]\n";
     out << "NumberOfEntries=" << items.size() << "\n";
     for (int i = 0; i < items.size(); ++i) {
-        //Write relative path if possible
-        if (useRelativePath) {
+        // FIXME add helper functions for these three types
+        if (filePathMode == PlaylistExportFilePathMode::AbsolutePaths) {
+            out << "File" << i << "=" << items.at(i);
+        } else if (filePathMode == PlaylistExportFilePathMode::RelativePaths) {
             //QDir::relativePath() will return the absolutePath if it cannot compute the
             //relative Path
-            out << "File" << i << "=" << base_dir.relativeFilePath(items.at(i)) << "\n";
-        } else {
-            out << "File" << i << "=" << items.at(i) << "\n";
+            out << "File" << i << "=" << base_dir.relativeFilePath(items.at(i));
+        } else { // NoPaths
+            mixxx::FileInfo file(items.at(i));
+            out << "File" << i << "=" << QStringLiteral("./") << file.fileName();
         }
+        out << QStringLiteral("\n");
     }
 
     return true;

--- a/src/library/parserpls.h
+++ b/src/library/parserpls.h
@@ -15,6 +15,7 @@
 #include <QString>
 #include <QTextStream>
 
+#include "library/library_decl.h"
 #include "library/parser.h"
 
 class ParserPls : public Parser {
@@ -22,5 +23,7 @@ class ParserPls : public Parser {
     static bool isPlaylistFilenameSupported(const QString& fileName);
     static QList<QString> parseAllLocations(const QString& playlistFile);
     /// Playlist Export
-    static bool writePLSFile(const QString &file, const QList<QString> &items, bool useRelativePath);
+    static bool writePLSFile(const QString& file,
+            const QList<QString>& items,
+            PlaylistExportFilePathMode filePathMode);
 };

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -612,11 +612,11 @@ void BasePlaylistFeature::slotExportPlaylist() {
     pPlaylistTableModel->select();
 
     // check config if relative paths are desired
-    bool useRelativePath = m_pConfig->getValue<bool>(
+    PlaylistExportFilePathMode filePathMode = m_pConfig->getValue<PlaylistExportFilePathMode>(
             kUseRelativePathOnExportConfigKey);
 
     if (fileLocation.endsWith(".csv", Qt::CaseInsensitive)) {
-        ParserCsv::writeCSVFile(fileLocation, pPlaylistTableModel.get(), useRelativePath);
+        ParserCsv::writeCSVFile(fileLocation, pPlaylistTableModel.get(), filePathMode);
     } else if (fileLocation.endsWith(".txt", Qt::CaseInsensitive)) {
         if (m_playlistDao.getHiddenType(pPlaylistTableModel->getPlaylist()) ==
                 PlaylistDAO::PLHT_SET_LOG) {
@@ -635,7 +635,7 @@ void BasePlaylistFeature::slotExportPlaylist() {
         exportPlaylistItemsIntoFile(
                 fileLocation,
                 playlistItems,
-                useRelativePath);
+                filePathMode);
     }
 }
 

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -808,9 +808,8 @@ void CrateFeature::slotExportPlaylist() {
     // register a security bookmark.
 
     // check config if relative paths are desired
-    bool useRelativePath =
-            m_pConfig->getValue<bool>(
-                    kUseRelativePathOnExportConfigKey);
+    PlaylistExportFilePathMode filePathMode = m_pConfig->getValue<PlaylistExportFilePathMode>(
+            kUseRelativePathOnExportConfigKey);
 
     // Create list of files of the crate
     // Create a new table model since the main one might have an active search.
@@ -820,7 +819,7 @@ void CrateFeature::slotExportPlaylist() {
     pCrateTableModel->select();
 
     if (fileLocation.endsWith(".csv", Qt::CaseInsensitive)) {
-        ParserCsv::writeCSVFile(fileLocation, pCrateTableModel.get(), useRelativePath);
+        ParserCsv::writeCSVFile(fileLocation, pCrateTableModel.get(), filePathMode);
     } else if (fileLocation.endsWith(".txt", Qt::CaseInsensitive)) {
         ParserCsv::writeReadableTextFile(fileLocation, pCrateTableModel.get(), false);
     } else {
@@ -834,7 +833,7 @@ void CrateFeature::slotExportPlaylist() {
         exportPlaylistItemsIntoFile(
                 fileLocation,
                 playlistItems,
-                useRelativePath);
+                filePathMode);
     }
 }
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -269,7 +269,8 @@ void DlgPrefLibrary::slotResetToDefaults() {
     spinbox_history_min_tracks_to_keep->setValue(1);
     checkBox_sync_track_metadata->setChecked(false);
     checkBox_serato_metadata_export->setChecked(false);
-    checkBox_use_relative_path->setChecked(false);
+    radioButton_absolutePaths->setChecked(true);
+
     checkBox_edit_metadata_selected_clicked->setChecked(kEditMetadataSelectedClickDefault);
     radioButton_dbclick_deck->setChecked(true);
     spinbox_bpm_precision->setValue(BaseTrackTableModel::kBpmColumnPrecisionDefault);
@@ -325,8 +326,22 @@ void DlgPrefLibrary::slotUpdate() {
     checkBox_serato_metadata_export->setChecked(
             m_pConfig->getValue(kSyncSeratoMetadataConfigKey, false));
     setSeratoMetadataEnabled(checkBox_sync_track_metadata->isChecked());
-    checkBox_use_relative_path->setChecked(m_pConfig->getValue(
-            kUseRelativePathOnExportConfigKey, false));
+
+    PlaylistExportFilePathMode filePathMode =
+            m_pConfig->getValue<PlaylistExportFilePathMode>(
+                    kUseRelativePathOnExportConfigKey,
+                    PlaylistExportFilePathMode::AbsolutePaths);
+    switch (filePathMode) {
+    case PlaylistExportFilePathMode::RelativePaths:
+        radioButton_relativePaths->setChecked(true);
+        break;
+    case PlaylistExportFilePathMode::NoPaths:
+        radioButton_noPaths->setChecked(true);
+        break;
+    case PlaylistExportFilePathMode::AbsolutePaths:
+    default:
+        radioButton_absolutePaths->setChecked(true);
+    }
 
     checkBox_show_rhythmbox->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]", "ShowRhythmboxLibrary"), true));
@@ -598,8 +613,15 @@ void DlgPrefLibrary::slotApply() {
             kSyncSeratoMetadataConfigKey,
             ConfigValue{checkBox_serato_metadata_export->isChecked()});
 
-    m_pConfig->set(kUseRelativePathOnExportConfigKey,
-            ConfigValue((int)checkBox_use_relative_path->isChecked()));
+    PlaylistExportFilePathMode filePathMode =
+            PlaylistExportFilePathMode::AbsolutePaths;
+    if (radioButton_relativePaths->isChecked()) {
+        filePathMode = PlaylistExportFilePathMode::RelativePaths;
+    } else if (radioButton_noPaths->isChecked()) {
+        filePathMode = PlaylistExportFilePathMode::NoPaths;
+    }
+    m_pConfig->setValue<PlaylistExportFilePathMode>(
+            kUseRelativePathOnExportConfigKey, filePathMode);
 
     m_pConfig->set(kEnableSearchCompletionsConfigKey,
             ConfigValue(checkBox_enable_search_completions->isChecked()));

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -156,12 +156,50 @@
       </item>
 
       <item row="2" column="0" colspan="2">
-       <widget class="QCheckBox" name="checkBox_use_relative_path">
+       <widget class="QLabel" name="label_playlistTrackFilePaths">
         <property name="text">
-         <string>Use relative paths for playlist export if possible</string>
+         <string>Playlist Export:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
+
+      <item row="3" column="0" colspan="2">
+       <widget class="QRadioButton" name="radioButton_absolutePaths">
+        <property name="text">
+         <string>Absolute file paths</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">playlist_filepath_mode</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QRadioButton" name="radioButton_relativePaths">
+        <property name="text">
+         <string>Relative file paths, if possible</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">playlist_filepath_mode</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="5" column="0" colspan="2">
+       <widget class="QRadioButton" name="radioButton_noPaths">
+        <property name="text">
+         <string>File names only</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">playlist_filepath_mode</string>
+        </attribute>
+       </widget>
+      </item>
+
      </layout>
     </widget>
    </item>
@@ -200,6 +238,9 @@
         <property name="checked">
          <bool>true</bool>
         </property>
+        <attribute name="buttonGroup">
+         <string notr="true">dblclick_options</string>
+        </attribute>
        </widget>
       </item>
       <item row="4" column="0" colspan="4">
@@ -207,6 +248,9 @@
         <property name="text">
          <string>Add track to Auto DJ queue (bottom)</string>
         </property>
+        <attribute name="buttonGroup">
+         <string notr="true">dblclick_options</string>
+        </attribute>
        </widget>
       </item>
       <item row="5" column="0" colspan="4">
@@ -214,6 +258,9 @@
         <property name="text">
          <string>Add track to Auto DJ queue (top)</string>
         </property>
+        <attribute name="buttonGroup">
+         <string notr="true">dblclick_options</string>
+        </attribute>
        </widget>
       </item>
       <item row="6" column="0" colspan="4">
@@ -221,6 +268,9 @@
         <property name="text">
          <string>Ignore</string>
         </property>
+        <attribute name="buttonGroup">
+         <string notr="true">dblclick_options</string>
+        </attribute>
        </widget>
       </item>
 
@@ -729,7 +779,9 @@
   <tabstop>checkBox_library_scan_summary</tabstop>
   <tabstop>checkBox_sync_track_metadata</tabstop>
   <tabstop>checkBox_serato_metadata_export</tabstop>
-  <tabstop>checkBox_use_relative_path</tabstop>
+  <tabstop>radioButton_absolutePaths</tabstop>
+  <tabstop>radioButton_relativePaths</tabstop>
+  <tabstop>radioButton_noPaths</tabstop>
   <tabstop>checkBox_edit_metadata_selected_clicked</tabstop>
   <tabstop>radioButton_dbclick_deck</tabstop>
   <tabstop>radioButton_dbclick_bottom</tabstop>
@@ -758,6 +810,10 @@
   <tabstop>radioButton_cover_art_fetcher_lowest</tabstop>
   <tabstop>pushButton_open_settings_dir</tabstop>
  </tabstops>
+ <buttongroups>
+  <buttongroup name="playlist_filepath_mode"/>
+  <buttongroup name="dblclick_options"/>
+ </buttongroups>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Fixes #11315 

This allows to create self-contained (portable) playlist exports, meaning the files referenced in the playlist expect the tracks to be in same directory.

We now have three file path options (-> enum value):
1. Absolute paths (default) -> 0
2. Relative paths -> 1
3. File names only -> 2

<img width="550" height="253" alt="image" src="https://github.com/user-attachments/assets/8fad5df3-d2a8-43c0-8fbe-92ca9016c3b9" />



It uses the current config key `UseRelativePathOnExport`, so if enabled, the previous 'Use relative paths' option is adopted.
Note: "File names only" is not technically correct as it exports paths as `./filename.ext`

Any ideas how to make the pref ui more clear?