### PR TITLE
Menubar: avoid crash with invalid keyboard shortcut strings, verify QKeySequence

### DIFF
--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -25,6 +25,28 @@ QString buildWhatsThis(const QString& title, const QString& text) {
     return QString("%1\n\n%2").arg(preparedTitle.remove("&"), text);
 }
 
+// Returns a QKeySequence from str, or an empty QKeySequence if str contains an invalid key name.
+// Prevents a macOS crash where QCocoaMenuItem::sync() cannot convert Qt::Key_unknown (> 0xFFFF) to QChar.
+// See https://github.com/mixxxdj/mixxx/issues/16216
+QKeySequence safeKeySequence(const QString& str) {
+    if (str.isEmpty()) {
+        return {};
+    }
+    const QKeySequence ks(str);
+    for (int i = 0; i < ks.count(); ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        const Qt::Key key = ks[i].key();
+#else
+        const int key = ks[i] & ~Qt::KeyboardModifierMask;
+#endif
+        if (key == Qt::Key_unknown) {
+            qWarning() << "Ignoring invalid keyboard shortcut:" << str;
+            return {};
+        }
+    }
+    return ks;
+}
+
 #ifdef __VINYLCONTROL__
 QString vinylControlDefaultKeyBinding(int deck) {
     // More bindings need to be defined if you increment
@@ -102,7 +124,7 @@ void WMainMenuBar::initialize() {
                 ConfigKey("[KeyboardShortcuts]", QString("FileMenu_LoadDeck%1").arg(deck + 1)),
                 loadToDeckDefaultKeyBinding(deck));
         if (!binding.isEmpty()) {
-            pFileLoadSongToPlayer->setShortcut(QKeySequence(binding));
+            pFileLoadSongToPlayer->setShortcut(safeKeySequence(binding));
             pFileLoadSongToPlayer->setShortcutContext(Qt::ApplicationShortcut);
         }
         pFileLoadSongToPlayer->setStatusTip(playerLoadStatusText);
@@ -124,7 +146,7 @@ void WMainMenuBar::initialize() {
     QString quitText = tr("Quits Mixxx");
     auto* pFileQuit = new QAction(quitTitle, this);
     pFileQuit->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
+        safeKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
                                                   tr("Ctrl+q"))));
     pFileQuit->setShortcutContext(Qt::ApplicationShortcut);
     pFileQuit->setStatusTip(quitText);
@@ -144,7 +166,7 @@ void WMainMenuBar::initialize() {
     QString rescanTitle = tr("&Rescan Library");
     QString rescanText = tr("Rescans library folders for changes to tracks.");
     auto* pLibraryRescan = new QAction(rescanTitle, this);
-    pLibraryRescan->setShortcut(QKeySequence(m_pKbdConfig->getValue(
+    pLibraryRescan->setShortcut(safeKeySequence(m_pKbdConfig->getValue(
             ConfigKey("[KeyboardShortcuts]", "LibraryMenu_Rescan"),
             tr("Ctrl+Shift+L"))));
     pLibraryRescan->setStatusTip(rescanText);
@@ -173,7 +195,7 @@ void WMainMenuBar::initialize() {
     QString createPlaylistText = tr("Create a new playlist");
     auto* pLibraryCreatePlaylist = new QAction(createPlaylistTitle, this);
     pLibraryCreatePlaylist->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "LibraryMenu_NewPlaylist"),
                 tr("Ctrl+n"))));
     pLibraryCreatePlaylist->setShortcutContext(Qt::ApplicationShortcut);
@@ -186,7 +208,7 @@ void WMainMenuBar::initialize() {
     QString createCrateText = tr("Create a new crate");
     auto* pLibraryCreateCrate = new QAction(createCrateTitle, this);
     pLibraryCreateCrate->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]",
+        safeKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]",
                                                   "LibraryMenu_NewCrate"),
                                                   tr("Ctrl+Shift+N"))));
     pLibraryCreateCrate->setShortcutContext(Qt::ApplicationShortcut);
@@ -243,7 +265,7 @@ void WMainMenuBar::initialize() {
     auto* pViewShowSkinSettings = new QAction(showSkinSettingsTitle, this);
     pViewShowSkinSettings->setCheckable(true);
     pViewShowSkinSettings->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
             ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowSkinSettings"),
             tr("Ctrl+1", "Menubar|View|Show Skin Settings"))));
     pViewShowSkinSettings->setStatusTip(showSkinSettingsText);
@@ -259,7 +281,7 @@ void WMainMenuBar::initialize() {
     auto* pViewShowMicrophone = new QAction(showMicrophoneTitle, this);
     pViewShowMicrophone->setCheckable(true);
     pViewShowMicrophone->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
             ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowMicrophone"),
             tr("Ctrl+2", "Menubar|View|Show Microphone Section"))));
     pViewShowMicrophone->setStatusTip(showMicrophoneText);
@@ -275,7 +297,7 @@ void WMainMenuBar::initialize() {
     auto* pViewVinylControl = new QAction(showVinylControlTitle, this);
     pViewVinylControl->setCheckable(true);
     pViewVinylControl->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
             ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowVinylControl"),
             tr("Ctrl+3", "Menubar|View|Show Vinyl Control Section"))));
     pViewVinylControl->setStatusTip(showVinylControlText);
@@ -291,7 +313,7 @@ void WMainMenuBar::initialize() {
     auto* pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
     pViewShowPreviewDeck->setCheckable(true);
     pViewShowPreviewDeck->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowPreviewDeck"),
                 tr("Ctrl+4", "Menubar|View|Show Preview Deck"))));
     pViewShowPreviewDeck->setStatusTip(showPreviewDeckText);
@@ -307,7 +329,7 @@ void WMainMenuBar::initialize() {
     auto* pViewShowCoverArt = new QAction(showCoverArtTitle, this);
     pViewShowCoverArt->setCheckable(true);
     pViewShowCoverArt->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowCoverArt"),
                 tr("Ctrl+6", "Menubar|View|Show Cover Art"))));
     pViewShowCoverArt->setStatusTip(showCoverArtText);
@@ -323,7 +345,7 @@ void WMainMenuBar::initialize() {
     m_pViewKeywheel = new QAction(keywheelTitle, this);
     m_pViewKeywheel->setCheckable(true);
     m_pViewKeywheel->setShortcut(
-            QKeySequence(m_pKbdConfig->getValue(
+            safeKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowKeywheel"),
                     tr("F12", "Menubar|View|Show Keywheel"))));
     m_pViewKeywheel->setShortcutContext(Qt::ApplicationShortcut);
@@ -338,7 +360,7 @@ void WMainMenuBar::initialize() {
     auto* pViewMaximizeLibrary = new QAction(maximizeLibraryTitle, this);
     pViewMaximizeLibrary->setCheckable(true);
     pViewMaximizeLibrary->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "ViewMenu_MaximizeLibrary"),
                 tr("Space", "Menubar|View|Maximize Library"))));
     pViewMaximizeLibrary->setStatusTip(maximizeLibraryText);
@@ -357,7 +379,7 @@ void WMainMenuBar::initialize() {
     // newer macOS versions there might be issues with getting F11 working.
     // https://github.com/mixxxdj/mixxx/pull/3011#issuecomment-678678328
 #ifndef __APPLE__
-    shortcuts << QKeySequence("F11");
+    shortcuts << safeKeySequence("F11");
 #endif
     QKeySequence osShortcut = QKeySequence::FullScreen;
     // Note(ronso0) Only add the OS shortcut if it's not empty and not F11.
@@ -406,7 +428,7 @@ void WMainMenuBar::initialize() {
                     QString("OptionsMenu_EnableVinyl%1").arg(i + 1)),
             vinylControlDefaultKeyBinding(i));
         if (!binding.isEmpty()) {
-            vc_checkbox->setShortcut(QKeySequence(binding));
+            vc_checkbox->setShortcut(safeKeySequence(binding));
             vc_checkbox->setShortcutContext(Qt::ApplicationShortcut);
         }
 
@@ -432,7 +454,7 @@ void WMainMenuBar::initialize() {
     QString recordText = tr("Record your mix to a file");
     auto* pOptionsRecord = new QAction(recordTitle, this);
     pOptionsRecord->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "OptionsMenu_RecordMix"),
                 tr("Ctrl+R"))));
     pOptionsRecord->setShortcutContext(Qt::ApplicationShortcut);
@@ -451,7 +473,7 @@ void WMainMenuBar::initialize() {
     QString broadcastingText = tr("Stream your mixes to a shoutcast or icecast server");
     auto* pOptionsBroadcasting = new QAction(broadcastingTitle, this);
     pOptionsBroadcasting->setShortcut(
-            QKeySequence(m_pKbdConfig->getValue(
+            safeKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]",
                               "OptionsMenu_EnableLiveBroadcasting"),
                     tr("Ctrl+L"))));
@@ -476,7 +498,7 @@ void WMainMenuBar::initialize() {
         ConfigKey("[Keyboard]", "Enabled")) == "1";
     auto* pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
     pOptionsKeyboard->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableShortcuts"),
                 tr("Ctrl+`"))));
     pOptionsKeyboard->setShortcutContext(Qt::ApplicationShortcut);
@@ -494,7 +516,7 @@ void WMainMenuBar::initialize() {
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
     auto* pOptionsPreferences = new QAction(preferencesTitle, this);
     pOptionsPreferences->setShortcut(
-        QKeySequence(m_pKbdConfig->getValue(
+        safeKeySequence(m_pKbdConfig->getValue(
                 ConfigKey("[KeyboardShortcuts]", "OptionsMenu_Preferences"),
                 showPreferencesKeyBinding())));
     pOptionsPreferences->setShortcutContext(Qt::ApplicationShortcut);
@@ -517,7 +539,7 @@ void WMainMenuBar::initialize() {
         QString reloadSkinText = tr("Reload the skin");
         auto* pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
         pDeveloperReloadSkin->setShortcut(
-            QKeySequence(m_pKbdConfig->getValue(
+            safeKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "OptionsMenu_ReloadSkin"),
                     tr("Ctrl+Shift+R"))));
         pDeveloperReloadSkin->setShortcutContext(Qt::ApplicationShortcut);
@@ -530,7 +552,7 @@ void WMainMenuBar::initialize() {
         QString developerToolsText = tr("Opens the developer tools dialog");
         auto* pDeveloperTools = new QAction(developerToolsTitle, this);
         pDeveloperTools->setShortcut(
-            QKeySequence(m_pKbdConfig->getValue(
+            safeKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperTools"),
                     tr("Ctrl+Shift+T"))));
         pDeveloperTools->setShortcutContext(Qt::ApplicationShortcut);
@@ -550,7 +572,7 @@ void WMainMenuBar::initialize() {
             "Enables experiment mode. Collects stats in the EXPERIMENT tracking bucket.");
         auto* pDeveloperStatsExperiment = new QAction(enableExperimentTitle, this);
         pDeveloperStatsExperiment->setShortcut(
-            QKeySequence(m_pKbdConfig->getValue(
+            safeKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsExperiment"),
                     tr("Ctrl+Shift+E"))));
         pDeveloperStatsExperiment->setShortcutContext(Qt::ApplicationShortcut);
@@ -570,7 +592,7 @@ void WMainMenuBar::initialize() {
             "Enables base mode. Collects stats in the BASE tracking bucket.");
         auto* pDeveloperStatsBase = new QAction(enableBaseTitle, this);
         pDeveloperStatsBase->setShortcut(
-            QKeySequence(m_pKbdConfig->getValue(
+            safeKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsBase"),
                     tr("Ctrl+Shift+B"))));
         pDeveloperStatsBase->setShortcutContext(Qt::ApplicationShortcut);
@@ -592,7 +614,7 @@ void WMainMenuBar::initialize() {
             ConfigKey("[ScriptDebugger]", "Enabled")) == "1";
         auto* pDeveloperDebugger = new QAction(scriptDebuggerTitle, this);
         pDeveloperDebugger->setShortcut(
-            QKeySequence(m_pKbdConfig->getValue(
+            safeKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "DeveloperMenu_EnableDebugger"),
                     tr("Ctrl+Shift+D"))));
         pDeveloperDebugger->setShortcutContext(Qt::ApplicationShortcut);

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -25,9 +25,10 @@ QString buildWhatsThis(const QString& title, const QString& text) {
     return QString("%1\n\n%2").arg(preparedTitle.remove("&"), text);
 }
 
-// Returns a QKeySequence from str, or an empty QKeySequence if str contains an invalid key name.
-// Prevents a macOS crash where QCocoaMenuItem::sync() cannot convert Qt::Key_unknown (> 0xFFFF) to QChar.
-// See https://github.com/mixxxdj/mixxx/issues/16216
+// Returns a QKeySequence from str, or an empty QKeySequence if str contains an
+// invalid key name. Prevents a macOS crash where QCocoaMenuItem::sync() cannot
+// convert Qt::Key_unknown (> 0xFFFF) to QChar. See
+// https://github.com/mixxxdj/mixxx/issues/16216
 QKeySequence safeKeySequence(const QString& str) {
     if (str.isEmpty()) {
         return {};
@@ -53,28 +54,36 @@ QString vinylControlDefaultKeyBinding(int deck) {
     // kMaximumVinylControlInputs.
     DEBUG_ASSERT(deck < kMaximumVinylControlInputs);
     switch (deck) {
-        case 0: return QObject::tr("Ctrl+t");
-        case 1: return QObject::tr("Ctrl+y");
-        case 2: return QObject::tr("Ctrl+u");
-        case 3: return QObject::tr("Ctrl+i");
-        default: return QString();
+    case 0:
+        return QStringLiteral("Ctrl+t");
+    case 1:
+        return QStringLiteral("Ctrl+y");
+    case 2:
+        return QStringLiteral("Ctrl+u");
+    case 3:
+        return QStringLiteral("Ctrl+i");
+    default:
+        return QString();
     }
 }
 #endif // __VINYLCONTROL__
 
 QString loadToDeckDefaultKeyBinding(int deck) {
     switch (deck) {
-        case 0: return QObject::tr("Ctrl+o");
-        case 1: return QObject::tr("Ctrl+Shift+O");
-        default: return QString();
+    case 0:
+        return QStringLiteral("Ctrl+o");
+    case 1:
+        return QStringLiteral("Ctrl+Shift+O");
+    default:
+        return QString();
     }
 }
 
 QString showPreferencesKeyBinding() {
 #ifdef __APPLE__
-    return QObject::tr("Ctrl+,");
+    return QStringLiteral("Ctrl+,");
 #else
-    return QObject::tr("Ctrl+P");
+    return QStringLiteral("Ctrl+P");
 #endif
 }
 
@@ -145,9 +154,9 @@ void WMainMenuBar::initialize() {
     QString quitTitle = tr("&Exit");
     QString quitText = tr("Quits Mixxx");
     auto* pFileQuit = new QAction(quitTitle, this);
-    pFileQuit->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
-                                                  tr("Ctrl+q"))));
+    pFileQuit->setShortcut(safeKeySequence(m_pKbdConfig->getValue(
+            ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
+            QStringLiteral("Ctrl+q"))));
     pFileQuit->setShortcutContext(Qt::ApplicationShortcut);
     pFileQuit->setStatusTip(quitText);
     pFileQuit->setWhatsThis(buildWhatsThis(quitTitle, quitText));
@@ -168,7 +177,7 @@ void WMainMenuBar::initialize() {
     auto* pLibraryRescan = new QAction(rescanTitle, this);
     pLibraryRescan->setShortcut(safeKeySequence(m_pKbdConfig->getValue(
             ConfigKey("[KeyboardShortcuts]", "LibraryMenu_Rescan"),
-            tr("Ctrl+Shift+L"))));
+            QStringLiteral("Ctrl+Shift+L"))));
     pLibraryRescan->setStatusTip(rescanText);
     pLibraryRescan->setWhatsThis(buildWhatsThis(rescanTitle, rescanText));
     pLibraryRescan->setCheckable(false);
@@ -195,9 +204,9 @@ void WMainMenuBar::initialize() {
     QString createPlaylistText = tr("Create a new playlist");
     auto* pLibraryCreatePlaylist = new QAction(createPlaylistTitle, this);
     pLibraryCreatePlaylist->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-                ConfigKey("[KeyboardShortcuts]", "LibraryMenu_NewPlaylist"),
-                tr("Ctrl+n"))));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "LibraryMenu_NewPlaylist"),
+                    QStringLiteral("Ctrl+n"))));
     pLibraryCreatePlaylist->setShortcutContext(Qt::ApplicationShortcut);
     pLibraryCreatePlaylist->setStatusTip(createPlaylistText);
     pLibraryCreatePlaylist->setWhatsThis(buildWhatsThis(createPlaylistTitle, createPlaylistText));
@@ -208,9 +217,9 @@ void WMainMenuBar::initialize() {
     QString createCrateText = tr("Create a new crate");
     auto* pLibraryCreateCrate = new QAction(createCrateTitle, this);
     pLibraryCreateCrate->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]",
-                                                  "LibraryMenu_NewCrate"),
-                                                  tr("Ctrl+Shift+N"))));
+            safeKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]",
+                                                           "LibraryMenu_NewCrate"),
+                    QStringLiteral("Ctrl+Shift+N"))));
     pLibraryCreateCrate->setShortcutContext(Qt::ApplicationShortcut);
     pLibraryCreateCrate->setStatusTip(createCrateText);
     pLibraryCreateCrate->setWhatsThis(buildWhatsThis(createCrateTitle, createCrateText));
@@ -265,9 +274,9 @@ void WMainMenuBar::initialize() {
     auto* pViewShowSkinSettings = new QAction(showSkinSettingsTitle, this);
     pViewShowSkinSettings->setCheckable(true);
     pViewShowSkinSettings->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-            ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowSkinSettings"),
-            tr("Ctrl+1", "Menubar|View|Show Skin Settings"))));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowSkinSettings"),
+                    QStringLiteral("Ctrl+1"))));
     pViewShowSkinSettings->setStatusTip(showSkinSettingsText);
     pViewShowSkinSettings->setWhatsThis(buildWhatsThis(showSkinSettingsTitle, showSkinSettingsText));
     createVisibilityControl(pViewShowSkinSettings,
@@ -281,9 +290,9 @@ void WMainMenuBar::initialize() {
     auto* pViewShowMicrophone = new QAction(showMicrophoneTitle, this);
     pViewShowMicrophone->setCheckable(true);
     pViewShowMicrophone->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-            ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowMicrophone"),
-            tr("Ctrl+2", "Menubar|View|Show Microphone Section"))));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowMicrophone"),
+                    QStringLiteral("Ctrl+2"))));
     pViewShowMicrophone->setStatusTip(showMicrophoneText);
     pViewShowMicrophone->setWhatsThis(buildWhatsThis(showMicrophoneTitle, showMicrophoneText));
     createVisibilityControl(pViewShowMicrophone,
@@ -297,9 +306,9 @@ void WMainMenuBar::initialize() {
     auto* pViewVinylControl = new QAction(showVinylControlTitle, this);
     pViewVinylControl->setCheckable(true);
     pViewVinylControl->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-            ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowVinylControl"),
-            tr("Ctrl+3", "Menubar|View|Show Vinyl Control Section"))));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowVinylControl"),
+                    QStringLiteral("Ctrl+3"))));
     pViewVinylControl->setStatusTip(showVinylControlText);
     pViewVinylControl->setWhatsThis(buildWhatsThis(showVinylControlTitle, showVinylControlText));
     createVisibilityControl(pViewVinylControl,
@@ -313,9 +322,9 @@ void WMainMenuBar::initialize() {
     auto* pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
     pViewShowPreviewDeck->setCheckable(true);
     pViewShowPreviewDeck->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-                ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowPreviewDeck"),
-                tr("Ctrl+4", "Menubar|View|Show Preview Deck"))));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowPreviewDeck"),
+                    QStringLiteral("Ctrl+4"))));
     pViewShowPreviewDeck->setStatusTip(showPreviewDeckText);
     pViewShowPreviewDeck->setWhatsThis(buildWhatsThis(showPreviewDeckTitle, showPreviewDeckText));
     createVisibilityControl(pViewShowPreviewDeck,
@@ -329,9 +338,9 @@ void WMainMenuBar::initialize() {
     auto* pViewShowCoverArt = new QAction(showCoverArtTitle, this);
     pViewShowCoverArt->setCheckable(true);
     pViewShowCoverArt->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-                ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowCoverArt"),
-                tr("Ctrl+6", "Menubar|View|Show Cover Art"))));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowCoverArt"),
+                    QStringLiteral("Ctrl+6"))));
     pViewShowCoverArt->setStatusTip(showCoverArtText);
     pViewShowCoverArt->setWhatsThis(buildWhatsThis(showCoverArtTitle, showCoverArtText));
     createVisibilityControl(pViewShowCoverArt,
@@ -347,7 +356,7 @@ void WMainMenuBar::initialize() {
     m_pViewKeywheel->setShortcut(
             safeKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowKeywheel"),
-                    tr("F12", "Menubar|View|Show Keywheel"))));
+                    QStringLiteral("F12"))));
     m_pViewKeywheel->setShortcutContext(Qt::ApplicationShortcut);
     m_pViewKeywheel->setStatusTip(keywheelText);
     m_pViewKeywheel->setWhatsThis(buildWhatsThis(keywheelTitle, keywheelText));
@@ -360,9 +369,9 @@ void WMainMenuBar::initialize() {
     auto* pViewMaximizeLibrary = new QAction(maximizeLibraryTitle, this);
     pViewMaximizeLibrary->setCheckable(true);
     pViewMaximizeLibrary->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-                ConfigKey("[KeyboardShortcuts]", "ViewMenu_MaximizeLibrary"),
-                tr("Space", "Menubar|View|Maximize Library"))));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_MaximizeLibrary"),
+                    QStringLiteral("Space"))));
     pViewMaximizeLibrary->setStatusTip(maximizeLibraryText);
     pViewMaximizeLibrary->setWhatsThis(buildWhatsThis(maximizeLibraryTitle, maximizeLibraryText));
     createVisibilityControl(pViewMaximizeLibrary,
@@ -454,9 +463,9 @@ void WMainMenuBar::initialize() {
     QString recordText = tr("Record your mix to a file");
     auto* pOptionsRecord = new QAction(recordTitle, this);
     pOptionsRecord->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-                ConfigKey("[KeyboardShortcuts]", "OptionsMenu_RecordMix"),
-                tr("Ctrl+R"))));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_RecordMix"),
+                    QStringLiteral("Ctrl+R"))));
     pOptionsRecord->setShortcutContext(Qt::ApplicationShortcut);
     pOptionsRecord->setCheckable(true);
     pOptionsRecord->setStatusTip(recordText);
@@ -475,8 +484,8 @@ void WMainMenuBar::initialize() {
     pOptionsBroadcasting->setShortcut(
             safeKeySequence(m_pKbdConfig->getValue(
                     ConfigKey("[KeyboardShortcuts]",
-                              "OptionsMenu_EnableLiveBroadcasting"),
-                    tr("Ctrl+L"))));
+                            "OptionsMenu_EnableLiveBroadcasting"),
+                    QStringLiteral("Ctrl+L"))));
     pOptionsBroadcasting->setShortcutContext(Qt::ApplicationShortcut);
     pOptionsBroadcasting->setCheckable(true);
     pOptionsBroadcasting->setStatusTip(broadcastingText);
@@ -498,9 +507,9 @@ void WMainMenuBar::initialize() {
         ConfigKey("[Keyboard]", "Enabled")) == "1";
     auto* pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
     pOptionsKeyboard->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-                ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableShortcuts"),
-                tr("Ctrl+`"))));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableShortcuts"),
+                    QStringLiteral("Ctrl+`"))));
     pOptionsKeyboard->setShortcutContext(Qt::ApplicationShortcut);
     pOptionsKeyboard->setCheckable(true);
     pOptionsKeyboard->setChecked(keyboardShortcutsEnabled);
@@ -516,9 +525,9 @@ void WMainMenuBar::initialize() {
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
     auto* pOptionsPreferences = new QAction(preferencesTitle, this);
     pOptionsPreferences->setShortcut(
-        safeKeySequence(m_pKbdConfig->getValue(
-                ConfigKey("[KeyboardShortcuts]", "OptionsMenu_Preferences"),
-                showPreferencesKeyBinding())));
+            safeKeySequence(m_pKbdConfig->getValue(
+                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_Preferences"),
+                    showPreferencesKeyBinding())));
     pOptionsPreferences->setShortcutContext(Qt::ApplicationShortcut);
     pOptionsPreferences->setStatusTip(preferencesText);
     pOptionsPreferences->setWhatsThis(buildWhatsThis(preferencesTitle, preferencesText));
@@ -539,9 +548,9 @@ void WMainMenuBar::initialize() {
         QString reloadSkinText = tr("Reload the skin");
         auto* pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
         pDeveloperReloadSkin->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_ReloadSkin"),
-                    tr("Ctrl+Shift+R"))));
+                safeKeySequence(m_pKbdConfig->getValue(
+                        ConfigKey("[KeyboardShortcuts]", "OptionsMenu_ReloadSkin"),
+                        QStringLiteral("Ctrl+Shift+R"))));
         pDeveloperReloadSkin->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperReloadSkin->setStatusTip(reloadSkinText);
         pDeveloperReloadSkin->setWhatsThis(buildWhatsThis(reloadSkinTitle, reloadSkinText));
@@ -552,9 +561,9 @@ void WMainMenuBar::initialize() {
         QString developerToolsText = tr("Opens the developer tools dialog");
         auto* pDeveloperTools = new QAction(developerToolsTitle, this);
         pDeveloperTools->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperTools"),
-                    tr("Ctrl+Shift+T"))));
+                safeKeySequence(m_pKbdConfig->getValue(
+                        ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperTools"),
+                        QStringLiteral("Ctrl+Shift+T"))));
         pDeveloperTools->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperTools->setCheckable(true);
         pDeveloperTools->setChecked(false);
@@ -572,9 +581,9 @@ void WMainMenuBar::initialize() {
             "Enables experiment mode. Collects stats in the EXPERIMENT tracking bucket.");
         auto* pDeveloperStatsExperiment = new QAction(enableExperimentTitle, this);
         pDeveloperStatsExperiment->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsExperiment"),
-                    tr("Ctrl+Shift+E"))));
+                safeKeySequence(m_pKbdConfig->getValue(
+                        ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsExperiment"),
+                        QStringLiteral("Ctrl+Shift+E"))));
         pDeveloperStatsExperiment->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperStatsExperiment->setStatusTip(enableExperimentToolsText);
         pDeveloperStatsExperiment->setWhatsThis(buildWhatsThis(
@@ -592,9 +601,9 @@ void WMainMenuBar::initialize() {
             "Enables base mode. Collects stats in the BASE tracking bucket.");
         auto* pDeveloperStatsBase = new QAction(enableBaseTitle, this);
         pDeveloperStatsBase->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsBase"),
-                    tr("Ctrl+Shift+B"))));
+                safeKeySequence(m_pKbdConfig->getValue(
+                        ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsBase"),
+                        QStringLiteral("Ctrl+Shift+B"))));
         pDeveloperStatsBase->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperStatsBase->setStatusTip(enableBaseToolsText);
         pDeveloperStatsBase->setWhatsThis(buildWhatsThis(
@@ -614,9 +623,9 @@ void WMainMenuBar::initialize() {
             ConfigKey("[ScriptDebugger]", "Enabled")) == "1";
         auto* pDeveloperDebugger = new QAction(scriptDebuggerTitle, this);
         pDeveloperDebugger->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "DeveloperMenu_EnableDebugger"),
-                    tr("Ctrl+Shift+D"))));
+                safeKeySequence(m_pKbdConfig->getValue(
+                        ConfigKey("[KeyboardShortcuts]", "DeveloperMenu_EnableDebugger"),
+                        QStringLiteral("Ctrl+Shift+D"))));
         pDeveloperDebugger->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperDebugger->setWhatsThis(buildWhatsThis(keyboardShortcutTitle, keyboardShortcutText));
         pDeveloperDebugger->setCheckable(true);


### PR DESCRIPTION
Keyboard shortcut strings in non-English languages were incorrect.

1. Adds `safeKeySequence()` in `WMainMenuBar` to validate shortcuts
   before use, preventing the crash defensively.
2. Marks all invalid shortcut translations as `unfinished` in affected locales (ca, cs, de, es×9, fa, fr, gl, it, ja, ko, nl, pl, ru, sl, sr, vi, zh, zh_CN, zh_HK, zh_TW) so Qt falls back to the English source string.
3. Adds `tools/check_shortcut_translations.py` to detect, fix, and compile invalid translation of short cuts automatically.

Fixes #16216