### PR TITLE
wtracktableview: manage column delegates with unique_ptr

### DIFF
--- a/src/library/tabledelegates/bpmdelegate.cpp
+++ b/src/library/tabledelegates/bpmdelegate.cpp
@@ -34,11 +34,13 @@ BPMDelegate::BPMDelegate(QTableView* pTableView)
         : CheckboxDelegate(pTableView, QStringLiteral("LibraryBPMButton")) {
     // Register a custom QItemEditorFactory to override the default
     // QDoubleSpinBox editor.
-    m_pFactory = new QItemEditorFactory();
+    m_pFactory = std::make_unique<QItemEditorFactory>();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     m_pFactory->registerEditor(QMetaType::Double, new BpmEditorCreator());
 #else
     m_pFactory->registerEditor(QVariant::Double, new BpmEditorCreator());
 #endif
-    setItemEditorFactory(m_pFactory);
+    setItemEditorFactory(m_pFactory.get());
 }
+
+BPMDelegate::~BPMDelegate() = default;

--- a/src/library/tabledelegates/bpmdelegate.h
+++ b/src/library/tabledelegates/bpmdelegate.h
@@ -1,12 +1,16 @@
 #pragma once
+#include <memory>
 
 #include "library/tabledelegates/checkboxdelegate.h"
+
+class QItemEditorFactory;
 
 class BPMDelegate : public CheckboxDelegate {
     Q_OBJECT
   public:
     explicit BPMDelegate(QTableView* pTableView);
+    ~BPMDelegate() override;
 
   private:
-    QItemEditorFactory* m_pFactory;
+    std::unique_ptr<QItemEditorFactory> m_pFactory;
 };

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -272,16 +272,16 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* pNewModel, bool restore
     pHeader->setDefaultAlignment(Qt::AlignLeft);
 
     // Initialize all column-specific things
+    std::vector<std::unique_ptr<QAbstractItemDelegate>> newDelegates;
     for (int i = 0; i < pNewModel->columnCount(); ++i) {
         // Setup delegates according to what the model tells us
-        QAbstractItemDelegate* delegate =
-                pNewTrackModel->delegateForColumn(i, this);
-        // We need to delete the old delegates, since the docs say the view will
-        // not take ownership of them.
-        QAbstractItemDelegate* old_delegate = itemDelegateForColumn(i);
+        auto delegate = std::unique_ptr<QAbstractItemDelegate>(
+                pNewTrackModel->delegateForColumn(i, this));
         // If delegate is NULL, it will unset the delegate for the column
-        setItemDelegateForColumn(i, delegate);
-        delete old_delegate;
+        setItemDelegateForColumn(i, delegate.get());
+        if (delegate) {
+            newDelegates.push_back(std::move(delegate));
+        }
 
         // Show or hide the column based on whether it should be shown or not.
         if (pNewTrackModel->isColumnInternal(i)) {
@@ -298,6 +298,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* pNewModel, bool restore
             horizontalHeader()->hideSection(i);
         }
     }
+    m_columnDelegates = std::move(newDelegates);
 
     if (m_sorting) {
         // NOTE: Should be a UniqueConnection but that requires Qt 4.6

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -2,6 +2,8 @@
 
 #include <QAbstractItemModel>
 #include <QSortFilterProxyModel>
+#include <memory>
+#include <vector>
 
 #include "control/controlproxy.h"
 #include "control/pollingcontrolproxy.h"
@@ -216,4 +218,5 @@ class WTrackTableView : public WLibraryTableView {
     ControlProxy* m_pSortOrder;
 
     int m_dropRow;
+    std::vector<std::unique_ptr<QAbstractItemDelegate>> m_columnDelegates;
 };


### PR DESCRIPTION
Fixes: #16055 

Added a `std::vector<std::unique_ptr<QAbstractItemDelegate>>` in WTrackTableView to own the column delegates. 

Also fixed a small leak in BPMDelegate. it news a QItemEditorFactory but never deletes it since `setItemEditorFactory()` doesn't take ownership either. And I change it to unique_ptr

The delegates have pTableView as their QObject parent so Qt would clean them up anyway

