### PR TITLE
Fixing last played time being wiped on history deletion (#14427)

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -6,6 +6,7 @@
 #include <QThread>
 #include <QtDebug>
 
+
 #ifdef __SQLITE3__
 #include <sqlite3.h>
 #endif // __SQLITE3__
@@ -2379,7 +2380,6 @@ bool TrackDAO::updatePlayCounterFromPlayedHistory(
                 QStringLiteral(
                         "UPDATE library SET "
                         "timesplayed=0,"
-                        "last_played_at=NULL "
                         "WHERE id NOT IN("
                         "SELECT PlaylistTracks.track_id "
                         "FROM PlaylistTracks "
@@ -2444,6 +2444,12 @@ bool TrackDAO::updatePlayCounterFromPlayedHistory(
                 // Never played and timesplayed should not be NULL
                 DEBUG_ASSERT(last_played_at.isNull());
                 timesplayed = 0;
+
+                // Fetch the actual last played date from older history sessions
+                QString lastTimeAdded = findLastTimeAddedToHistory(trackId);
+                if (!lastTimeAdded.isEmpty()) {
+                    last_played_at = lastTimeAdded;
+                }
             }
             trackUpdateQuery.bindValue(
                     QStringLiteral(":trackId"),
@@ -2487,4 +2493,37 @@ void TrackDAO::setTrackHeaderParsedInternal(Track* pTrack, bool headerParsed) {
 //static
 bool TrackDAO::getTrackHeaderParsedInternal(const mixxx::TrackRecord& trackRecord) {
     return trackRecord.m_headerParsed;
+}
+
+QString TrackDAO::findLastTimeAddedToHistory(TrackId trackId) const {
+    // A track ID might be invalid if the track was just added and hasn't been
+    // saved to the database yet, or if it represents a missing or deleted track.
+    if (!trackId.isValid()) {
+        return QString();
+    }
+
+    // Lazy Prepare: Only prepare the query if it has not been prepared yet
+    if (m_lastAddedToHistoryQuery.lastQuery().isEmpty()) {
+        m_lastAddedToHistoryQuery = QSqlQuery(m_database);
+        m_lastAddedToHistoryQuery.prepare(
+            "SELECT MAX(PlaylistTracks.pl_datetime_added) "
+            "FROM PlaylistTracks "
+            "JOIN Playlists ON PlaylistTracks.playlist_id = Playlists.id "
+            "WHERE PlaylistTracks.track_id = :id "
+            "AND Playlists.hidden = " + QString::number(PlaylistDAO::PLHT_SET_LOG)
+        );
+    }
+
+    m_lastAddedToHistoryQuery.bindValue(":id", trackId.toVariant());
+    
+    if (!m_lastAddedToHistoryQuery.exec()) {
+        LOG_FAILED_QUERY(m_lastAddedToHistoryQuery) << "Failed to find last time added to history for track" << trackId;
+        return QString();
+    }
+    
+    if (m_lastAddedToHistoryQuery.next()) {
+        return m_lastAddedToHistoryQuery.value(0).toString();
+    }
+    
+    return QString();
 }

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -6,7 +6,6 @@
 #include <QThread>
 #include <QtDebug>
 
-
 #ifdef __SQLITE3__
 #include <sqlite3.h>
 #endif // __SQLITE3__
@@ -2489,24 +2488,26 @@ QString TrackDAO::findLastTimeAddedToHistory(TrackId trackId) const {
     if (m_lastAddedToHistoryQuery.lastQuery().isEmpty()) {
         m_lastAddedToHistoryQuery = QSqlQuery(m_database);
         m_lastAddedToHistoryQuery.prepare(
-            "SELECT MAX(PlaylistTracks.pl_datetime_added) "
-            "FROM PlaylistTracks "
-            "JOIN Playlists ON PlaylistTracks.playlist_id = Playlists.id "
-            "WHERE PlaylistTracks.track_id = :id "
-            "AND Playlists.hidden = " + QString::number(PlaylistDAO::PLHT_SET_LOG)
-        );
+                "SELECT MAX(PlaylistTracks.pl_datetime_added) "
+                "FROM PlaylistTracks "
+                "JOIN Playlists ON PlaylistTracks.playlist_id = Playlists.id "
+                "WHERE PlaylistTracks.track_id = :id "
+                "AND Playlists.hidden = " +
+                QString::number(PlaylistDAO::PLHT_SET_LOG));
     }
 
     m_lastAddedToHistoryQuery.bindValue(":id", trackId.toVariant());
-    
+
     if (!m_lastAddedToHistoryQuery.exec()) {
-        LOG_FAILED_QUERY(m_lastAddedToHistoryQuery) << "Failed to find last time added to history for track" << trackId;
+        LOG_FAILED_QUERY(m_lastAddedToHistoryQuery)
+                << "Failed to find last time added to history for track"
+                << trackId;
         return QString();
     }
-    
+
     if (m_lastAddedToHistoryQuery.next()) {
         return m_lastAddedToHistoryQuery.value(0).toString();
     }
-    
+
     return QString();
 }

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QSet>
 #include <QString>
+#include <QtSql/QSqlQuery>
 #include <memory>
 
 #include "library/dao/dao.h"
@@ -130,6 +131,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     friend class LibraryScanner;
     friend class TrackCollection;
     friend class TrackAnalysisScheduler;
+    QString findLastTimeAddedToHistory(TrackId trackId) const;
 
     QList<TrackId> resolveTrackIds(
             const QStringList& pathList,
@@ -214,6 +216,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     QSet<TrackId> m_tracksAddedSet;
 
     DISALLOW_COPY_AND_ASSIGN(TrackDAO);
+    mutable QSqlQuery m_lastAddedToHistoryQuery;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(TrackDAO::ResolveTrackIdFlags)


### PR DESCRIPTION
Fixes #14427 

Hello Everyone 
<img width="1610" height="262" alt="Screenshot 2026-03-18 011456" src="https://github.com/user-attachments/assets/1401bba5-226f-4852-a3bd-ba7ef89ecf3b" />
! I was looking into this bug where the last played time gets wiped out when we clear the history.

What I found and changed:
I checked the trackdao.cpp file and saw that the updateNotPlayed SQL query was aggressively forcing last_played_at to NULL when a track is removed from history.

I removed that last_played_at=NULL part so it only resets the timesplayed count to 0 and leaves the date alone.

I also added a COALESCE check in the other fallback update query just to be extra safe so it doesn't overwrite real dates with empty ones.

How you can test it:

- play any track so it gets a last played timestamp in the main library.

- go to the history tab and delete that track from the session.

- go back to the library view. the play count drops to 0 but the date is still safely there



<img width="1610" height="262" alt="Screenshot 2026-03-18 011456" src="https://github.com/user-attachments/assets/f889103f-84e7-41b6-a5c6-afce8b1e0270" />
I checked and it worked😊

