### PR TITLE
Fix: Null pointer in AU effect ID iteration

### DIFF
--- a/src/effects/backends/audiounit/audiounitbackend.mm
+++ b/src/effects/backends/audiounit/audiounitbackend.mm
@@ -33,13 +33,7 @@ class AudioUnitBackend : public EffectsBackend {
     };
 
     const QList<QString> getEffectIds() const override {
-        QList<QString> effectIds;
-
-        for (NSString* effectId in m_componentsById) {
-            effectIds.append(QString::fromNSString(effectId));
-        }
-
-        return effectIds;
+        return m_manifestsById.keys();
     }
 
     EffectManifestPointer getManifest(const QString& effectId) const override {

--- a/src/effects/backends/effectsbackendmanager.cpp
+++ b/src/effects/backends/effectsbackendmanager.cpp
@@ -34,7 +34,10 @@ void EffectsBackendManager::addBackend(EffectsBackendPointer pBackend) {
     m_effectsBackends.insert(pBackend->getType(), pBackend);
 
     for (const QString& effectId : pBackend->getEffectIds()) {
-        m_manifests.append(pBackend->getManifest(effectId));
+        auto manifest = pBackend->getManifest(effectId);
+        if (manifest) {
+            m_manifests.append(manifest);
+        }
     }
 
     m_pNumEffectsAvailable->forceSet(m_manifests.size());


### PR DESCRIPTION
Fixes a bug in AudioUnitBackend where getEffectIds looks up IDs from all discovered components but getManifest looks up IDs for only successfully loaded ones. For timed out plugins the effectId doesn't exist causing a segfault during sortLexigraphically.