### PR TITLE
WIP: add 2 and 4 band biquad filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1274,6 +1274,8 @@ add_library(
   src/effects/backends/builtin/phasereffect.cpp
   src/effects/backends/builtin/reverbeffect.cpp
   src/effects/backends/builtin/threebandbiquadeqeffect.cpp
+  src/effects/backends/builtin/twobandbiquadeqeffect.cpp
+  src/effects/backends/builtin/fourbandbiquadeqeffect.cpp
   src/effects/backends/builtin/tremoloeffect.cpp
   src/effects/backends/builtin/whitenoiseeffect.cpp
   src/effects/backends/effectmanifest.cpp

--- a/res/skins/Deere/mixer_column_eq_left.xml
+++ b/res/skins/Deere/mixer_column_eq_left.xml
@@ -10,6 +10,10 @@
     <SizePolicy>min,p</SizePolicy>
     <Children>
       <Template src="skin:equalizer_rack_parameter_left.xml">
+        <SetVariable name="parameter">4</SetVariable>
+      </Template>
+
+      <Template src="skin:equalizer_rack_parameter_left.xml">
         <SetVariable name="parameter">3</SetVariable>
       </Template>
 

--- a/res/skins/Deere/mixer_column_eq_right.xml
+++ b/res/skins/Deere/mixer_column_eq_right.xml
@@ -10,6 +10,10 @@
     <SizePolicy>min,min</SizePolicy>
     <Children>
       <Template src="skin:equalizer_rack_parameter_right.xml">
+        <SetVariable name="parameter">4</SetVariable>
+      </Template>
+
+      <Template src="skin:equalizer_rack_parameter_right.xml">
         <SetVariable name="parameter">3</SetVariable>
       </Template>
 

--- a/res/skins/LateNight/classic/buttons/btn__eq_kill_super_high.svg
+++ b/res/skins/LateNight/classic/buttons/btn__eq_kill_super_high.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="36"
+   height="36"
+   version="1.1"
+   id="svg17" viewBox="0 0 18 18">
+  <metadata
+     id="metadata21">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs9">
+    <linearGradient
+       id="a"
+       x1="2"
+       x2="24"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(.69565216 0 0 .69565216 -.04349915 -16.652173)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-opacity=".0047619"
+         offset="0"
+         id="stop2" />
+      <stop
+         stop-opacity="0"
+         offset=".5"
+         id="stop4" />
+      <stop
+         stop-opacity=".47451"
+         offset="1"
+         id="stop6" />
+    </linearGradient>
+  </defs>
+  <text
+     id="text838"
+     y="14.63623"
+     x="5.1662478"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     xml:space="preserve"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:13.33333302px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Semi-Bold';fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       y="14.63623"
+       x="5.1662478"
+       id="tspan836">S</tspan></text>
+  <text
+     id="text838-3"
+     y="14.63623"
+     x="5.1662478"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#bbb;fill-opacity:1;stroke:none"
+     xml:space="preserve"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:13.33333302px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Semi-Bold';fill:#bbb;fill-opacity:1"
+       y="14.63623"
+       x="5.1662478"
+       id="tspan836-6">S</tspan></text>
+</svg>

--- a/res/skins/LateNight/mixer/channel_left.xml
+++ b/res/skins/LateNight/mixer/channel_left.xml
@@ -29,6 +29,13 @@ vertical layout and a side-by-side layout for two-deck mode -->
           <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
 
           <Template src="skins:LateNight/mixer/eq_knob_left.xml">
+            <SetVariable name="EqParameter">4</SetVariable>
+            <SetVariable name="EqRange">SuperHigh</SetVariable>
+          </Template>
+
+          <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
+
+          <Template src="skins:LateNight/mixer/eq_knob_left.xml">
             <SetVariable name="EqParameter">3</SetVariable>
             <SetVariable name="EqRange">High</SetVariable>
           </Template>

--- a/res/skins/LateNight/mixer/channel_right.xml
+++ b/res/skins/LateNight/mixer/channel_right.xml
@@ -65,6 +65,13 @@ vertical layout and a reversed side-by-side layout for two-deck mode -->
           <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
 
           <Template src="skins:LateNight/mixer/eq_knob_right.xml">
+            <SetVariable name="EqParameter">4</SetVariable>
+            <SetVariable name="EqRange">SuperHigh</SetVariable>
+          </Template>
+
+          <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
+
+          <Template src="skins:LateNight/mixer/eq_knob_right.xml">
             <SetVariable name="EqParameter">3</SetVariable>
             <SetVariable name="EqRange">High</SetVariable>
           </Template>

--- a/res/skins/LateNight/palemoon/buttons/btn__eq_kill_super_high.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__eq_kill_super_high.svg
@@ -1,0 +1,4 @@
+<svg width="36" height="36" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18">
+  <text x="5.1662478" y="14.63623" fill="none" font-family="sans-serif" font-size="40px" letter-spacing="0px" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" word-spacing="0px" style="line-height:1.25" xml:space="preserve"><tspan x="5.1662478" y="14.63623" fill="none" font-family="'Open Sans'" font-size="13.3333px" font-weight="600" stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6">S</tspan></text>
+  <text x="5.1662478" y="14.63623" fill="#91806e" font-family="sans-serif" font-size="40px" letter-spacing="0px" word-spacing="0px" style="line-height:1.25" xml:space="preserve"><tspan x="5.1662478" y="14.63623" fill="#91806e" font-family="'Open Sans'" font-size="13.3333px" font-weight="600">S</tspan></text>
+</svg>

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1928,6 +1928,9 @@ WPushButton#BpmLockToggle[value="1"] {
 }
 
 /* EQ Kill button icons H / M / L */
+#EQKillButton_SuperHigh[displayValue="0"] {
+  image: url(skins:LateNight/classic/buttons/btn__eq_kill_super_high.svg) no-repeat center center;
+}
 #EQKillButton_High[displayValue="0"] {
   image: url(skins:LateNight/classic/buttons/btn__eq_kill_high.svg) no-repeat center center;
 }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2549,6 +2549,9 @@ WPushButton#PlayDeck[value="0"] {
 }
 
 /* EQ Kill button icons H / M / L */
+#EQKillButton_SuperHigh[displayValue="0"] {
+  image: url(skins:LateNight/palemoon/buttons/btn__eq_kill_super_high.svg) no-repeat center center;
+}
 #EQKillButton_High[displayValue="0"] {
   image: url(skins:LateNight/palemoon/buttons/btn__eq_kill_high.svg) no-repeat center center;
 }

--- a/src/effects/backends/builtin/builtinbackend.cpp
+++ b/src/effects/backends/builtin/builtinbackend.cpp
@@ -8,11 +8,13 @@
 #include "effects/backends/builtin/bitcrushereffect.h"
 #include "effects/backends/builtin/filtereffect.h"
 #include "effects/backends/builtin/flangereffect.h"
+#include "effects/backends/builtin/fourbandbiquadeqeffect.h"
 #include "effects/backends/builtin/graphiceqeffect.h"
 #include "effects/backends/builtin/linkwitzriley8eqeffect.h"
 #include "effects/backends/builtin/moogladder4filtereffect.h"
 #include "effects/backends/builtin/parametriceqeffect.h"
 #include "effects/backends/builtin/threebandbiquadeqeffect.h"
+#include "effects/backends/builtin/twobandbiquadeqeffect.h"
 #ifndef __MACAPPSTORE__
 #include "effects/backends/builtin/reverbeffect.h"
 #endif
@@ -39,6 +41,8 @@ BuiltInBackend::BuiltInBackend() {
     registerEffect<Bessel8LVMixEQEffect>();
     registerEffect<LinkwitzRiley8EQEffect>();
     registerEffect<ThreeBandBiquadEQEffect>();
+    registerEffect<TwoBandBiquadEQEffect>();
+    registerEffect<FourBandBiquadEQEffect>();
     registerEffect<BiquadFullKillEQEffect>();
     // Compensations EQs
     registerEffect<GraphicEQEffect>();

--- a/src/effects/backends/builtin/fourbandbiquadeqeffect.cpp
+++ b/src/effects/backends/builtin/fourbandbiquadeqeffect.cpp
@@ -1,0 +1,512 @@
+#include "effects/backends/builtin/fourbandbiquadeqeffect.h"
+
+#include "effects/backends/builtin/equalizer_util.h"
+#include "effects/defs.h"
+#include "engine/effects/engineeffectparameter.h"
+#include "util/math.h"
+
+namespace {
+
+// The defaults are tweaked to match the Xone:23 EQ
+// but allow 12 dB boost instead of just 6 dB
+static constexpr int kStartupSamplerate = 44100;
+static constexpr double kMinimumFrequency = 10.0;
+static constexpr double kMaximumFrequency = kStartupSamplerate / 2;
+static constexpr double kStartupLoFreq = 50.0;
+static constexpr double kStartupLowMidFreq = 1100.0;
+static constexpr double kStartupHighMidFreq = 6100.0;
+static constexpr double kStartupHiFreq = 12000.0;
+static constexpr double kQBoost = 0.3;
+static constexpr double kQKill = 0.9;
+static constexpr double kQKillShelve = 0.4;
+static constexpr double kBoostGain = 12;
+static constexpr double kKillGain = -26;
+
+double getCenterFrequency(double low, double high) {
+    double scaleLow = log10(low);
+    double scaleHigh = log10(high);
+
+    double scaleCenter = (scaleHigh - scaleLow) / 2 + scaleLow;
+    return pow(10, scaleCenter);
+}
+
+double knobValueToBiquadGainDb(double value, bool kill) {
+    if (kill) {
+        return kKillGain;
+    }
+
+    double ret = value - 1;
+    if (ret >= 0) {
+        ret *= kBoostGain;
+    } else {
+        ret *= -kKillGain;
+    }
+    return ret;
+}
+
+} // anonymous namespace
+
+// static
+QString FourBandBiquadEQEffect::getId() {
+    return "org.mixxx.effects.fourbandbiquadeq";
+}
+
+// static
+EffectManifestPointer FourBandBiquadEQEffect::getManifest() {
+    EffectManifestPointer pManifest(new EffectManifest());
+    pManifest->setId(getId());
+    pManifest->setName(QObject::tr("Biquad Equalizer"));
+    pManifest->setShortName(QObject::tr("4BQ EQ"));
+    pManifest->setAuthor("The Mixxx Team");
+    pManifest->setVersion("1.0");
+    pManifest->setDescription(
+            QObject::tr("A 3-band Equalizer with four biquad bell filters, a "
+                        "shelving high pass and kill switches.") +
+            " " + EqualizerUtil::adjustFrequencyShelvesTip());
+    pManifest->setEffectRampsFromDry(true);
+    pManifest->setIsMixingEQ(true);
+
+    EffectManifestParameter::ValueScaler valueScaler =
+            EffectManifestParameter::ValueScaler::Linear;
+    ;
+    double maximum = 2.0;
+
+    EffectManifestParameterPointer low = pManifest->addParameter();
+    low->setId("low");
+    low->setName(QObject::tr("Low"));
+    low->setDescription(QObject::tr("Gain for Low Filter"));
+    low->setValueScaler(valueScaler);
+    low->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    low->setNeutralPointOnScale(0.5);
+    low->setRange(0, 1.0, maximum);
+
+    EffectManifestParameterPointer killLow = pManifest->addParameter();
+    killLow->setId("killLow");
+    killLow->setName(QObject::tr("Kill Low"));
+    killLow->setDescription(QObject::tr("Kill the Low Filter"));
+    killLow->setValueScaler(EffectManifestParameter::ValueScaler::Toggle);
+    killLow->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    killLow->setRange(0, 0, 1);
+
+    EffectManifestParameterPointer lowMid = pManifest->addParameter();
+    lowMid->setId("lowMid");
+    lowMid->setName(QObject::tr("lowMid"));
+    lowMid->setDescription(QObject::tr("Gain for lowMid Filter"));
+    lowMid->setValueScaler(valueScaler);
+    lowMid->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    lowMid->setNeutralPointOnScale(0.5);
+    lowMid->setRange(0, 1.0, maximum);
+
+    EffectManifestParameterPointer killLowMid = pManifest->addParameter();
+    killLowMid->setId("killLowMid");
+    killLowMid->setName(QObject::tr("Kill LowMid"));
+    killLowMid->setDescription(QObject::tr("Kill the LowMid Filter"));
+    killLowMid->setValueScaler(EffectManifestParameter::ValueScaler::Toggle);
+    killLowMid->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    killLowMid->setRange(0, 0, 1);
+
+    EffectManifestParameterPointer highMid = pManifest->addParameter();
+    highMid->setId("highMid");
+    highMid->setName(QObject::tr("HighMid"));
+    highMid->setDescription(QObject::tr("Gain for HighMid Filter"));
+    highMid->setValueScaler(valueScaler);
+    highMid->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    highMid->setNeutralPointOnScale(0.5);
+    highMid->setRange(0, 1.0, maximum);
+
+    EffectManifestParameterPointer killHighMid = pManifest->addParameter();
+    killHighMid->setId("killHighMid");
+    killHighMid->setName(QObject::tr("Kill HighMid"));
+    killHighMid->setDescription(QObject::tr("Kill the HighMid Filter"));
+    killHighMid->setValueScaler(EffectManifestParameter::ValueScaler::Toggle);
+    killHighMid->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    killHighMid->setRange(0, 0, 1);
+
+    EffectManifestParameterPointer high = pManifest->addParameter();
+    high->setId("high");
+    high->setName(QObject::tr("High"));
+    high->setDescription(QObject::tr("Gain for High Filter"));
+    high->setValueScaler(valueScaler);
+    high->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    high->setNeutralPointOnScale(0.5);
+    high->setRange(0, 1.0, maximum);
+
+    EffectManifestParameterPointer killHigh = pManifest->addParameter();
+    killHigh->setId("killHigh");
+    killHigh->setName(QObject::tr("Kill High"));
+    killHigh->setDescription(QObject::tr("Kill the High Filter"));
+    killHigh->setValueScaler(EffectManifestParameter::ValueScaler::Toggle);
+    killHigh->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    killHigh->setRange(0, 0, 1);
+
+    return pManifest;
+}
+
+FourBandBiquadEQEffectGroupState::FourBandBiquadEQEffectGroupState(
+        const mixxx::EngineParameters& engineParameters)
+        : EffectState(engineParameters),
+          m_tempBuf(engineParameters.samplesPerBuffer()),
+          m_oldLowBoost(0),
+          m_oldLowMidBoost(0),
+          m_oldHighMidBoost(0),
+          m_oldHighBoost(0),
+          m_oldLowCut(0),
+          m_oldLowMidCut(0),
+          m_oldHighMidCut(0),
+          m_oldHighCut(0),
+          m_loFreqCorner(0),
+          m_midFreqCorner(0),
+          m_highFreqCorner(0),
+          m_oldSampleRate(engineParameters.sampleRate()) {
+    // Initialize the filters with default parameters
+
+    m_lowBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupLoFreq, kQBoost);
+    m_lowMidBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupLowMidFreq, kQBoost);
+    m_highMidBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupHighMidFreq, kQBoost);
+    m_highBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupHiFreq, kQBoost);
+    m_lowCut = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupLoFreq, kQKill);
+    m_lowMidCut = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupLowMidFreq, kQBoost);
+    m_highMidCut = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupHighMidFreq, kQKill);
+    m_highCut = std::make_unique<EngineFilterBiquad1HighShelving>(
+            engineParameters.sampleRate(), kStartupHiFreq / 2, kQKillShelve);
+}
+
+void FourBandBiquadEQEffectGroupState::setFilters(
+        mixxx::audio::SampleRate sampleRate,
+        double lowFreqCorner,
+        double midFreqCorner,
+        double highFreqCorner) {
+    double lowCenter = getCenterFrequency(kMinimumFrequency, lowFreqCorner);
+    double lowMidCenter = getCenterFrequency(lowFreqCorner, midFreqCorner);
+    double highMidCenter = getCenterFrequency(midFreqCorner, highFreqCorner);
+    double highCenter = getCenterFrequency(highFreqCorner, kMaximumFrequency);
+
+    m_lowBoost->setFrequencyCorners(
+            sampleRate, lowCenter, kQBoost, m_oldLowBoost);
+    m_lowMidBoost->setFrequencyCorners(
+            sampleRate, lowMidCenter, kQBoost, m_oldLowMidBoost);
+    m_highMidBoost->setFrequencyCorners(
+            sampleRate, highMidCenter, kQBoost, m_oldHighMidBoost);
+    m_highBoost->setFrequencyCorners(
+            sampleRate, highCenter, kQBoost, m_oldHighBoost);
+    m_lowCut->setFrequencyCorners(
+            sampleRate, lowCenter, kQKill, m_oldLowCut);
+    m_lowMidCut->setFrequencyCorners(
+            sampleRate, lowMidCenter, kQKill, m_oldLowMidCut);
+    m_highMidCut->setFrequencyCorners(
+            sampleRate, highMidCenter, kQKill, m_oldHighMidCut);
+    m_highCut->setFrequencyCorners(
+            sampleRate, highCenter / 2, kQKillShelve, m_oldHighCut);
+}
+
+FourBandBiquadEQEffect::FourBandBiquadEQEffect()
+        : m_pLoFreqCorner(kMixerProfile, kLowEqFrequency),
+          m_pMidFreqCorner(kMixerProfile, kMidEqFrequency),
+          m_pHiFreqCorner(kMixerProfile, kHighEqFrequency) {
+}
+
+void FourBandBiquadEQEffect::loadEngineEffectParameters(
+        const QMap<QString, EngineEffectParameterPointer>& parameters) {
+    m_pPotLow = parameters.value("low");
+    m_pPotLowMid = parameters.value("lowMid");
+    m_pPotHighMid = parameters.value("highMid");
+    m_pPotHigh = parameters.value("high");
+    m_pKillLow = parameters.value("killLow");
+    m_pKillLowMid = parameters.value("killLowMid");
+    m_pKillHighMid = parameters.value("killHighMid");
+    m_pKillHigh = parameters.value("killHigh");
+}
+
+void FourBandBiquadEQEffect::processChannel(
+        FourBandBiquadEQEffectGroupState* pState,
+        const CSAMPLE* pInput,
+        CSAMPLE* pOutput,
+        const mixxx::EngineParameters& engineParameters,
+        const EffectEnableState enableState,
+        const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(groupFeatures);
+
+    if (pState->m_oldSampleRate != engineParameters.sampleRate() ||
+            (pState->m_loFreqCorner != m_pLoFreqCorner.get()) ||
+            (pState->m_midFreqCorner != m_pMidFreqCorner.get()) ||
+            (pState->m_highFreqCorner != m_pHiFreqCorner.get())) {
+        pState->m_loFreqCorner = m_pLoFreqCorner.get();
+        pState->m_midFreqCorner = m_pMidFreqCorner.get();
+        pState->m_highFreqCorner = m_pHiFreqCorner.get();
+        pState->m_oldSampleRate = engineParameters.sampleRate();
+        pState->setFilters(engineParameters.sampleRate(),
+                pState->m_loFreqCorner,
+                pState->m_midFreqCorner,
+                pState->m_highFreqCorner);
+    }
+
+    // Ramp to dry, when disabling, this will ramp from dry when enabling as well
+    double bqGainLow = 0;
+    double bqGainLowMid = 0;
+    double bqGainHighMid = 0;
+    double bqGainHigh = 0;
+    if (enableState != EffectEnableState::Disabling) {
+        bqGainLow = knobValueToBiquadGainDb(
+                m_pPotLow->value(), m_pKillLow->toBool());
+        bqGainLowMid = knobValueToBiquadGainDb(
+                m_pPotLowMid->value(), m_pKillLowMid->toBool());
+        bqGainHighMid = knobValueToBiquadGainDb(
+                m_pPotHighMid->value(), m_pKillHighMid->toBool());
+        bqGainHigh = knobValueToBiquadGainDb(
+                m_pPotHigh->value(), m_pKillHigh->toBool());
+    }
+
+    int activeFilters = 0;
+
+    if (bqGainLow > 0.0 || pState->m_oldLowBoost > 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainLow < 0.0 || pState->m_oldLowCut < 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainLowMid > 0.0 || pState->m_oldLowMidBoost > 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainLowMid < 0.0 || pState->m_oldLowMidCut < 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainHighMid > 0.0 || pState->m_oldHighMidBoost > 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainHighMid < 0.0 || pState->m_oldHighMidCut < 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainHigh > 0.0 || pState->m_oldHighBoost > 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainHigh < 0.0 || pState->m_oldHighCut < 0.0) {
+        ++activeFilters;
+    }
+
+    QVarLengthArray<const CSAMPLE*, 6> inBuffer;
+    QVarLengthArray<CSAMPLE*, 6> outBuffer;
+
+    if (activeFilters % 2 == 0) {
+        inBuffer.append(pInput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+    } else {
+        inBuffer.append(pInput);
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+    }
+
+    int bufIndex = 0;
+
+    if (bqGainLow > 0.0 || pState->m_oldLowBoost > 0.0) {
+        if (bqGainLow != pState->m_oldLowBoost) {
+            double lowCenter = getCenterFrequency(
+                    kMinimumFrequency, pState->m_loFreqCorner);
+            pState->m_lowBoost->setFrequencyCorners(
+                    engineParameters.sampleRate(), lowCenter, kQBoost, bqGainLow);
+            pState->m_oldLowBoost = bqGainLow;
+        }
+        if (bqGainLow > 0.0) {
+            pState->m_lowBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_lowBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_lowBoost->pauseFilter();
+    }
+
+    if (bqGainLow < 0.0 || pState->m_oldLowCut < 0.0) {
+        if (bqGainLow != pState->m_oldLowCut) {
+            double lowCenter = getCenterFrequency(
+                    kMinimumFrequency, pState->m_loFreqCorner);
+            pState->m_lowCut->setFrequencyCorners(
+                    engineParameters.sampleRate(), lowCenter, kQKill, bqGainLow);
+            pState->m_oldLowCut = bqGainLow;
+        }
+        if (bqGainLow < 0.0) {
+            pState->m_lowCut->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_lowCut->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_lowCut->pauseFilter();
+    }
+
+    if (bqGainLowMid > 0.0 || pState->m_oldLowMidBoost > 0.0) {
+        if (bqGainLowMid != pState->m_oldLowMidBoost) {
+            double lowMidCenter = getCenterFrequency(
+                    pState->m_loFreqCorner, pState->m_midFreqCorner);
+            pState->m_lowMidBoost->setFrequencyCorners(
+                    engineParameters.sampleRate(), lowMidCenter, kQBoost, bqGainLowMid);
+            pState->m_oldLowMidBoost = bqGainLowMid;
+        }
+        if (bqGainLowMid > 0.0) {
+            pState->m_lowMidBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_lowMidBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_lowMidBoost->pauseFilter();
+    }
+
+    if (bqGainLowMid < 0.0 || pState->m_oldLowMidCut < 0.0) {
+        if (bqGainLowMid != pState->m_oldLowMidCut) {
+            double lowMidCenter = getCenterFrequency(
+                    pState->m_loFreqCorner, pState->m_midFreqCorner);
+            pState->m_lowMidCut->setFrequencyCorners(
+                    engineParameters.sampleRate(), lowMidCenter, kQKill, bqGainLowMid);
+            pState->m_oldLowMidCut = bqGainLowMid;
+        }
+        if (bqGainLowMid < 0.0) {
+            pState->m_lowMidCut->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_lowMidCut->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_lowMidCut->pauseFilter();
+    }
+
+    if (bqGainHighMid > 0.0 || pState->m_oldHighMidBoost > 0.0) {
+        if (bqGainHighMid != pState->m_oldHighMidBoost) {
+            double highMidCenter = getCenterFrequency(
+                    pState->m_midFreqCorner, pState->m_highFreqCorner);
+            pState->m_highMidBoost->setFrequencyCorners(
+                    engineParameters.sampleRate(), highMidCenter, kQBoost, bqGainHighMid);
+            pState->m_oldHighMidBoost = bqGainHighMid;
+        }
+        if (bqGainHighMid > 0.0) {
+            pState->m_highMidBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_highMidBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_highMidBoost->pauseFilter();
+    }
+
+    if (bqGainHighMid < 0.0 || pState->m_oldHighMidCut < 0.0) {
+        if (bqGainHighMid != pState->m_oldHighMidCut) {
+            double highMidCenter = getCenterFrequency(
+                    pState->m_midFreqCorner, pState->m_highFreqCorner);
+            pState->m_highMidCut->setFrequencyCorners(
+                    engineParameters.sampleRate(), highMidCenter, kQKill, bqGainHighMid);
+            pState->m_oldHighMidCut = bqGainHighMid;
+        }
+        if (bqGainHighMid < 0.0) {
+            pState->m_highMidCut->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_highMidCut->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_highMidCut->pauseFilter();
+    }
+
+    if (bqGainHigh > 0.0 || pState->m_oldHighBoost > 0.0) {
+        if (bqGainHigh != pState->m_oldHighBoost) {
+            double highCenter = getCenterFrequency(
+                    pState->m_highFreqCorner, kMaximumFrequency);
+            pState->m_highBoost->setFrequencyCorners(
+                    engineParameters.sampleRate(), highCenter, kQBoost, bqGainHigh);
+            pState->m_oldHighBoost = bqGainHigh;
+        }
+        if (bqGainHigh > 0.0) {
+            pState->m_highBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_highBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_highBoost->pauseFilter();
+    }
+
+    if (bqGainHigh < 0.0 || pState->m_oldHighCut < 0.0) {
+        if (bqGainHigh != pState->m_oldHighCut) {
+            double highCenter = getCenterFrequency(
+                    pState->m_highFreqCorner, kMaximumFrequency);
+            pState->m_highCut->setFrequencyCorners(
+                    engineParameters.sampleRate(), highCenter / 2, kQKillShelve, bqGainHigh);
+            pState->m_oldHighCut = bqGainHigh;
+        }
+        if (bqGainHigh < 0.0) {
+            pState->m_highCut->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_highCut->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_highCut->pauseFilter();
+    }
+
+    if (activeFilters == 0) {
+        if (pOutput != pInput) {
+            SampleUtil::copy(pOutput, pInput, engineParameters.samplesPerBuffer());
+        }
+    }
+
+    if (enableState == EffectEnableState::Disabling) {
+        pState->m_lowBoost->pauseFilter();
+        pState->m_lowMidBoost->pauseFilter();
+        pState->m_highMidBoost->pauseFilter();
+        pState->m_highBoost->pauseFilter();
+        pState->m_lowCut->pauseFilter();
+        pState->m_lowMidCut->pauseFilter();
+        pState->m_highMidCut->pauseFilter();
+        pState->m_highCut->pauseFilter();
+    }
+}

--- a/src/effects/backends/builtin/fourbandbiquadeqeffect.h
+++ b/src/effects/backends/builtin/fourbandbiquadeqeffect.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <memory>
+
+#include "control/pollingcontrolproxy.h"
+#include "effects/backends/effectprocessor.h"
+#include "engine/filters/enginefilterbiquad1.h"
+#include "util/samplebuffer.h"
+#include "util/types.h"
+
+class FourBandBiquadEQEffectGroupState final : public EffectState {
+  public:
+    FourBandBiquadEQEffectGroupState(const mixxx::EngineParameters& engineParameters);
+    ~FourBandBiquadEQEffectGroupState() override = default;
+
+    void setFilters(mixxx::audio::SampleRate sampleRate,
+            double lowFreqCorner,
+            double midFreqCorner,
+            double highFreqCorner);
+
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_lowBoost;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_lowMidBoost;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_highMidBoost;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_highBoost;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_lowCut;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_lowMidCut;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_highMidCut;
+    std::unique_ptr<EngineFilterBiquad1HighShelving> m_highCut;
+    mixxx::SampleBuffer m_tempBuf;
+    double m_oldLowBoost;
+    double m_oldLowMidBoost;
+    double m_oldHighMidBoost;
+    double m_oldHighBoost;
+    double m_oldLowCut;
+    double m_oldLowMidCut;
+    double m_oldHighMidCut;
+    double m_oldHighCut;
+
+    double m_loFreqCorner;
+    double m_midFreqCorner;
+    double m_highFreqCorner;
+
+    mixxx::audio::SampleRate m_oldSampleRate;
+};
+
+class FourBandBiquadEQEffect : public EffectProcessorImpl<FourBandBiquadEQEffectGroupState> {
+  public:
+    FourBandBiquadEQEffect();
+    ~FourBandBiquadEQEffect() override = default;
+
+    static QString getId();
+    static EffectManifestPointer getManifest();
+
+    void loadEngineEffectParameters(
+            const QMap<QString, EngineEffectParameterPointer>& parameters) override;
+
+    void processChannel(
+            FourBandBiquadEQEffectGroupState* pState,
+            const CSAMPLE* pInput,
+            CSAMPLE* pOutput,
+            const mixxx::EngineParameters& engineParameters,
+            const EffectEnableState enableState,
+            const GroupFeatureState& groupFeatureState) override;
+
+    void setFilters(mixxx::audio::SampleRate sampleRate,
+            double lowFreqCorner,
+            double midFreqCorner,
+            double highFreqCorner);
+
+  private:
+    FourBandBiquadEQEffect(const FourBandBiquadEQEffect&) = delete;
+    void operator=(const FourBandBiquadEQEffect&) = delete;
+
+    QString debugString() const {
+        return getId();
+    }
+
+    EngineEffectParameterPointer m_pPotLow;
+    EngineEffectParameterPointer m_pPotLowMid;
+    EngineEffectParameterPointer m_pPotHighMid;
+    EngineEffectParameterPointer m_pPotHigh;
+
+    EngineEffectParameterPointer m_pKillLow;
+    EngineEffectParameterPointer m_pKillLowMid;
+    EngineEffectParameterPointer m_pKillHighMid;
+    EngineEffectParameterPointer m_pKillHigh;
+
+    PollingControlProxy m_pLoFreqCorner;
+    PollingControlProxy m_pMidFreqCorner;
+    PollingControlProxy m_pHiFreqCorner;
+};

--- a/src/effects/backends/builtin/twobandbiquadeqeffect.cpp
+++ b/src/effects/backends/builtin/twobandbiquadeqeffect.cpp
@@ -1,0 +1,335 @@
+#include "effects/backends/builtin/twobandbiquadeqeffect.h"
+
+#include "effects/backends/effectmanifest.h"
+#include "effects/defs.h"
+#include "engine/effects/engineeffectparameter.h"
+#include "util/math.h"
+
+namespace {
+
+// The defaults are tweaked to match the Xone:23 EQ
+// but allow 12 dB boost instead of just 6 dB
+static constexpr int kStartupSamplerate = 44100;
+static constexpr double kMinimumFrequency = 10.0;
+static constexpr double kMaximumFrequency = kStartupSamplerate / 2;
+static constexpr double kStartupLoFreq = 50.0;
+static constexpr double kStartupHiFreq = 12000.0;
+static constexpr double kQBoost = 0.3;
+static constexpr double kQKill = 0.9;
+static constexpr double kQKillShelve = 0.4;
+static constexpr double kBoostGain = 12;
+static constexpr double kKillGain = -26;
+
+double getCenterFrequency(double low, double high) {
+    double scaleLow = log10(low);
+    double scaleHigh = log10(high);
+
+    double scaleCenter = (scaleHigh - scaleLow) / 2 + scaleLow;
+    return pow(10, scaleCenter);
+}
+
+double knobValueToBiquadGainDb(double value, bool kill) {
+    if (kill) {
+        return kKillGain;
+    }
+
+    double ret = value - 1;
+    if (ret >= 0) {
+        ret *= kBoostGain;
+    } else {
+        ret *= -kKillGain;
+    }
+    return ret;
+}
+
+} // anonymous namespace
+
+// static
+QString TwoBandBiquadEQEffect::getId() {
+    return "org.mixxx.effects.twobandbiquadeq";
+}
+
+// static
+EffectManifestPointer TwoBandBiquadEQEffect::getManifest() {
+    EffectManifestPointer pManifest(new EffectManifest());
+    pManifest->setId(getId());
+    pManifest->setName(QObject::tr("Biquad Equalizer"));
+    pManifest->setShortName(QObject::tr("2BQ EQ"));
+    pManifest->setAuthor("The Mixxx Team");
+    pManifest->setVersion("1.0");
+    pManifest->setDescription(
+            QObject::tr("A 3-band Equalizer with two biquad bell filters, a "
+                        "shelving high pass and kill switches.") +
+            " " + QObject::tr("To adjust frequency shelves, go to Preferences -> Mixer."));
+    pManifest->setEffectRampsFromDry(true);
+    pManifest->setIsMixingEQ(true);
+
+    EffectManifestParameter::ValueScaler valueScaler =
+            EffectManifestParameter::ValueScaler::Linear;
+    ;
+    double maximum = 2.0;
+
+    EffectManifestParameterPointer low = pManifest->addParameter();
+    low->setId("low");
+    low->setName(QObject::tr("Low"));
+    low->setDescription(QObject::tr("Gain for Low Filter"));
+    low->setValueScaler(valueScaler);
+    low->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    low->setNeutralPointOnScale(0.5);
+    low->setRange(0, 1.0, maximum);
+
+    EffectManifestParameterPointer killLow = pManifest->addParameter();
+    killLow->setId("killLow");
+    killLow->setName(QObject::tr("Kill Low"));
+    killLow->setDescription(QObject::tr("Kill the Low Filter"));
+    killLow->setValueScaler(EffectManifestParameter::ValueScaler::Toggle);
+    killLow->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    killLow->setRange(0, 0, 1);
+
+    EffectManifestParameterPointer high = pManifest->addParameter();
+    high->setId("high");
+    high->setName(QObject::tr("High"));
+    high->setDescription(QObject::tr("Gain for High Filter"));
+    high->setValueScaler(valueScaler);
+    high->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    high->setNeutralPointOnScale(0.5);
+    high->setRange(0, 1.0, maximum);
+
+    EffectManifestParameterPointer killHigh = pManifest->addParameter();
+    killHigh->setId("killHigh");
+    killHigh->setName(QObject::tr("Kill High"));
+    killHigh->setDescription(QObject::tr("Kill the High Filter"));
+    killHigh->setValueScaler(EffectManifestParameter::ValueScaler::Toggle);
+    killHigh->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    killHigh->setRange(0, 0, 1);
+
+    return pManifest;
+}
+
+TwoBandBiquadEQEffectGroupState::TwoBandBiquadEQEffectGroupState(
+        const mixxx::EngineParameters& engineParameters)
+        : EffectState(engineParameters),
+          m_tempBuf(engineParameters.samplesPerBuffer()),
+          m_oldLowBoost(0),
+          m_oldHighBoost(0),
+          m_oldLowCut(0),
+          m_oldHighCut(0),
+          m_freqCorner(0),
+          m_oldSampleRate(engineParameters.sampleRate()) {
+    // Initialize the filters with default parameters
+
+    m_lowBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupLoFreq, kQBoost);
+    m_highBoost = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupHiFreq, kQBoost);
+    m_lowCut = std::make_unique<EngineFilterBiquad1Peaking>(
+            engineParameters.sampleRate(), kStartupLoFreq, kQKill);
+    m_highCut = std::make_unique<EngineFilterBiquad1HighShelving>(
+            engineParameters.sampleRate(), kStartupHiFreq / 2, kQKillShelve);
+}
+
+void TwoBandBiquadEQEffectGroupState::setFilters(
+        mixxx::audio::SampleRate sampleRate, double freqCorner) {
+    double lowCenter = getCenterFrequency(kMinimumFrequency, freqCorner);
+    double highCenter = getCenterFrequency(freqCorner, kMaximumFrequency);
+
+    m_lowBoost->setFrequencyCorners(
+            sampleRate, lowCenter, kQBoost, m_oldLowBoost);
+    m_highBoost->setFrequencyCorners(
+            sampleRate, highCenter, kQBoost, m_oldHighBoost);
+    m_lowCut->setFrequencyCorners(
+            sampleRate, lowCenter, kQKill, m_oldLowCut);
+    m_highCut->setFrequencyCorners(
+            sampleRate, highCenter / 2, kQKillShelve, m_oldHighCut);
+}
+
+TwoBandBiquadEQEffect::TwoBandBiquadEQEffect()
+        : m_pFreqCorner(kMixerProfile, kMidEqFrequency) {
+}
+
+void TwoBandBiquadEQEffect::loadEngineEffectParameters(
+        const QMap<QString, EngineEffectParameterPointer>& parameters) {
+    m_pPotLow = parameters.value("low");
+    m_pPotHigh = parameters.value("high");
+    m_pKillLow = parameters.value("killLow");
+    m_pKillHigh = parameters.value("killHigh");
+}
+
+void TwoBandBiquadEQEffect::processChannel(
+        TwoBandBiquadEQEffectGroupState* pState,
+        const CSAMPLE* pInput,
+        CSAMPLE* pOutput,
+        const mixxx::EngineParameters& engineParameters,
+        const EffectEnableState enableState,
+        const GroupFeatureState& groupFeatures) {
+    Q_UNUSED(groupFeatures);
+
+    if (pState->m_oldSampleRate != engineParameters.sampleRate() ||
+            (pState->m_freqCorner != m_pFreqCorner.get())) {
+        pState->m_freqCorner = m_pFreqCorner.get();
+        pState->m_oldSampleRate = engineParameters.sampleRate();
+        pState->setFilters(engineParameters.sampleRate(),
+                pState->m_freqCorner);
+    }
+
+    // Ramp to dry, when disabling, this will ramp from dry when enabling as well
+    double bqGainLow = 0;
+    double bqGainHigh = 0;
+    if (enableState != EffectEnableState::Disabling) {
+        bqGainLow = knobValueToBiquadGainDb(
+                m_pPotLow->value(), m_pKillLow->toBool());
+        bqGainHigh = knobValueToBiquadGainDb(
+                m_pPotHigh->value(), m_pKillHigh->toBool());
+    }
+
+    int activeFilters = 0;
+
+    if (bqGainLow > 0.0 || pState->m_oldLowBoost > 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainLow < 0.0 || pState->m_oldLowCut < 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainHigh > 0.0 || pState->m_oldHighBoost > 0.0) {
+        ++activeFilters;
+    }
+    if (bqGainHigh < 0.0 || pState->m_oldHighCut < 0.0) {
+        ++activeFilters;
+    }
+
+    QVarLengthArray<const CSAMPLE*, 6> inBuffer;
+    QVarLengthArray<CSAMPLE*, 6> outBuffer;
+
+    if (activeFilters % 2 == 0) {
+        inBuffer.append(pInput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+    } else {
+        inBuffer.append(pInput);
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+
+        inBuffer.append(pState->m_tempBuf.data());
+        outBuffer.append(pOutput);
+
+        inBuffer.append(pOutput);
+        outBuffer.append(pState->m_tempBuf.data());
+    }
+
+    int bufIndex = 0;
+
+    if (bqGainLow > 0.0 || pState->m_oldLowBoost > 0.0) {
+        if (bqGainLow != pState->m_oldLowBoost) {
+            double lowCenter = getCenterFrequency(
+                    kMinimumFrequency, pState->m_freqCorner);
+            pState->m_lowBoost->setFrequencyCorners(
+                    engineParameters.sampleRate(), lowCenter, kQBoost, bqGainLow);
+            pState->m_oldLowBoost = bqGainLow;
+        }
+        if (bqGainLow > 0.0) {
+            pState->m_lowBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_lowBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_lowBoost->pauseFilter();
+    }
+
+    if (bqGainLow < 0.0 || pState->m_oldLowCut < 0.0) {
+        if (bqGainLow != pState->m_oldLowCut) {
+            double lowCenter = getCenterFrequency(
+                    kMinimumFrequency, pState->m_freqCorner);
+            pState->m_lowCut->setFrequencyCorners(
+                    engineParameters.sampleRate(), lowCenter, kQKill, bqGainLow);
+            pState->m_oldLowCut = bqGainLow;
+        }
+        if (bqGainLow < 0.0) {
+            pState->m_lowCut->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_lowCut->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_lowCut->pauseFilter();
+    }
+
+    if (bqGainHigh > 0.0 || pState->m_oldHighBoost > 0.0) {
+        if (bqGainHigh != pState->m_oldHighBoost) {
+            double highCenter = getCenterFrequency(
+                    pState->m_freqCorner, kMaximumFrequency);
+            pState->m_highBoost->setFrequencyCorners(
+                    engineParameters.sampleRate(), highCenter, kQBoost, bqGainHigh);
+            pState->m_oldHighBoost = bqGainHigh;
+        }
+        if (bqGainHigh > 0.0) {
+            pState->m_highBoost->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_highBoost->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_highBoost->pauseFilter();
+    }
+
+    if (bqGainHigh < 0.0 || pState->m_oldHighCut < 0.0) {
+        if (bqGainHigh != pState->m_oldHighCut) {
+            double highCenter = getCenterFrequency(
+                    pState->m_freqCorner, kMaximumFrequency);
+            pState->m_highCut->setFrequencyCorners(
+                    engineParameters.sampleRate(), highCenter / 2, kQKillShelve, bqGainHigh);
+            pState->m_oldHighCut = bqGainHigh;
+        }
+        if (bqGainHigh < 0.0) {
+            pState->m_highCut->process(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        } else {
+            pState->m_highCut->processAndPauseFilter(
+                    inBuffer[bufIndex], outBuffer[bufIndex], engineParameters.samplesPerBuffer());
+        }
+        ++bufIndex;
+    } else {
+        pState->m_highCut->pauseFilter();
+    }
+
+    if (activeFilters == 0) {
+        if (pOutput != pInput) {
+            SampleUtil::copy(pOutput, pInput, engineParameters.samplesPerBuffer());
+        }
+    }
+
+    if (enableState == EffectEnableState::Disabling) {
+        pState->m_lowBoost->pauseFilter();
+        pState->m_highBoost->pauseFilter();
+        pState->m_lowCut->pauseFilter();
+        pState->m_highCut->pauseFilter();
+    }
+}

--- a/src/effects/backends/builtin/twobandbiquadeqeffect.h
+++ b/src/effects/backends/builtin/twobandbiquadeqeffect.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <memory>
+
+#include "control/pollingcontrolproxy.h"
+#include "effects/backends/effectprocessor.h"
+#include "engine/filters/enginefilterbiquad1.h"
+#include "util/samplebuffer.h"
+#include "util/types.h"
+
+class TwoBandBiquadEQEffectGroupState final : public EffectState {
+  public:
+    TwoBandBiquadEQEffectGroupState(const mixxx::EngineParameters& engineParameters);
+    ~TwoBandBiquadEQEffectGroupState() override = default;
+
+    void setFilters(
+            mixxx::audio::SampleRate sampleRate, double freqCorner);
+
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_lowBoost;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_highBoost;
+    std::unique_ptr<EngineFilterBiquad1Peaking> m_lowCut;
+    std::unique_ptr<EngineFilterBiquad1HighShelving> m_highCut;
+    mixxx::SampleBuffer m_tempBuf;
+    double m_oldLowBoost;
+    double m_oldHighBoost;
+    double m_oldLowCut;
+    double m_oldHighCut;
+
+    double m_freqCorner;
+
+    mixxx::audio::SampleRate m_oldSampleRate;
+};
+
+class TwoBandBiquadEQEffect : public EffectProcessorImpl<TwoBandBiquadEQEffectGroupState> {
+  public:
+    TwoBandBiquadEQEffect();
+    ~TwoBandBiquadEQEffect() override = default;
+
+    static QString getId();
+    static EffectManifestPointer getManifest();
+
+    void loadEngineEffectParameters(
+            const QMap<QString, EngineEffectParameterPointer>& parameters) override;
+
+    void processChannel(
+            TwoBandBiquadEQEffectGroupState* pState,
+            const CSAMPLE* pInput,
+            CSAMPLE* pOutput,
+            const mixxx::EngineParameters& engineParameters,
+            const EffectEnableState enableState,
+            const GroupFeatureState& groupFeatureState) override;
+
+    void setFilters(mixxx::audio::SampleRate sampleRate,
+            double lowFreqCorner,
+            double highFreqCorner);
+
+  private:
+    TwoBandBiquadEQEffect(const TwoBandBiquadEQEffect&) = delete;
+    void operator=(const TwoBandBiquadEQEffect&) = delete;
+
+    QString debugString() const {
+        return getId();
+    }
+
+    EngineEffectParameterPointer m_pPotLow;
+    EngineEffectParameterPointer m_pPotHigh;
+
+    EngineEffectParameterPointer m_pKillLow;
+    EngineEffectParameterPointer m_pKillHigh;
+
+    PollingControlProxy m_pFreqCorner;
+};

--- a/src/effects/defs.h
+++ b/src/effects/defs.h
@@ -44,6 +44,7 @@ const QString kNoEffectString = QStringLiteral("---");
 
 const QString kMixerProfile = QStringLiteral("[Mixer Profile]");
 const QString kHighEqFrequency = QStringLiteral("HiEQFrequency");
+const QString kMidEqFrequency = QStringLiteral("MidEQFrequency");
 const QString kLowEqFrequency = QStringLiteral("LoEQFrequency");
 
 // NOTE: Setting this to true will enable string manipulation and calls to

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -27,6 +27,7 @@ EffectsManager::EffectsManager(
         : m_pConfig(pConfig),
           m_pChannelHandleFactory(pChannelHandleFactory),
           m_loEqFreq(ConfigKey(kMixerProfile, kLowEqFrequency), 0., 22040),
+          m_midEqFreq(ConfigKey(kMixerProfile, kMidEqFrequency), 0., 22040),
           m_hiEqFreq(ConfigKey(kMixerProfile, kHighEqFrequency), 0., 22040),
           m_initializedFromEffectsXml(false) {
     qRegisterMetaType<EffectChainMixMode>("EffectChainMixMode");

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -117,6 +117,7 @@ class EffectsManager {
     // ControlObjects for Equalizers' frequencies
     // TODO: replace these with effect parameters that are hidden by default
     ControlPotmeter m_loEqFreq;
+    ControlPotmeter m_midEqFreq;
     ControlPotmeter m_hiEqFreq;
 
     // This is set true when setup() is run. Then, the initial decks (their EQ

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -37,6 +37,9 @@ const QString kDefaultMainEqId = QString();
 const ConfigKey kHighEqFreqKey = ConfigKey(kMixerProfile, kHighEqFrequency);
 const ConfigKey kHighEqFreqPreciseKey =
         ConfigKey(kMixerProfile, QStringLiteral("HiEQFrequencyPrecise"));
+const ConfigKey kMidEqFreqKey = ConfigKey(kMixerProfile, kMidEqFrequency);
+const ConfigKey kMidEqFreqPreciseKey =
+        ConfigKey(kMixerProfile, QStringLiteral("MidEQFrequencyPrecise"));
 const ConfigKey kLowEqFreqKey = ConfigKey(kMixerProfile, kLowEqFrequency);
 const ConfigKey kLowEqFreqPreciseKey =
         ConfigKey(kMixerProfile, QStringLiteral("LoEQFrequencyPrecise"));
@@ -81,8 +84,10 @@ DlgPrefMixer::DlgPrefMixer(
           m_crossfader(QStringLiteral("[Master]"), QStringLiteral("crossfader")),
           m_xFaderReverse(false),
           m_COLoFreq(kLowEqFreqKey),
+          m_COMidFreq(kMidEqFreqKey),
           m_COHiFreq(kHighEqFreqKey),
           m_lowEqFreq(0.0),
+          m_midEqFreq(0.0),
           m_highEqFreq(0.0),
           m_pChainPresetManager(pEffectsManager->getChainPresetManager()),
           m_pEffectsManager(pEffectsManager),
@@ -142,6 +147,10 @@ DlgPrefMixer::DlgPrefMixer(
     connect(SliderHiEQ, &QSlider::valueChanged, this, &DlgPrefMixer::slotHiEqSliderChanged);
     connect(SliderHiEQ, &QSlider::sliderMoved, this, &DlgPrefMixer::slotHiEqSliderChanged);
     connect(SliderHiEQ, &QSlider::sliderReleased, this, &DlgPrefMixer::slotHiEqSliderChanged);
+
+    connect(SliderMidEQ, &QSlider::valueChanged, this, &DlgPrefMixer::slotMidEqSliderChanged);
+    connect(SliderMidEQ, &QSlider::sliderMoved, this, &DlgPrefMixer::slotMidEqSliderChanged);
+    connect(SliderMidEQ, &QSlider::sliderReleased, this, &DlgPrefMixer::slotMidEqSliderChanged);
 
     connect(SliderLoEQ, &QSlider::valueChanged, this, &DlgPrefMixer::slotLoEqSliderChanged);
     connect(SliderLoEQ, &QSlider::sliderMoved, this, &DlgPrefMixer::slotLoEqSliderChanged);
@@ -222,6 +231,7 @@ DlgPrefMixer::DlgPrefMixer(
 
     setScrollSafeGuard(SliderXFader);
     setScrollSafeGuard(SliderHiEQ);
+    setScrollSafeGuard(SliderMidEQ);
     setScrollSafeGuard(SliderLoEQ);
     setScrollSafeGuard(comboBoxMainEq);
 
@@ -493,9 +503,13 @@ QUrl DlgPrefMixer::helpUrl() const {
 
 void DlgPrefMixer::setDefaultShelves() {
     SliderHiEQ->setValue(
-            getSliderPosition(2500,
+            getSliderPosition(4500,
                     SliderHiEQ->minimum(),
                     SliderHiEQ->maximum()));
+    SliderMidEQ->setValue(
+            getSliderPosition(1500,
+                    SliderMidEQ->minimum(),
+                    SliderMidEQ->maximum()));
     SliderLoEQ->setValue(
             getSliderPosition(250,
                     SliderLoEQ->minimum(),
@@ -641,8 +655,8 @@ void DlgPrefMixer::applyQuickEffects() {
 }
 
 void DlgPrefMixer::slotHiEqSliderChanged() {
-    if (SliderHiEQ->value() < SliderLoEQ->value()) {
-        SliderHiEQ->setValue(SliderLoEQ->value());
+    if (SliderHiEQ->value() < SliderMidEQ->value()) {
+        SliderMidEQ->setValue(SliderHiEQ->value());
     }
     m_highEqFreq = getEqFreq(SliderHiEQ->value(),
             SliderHiEQ->minimum(),
@@ -657,9 +671,28 @@ void DlgPrefMixer::slotHiEqSliderChanged() {
     m_COHiFreq.set(m_highEqFreq);
 }
 
+void DlgPrefMixer::slotMidEqSliderChanged() {
+    if (SliderMidEQ->value() < SliderLoEQ->value()) {
+        SliderLoEQ->setValue(SliderMidEQ->value());
+    } else if (SliderHiEQ->value() < SliderMidEQ->value()) {
+        SliderHiEQ->setValue(SliderMidEQ->value());
+    }
+    m_midEqFreq = getEqFreq(SliderMidEQ->value(),
+            SliderMidEQ->minimum(),
+            SliderMidEQ->maximum());
+    validateEQShelves();
+    if (m_midEqFreq < 1000) {
+        TextMidEQ->setText(QString("%1 Hz").arg(std::round(m_midEqFreq)));
+    } else {
+        TextMidEQ->setText(QString("%1 kHz").arg(std::round(m_midEqFreq) / 1000.));
+    }
+
+    m_COMidFreq.set(m_midEqFreq);
+}
+
 void DlgPrefMixer::slotLoEqSliderChanged() {
-    if (SliderLoEQ->value() > SliderHiEQ->value()) {
-        SliderLoEQ->setValue(SliderHiEQ->value());
+    if (SliderLoEQ->value() > SliderMidEQ->value()) {
+        SliderMidEQ->setValue(SliderLoEQ->value());
     }
     m_lowEqFreq = getEqFreq(SliderLoEQ->value(),
             SliderLoEQ->minimum(),
@@ -765,6 +798,7 @@ void DlgPrefMixer::storeEqShelves() {
     }
 
     m_pConfig->set(kHighEqFreqPreciseKey, ConfigValue(QString::number(m_highEqFreq, 'f')));
+    m_pConfig->set(kMidEqFreqPreciseKey, ConfigValue(QString::number(m_midEqFreq, 'f')));
     m_pConfig->set(kLowEqFreqPreciseKey, ConfigValue(QString::number(m_lowEqFreq, 'f')));
 }
 
@@ -807,24 +841,35 @@ void DlgPrefMixer::slotUpdate() {
     // EQ shelves //////////////////////////////////////////////////////////////
     QString highEqCoarse = m_pConfig->getValueString(kHighEqFreqKey);
     QString highEqPrecise = m_pConfig->getValueString(kHighEqFreqPreciseKey);
+    QString midEqCoarse = m_pConfig->getValueString(kMidEqFreqKey);
+    QString midEqPrecise = m_pConfig->getValueString(kMidEqFreqPreciseKey);
     QString lowEqCoarse = m_pConfig->getValueString(kLowEqFreqKey);
     QString lowEqPrecise = m_pConfig->getValueString(kLowEqFreqPreciseKey);
     double lowEqFreq = 0.0;
+    double midEqFreq = 0.0;
     double highEqFreq = 0.0;
 
     // Precise takes precedence over coarse.
     lowEqFreq = lowEqCoarse.isEmpty() ? lowEqFreq : lowEqCoarse.toDouble();
     lowEqFreq = lowEqPrecise.isEmpty() ? lowEqFreq : lowEqPrecise.toDouble();
+    midEqFreq = midEqCoarse.isEmpty() ? midEqFreq : midEqCoarse.toDouble();
+    midEqFreq = midEqPrecise.isEmpty() ? midEqFreq : midEqPrecise.toDouble();
     highEqFreq = highEqCoarse.isEmpty() ? highEqFreq : highEqCoarse.toDouble();
     highEqFreq = highEqPrecise.isEmpty() ? highEqFreq : highEqPrecise.toDouble();
 
-    if (lowEqFreq == 0.0 || highEqFreq == 0.0 || lowEqFreq == highEqFreq) {
+    if (lowEqFreq == 0.0 || midEqFreq == 0.0 || highEqFreq == 0.0 ||
+            lowEqFreq == midEqFreq || midEqFreq == highEqFreq) {
         setDefaultShelves();
     } else {
         SliderHiEQ->setValue(
                 getSliderPosition(highEqFreq,
                         SliderHiEQ->minimum(),
                         SliderHiEQ->maximum()));
+
+        SliderMidEQ->setValue(
+                getSliderPosition(midEqFreq,
+                        SliderMidEQ->minimum(),
+                        SliderMidEQ->maximum()));
 
         SliderLoEQ->setValue(
                 getSliderPosition(lowEqFreq,
@@ -1313,12 +1358,22 @@ double DlgPrefMixer::getEqFreq(int sliderVal, int minValue, int maxValue) {
 
 void DlgPrefMixer::validateEQShelves() {
     m_highEqFreq = math_clamp<double>(m_highEqFreq, kFrequencyLowerLimit, kFrequencyUpperLimit);
+    m_midEqFreq = math_clamp<double>(m_midEqFreq, kFrequencyLowerLimit, kFrequencyUpperLimit);
     m_lowEqFreq = math_clamp<double>(m_lowEqFreq, kFrequencyLowerLimit, kFrequencyUpperLimit);
-    if (m_lowEqFreq == m_highEqFreq) {
+    if (m_lowEqFreq == m_midEqFreq) {
         if (m_lowEqFreq == kFrequencyLowerLimit) {
+            ++m_midEqFreq;
+        } else if (m_midEqFreq == kFrequencyUpperLimit) {
+            --m_lowEqFreq;
+        } else {
+            ++m_midEqFreq;
+        }
+    }
+    if (m_midEqFreq == m_highEqFreq) {
+        if (m_midEqFreq == kFrequencyLowerLimit) {
             ++m_highEqFreq;
         } else if (m_highEqFreq == kFrequencyUpperLimit) {
-            --m_lowEqFreq;
+            --m_midEqFreq;
         } else {
             ++m_highEqFreq;
         }

--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -61,6 +61,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     void slotXFaderReverseControlChanged(double v);
 
     void slotHiEqSliderChanged();
+    void slotMidEqSliderChanged();
     void slotLoEqSliderChanged();
 
     /// Update the Main EQ
@@ -106,8 +107,9 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     parented_ptr<QGraphicsScene> m_pxfScene;
 
     PollingControlProxy m_COLoFreq;
+    PollingControlProxy m_COMidFreq;
     PollingControlProxy m_COHiFreq;
-    double m_lowEqFreq, m_highEqFreq;
+    double m_lowEqFreq, m_midEqFreq, m_highEqFreq;
 
     EffectChainPresetManagerPointer m_pChainPresetManager;
     std::shared_ptr<EffectsManager> m_pEffectsManager;

--- a/src/preferences/dialog/dlgprefmixerdlg.ui
+++ b/src/preferences/dialog/dlgprefmixerdlg.ui
@@ -441,8 +441,120 @@
       </item>
 
       <item>
-       <widget class="QWidget" name="GroupLoEQ" native="true">
+       <widget class="QWidget" name="GroupMidEQ" native="true">
         <layout class="QVBoxLayout" name="vBoxLayout_3">
+
+         <item>
+          <widget class="QLabel" name="label_midshelf">
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Mid EQ</string>
+           </property>
+           <property name="wordWrap">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+
+         <item>
+          <widget class="QSlider" name="SliderMidEQ">
+           <property name="minimum">
+            <number>100</number>
+           </property>
+           <property name="maximum">
+            <number>100000</number>
+           </property>
+           <property name="singleStep">
+            <number>30</number>
+           </property>
+           <property name="pageStep">
+            <number>300</number>
+           </property>
+           <property name="value">
+            <number>100</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+
+         <item>
+          <layout class="QHBoxLayout" name="sliderMidEQ_labels">
+           <item>
+            <widget class="QLabel" name="label_16hz_mid">
+             <property name="text">
+              <string>16 Hz</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="TextMidEQ">
+             <property name="text">
+              <string notr="true">textLabel2</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+             <property name="buddy">
+              <cstring>SliderMidEQ</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_20khz_mid">
+             <property name="text">
+              <string>20.05 kHz</string>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+
+        </layout>
+       </widget>
+      </item>
+
+      <item>
+       <widget class="QWidget" name="GroupLoEQ" native="true">
+        <layout class="QVBoxLayout" name="vBoxLayout_4">
 
          <item>
           <widget class="QLabel" name="label_lowshelf">
@@ -512,7 +624,7 @@
            <item>
             <widget class="QLabel" name="TextLoEQ">
              <property name="text">
-              <string notr="true">textLabel2</string>
+              <string notr="true">textLabel3</string>
              </property>
              <property name="wordWrap">
               <bool>false</bool>

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -385,7 +385,17 @@ void Tooltips::addStandardTooltips() {
             << tr("Adjusts the gain of the high EQ filter.")
             << resetWithRightAndDoubleClick;
 
+    add("filterSuperHigh")
+            << tr("SuperHigh EQ")
+            << tr("Adjusts the gain of the super high EQ filter.")
+            << resetWithRightAndDoubleClick;
+
     QString eqKillLatch = tr("Hold-to-kill or short click for latching.");
+    add("filterSuperHighKill")
+            << tr("SuperHigh EQ Kill")
+            << tr("Holds the gain of the super high EQ to zero while active.")
+            << eqKillLatch;
+
     add("filterHighKill")
             << tr("High EQ Kill")
             << tr("Holds the gain of the high EQ to zero while active.")


### PR DESCRIPTION
Added 2, 4 band biquad filters, and added Mid EQ slider to Mixer preference dialog. 3 band EQ is controlled with Low and High sliders, 2 band EQ is controlled with Mid slider, and 4 band EQ is controlled with all sliders. Maybe a checkbox can be added to toggle the Mid EQ slider, since its a rare usecase.

The main UI reacts fine to the 2 band filter (although the killLow and killHigh switches are labelled L and M instead of L and H), but shows 3 knobs with the 4 band filter. I could not find any clues on how to fix that, any pointers on where should I look?

In the Mixer preference dialog, one behaviour changed is that instead of an EQ frequency slider being blocked by sliders next to it, it moves those sliders along with it, so if an EQ doesn't use any bands, the respective sliders don't interfere with other sliders' movement.

Will resolve #14725