### PR TITLE
Pref Sound: move latency/underflow values closer to labels

### DIFF
--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -334,6 +334,11 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                     tr("Find details in the Mixxx user manual"),
                     MIXXX_MANUAL_OUTPUT_AND_INPUT_DEVICES);
     deckBusHint->setText(deckBusHintStr);
+
+    // Append a ':' to separate latency/underflow labels from values.
+    // (append here to keep existing tr strings)
+    latencyLabel->setText(latencyLabel->text() + ':');
+    underflowLabel->setText(underflowLabel->text() + ':');
 }
 
 /// Slot called when the preferences dialog is opened.

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QGridLayout" name="gridLayout">
+    <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
      <item row="0" column="0">
       <widget class="QLabel" name="apiLabel">
        <property name="text">
@@ -344,7 +344,7 @@
      <property name="title">
       <string>Hints and Diagnostics</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_6">
+     <layout class="QGridLayout" name="gridLayout_6" columnstretch="0,1">
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="deckBusHint">
         <property name="text">


### PR DESCRIPTION
before:
<img width="823" height="111" alt="image" src="https://github.com/user-attachments/assets/810af62d-e90c-4b45-8e1b-bb898efd01a1" />

this PR:
<img width="714" height="140" alt="image" src="https://github.com/user-attachments/assets/5aa45eb8-d867-4389-841e-f0db0e2b91c5" />
