### PR TITLE
[feat] Library: allow to always grey out selected columns

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -63,6 +63,10 @@ QString BaseTrackCache::columnSortForFieldIndex(int index) const {
     return m_columnCache.columnSortForFieldIndex(index);
 }
 
+QString BaseTrackCache::columnTitle(ColumnCache::Column column) const {
+    return m_columnCache.columnTitle(column);
+}
+
 void BaseTrackCache::slotTracksAddedOrChanged(const QSet<TrackId>& trackIds) {
     if (sDebug) {
         qDebug() << this << "slotTracksAddedOrChanged" << trackIds.size();

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -63,6 +63,7 @@ class BaseTrackCache : public QObject {
     virtual int fieldIndex(const QString& column) const;
     QString columnNameForFieldIndex(int index) const;
     QString columnSortForFieldIndex(int index) const;
+    QString columnTitle(ColumnCache::Column column) const;
     int fieldIndex(ColumnCache::Column column) const;
     int endFieldIndex() const;
     virtual void filterAndSort(const QSet<TrackId>& trackIds,

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -115,12 +115,21 @@ void BaseTrackTableModel::setApplyPlayedTrackColor(bool apply) {
     s_bApplyPlayedTrackColor = apply;
 }
 
+QList<ColumnCache::Column> BaseTrackTableModel::s_dimColumns =
+        QList<ColumnCache::Column>{};
+
 const QString BaseTrackTableModel::kDateFormatDefault = QString();
 QString BaseTrackTableModel::s_dateFormat = BaseTrackTableModel::kDateFormatDefault;
 
+// static
 void BaseTrackTableModel::setDateFormat(const QString& format) {
     s_dateFormat = format;
 }
+
+// static
+void BaseTrackTableModel::setDimColumns(const QList<ColumnCache::Column>& columns) {
+    s_dimColumns = columns;
+};
 
 BaseTrackTableModel::BaseTrackTableModel(
         QObject* parent,
@@ -444,6 +453,14 @@ QVariant BaseTrackTableModel::data(
                 missingRaw.toBool()) {
             return QVariant::fromValue(m_trackMissingColor);
         }
+
+        // Also use the 'played' color to grey out the columns selected in
+        // Library preferences, regardless the track's 'played' state
+        const auto field = mapColumn(index.column());
+        if (s_dimColumns.contains(field)) {
+            return QVariant::fromValue(m_trackPlayedColor);
+        }
+
         if (s_bApplyPlayedTrackColor) {
             // Custom text color for played tracks
             auto playedRaw = rawSiblingValue(

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -144,6 +144,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     static const QString kDateFormatDefault;
     static void setDateFormat(const QString& format);
+    static void setDimColumns(const QList<ColumnCache::Column>& columns);
 
   protected:
     // Build a map from the column names to their indices
@@ -323,4 +324,5 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     static bool s_bApplyPlayedTrackColor;
     static QString s_dateFormat;
+    static QList<ColumnCache::Column> s_dimColumns;
 };

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -803,6 +803,10 @@ bool Library::isTrackIdInCurrentLibraryView(const TrackId& trackId) {
     }
 }
 
+QString Library::columnTitle(ColumnCache::Column column) const {
+    return m_pTrackCollectionManager->internalCollection()->getTrackSource()->columnTitle(column);
+}
+
 void Library::slotSaveCurrentViewState() const {
     if (m_pLibraryWidget) {
         return m_pLibraryWidget->saveCurrentViewState();

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -6,6 +6,7 @@
 #include <QPointer>
 
 #include "analyzer/trackanalysisscheduler.h"
+#include "library/columncache.h"
 #include "library/library_decl.h"
 #ifdef __ENGINEPRIME__
 #include "library/trackset/crate/crateid.h"
@@ -98,6 +99,9 @@ class Library: public QObject {
     void setFont(const QFont& font);
     void setRowHeight(int rowHeight);
     void setEditMetadataSelectedClick(bool enable);
+
+    /// returns the localized column name used in the GUI
+    QString columnTitle(ColumnCache::Column column) const;
 
     /// Switches to the internal track collection view
     /// and focuses the search box.

--- a/src/library/tabledelegates/tableitemdelegate.cpp
+++ b/src/library/tabledelegates/tableitemdelegate.cpp
@@ -53,10 +53,7 @@ void TableItemDelegate::paint(
     // Brush color for the star rating polygons:
     painter->setBrush(brush);
     // Pen for the 'location' text
-    // Note: seems not to be required anymore (Qt 6.2.3)
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     painter->setPen(brush.color());
-#endif
 
     QStyle* style = m_pTableView->style();
     if (style) {

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -25,6 +25,9 @@
 
 namespace {
 constexpr int kDefaultFuzzyRateRangePercent = 75;
+const ConfigKey kDimColumnsCfgkey(
+        QStringLiteral("[Library]"), QStringLiteral("dim_columns"));
+const char* kColumnIdPropName = "colId";
 } // namespace
 
 using namespace mixxx::library::prefs;
@@ -134,6 +137,68 @@ DlgPrefLibrary::DlgPrefLibrary(
 
     connect(btn_library_font, &QAbstractButton::clicked, this, &DlgPrefLibrary::slotSelectFont);
 
+    // Dim columns checkboxes
+    // Collect all relevant columns (all visible columns with text data, and Rating)
+    // Note(ronso0) Let's assume that Artist and Title columns are never dimmed.
+    const QList<ColumnCache::Column> columns{
+            ColumnCache::COLUMN_LIBRARYTABLE_ALBUM,
+            ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST,
+            ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER,
+            ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER,
+            ColumnCache::COLUMN_LIBRARYTABLE_COMMENT,
+            ColumnCache::COLUMN_LIBRARYTABLE_GENRE,
+            ColumnCache::COLUMN_LIBRARYTABLE_GROUPING,
+            ColumnCache::COLUMN_LIBRARYTABLE_BPM,
+            ColumnCache::COLUMN_LIBRARYTABLE_DURATION,
+            ColumnCache::COLUMN_LIBRARYTABLE_YEAR,
+            ColumnCache::COLUMN_LIBRARYTABLE_KEY,
+            ColumnCache::COLUMN_LIBRARYTABLE_TUNING_FREQUENCY,
+            ColumnCache::COLUMN_LIBRARYTABLE_BITRATE,
+            ColumnCache::COLUMN_LIBRARYTABLE_RATING,
+            ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN,
+            ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE,
+            ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED,
+            ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT,
+            ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED,
+            ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED,
+            ColumnCache::COLUMN_TRACKLOCATIONSTABLE_LOCATION};
+    // Checkboxes are sorted into a 2-column grid, first column is filled first.
+    // Set number of grid rows (no need for bitwise or modulo wizardry since we
+    // can simply count the columns ;) -- adjust when columns are added/removed
+    // 21 column names => 11 rows
+    int gridRows = 11;
+    int num = 0;
+    // We need to adjust the existing Tab stops for the new items,
+    // ie. squeeze checkboxes in between the Played Color checkbox above and the
+    // Search Timeout spinbox below the grid layout
+    QWidget* pPrevWidget = checkbox_played_track_color;
+    for (auto col : columns) {
+        const QString title = m_pLibrary->columnTitle(col);
+        // Set `this` as parent, else the setting the tabstop will not work
+        auto pCheckBox = std::make_unique<QCheckBox>(title, this);
+        // For the checkbox <-> column relation we simply use the column id (enum),
+        // which also use to read from / write to the config (int).
+        // This allows a simple data flow to the BaseTrackTableModel
+        // FIXME this has the small downside that the column selection is shifted
+        // when a Mixxx version reorders, adds or removes columns.
+        pCheckBox->setProperty(kColumnIdPropName, col);
+
+        // Tab stop
+        auto* pBoxPtr = pCheckBox.get();
+        setTabOrder(pPrevWidget, pBoxPtr);
+        pPrevWidget = pBoxPtr;
+
+        // Insert into grid
+        int rowNum = (num + 1 <= gridRows) ? num : num - gridRows;
+        int colNum = (num + 1 <= gridRows) ? 0 : 1;
+        // The layout takes ownership!
+        layout_dimColumns->addWidget(pCheckBox.release(), rowNum, colNum);
+
+        num++;
+    }
+    setTabOrder(pPrevWidget, spinBox_search_debouncing_timeout);
+
+    // Plugins/decoders list
     // TODO(XXX) this string should be extracted from the soundsources
     QString builtInFormatsStr = "Ogg Vorbis, FLAC, WAVE, AIFF";
 #if defined(__MAD__) || defined(__COREAUDIO__)
@@ -301,6 +366,15 @@ void DlgPrefLibrary::slotResetToDefaults() {
 
     spinBox_sidebar_hover_expand_delay->setValue(kSidebarHoverExpandDelayDefault);
 
+    // By default no column is greyed out
+    for (int i = 0; i < layout_dimColumns->count(); i++) {
+        auto* pItem = layout_dimColumns->itemAt(i);
+        auto* pBox = qobject_cast<QCheckBox*>(pItem->widget());
+        if (pBox) {
+            pBox->setChecked(false);
+        }
+    }
+
     checkBox_show_rhythmbox->setChecked(true);
     checkBox_show_banshee->setChecked(true);
     checkBox_show_itunes->setChecked(true);
@@ -373,9 +447,35 @@ void DlgPrefLibrary::slotUpdate() {
     }
 
     updateDateFormatPreview(dateFormat);
-
     // Ensure the static member is updated on startup/load
     BaseTrackTableModel::setDateFormat(dateFormat);
+
+    // Dim columns
+    // Parse int list from config string, create ColumnCache::Column list
+    const QString columnIdsStr = m_pConfig->getValue(kDimColumnsCfgkey, QString());
+    const auto idStrList = columnIdsStr.tokenize(QLatin1Char(','));
+    QList<ColumnCache::Column> columns;
+    for (const auto& idStr : idStrList) {
+        bool isInt = false;
+        int colId = idStr.toInt(&isInt);
+        if (isInt &&
+                colId > ColumnCache::COLUMN_LIBRARYTABLE_INVALID &&
+                colId < ColumnCache::NUM_COLUMNS) {
+            columns.append(static_cast<ColumnCache::Column>(colId));
+        }
+    }
+    // update checkboxes
+    for (int i = 0; i < layout_dimColumns->count(); i++) {
+        auto* pItem = layout_dimColumns->itemAt(i);
+        auto* pBox = qobject_cast<QCheckBox*>(pItem->widget());
+        if (pBox) {
+            const QVariant colIdVar = pBox->property(kColumnIdPropName);
+            const auto column = colIdVar.value<ColumnCache::Column>();
+            pBox->setChecked(columns.contains(column));
+        }
+    }
+    // apply to table models immediately
+    BaseTrackTableModel::setDimColumns(columns);
 
     switch (m_pConfig->getValue<int>(
             kTrackDoubleClickActionConfigKey,
@@ -686,6 +786,25 @@ void DlgPrefLibrary::slotApply() {
     int sidebarHoverExpandDelay = spinBox_sidebar_hover_expand_delay->value();
     m_pConfig->setValue(kSidebarHoverExpandDelayConfigKey, sidebarHoverExpandDelay);
     emit m_pLibrary->setSidebarHoverExpandDelay(sidebarHoverExpandDelay);
+
+    // Dim columns
+    QStringList columnIds;
+    QList<ColumnCache::Column> columns;
+    for (int i = 0; i < layout_dimColumns->count(); i++) {
+        auto* pItem = layout_dimColumns->itemAt(i);
+        auto* pBox = qobject_cast<QCheckBox*>(pItem->widget());
+        if (pBox && pBox->isChecked()) {
+            const QVariant colIdVar = pBox->property(kColumnIdPropName);
+            bool isInt = false;
+            int colId = colIdVar.toInt(&isInt);
+            DEBUG_ASSERT(isInt);
+            columnIds.append(QString::number(colId));
+            columns.append(static_cast<ColumnCache::Column>(colId));
+        }
+    }
+    const QString columnIdsJoint = columnIds.join(',');
+    m_pConfig->set(kDimColumnsCfgkey, columnIdsJoint);
+    BaseTrackTableModel::setDimColumns(columns);
 
     // TODO(rryan): Don't save here.
     m_pConfig->save();

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -290,15 +290,7 @@
        <widget class="QSpinBox" name="spinbox_bpm_precision"/>
       </item>
 
-      <item row="10" column="0" colspan="4">
-       <widget class="QCheckBox" name="checkbox_played_track_color">
-        <property name="text">
-         <string>Grey out played tracks</string>
-        </property>
-       </widget>
-      </item>
-
-      <item row="11" column="0">
+      <item row="10" column="0">
        <widget class="QLabel" name="label_dateFormat">
         <property name="text">
          <string>Date Format:</string>
@@ -308,7 +300,7 @@
         </property>
        </widget>
       </item>
-      <item row="11" column="1" colspan="3">
+      <item row="10" column="1" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_dateFormat">
         <property name="leftMargin">
          <number>0</number>
@@ -340,6 +332,23 @@
          </widget>
         </item>
        </layout>
+      </item>
+
+      <item row="11" column="0" colspan="3">
+       <widget class="QCheckBox" name="checkbox_played_track_color">
+        <property name="text">
+         <string>Grey out played tracks</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0" colspan="3">
+       <widget class="QGroupBox" name="groupBox_dimColumns">
+        <property name="title">
+         <string>Always use 'Played' color for these columns:</string>
+        </property>
+        <layout class="QGridLayout" name="layout_dimColumns">
+        </layout>
+       </widget>
       </item>
 
      </layout>
@@ -780,10 +789,11 @@
   <tabstop>radioButton_dbclick_top</tabstop>
   <tabstop>radioButton_dbclick_ignore</tabstop>
   <tabstop>spinBox_row_height</tabstop>
+  <tabstop>lineEdit_library_font</tabstop>
   <tabstop>btn_library_font</tabstop>
   <tabstop>spinbox_bpm_precision</tabstop>
-  <tabstop>checkbox_played_track_color</tabstop>
   <tabstop>comboBox_dateFormat</tabstop>
+  <tabstop>checkbox_played_track_color</tabstop>
   <tabstop>spinBox_search_debouncing_timeout</tabstop>
   <tabstop>checkBox_enable_search_completions</tabstop>
   <tabstop>checkBox_enable_search_history_shortcuts</tabstop>


### PR DESCRIPTION
The tracks table can be pretty overwhelming with lots of columns.
I decided to grey out all columns except my 'top prio' columns so they are easier to spot.
-> I had this hard-coded for some columns in my production branch for a while now and don't want to miss it
Here's my attempt to make it configurable, let me know if you find it useful.

<img width="1322" height="359" alt="image" src="https://github.com/user-attachments/assets/4e89b46e-004f-4848-aa60-c7ba43a5d84b" />

And here's my proposal for the configuration in Preferences -> Library:
<img width="702" height="459" alt="image" src="https://github.com/user-attachments/assets/19e39a34-c669-426c-93bf-34608e4bd213" />

If you consider this useful, we need to make the column checkbox layout more compact since the Library page is now super long with all columns in a list. Options:
**edit** this uses 2 columns now, no urgent need to tweak the layout anymore IMO
1. grid with 2-3 columns
-> tr strings are compact (usually)
-> need to check what works with some long locales (fr, es)
2. make groupbox collapsible (same as in controller mapping settings)
-> initially collapsed, state persists as long as Mixxx is running
3. collapsible + grid <- **my preferred solution**
4. scroll area -> not sure if this is good UX
5. add column checkboxes on request with Add button -> complex but feasible

### Nice to have
* instant update on Apply, like proposed in #16047