### PR TITLE
(fix) Library, relocate directory: remove old dir if new is child of a root dir

### DIFF
--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -199,19 +199,42 @@ std::pair<DirectoryDAO::RelocateResult, QList<RelocatedTrack>> DirectoryDAO::rel
         return {RelocateResult::UnreadableDirectory, {}};
     }
 
-    // TODO(rryan): This method could use error reporting. It can fail in
-    // mysterious ways for example if a track in the oldDirectory also has a zombie
-    // track location in newDirectory then the replace query will fail because the
-    // location column becomes non-unique.
+    // Check if the new dir is a child of an existing dir.
+    bool newIsChildOfExistingDir = false;
+    for (const auto& rootDir : loadAllDirectories(true /* skipInvalidOrMissing */)) {
+        const auto rootDirLocation = rootDir.canonicalLocation();
+        DEBUG_ASSERT(!rootDirLocation.isEmpty());
+        if (mixxx::FileInfo::isRootSubCanonicalLocation(
+                    rootDirLocation,
+                    newFileInfo.canonicalLocation())) {
+            const mixxx::FileInfo oldFileInfo(oldDirectory);
+            const auto result = removeDirectory(oldFileInfo);
+            if (result != DirectoryDAO::RemoveResult::Ok) {
+                kLogger.warning() << "could not relocate directory"
+                                  << oldDirectory << "to" << newDirectory;
+                return {RelocateResult::SqlError, {}};
+            }
+            newIsChildOfExistingDir = true;
+            break;
+        }
+    }
+
     QSqlQuery query(m_database);
-    query.prepare("UPDATE " % kTable % " SET " % kLocationColumn %
-            "=:newDirectory WHERE " % kLocationColumn % "=:oldDirectory");
-    query.bindValue(":newDirectory", newDirectory);
-    query.bindValue(":oldDirectory", oldDirectory);
-    if (!query.exec()) {
-        LOG_FAILED_QUERY(query) << "could not relocate directory"
-                                << oldDirectory << "to" << newDirectory;
-        return {RelocateResult::SqlError, {}};
+    if (!newIsChildOfExistingDir) {
+        // Replace old with new dir
+        // TODO(rryan): This method could use error reporting. It can fail in
+        // mysterious ways for example if a track in the oldDirectory also has a zombie
+        // track location in newDirectory then the replace query will fail because the
+        // location column becomes non-unique.
+        query.prepare("UPDATE " % kTable % " SET " % kLocationColumn %
+                "=:newDirectory WHERE " % kLocationColumn % "=:oldDirectory");
+        query.bindValue(":newDirectory", newDirectory);
+        query.bindValue(":oldDirectory", oldDirectory);
+        if (!query.exec()) {
+            LOG_FAILED_QUERY(query) << "could not relocate directory"
+                                    << oldDirectory << "to" << newDirectory;
+            return {RelocateResult::SqlError, {}};
+        }
     }
 
     // Appending '/' is required to disambiguate files from parent

--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -219,20 +219,25 @@ std::pair<DirectoryDAO::RelocateResult, QList<RelocatedTrack>> DirectoryDAO::rel
         }
     }
 
-    QSqlQuery query(m_database);
     if (!newIsChildOfExistingDir) {
         // Replace old with new dir
         // TODO(rryan): This method could use error reporting. It can fail in
         // mysterious ways for example if a track in the oldDirectory also has a zombie
         // track location in newDirectory then the replace query will fail because the
         // location column becomes non-unique.
-        query.prepare("UPDATE " % kTable % " SET " % kLocationColumn %
-                "=:newDirectory WHERE " % kLocationColumn % "=:oldDirectory");
-        query.bindValue(":newDirectory", newDirectory);
-        query.bindValue(":oldDirectory", oldDirectory);
-        if (!query.exec()) {
-            LOG_FAILED_QUERY(query) << "could not relocate directory"
-                                    << oldDirectory << "to" << newDirectory;
+        const auto swapStatement =
+                QStringLiteral(
+                        "UPDATE %1 SET %2=:newDirectory "
+                        "WHERE %2=:oldDirectory")
+                        .arg(
+                                kTable,
+                                kLocationColumn);
+        FwdSqlQuery swapQuery(m_database, swapStatement);
+        swapQuery.bindValue(":newDirectory", newDirectory);
+        swapQuery.bindValue(":oldDirectory", oldDirectory);
+        if (!swapQuery.execPrepared()) {
+            LOG_FAILED_QUERY(swapQuery) << "could not relocate directory"
+                                        << oldDirectory << "to" << newDirectory;
             return {RelocateResult::SqlError, {}};
         }
     }
@@ -242,26 +247,27 @@ std::pair<DirectoryDAO::RelocateResult, QList<RelocatedTrack>> DirectoryDAO::rel
     // match both instead of only files in the parent directory "a/b/".
     DEBUG_ASSERT(!oldDirectory.endsWith('/'));
     const QString oldDirectoryPrefix = oldDirectory + '/';
-    query.prepare(QStringLiteral(
+    const auto collectTracksStatement = QStringLiteral(
             "SELECT library.id,track_locations.id,track_locations.location "
             "FROM library INNER JOIN track_locations ON "
             "track_locations.id=library.location WHERE "
-            "INSTR(track_locations.location,:oldDirectoryPrefix)=1"));
-    query.bindValue(":oldDirectoryPrefix", oldDirectoryPrefix);
-    if (!query.exec()) {
-        LOG_FAILED_QUERY(query) << "could not relocate path of tracks";
+            "INSTR(track_locations.location,:oldDirectoryPrefix)=1");
+    FwdSqlQuery collectTracksQuery(m_database, collectTracksStatement);
+    collectTracksQuery.bindValue(":oldDirectoryPrefix", oldDirectoryPrefix);
+    if (!collectTracksQuery.execPrepared()) {
+        LOG_FAILED_QUERY(collectTracksQuery) << "could not relocate path of tracks";
         return {RelocateResult::SqlError, {}};
     }
 
     QList<DbId> loc_ids;
     QList<RelocatedTrack> relocatedTracks;
-    while (query.next()) {
-        const auto oldLocation = query.value(2).toString();
+    while (collectTracksQuery.next()) {
+        const auto oldLocation = collectTracksQuery.fieldValue(2).toString();
         const int oldSuffixLen = oldLocation.size() - oldDirectory.size();
         QString newLocation = newDirectory + oldLocation.right(oldSuffixLen);
         DEBUG_ASSERT(oldLocation.startsWith(oldDirectoryPrefix));
-        loc_ids.append(DbId(query.value(1)));
-        const auto trackId = TrackId(query.value(0));
+        loc_ids.append(DbId(collectTracksQuery.fieldValue(1)));
+        const auto trackId = TrackId(collectTracksQuery.fieldValue(0));
         auto missingTrackRef = TrackRef::fromFilePath(
                 oldLocation,
                 std::move(trackId));
@@ -274,16 +280,16 @@ std::pair<DirectoryDAO::RelocateResult, QList<RelocatedTrack>> DirectoryDAO::rel
 
     // Also update information in the track_locations table. This is where mixxx
     // gets the location information for a track.
-    const QString replacement =
-            "UPDATE track_locations SET location=:newloc, directory=:newdir WHERE id=:id";
-    query.prepare(replacement);
+    const auto relocateTracksStatement = QStringLiteral(
+            "UPDATE track_locations SET location=:newloc, directory=:newdir WHERE id=:id");
+    FwdSqlQuery relocateTracksQuery(m_database, relocateTracksStatement);
     for (int i = 0; i < loc_ids.size(); ++i) {
-        query.bindValue(QStringLiteral(":newloc"),
+        relocateTracksQuery.bindValue(QStringLiteral(":newloc"),
                 relocatedTracks.at(i).updatedTrackRef().getLocation());
-        query.bindValue(QStringLiteral(":newdir"), newDirectory);
-        query.bindValue(QStringLiteral(":id"), loc_ids.at(i).toVariant());
-        if (!query.exec()) {
-            LOG_FAILED_QUERY(query) << "could not relocate path of track";
+        relocateTracksQuery.bindValue(QStringLiteral(":newdir"), newDirectory);
+        relocateTracksQuery.bindValue(QStringLiteral(":id"), loc_ids.at(i).toVariant());
+        if (!relocateTracksQuery.execPrepared()) {
+            LOG_FAILED_QUERY(relocateTracksQuery) << "could not relocate path of track";
             return {RelocateResult::SqlError, relocatedTracks};
         }
     }


### PR DESCRIPTION
Fixes a bug with music directory relocation to a child of an existing music directory.

During a b2b session I added a USB drive to my library for convenience (so the guest could benefit from #14687).
Later on I copied music from that USB drive to my music disc (folder structure unchanged) and ejected the USB drive.
Then I relocated the USB directory and noticed that new location (inside my root dir) would be added to the dir list.

### Reproduce:
* add a new dir not inside of a root dir
* Apply, scan
* File manager: move dir inside one of the root dirs
* Library preferences: select dir, click Relocate, select new location
== new dir is still in list even though it's child of one of the other dirs

### Fix:
check if new is a child
-> yes: remove old
-> no: replace old with new (as before)

______
Note:
when I noticed this, I considered removing the obsolete old dir, but I was hesitant since I wasn't sure what would happen with the tagged and sorted tracks.
Now I know I could have clicked Remove and select "Keep metadata" but I'm not 100 % the scanner would discover the moved tracks...