### PR TITLE
Add Fader Start functionally to EngineDeck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1337,7 +1337,6 @@ add_library(
   src/engine/enginemixer.cpp
   src/engine/engineobject.cpp
   src/engine/enginepregain.cpp
-  
   src/engine/enginesidechaincompressor.cpp
   src/engine/enginetalkoverducking.cpp
   src/engine/enginevumeter.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1337,6 +1337,7 @@ add_library(
   src/engine/enginemixer.cpp
   src/engine/engineobject.cpp
   src/engine/enginepregain.cpp
+  
   src/engine/enginesidechaincompressor.cpp
   src/engine/enginetalkoverducking.cpp
   src/engine/enginevumeter.cpp

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -1,6 +1,5 @@
 
 #include "engine/channels/enginedeck.h"
-#include "engine/faderstartcontrol.h"
 
 #include <QStringView>
 
@@ -11,6 +10,7 @@
 #include "engine/effects/groupfeaturestate.h"
 #include "engine/enginebuffer.h"
 #include "engine/enginepregain.h"
+#include "engine/faderstartcontrol.h"
 #include "moc_enginedeck.cpp"
 #include "track/track.h"
 #include "util/assert.h"

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -1,4 +1,6 @@
+
 #include "engine/channels/enginedeck.h"
+#include "engine/faderstartcontrol.h"
 
 #include <QStringView>
 
@@ -31,6 +33,7 @@ EngineDeck::EngineDeck(
           m_pInputConfigured(new ControlObject(ConfigKey(getGroup(), "input_configured"))),
           m_pPassing(new ControlPushButton(ConfigKey(getGroup(), "passthrough"))) {
     m_pInputConfigured->setReadOnly();
+    m_faderStart = new FaderStartControl(getGroup());
     // Set up passthrough utilities and fields
     m_pPassing->setButtonMode(mixxx::control::ButtonMode::PowerWindow);
     m_bPassthroughIsActive = false;
@@ -113,6 +116,7 @@ void EngineDeck::slotTrackLoaded(TrackPointer pNewTrack,
 #endif
 
 EngineDeck::~EngineDeck() {
+    delete m_faderStart;
     delete m_pPassing;
     delete m_pBuffer;
     delete m_pPregain;

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -8,11 +8,13 @@
 #include "track/track_decl.h"
 #include "util/samplebuffer.h"
 
+
 class EnginePregain;
 class EngineBuffer;
 class EngineMixer;
 class ControlPushButton;
 class ControlPotmeter;
+class FaderStartControl;
 
 class EngineDeck : public EngineChannel, public AudioDestination {
     Q_OBJECT
@@ -96,6 +98,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     UserSettingsPointer m_pConfig;
     EngineBuffer* m_pBuffer;
     EnginePregain* m_pPregain;
+    FaderStartControl* m_faderStart;
 
 #ifdef __STEM__
     // Stem buffer used to retrieve all the channel to mix together

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -8,7 +8,6 @@
 #include "track/track_decl.h"
 #include "util/samplebuffer.h"
 
-
 class EnginePregain;
 class EngineBuffer;
 class EngineMixer;

--- a/src/engine/faderstartcontrol.cpp
+++ b/src/engine/faderstartcontrol.cpp
@@ -1,25 +1,16 @@
 #include "engine/faderstartcontrol.h"
 
-FaderStartControl::FaderStartControl(const QString& group) 
-{
-
-    m_pPlay=ControlObject::getControl(ConfigKey(group,"play"));
-    m_pVolume=ControlObject::getControl(ConfigKey(group,"volume"));
-
-    QObject::connect(
-        m_pVolume,
-        &ControlObject::valueChanged,
-        [this](double value)
-        {
-            slotVolumeChanged(value);
-        });
+FaderStartControl::FaderStartControl(const QString& group)
+        : m_play(group, "play"),
+          m_volume(group, "volume") {
 }
 
-void FaderStartControl::slotVolumeChanged(double value) {
+void FaderStartControl::process() {
+    double value = m_volume.get();
 
-    if (value>0.01) {
-        m_pPlay->set(1.0);
+    if (value > 0.01) {
+        m_play.set(1.0);
     } else {
-        m_pPlay->set(0.0);
+        m_play.set(0.0);
     }
 }

--- a/src/engine/faderstartcontrol.cpp
+++ b/src/engine/faderstartcontrol.cpp
@@ -1,0 +1,25 @@
+#include "engine/faderstartcontrol.h"
+
+FaderStartControl::FaderStartControl(const QString& group) 
+{
+
+    m_pPlay=ControlObject::getControl(ConfigKey(group,"play"));
+    m_pVolume=ControlObject::getControl(ConfigKey(group,"volume"));
+
+    QObject::connect(
+        m_pVolume,
+        &ControlObject::valueChanged,
+        [this](double value)
+        {
+            slotVolumeChanged(value);
+        });
+}
+
+void FaderStartControl::slotVolumeChanged(double value) {
+
+    if (value>0.01) {
+        m_pPlay->set(1.0);
+    } else {
+        m_pPlay->set(0.0);
+    }
+}

--- a/src/engine/faderstartcontrol.h
+++ b/src/engine/faderstartcontrol.h
@@ -1,21 +1,13 @@
 #pragma once
 
-#include <QObject>
-#include <QString>
+#include "control/controlproxy.h"
 
-#include "control/controlobject.h"
-#include "util/configkey.h"
-
-class FaderStartControl : public QObject {
-    Q_OBJECT
-
-public:
+class FaderStartControl {
+  public:
     explicit FaderStartControl(const QString& group);
+    void process();
 
-private slots:
-    void slotVolumeChanged(double value);
-
-private:
-    ControlObject* m_pPlay{nullptr};
-    ControlObject* m_pVolume{nullptr};
+  private:
+    ControlProxy m_play;
+    ControlProxy m_volume;
 };

--- a/src/engine/faderstartcontrol.h
+++ b/src/engine/faderstartcontrol.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+
+#include "control/controlobject.h"
+#include "util/configkey.h"
+
+class FaderStartControl : public QObject {
+    Q_OBJECT
+
+public:
+    explicit FaderStartControl(const QString& group);
+
+private slots:
+    void slotVolumeChanged(double value);
+
+private:
+    ControlObject* m_pPlay{nullptr};
+    ControlObject* m_pVolume{nullptr};
+};

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -11,6 +11,7 @@
 #include "engine/engine.h"
 #include "engine/enginebuffer.h"
 #include "engine/enginemixer.h"
+#include "engine/faderstartcontrol.h"
 #include "engine/sync/enginesync.h"
 #include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
@@ -52,7 +53,8 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
           m_pLoadedTrack(),
           m_pPrevFailedTrackId(),
           m_replaygainPending(false),
-          m_pChannelToCloneFrom(nullptr) {
+          m_pChannelToCloneFrom(nullptr),
+          m_pFaderStartControl(std::make_unique<FaderStartControl>(handleGroup.name())) {
     auto channel = std::make_unique<EngineDeck>(handleGroup,
             pConfig,
             pMixingEngine,
@@ -974,6 +976,10 @@ void BaseTrackPlayerImpl::slotTrackRatingChangeRequestRelative(int change) {
 void BaseTrackPlayerImpl::slotPlayToggled(double value) {
     if (value == 0 && m_replaygainPending) {
         setReplayGain(m_pLoadedTrack->getReplayGain().getRatio());
+    }
+
+    if (m_pFaderStartControl) {
+        m_pFaderStartControl->process();
     }
 }
 

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -24,6 +24,7 @@ class ControlEncoder;
 class EffectsManager;
 class QString;
 class EngineDeck;
+class FaderStartControl;
 
 constexpr int kUnreplaceDelay = 500;
 
@@ -230,6 +231,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 
     parented_ptr<ControlProxy> m_pReplayGain;
     parented_ptr<ControlProxy> m_pPlay;
+    std::unique_ptr<FaderStartControl> m_pFaderStartControl;
     parented_ptr<ControlProxy> m_pLowFilter;
     parented_ptr<ControlProxy> m_pMidFilter;
     parented_ptr<ControlProxy> m_pHighFilter;


### PR DESCRIPTION
This pull request adds a simple Fader Start feature to Mixxx.
The idea is to allow playback to be controlled using the channel volume fader. When the fader is moved up, the track starts playing automatically. When the fader is moved back down to zero, the track stops. This behavior is similar to the fader start functionality found on many DJ mixers.
To implement this, I added a new class called "FaderStartControl" that listens to changes in the channel volume control. When the volume value changes, it checks the fader position and triggers the play control accordingly.
The feature was integrated into "EngineDeck" so it works directly with the deck’s controls.

Testing:

I tested the feature by building Mixxx from source, loading a track into a deck, and moving the channel volume fader. When the fader was raised, the track started playing automatically. When the fader was lowered back to zero, playback stopped.
This is a prototype implementation meant to demonstrate the basic idea of fader-based playback control.