### PR TITLE
Remove unsupported HID Feature Report 0xD3 from Traktor Z1 mapping

### DIFF
--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -125,7 +125,6 @@ class TraktorZ1Class {
         this.rawCalibration.faders = new Uint8Array(0x20 * 3);
         this.rawCalibration.faders.set(new Uint8Array(controller.getFeatureReport(0xD1)), 0x00);
         this.rawCalibration.faders.set(new Uint8Array(controller.getFeatureReport(0xD2)), 0x20);
-        this.rawCalibration.faders.set(new Uint8Array(controller.getFeatureReport(0xD3)), 0x40);
         this.calibration = this.parseRawCalibration();
     }
 

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -122,7 +122,7 @@ class TraktorZ1Class {
     }
 
     calibrate() {
-        this.rawCalibration.faders = new Uint8Array(0x20 * 3);
+        this.rawCalibration.faders = new Uint8Array(0x20 * 2);
         this.rawCalibration.faders.set(new Uint8Array(controller.getFeatureReport(0xD1)), 0x00);
         this.rawCalibration.faders.set(new Uint8Array(controller.getFeatureReport(0xD2)), 0x20);
         this.calibration = this.parseRawCalibration();


### PR DESCRIPTION
This PR removes unsupported HID Feature Report 0xD3 from Traktor Z1 crossfader calibration code. This lead to the mapping working fine on Linux, while throwing a TypeError on Windows.

Fixes #16172