### PR TITLE
Analyzer: Fix MSVC crash in TempoTrackV2 pointer math

### DIFF
--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -165,7 +165,7 @@ TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
             std::fill(dfframe.begin() + l, dfframe.end(), 0.0);
         }
         
-        std::copy(df.begin() + i + k, df.begin() + i + l,
+        std::copy(df.begin() + (i + k), df.begin() + (i + l),
                       dfframe.begin() + k);
 
         // Apply the resonator comb filter (RCF) bank to the window


### PR DESCRIPTION
Hey everyone,

I got a crash on Windows when dropping a track into a deck while using MSVC.

The issue is how the math evaluates. Since `i` starts negative, adding it directly to the iterator triggers an out of bounds error before the rest of the offset can be calculated.

I just added parentheses `(i + k)` so the math happens before the pointer moves. Tested locally and tracks load perfectly now.