### PR TITLE
Activate dependabot for pre-commit too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "2.5"
+    target-branch: "2.6"
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "2.6"


### PR DESCRIPTION
-Activate dependabot for pre-commit too
-Changed target-branch for dependabot updates from 2.5 to 2.6 as the last 2.5 release is immediate.