### PR TITLE
Fix Traktor Collection Access in macOS Sandbox

### DIFF
--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -12,7 +12,6 @@
 
 #include "library/dao/settingsdao.h"
 #include "library/library.h"
-#include "library/librarytablemodel.h"
 #include "library/missing_hidden/missingtablemodel.h"
 #include "library/queryutil.h"
 #include "library/trackcollection.h"

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -1,5 +1,6 @@
 #include "library/traktor/traktorfeature.h"
 
+#include <QFileDialog>
 #include <QMap>
 #include <QMessageBox>
 #include <QRegularExpression>
@@ -9,6 +10,7 @@
 #include <QXmlStreamReader>
 #include <QtDebug>
 
+#include "library/dao/settingsdao.h"
 #include "library/library.h"
 #include "library/librarytablemodel.h"
 #include "library/missing_hidden/missingtablemodel.h"
@@ -152,6 +154,11 @@ QVariant TraktorFeature::title() {
 }
 
 bool TraktorFeature::isSupported() {
+#if defined(Q_OS_MACOS)
+    if (Sandbox::enabled()) {
+        return true;
+    }
+#endif
     return (QFile::exists(getTraktorMusicDatabase()));
 }
 
@@ -167,14 +174,57 @@ void TraktorFeature::activate() {
 
     if (!m_isActivated) {
         m_isActivated =  true;
+
+        SettingsDAO settings(m_pTrackCollection->database());
+        QString dbFile(settings.getValue("mixxx.traktorfeature.dbpath"));
+
+        bool hasValidDbFile = false;
+
+        if (!dbFile.isEmpty()) {
+            mixxx::FileInfo dbFileInfo(dbFile);
+#if defined(Q_OS_MACOS)
+            if (Sandbox::enabled() && Sandbox::canAccess(&dbFileInfo)) {
+                hasValidDbFile = true;
+            }
+#endif
+            if (!hasValidDbFile && dbFileInfo.checkFileExists()) {
+                hasValidDbFile = true;
+            }
+        }
+
+        if (!hasValidDbFile) {
+            dbFile = getTraktorMusicDatabase();
+            mixxx::FileInfo dbFileInfo(dbFile);
+
+#if defined(Q_OS_MACOS)
+            if (Sandbox::enabled()) {
+                if (!dbFileInfo.checkFileExists() || !Sandbox::canAccess(&dbFileInfo)) {
+                    if (!Sandbox::askForAccess(&dbFileInfo)) {
+                        QString newDbFile = QFileDialog::getOpenFileName(nullptr,
+                                tr("Select your Traktor collection"),
+                                dbFile,
+                                "Traktor Collection (*.nml)");
+                        if (newDbFile.isEmpty()) {
+                            m_isActivated = false;
+                            return;
+                        }
+                        dbFile = newDbFile;
+                        mixxx::FileInfo newFileInfo(dbFile);
+                        Sandbox::createSecurityToken(&newFileInfo);
+                    }
+                }
+            }
+#endif
+            settings.setValue("mixxx.traktorfeature.dbpath", dbFile);
+        }
+
         // Let a worker thread do the XML parsing
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         m_future = QtConcurrent::run(&TraktorFeature::importLibrary,
                 this,
-                getTraktorMusicDatabase());
+                dbFile);
 #else
-        m_future = QtConcurrent::run(this, &TraktorFeature::importLibrary,
-                                     getTraktorMusicDatabase());
+        m_future = QtConcurrent::run(this, &TraktorFeature::importLibrary, dbFile);
 #endif
         m_future_watcher.setFuture(m_future);
         m_title = tr("(loading) Traktor");
@@ -611,15 +661,16 @@ QString TraktorFeature::getTraktorMusicDatabase() {
 
     //Let's try to detect the latest Traktor version and its collection.nml
     QString myDocuments = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
+#if defined(Q_OS_MACOS)
+    if (Sandbox::enabled()) {
+        QString user = qgetenv("USER");
+        if (!user.isEmpty()) {
+            myDocuments = QLatin1String("/Users/") + user + QLatin1String("/Documents");
+        }
+    }
+#endif
     QDir ni_directory(myDocuments +"/Native Instruments/");
     ni_directory.setFilter(QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks);
-
-    // We may not have access to this directory since it is in the user's
-    // Documents folder. Ask for access if we don't have it.
-    if (ni_directory.exists()) {
-        auto fileInfo = mixxx::FileInfo(ni_directory);
-        Sandbox::askForAccess(&fileInfo);
-    }
 
     //Iterate over the subfolders
     QFileInfoList list = ni_directory.entryInfoList();

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -182,7 +182,8 @@ void TraktorFeature::activate() {
         if (!dbFile.isEmpty()) {
             mixxx::FileInfo dbFileInfo(dbFile);
 #if defined(Q_OS_MACOS)
-            if (Sandbox::enabled() && Sandbox::canAccess(&dbFileInfo)) {
+            if (Sandbox::enabled() && Sandbox::canAccess(&dbFileInfo) &&
+                    dbFileInfo.checkFileExists()) {
                 hasValidDbFile = true;
             }
 #endif
@@ -201,7 +202,7 @@ void TraktorFeature::activate() {
                     if (!Sandbox::askForAccess(&dbFileInfo)) {
                         QString newDbFile = QFileDialog::getOpenFileName(nullptr,
                                 tr("Select your Traktor collection"),
-                                dbFile,
+                                QFileInfo(dbFile).absolutePath(),
                                 "Traktor Collection (*.nml)");
                         if (newDbFile.isEmpty()) {
                             m_isActivated = false;


### PR DESCRIPTION
# Fix Traktor Collection Access in macOS Sandbox (Issue #16192)

### Summary

This PR fixes an issue where Mixxx, when running in a sandboxed macOS environment, was unable to access the user's Traktor collection (`collection.nml`) in the real `~/Documents` folder.

### The Problem

When Mixxx is sandboxed on macOS, `QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation)` incorrectly points to an empty container path (e.g., `~/Library/Containers/org.mixxx.mixxx/Data/Documents`) instead of the user's actual Documents folder. Because of these sandbox restrictions, Mixxx's initial scan of the Traktor directory would fail, and the feature would hide itself from the sidebar (`isSupported()` returning `false`).

### The Solution

1. **Manual Path Reconstruction**: In `getTraktorMusicDatabase()`, we now manually construct the `/Users/$USER/Documents` path when sandboxing is detected on macOS, ensuring we look at the real user folder.
2. **Persistent Feature Visibility**: Modified `isSupported()` to always return `true` on sandboxed macOS. This ensures the Traktor entry stays visible in the sidebar, allowing users to manually grant permission if the automatic discovery fails.
3. **Manual Fallback & Permissions**:
   - If the automated scan fails, the `activate()` function now prompts the user with a `QFileDialog` to manually locate their `collection.nml`.
   - Selecting the file via this dialog triggers the macOS `NSOpenPanel`, which grants the application OS-level permission to access the chosen directory.
   - We then call `Sandbox::createSecurityToken()` to create a **Security Scoped Bookmark**, ensuring this permission persists across application restarts.
4. **Settings Persistence**: The verified path is stored in the Mixxx database (`mixxx.traktorfeature.dbpath`) via `SettingsDAO`, making subsequent launches seamless.

### Changes

- `src/library/traktor/traktorfeature.cpp`:
  - Updated `isSupported()` for macOS sandbox compatibility.
  - Enhanced `activate()` with a manual file picker fallback and permission handling.
  - Modified `getTraktorMusicDatabase()` for real path resolution.
  - Linked `SettingsDAO` for path persistence.
  - Removed unused `librarytablemodel.h` header.

Fixes: #16192

Direct download for mac ARM (M-series chips): https://github.com/mixxxdj/mixxx/actions/runs/23421427713/artifacts/6052367393
