### PR TITLE
Implement pregain threshold for broadcasting

### DIFF
--- a/src/mixer/playerinfo.cpp
+++ b/src/mixer/playerinfo.cpp
@@ -11,7 +11,6 @@
 namespace {
 
 constexpr int kPlayingDeckUpdateIntervalMillis = 2000;
-
 PlayerInfo* s_pPlayerInfo = nullptr;
 
 const QString kAppGroup = QStringLiteral("[App]");
@@ -149,6 +148,11 @@ void PlayerInfo::updateCurrentPlayingDeck() {
             &xfl,
             &xfr);
 
+    // Below is a list of failed decks that will be excluded from being selected
+    // as the currently playing deck and alert the user as to which decks will
+    // not be able to be played.
+    std::vector<int> failedDecks;
+
     for (int i = 0; i < numDecks(); ++i) {
         DeckControls* pDc = getDeckControls(i);
 
@@ -156,7 +160,8 @@ void PlayerInfo::updateCurrentPlayingDeck() {
             continue;
         }
 
-        if (pDc->m_pregain.get() <= 0.25) {
+        if (pDc->m_pregain.get() <= pregain_threshold) {
+            failedDecks.push_back(i);
             continue;
         }
 
@@ -181,7 +186,12 @@ void PlayerInfo::updateCurrentPlayingDeck() {
             maxVolume = dvol;
         }
     }
+
     locker.unlock();
+    if (failedDecks != previouslyFailedDecks) {
+        previouslyFailedDecks = failedDecks;
+        emit failedDecksChanged(failedDecks);
+    }
 
     int oldDeck = m_currentlyPlayingDeck.fetchAndStoreRelease(maxDeck);
     if (maxDeck != oldDeck) {
@@ -230,4 +240,19 @@ int PlayerInfo::numPreviewDecks() const {
 
 int PlayerInfo::numSamplers() const {
     return static_cast<int>(m_numSamplers.get());
+}
+
+double PlayerInfo::getPregainThreshold() const {
+    return pregain_threshold;
+}
+void PlayerInfo::setPregainThreshold(double threshold) {
+    const auto locker = lockMutex(&m_mutex);
+
+    if (threshold < 0.0) {
+        threshold = 0.0;
+    }
+    if (threshold > 1.0) {
+        threshold = 1.0;
+    }
+    pregain_threshold = threshold;
 }

--- a/src/mixer/playerinfo.cpp
+++ b/src/mixer/playerinfo.cpp
@@ -247,12 +247,6 @@ double PlayerInfo::getPregainThreshold() const {
 }
 void PlayerInfo::setPregainThreshold(double threshold) {
     const auto locker = lockMutex(&m_mutex);
-
-    if (threshold < 0.0) {
-        threshold = 0.0;
-    }
-    if (threshold > 1.0) {
-        threshold = 1.0;
-    }
+    //no hard boundary checks needed because the logic in its only call will handle that
     pregain_threshold = threshold;
 }

--- a/src/mixer/playerinfo.h
+++ b/src/mixer/playerinfo.h
@@ -27,11 +27,15 @@ class PlayerInfo : public QObject {
     int numDecks() const;
     int numPreviewDecks() const;
     int numSamplers() const;
+    double getPregainThreshold() const;
+    void setPregainThreshold(double threshold);
 
   signals:
     void currentPlayingDeckChanged(int deck);
     void currentPlayingTrackChanged(TrackPointer pTrack);
     void trackChanged(const QString& group, TrackPointer pNewTrack, TrackPointer pOldTrack);
+
+    void failedDecksChanged(std::vector<int> failedDecks);
 
   private:
     class DeckControls {
@@ -70,4 +74,6 @@ class PlayerInfo : public QObject {
     QList<DeckControls*> m_deckControlList;
 
     static PlayerInfo* m_pPlayerinfo;
+    double pregain_threshold = 0.25;
+    std::vector<int> previouslyFailedDecks;
 };

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -30,6 +30,7 @@ using namespace QKeychain;
 #include "util/xml.h"
 
 namespace {
+constexpr const char* kBroadcastPregainThreshold = "BroadcastPregainThreshold";
 constexpr const char* kDoctype = "broadcastprofile";
 constexpr const char* kDocumentRoot = "BroadcastProfile";
 constexpr const char* kSecureCredentials = "SecureCredentialsStorage";
@@ -188,37 +189,38 @@ bool BroadcastProfile::equals(BroadcastProfilePtr other) {
 }
 
 bool BroadcastProfile::valuesEquals(BroadcastProfilePtr other) {
-    if (getEnabled() == other->getEnabled()
-            && secureCredentialStorage() == other->secureCredentialStorage()
-            && getHost() == other->getHost()
-            && getPort() == other->getPort()
-            && getServertype() == other->getServertype()
-            && getLogin() == other->getLogin()
-            && getPassword() == other->getPassword()
-            && getEnableReconnect() == other->getEnableReconnect()
-            && getReconnectPeriod() == other->getReconnectPeriod()
-            && getLimitReconnects() == other->getLimitReconnects()
-            && getMaximumRetries() == other->getMaximumRetries()
-            && getNoDelayFirstReconnect() == other->getNoDelayFirstReconnect()
-            && getReconnectFirstDelay() == other->getReconnectFirstDelay()
-            && getFormat() == other->getFormat()
-            && getBitrate() == other->getBitrate()
-            && getChannels() == other->getChannels()
-            && getMountpoint() == other->getMountpoint()
-            && getStreamName() == other->getStreamName()
-            && getStreamDesc() == other->getStreamDesc()
-            && getStreamGenre() == other->getStreamGenre()
-            && getStreamPublic() == other->getStreamPublic()
-            && getStreamWebsite() == other->getStreamWebsite()
-            && getStreamIRC() == other->getStreamIRC()
-            && getStreamAIM() == other->getStreamAIM()
-            && getStreamICQ() == other->getStreamICQ()
-            && getEnableMetadata() == other->getEnableMetadata()
-            && getMetadataCharset() == other->getMetadataCharset()
-            && getCustomArtist() == other->getCustomArtist()
-            && getCustomTitle() == other->getCustomTitle()
-            && getMetadataFormat() == other->getMetadataFormat()
-            && getOggDynamicUpdate() == other->getOggDynamicUpdate()) {
+    if (getEnabled() == other->getEnabled() &&
+            secureCredentialStorage() == other->secureCredentialStorage() &&
+            getHost() == other->getHost() && getPort() == other->getPort() &&
+            getServertype() == other->getServertype() &&
+            getLogin() == other->getLogin() &&
+            getPassword() == other->getPassword() &&
+            getEnableReconnect() == other->getEnableReconnect() &&
+            getReconnectPeriod() == other->getReconnectPeriod() &&
+            getLimitReconnects() == other->getLimitReconnects() &&
+            getMaximumRetries() == other->getMaximumRetries() &&
+            getNoDelayFirstReconnect() == other->getNoDelayFirstReconnect() &&
+            getReconnectFirstDelay() == other->getReconnectFirstDelay() &&
+            getFormat() == other->getFormat() &&
+            getBitrate() == other->getBitrate() &&
+            getChannels() == other->getChannels() &&
+            getMountpoint() == other->getMountpoint() &&
+            getStreamName() == other->getStreamName() &&
+            getStreamDesc() == other->getStreamDesc() &&
+            getStreamGenre() == other->getStreamGenre() &&
+            getStreamPublic() == other->getStreamPublic() &&
+            getStreamWebsite() == other->getStreamWebsite() &&
+            getStreamIRC() == other->getStreamIRC() &&
+            getStreamAIM() == other->getStreamAIM() &&
+            getStreamICQ() == other->getStreamICQ() &&
+            getEnableMetadata() == other->getEnableMetadata() &&
+            getMetadataCharset() == other->getMetadataCharset() &&
+            getCustomArtist() == other->getCustomArtist() &&
+            getCustomTitle() == other->getCustomTitle() &&
+            getMetadataFormat() == other->getMetadataFormat() &&
+            getOggDynamicUpdate() == other->getOggDynamicUpdate() &&
+            getBroadcastPregainThreshold() ==
+                    other->getBroadcastPregainThreshold()) {
         return true;
     }
 
@@ -271,7 +273,7 @@ void BroadcastProfile::copyValuesTo(BroadcastProfilePtr other) {
     other->setCustomTitle(this->getCustomTitle());
     other->setMetadataFormat(this->getMetadataFormat());
     other->setOggDynamicUpdate(this->getOggDynamicUpdate());
-
+    other->setBroadcastPregainThreshold(this->getBroadcastPregainThreshold());
     other->setEnabled(this->getEnabled());
 }
 
@@ -305,6 +307,7 @@ void BroadcastProfile::adoptDefaultValues() {
     m_customTitle = QString();
     m_metadataFormat = kDefaultMetadataFormat;
     m_oggDynamicUpdate = kDefaultOggDynamicupdate;
+    m_broadcastPregainThreshold = 0.25;
 
     m_bitrate = kDefaultBitrate;
     m_channels = kDefaultChannels;
@@ -403,7 +406,14 @@ bool BroadcastProfile::loadValues(const QString& filename) {
     m_metadataFormat = selectCleanNodeString(doc, kMetadataFormat, &fixedStrings);
     m_oggDynamicUpdate =
             (bool)XmlParse::selectNodeInt(doc, kOggDynamicUpdate);
-
+    QDomNode pregainThresholdNode = XmlParse::selectNode(doc, kBroadcastPregainThreshold);
+    // here, m_broadcastPregainThreshold follows the same command structure as m_profileName
+    if (!pregainThresholdNode.isNull()) {
+        m_broadcastPregainThreshold =
+                XmlParse::selectNodeDouble(doc, kBroadcastPregainThreshold);
+    } else {
+        m_broadcastPregainThreshold = 0.25;
+    }
     if (fixedStrings) {
         if (save(m_filename)) {
             qWarning() << "BroadcastProfile::loadValues: wrote config for profile"
@@ -481,6 +491,10 @@ bool BroadcastProfile::save(const QString& filename) {
     XmlParse::addElement(doc, docRoot, kMetadataFormat, m_metadataFormat);
     XmlParse::addElement(doc, docRoot, kOggDynamicUpdate,
                          QString::number((int)m_oggDynamicUpdate));
+    XmlParse::addElement(doc,
+            docRoot,
+            kBroadcastPregainThreshold,
+            QString::number((double)m_broadcastPregainThreshold));
 
     doc.appendChild(docRoot);
 
@@ -868,4 +882,19 @@ bool BroadcastProfile::getOggDynamicUpdate() const {
 
 void BroadcastProfile::setOggDynamicUpdate(bool value) {
     m_oggDynamicUpdate = value;
+}
+
+double BroadcastProfile::getBroadcastPregainThreshold() const {
+    return m_broadcastPregainThreshold;
+}
+
+void BroadcastProfile::setBroadcastPregainThreshold(double value) {
+    // Range check to keep the value between 0 and 1
+    if (value < 0.0) {
+        value = 0.0;
+    }
+    if (value > 1.0) {
+        value = 1.0;
+    }
+    m_broadcastPregainThreshold = value;
 }

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -28,6 +28,7 @@ using namespace QKeychain;
 #include "util/compatibility/qatomic.h"
 #include "util/logger.h"
 #include "util/xml.h"
+#include "mixer/playerinfo.h"
 
 namespace {
 constexpr const char* kBroadcastPregainThreshold = "BroadcastPregainThreshold";
@@ -896,5 +897,7 @@ void BroadcastProfile::setBroadcastPregainThreshold(double value) {
     if (value > 1.0) {
         value = 1.0;
     }
+    PlayerInfo::instance().setPregainThreshold(value);
     m_broadcastPregainThreshold = value;
+
 }

--- a/src/preferences/broadcastprofile.h
+++ b/src/preferences/broadcastprofile.h
@@ -145,6 +145,9 @@ class BroadcastProfile : public QObject {
     bool getOggDynamicUpdate() const;
     void setOggDynamicUpdate(bool value);
 
+    double getBroadcastPregainThreshold() const;
+    void setBroadcastPregainThreshold(double value);
+
   signals:
     void profileNameChanged(const QString& oldName, const QString& newName);
     void statusChanged(bool newStatus);
@@ -205,4 +208,6 @@ class BroadcastProfile : public QObject {
     bool m_oggDynamicUpdate;
 
     QAtomicInt m_connectionStatus;
+
+    double m_broadcastPregainThreshold;
 };

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -220,6 +220,7 @@ void DlgPrefBroadcast::slotApply() {
     const QString failedStr = tr("Saving settings failed");
     QMap<QString, QString> mountpoints;
     const QList<BroadcastProfilePtr> broadcastProfiles = m_pSettingsModel->profiles();
+
     for (const auto& profile : broadcastProfiles) {
         QString profileName = profile->getProfileName();
         qWarning() << "--> slotApply()" << profileName;
@@ -552,6 +553,10 @@ void DlgPrefBroadcast::getValuesFromProfile(BroadcastProfilePtr profile) {
     // OGG "dynamicupdate" checkbox
     ogg_dynamicupdate->setEnabled(profile->getFormat() == ENCODING_OGG);
     ogg_dynamicupdate->setChecked(profile->getOggDynamicUpdate());
+
+    // Threshold for broadcasting pregain based on spinBox
+    double pregainThreshold = profile->getBroadcastPregainThreshold();
+    spinBoxPregainThreshold->setValue(pregainThreshold);
 }
 
 void DlgPrefBroadcast::setValuesToProfile(BroadcastProfilePtr profile) {
@@ -591,6 +596,7 @@ void DlgPrefBroadcast::setValuesToProfile(BroadcastProfilePtr profile) {
     profile->setStreamGenre(stream_genre->text());
     profile->setStreamPublic(stream_public->isChecked());
     profile->setOggDynamicUpdate(ogg_dynamicupdate->isChecked());
+    profile->setBroadcastPregainThreshold(spinBoxPregainThreshold->value());
 
     QString charset = "";
     if (enableUtf8Metadata->isChecked()) {

--- a/src/preferences/dialog/dlgprefbroadcastdlg.ui
+++ b/src/preferences/dialog/dlgprefbroadcastdlg.ui
@@ -411,6 +411,38 @@
              </property>
             </widget>
            </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_15_2">
+             <property name="text">
+              <string>Pregain threshold</string>
+             </property>
+             <property name="buddy">
+              <cstring>spinBoxPregainThreshold</cstring>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QDoubleSpinBox" name="spinBoxPregainThreshold">
+              <property name="toolTip">
+              <string>Minimum pregain for a playing deck to be audible enough for playing when live broadcasting.</string>
+              </property>
+              <property name="decimals">
+              <number>2</number>
+              </property>
+              <property name="minimum">
+              <double>0.00</double>
+              </property>
+              <property name="maximum">
+              <double>1.00</double>
+              </property>
+              <property name="singleStep">
+              <double>0.05</double>
+              </property>
+              <property name="value">
+              <double>0.25</double>
+              </property>
+            </widget>
+           </item>
            <item row="3" column="1">
             <widget class="QLineEdit" name="custom_title">
              <property name="text">
@@ -428,7 +460,7 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="0" colspan="2">
+           <item row="5" column="0" colspan="2">
             <widget class="QCheckBox" name="ogg_dynamicupdate">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -444,14 +476,14 @@
              </property>
             </widget>
            </item>
-           <item row="5" column="0" colspan="2">
+           <item row="6" column="0" colspan="2">
             <widget class="QCheckBox" name="enableUtf8Metadata">
              <property name="text">
               <string>Use UTF-8 encoding for metadata.</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="1">
+           <item row="7" column="1">
             <spacer name="verticalSpacer_3">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -483,14 +515,14 @@
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
           <layout class="QGridLayout">
-           <item row="7" column="0">
+           <item row="8" column="0">
             <widget class="QLabel" name="stream_ICQ_label">
              <property name="text">
               <string>ICQ</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="0">
+           <item row="7" column="0">
             <widget class="QLabel" name="stream_AIM_label">
              <property name="text">
               <string>AIM</string>
@@ -620,7 +652,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="4" column="1">
+           <item row="5" column="1">
             <widget class="QLineEdit" name="stream_genre">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -640,20 +672,20 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
+           <item row="6" column="0">
             <widget class="QLabel" name="stream_IRC_label">
              <property name="text">
               <string>IRC</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="1">
+           <item row="6" column="1">
             <widget class="QLineEdit" name="stream_IRC"/>
            </item>
-           <item row="6" column="1">
+           <item row="7" column="1">
             <widget class="QLineEdit" name="stream_AIM"/>
            </item>
-           <item row="7" column="1">
+           <item row="8" column="1">
             <widget class="QLineEdit" name="stream_ICQ"/>
            </item>
           </layout>


### PR DESCRIPTION
This PR adds a configurable pregain threshold, which allows users to modify the minimum pregain needed by a track to be selected in live broadcasting. Previously, this threshold was hardcoded to 0.25.

It adds the user interfacing element required for this change in Preferences and stores metadata about the decks that fail to meet the threshold (to be possibly used in further development).

Please test this feature if you are knowledgeable about pregain for individual decks and live broadcasting. I personally used breakpoints and LLDB to test this feature as it primarily affects metadata. The feature will hopefully be very useful for user-facing features that use the current playing track metadata in the feature. Some experienced users may need more customizable control over which deck is considered "the current playing deck" for broadcast metadata. 

Suggestions for improvement are welcome. If accepted, I can suggest documentation to the wiki.
Thank you.