### PR TITLE
gui: Save pending track metadata before closing main window

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -48,6 +48,7 @@
 #include "skin/skinloader.h"
 #include "soundio/soundmanager.h"
 #include "sources/soundsourceproxy.h"
+#include "track/globaltrackcache.h"
 #include "track/track.h"
 #include "util/debug.h"
 #include "util/desktophelper.h"
@@ -1520,6 +1521,20 @@ void MixxxMainWindow::closeEvent(QCloseEvent *event) {
         event->ignore();
         return;
     }
+
+    ScopedWaitCursor cursor;
+
+    QMessageBox savingMsg(this);
+    savingMsg.setIcon(QMessageBox::Information);
+    savingMsg.setWindowTitle(tr("Saving Metadata"));
+    savingMsg.setText(tr("Mixxx is saving track metadata to the database. Please wait..."));
+    savingMsg.setStandardButtons(QMessageBox::NoButton);
+    savingMsg.show();
+
+    QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+
+    GlobalTrackCacheLocker().deactivateCache();
+
     QMainWindow::closeEvent(event);
 }
 


### PR DESCRIPTION
Closes #16191

This PR makes sure Mixxx saves pending track metadata to the database before the main window completely closes. Previously, this happened in the background after closing, which could potentially cause database or config trouble if the app was restarted too quickly.

**What changed:**
* Deactivates the track cache before the close event is accepted to trigger the metadata save.
* Displays a "Saving Metadata" message box so the user knows to wait while the app finishes up.
