### PR TITLE
Require compatibility profile context when not forcing OpenGL ES

### DIFF
--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1419,6 +1419,9 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer confi
     format.setRenderableType(QSurfaceFormat::OpenGLES);
     format.setVersion(3, 0);
     QSurfaceFormat::setDefaultFormat(format);
+#else
+    format.setProfile(QSurfaceFormat::CompatibilityProfile);
+    format.setRenderableType(QSurfaceFormat::OpenGL);
 #endif
 
     return format;


### PR DESCRIPTION
This prevents a potential version conflict between the context and packed shaders, which would result in shader compilation failure. 

Fixes bug #16213 

I'm not sure if altering the context is a good solution, or if it would be better to change the packed shader versions. I'd appreciate some feedback here.