### PR TITLE
Allow to verify the first sound at the beginning of the file

### DIFF
--- a/src/engine/cachingreader/cachingreaderworker.cpp
+++ b/src/engine/cachingreader/cachingreaderworker.cpp
@@ -273,21 +273,23 @@ void CachingReaderWorker::verifyFirstSound(const CachingReaderChunk* pChunk) {
                     m_firstSoundFrameToVerify.toLowerFrameBoundary()
                             .value()));
     if (pChunk->getIndex() == firstSoundIndex) {
-        CSAMPLE sampleBuffer[kNumSoundFrameToVerify * mixxx::kEngineChannelCount];
+        auto sampleBuffer = mixxx::SampleBuffer(
+                kNumSoundFrameToVerify * mixxx::kEngineChannelCount);
         // We read two frames, the last silence frame and the first non-silence frame from
         // m_firstSoundFrameToVerify. end points to one position after them.
+        sampleBuffer.clear(); // we need to clear the buffer, for the case the
+                              // very first sample is the first sound.
         SINT end = static_cast<SINT>(m_firstSoundFrameToVerify.toLowerFrameBoundary().value()) + 1;
         mixxx::IndexRange probeFrameIndexRange =
                 mixxx::IndexRange::between(end - kNumSoundFrameToVerify, end);
         mixxx::IndexRange bufferedFrameIndexRange =
                 pChunk->readBufferedSampleFrames(
-                        sampleBuffer, probeFrameIndexRange);
-        VERIFY_OR_DEBUG_ASSERT(bufferedFrameIndexRange == probeFrameIndexRange) {
+                        sampleBuffer.data(), probeFrameIndexRange);
+        VERIFY_OR_DEBUG_ASSERT(bufferedFrameIndexRange.end() == probeFrameIndexRange.end()) {
             qWarning() << "skipping verifyFirstSound()";
             return;
         }
-        if (AnalyzerSilence::verifyFirstSound(std::span<const CSAMPLE>(sampleBuffer),
-                    mixxx::audio::FramePos(1))) {
+        if (AnalyzerSilence::verifyFirstSound(sampleBuffer.span(), mixxx::audio::FramePos(1))) {
             qDebug() << "First sound found at the previously stored position";
         } else {
             // This can happen in case of track edits or replacements, changed


### PR DESCRIPTION
by padding with silence. Then relaxed the related assertion.

This fixes the first part of #16183 and a regression form #16054.

I think this shall slip in to the 2.5.5 release. It fixes "only" a false positive assertion. 