### PR TITLE
Search: allow OR in parenthesis

### DIFF
--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -250,6 +250,20 @@ void SearchQueryParser::parseTokens(QStringList tokens,
         if (textFilterMatch.hasMatch()) {
             const QString field = resolveFilter(textFilterMatch.captured(1));
             qWarning().noquote() << "-> parseTokens -> text filter:" << token;
+            // TODO/NiceToHave
+            // allow 'cm:(one|two|three)
+            // * check if token is '(...)'
+            // * try split OR
+            // * if parts > 1
+            //     -> create node from each part
+            //     -> wrap in OrNode
+            //   else
+            //     -> proceed with entire token
+            //
+            // alternative:
+            // * check if token is '(...)'
+            // * split OR
+            // * prepend each part with field: cm:one|cm:two|cm:three
             auto [argument, matchMode] = getTextArgument(textFilterMatch.captured(2), &tokens);
 
             if (argument == kMissingFieldSearchTerm) {

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -53,6 +53,18 @@ std::pair<QString, Quoted> consumeQuotedArgument(QString argument,
     return {argument, Quoted::Complete};
 }
 
+bool hasClosingParenthesis(const QString& token, const QStringList& tokens) {
+    if (token.contains(")")) {
+        return true;
+    }
+    for (const QString& t : tokens) {
+        if (t.contains(")")) {
+            return true;
+        }
+    }
+    return false;
+}
+
 } // anonymous namespace
 
 constexpr char kNegatePrefix[] = "-";
@@ -64,8 +76,9 @@ constexpr char kFuzzyPrefix[] = "~";
 const QRegularExpression kSplitIntoWordsRegexp = QRegularExpression(
         QStringLiteral(" " QUOTED_STRING_LOOKAHEAD));
 
+// Matches ' OR ' (case-sensitive) or the '|' character
 const QRegularExpression kSplitOnOrOperatorRegexp = QRegularExpression(
-        QStringLiteral("(?:\\||\\bOR\\b)" QUOTED_STRING_LOOKAHEAD));
+        QStringLiteral("(?:\\||\\bOR\\b)"));
 
 SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection, QStringList searchColumns)
         : m_pTrackCollection(pTrackCollection),
@@ -196,6 +209,22 @@ SearchQueryParser::TextArgumentResult SearchQueryParser::getTextArgument(QString
 
 void SearchQueryParser::parseTokens(QStringList tokens,
                                     AndNode* pQuery) const {
+    // This lambda avoids duplication in the branches for
+    // 1) nested OR (invalid query or literal '(||)') and
+    // 2) plain text/crate queries.
+    auto createUntaggedNode = [&](const QString& arg) {
+        if (m_searchCrates) {
+            auto gNode = std::make_unique<OrNode>();
+            gNode->addNode(std::make_unique<CrateFilterNode>(
+                    &m_pTrackCollection->crates(), arg));
+            gNode->addNode(std::make_unique<TextFilterNode>(
+                    m_pTrackCollection->database(), m_queryColumns, arg));
+            return std::unique_ptr<QueryNode>(std::move(gNode));
+        }
+        return std::unique_ptr<QueryNode>(std::make_unique<TextFilterNode>(
+                m_pTrackCollection->database(), m_queryColumns, arg));
+    };
+
     while (tokens.size() > 0) {
         QString token = tokens.takeFirst().trimmed();
         if (token.length() == 0) {
@@ -299,6 +328,37 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                             m_pTrackCollection->database());
                 }
             }
+        } else if (token.startsWith("(") && hasClosingParenthesis(token, tokens)) {
+            QString nestedQuery = token.mid(1);
+
+            // We found an opening ( and a closing ) somewhere.
+            // Now we collect tokens until we find the one containing the closing ')'
+            while (!nestedQuery.contains(")") && !tokens.isEmpty()) {
+                nestedQuery += " " + tokens.takeFirst();
+            }
+
+            // If there is text AFTER the ')', put it back in the tokens list
+            int closingIdx = nestedQuery.lastIndexOf(")");
+            DEBUG_ASSERT(closingIdx != -1);
+            qWarning() << "   > isolate parenthesis content";
+            if (closingIdx < nestedQuery.length()) {
+                const QString trailing = nestedQuery.mid(closingIdx + 1).trimmed();
+                if (!trailing.isEmpty()) {
+                    tokens.prepend(trailing);
+                }
+            }
+            nestedQuery = nestedQuery.left(closingIdx);
+
+            const QString trimmedNested = nestedQuery.trimmed();
+            if (trimmedNested.isEmpty() ||
+                    trimmedNested == QStringLiteral("OR") ||
+                    trimmedNested == QStringLiteral("|")) {
+                // Safeguard: If the parenthesis is empty or just an operator,
+                // we call our lambda to treat the whole thing as a literal term.
+                pNode = createUntaggedNode("(" + nestedQuery + ")");
+            } else {
+                pNode = parseOrNode(nestedQuery);
+            }
         } else {
             // If no advanced search feature matched, treat it as a search term.
             if (negate) {
@@ -306,21 +366,8 @@ void SearchQueryParser::parseTokens(QStringList tokens,
             }
             // Don't trigger on a lone minus sign.
             if (!token.isEmpty()) {
-                QString argument = getTextArgument(token, &tokens).argument;
-                // For untagged strings we search the track fields as well
-                // as the crate names the track is in. This allows the user
-                // to use crates like tags
-                if (m_searchCrates) {
-                    auto gNode = std::make_unique<OrNode>();
-                    gNode->addNode(std::make_unique<CrateFilterNode>(
-                                    &m_pTrackCollection->crates(), argument));
-                    gNode->addNode(std::make_unique<TextFilterNode>(
-                            m_pTrackCollection->database(), m_queryColumns, argument));
-                    pNode = std::move(gNode);
-                } else {
-                    pNode = std::make_unique<TextFilterNode>(
-                            m_pTrackCollection->database(), m_queryColumns, argument);
-                }
+                const QString argument = getTextArgument(token, &tokens).argument;
+                pNode = createUntaggedNode(argument);
             }
         }
         if (pNode) {
@@ -344,12 +391,8 @@ std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(const QString& query) c
 std::unique_ptr<OrNode> SearchQueryParser::parseOrNode(const QString& query) const {
     auto pQuery = std::make_unique<OrNode>();
 
-    const QStringList rawAndNodes = query.split(kSplitOnOrOperatorRegexp,
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-            Qt::SkipEmptyParts);
-#else
-            QString::SkipEmptyParts);
-#endif
+    const QStringList rawAndNodes = splitTopLevelOr(query);
+
     for (const QString& rawAndNode : rawAndNodes) {
         if (!rawAndNode.isEmpty()) {
             pQuery->addNode(parseAndNode(rawAndNode));
@@ -383,6 +426,58 @@ QStringList SearchQueryParser::splitQueryIntoWords(const QString& query) {
             QString::SkipEmptyParts);
 #endif
     return queryWordList;
+}
+
+QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
+    QStringList parts;
+    int lastSplitPos = 0;  // start of the current segment
+    int scanPos = 0;       // count of chars we've checked for quotes/parenthesis
+    int parenthLevel = 0;  //
+    bool inQuotes = false; // is the current OR/| in quotes or not
+
+    QRegularExpressionMatchIterator it = kSplitOnOrOperatorRegexp.globalMatch(query);
+
+    while (it.hasNext()) {
+        // Nth occurrence of OR/|
+        QRegularExpressionMatch match = it.next();
+        // position of 'O'/'|'
+        int matchPos = match.capturedStart();
+
+        // scan characters since the last match (pos after last 'R'/'|')
+        // for quotes.
+        for (; scanPos < matchPos; ++scanPos) {
+            const QChar c = query[scanPos];
+            if (c == '\"') {
+                // toggle quote state
+                inQuotes = !inQuotes;
+            } else if (!inQuotes) {
+                // sount parenthesis if we aren't inside a quoted string
+                if (c == '(') {
+                    parenthLevel++;
+                } else if (c == ')') {
+                    parenthLevel--;
+                }
+            }
+        }
+
+        // split if we are at the top level AND not in quotes
+        if (!inQuotes && parenthLevel == 0) {
+            parts << query.mid(lastSplitPos, matchPos - lastSplitPos).trimmed();
+            lastSplitPos = match.capturedEnd();
+        }
+
+        // advance the scan position past the operator so we have a start
+        // position for the next scan
+        scanPos = match.capturedEnd();
+    }
+
+    // capture the final segment
+    const QString finalPart = query.mid(lastSplitPos).trimmed();
+    if (!finalPart.isEmpty()) {
+        parts << finalPart;
+    }
+
+    return parts;
 }
 
 bool SearchQueryParser::queryIsLessSpecific(const QString& original, const QString& changed) {

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -213,6 +213,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
     // 1) nested OR (invalid query or literal '(||)') and
     // 2) plain text/crate queries.
     auto createUntaggedNode = [&](const QString& arg) {
+        qWarning().noquote() << "   create untagged node:        " << arg;
         if (m_searchCrates) {
             auto gNode = std::make_unique<OrNode>();
             gNode->addNode(std::make_unique<CrateFilterNode>(
@@ -248,6 +249,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
         const QRegularExpressionMatch specialFilterMatch = m_specialFilterMatcher.match(token);
         if (textFilterMatch.hasMatch()) {
             const QString field = resolveFilter(textFilterMatch.captured(1));
+            qWarning().noquote() << "-> parseTokens -> text filter:" << token;
             auto [argument, matchMode] = getTextArgument(textFilterMatch.captured(2), &tokens);
 
             if (argument == kMissingFieldSearchTerm) {
@@ -275,6 +277,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
             }
         } else if (numericFilterMatch.hasMatch()) {
             const QString field = numericFilterMatch.captured(1);
+            qWarning().noquote() << "-> parseTokens -> num filter:" << token;
             QString argument = getTextArgument(numericFilterMatch.captured(2), &tokens).argument;
 
             if (!argument.isEmpty()) {
@@ -287,6 +290,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 }
             }
         } else if (specialFilterMatch.hasMatch()) {
+            qWarning().noquote() << "  > special filter:" << token;
             bool fuzzy = token.startsWith(kFuzzyPrefix);
             bool negate = token.startsWith(kNegatePrefix);
             const QString field = resolveFilter(specialFilterMatch.captured(1));
@@ -329,6 +333,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 }
             }
         } else if (token.startsWith("(") && hasClosingParenthesis(token, tokens)) {
+            qWarning().noquote() << "-> parseTokens -> (...) query:" << token;
             QString nestedQuery = token.mid(1);
 
             // We found an opening ( and a closing ) somewhere.
@@ -339,10 +344,13 @@ void SearchQueryParser::parseTokens(QStringList tokens,
 
             // If there is text AFTER the ')', put it back in the tokens list
             int closingIdx = nestedQuery.lastIndexOf(")");
+            qWarning() << "   > closing idx:" << closingIdx;
             DEBUG_ASSERT(closingIdx != -1);
             qWarning() << "   > isolate parenthesis content";
             if (closingIdx < nestedQuery.length()) {
+                qWarning() << "   >> text after closingIdx";
                 const QString trailing = nestedQuery.mid(closingIdx + 1).trimmed();
+                qWarning().noquote() << "   >> trailing:" << trailing;
                 if (!trailing.isEmpty()) {
                     tokens.prepend(trailing);
                 }
@@ -355,11 +363,14 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                     trimmedNested == QStringLiteral("|")) {
                 // Safeguard: If the parenthesis is empty or just an operator,
                 // we call our lambda to treat the whole thing as a literal term.
+                qWarning() << "   > ! nested query is empty or operator, "
+                              "falling back to literal";
                 pNode = createUntaggedNode("(" + nestedQuery + ")");
             } else {
                 pNode = parseOrNode(nestedQuery);
             }
         } else {
+            qWarning().noquote() << "-> parseTokens -> untagged query:" << token;
             // If no advanced search feature matched, treat it as a search term.
             if (negate) {
                 token = token.mid(1);
@@ -389,6 +400,7 @@ std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(const QString& query) c
 }
 
 std::unique_ptr<OrNode> SearchQueryParser::parseOrNode(const QString& query) const {
+    qWarning().noquote() << " > parseOrNode:" << query;
     auto pQuery = std::make_unique<OrNode>();
 
     const QStringList rawAndNodes = splitTopLevelOr(query);
@@ -407,13 +419,18 @@ std::unique_ptr<QueryNode> SearchQueryParser::parseQuery(
         const QString& extraFilter) const {
     auto pQuery(std::make_unique<AndNode>());
 
+    qWarning() << ".";
     if (!extraFilter.isEmpty()) {
+        qWarning().noquote() << "> parseQuery:" << query << "| extra:" << extraFilter;
         pQuery->addNode(std::make_unique<SqlNode>(extraFilter));
+    } else {
+        qWarning().noquote() << "> parseQuery:" << query;
     }
 
     if (!query.isEmpty()) {
         pQuery->addNode(parseOrNode(query));
     }
+    qWarning() << ".";
 
     return pQuery;
 }
@@ -429,6 +446,7 @@ QStringList SearchQueryParser::splitQueryIntoWords(const QString& query) {
 }
 
 QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
+    qWarning().noquote() << "     splitTopLevelOr:" << query;
     QStringList parts;
     int lastSplitPos = 0;  // start of the current segment
     int scanPos = 0;       // count of chars we've checked for quotes/parenthesis
@@ -440,6 +458,7 @@ QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
     while (it.hasNext()) {
         // Nth occurrence of OR/|
         QRegularExpressionMatch match = it.next();
+        qWarning().noquote() << "     -> it next:" << match.captured(0);
         // position of 'O'/'|'
         int matchPos = match.capturedStart();
 
@@ -462,6 +481,9 @@ QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
 
         // split if we are at the top level AND not in quotes
         if (!inQuotes && parenthLevel == 0) {
+            qWarning().noquote() << "        found:"
+                                 << query.mid(lastSplitPos, matchPos - lastSplitPos)
+                                            .trimmed();
             parts << query.mid(lastSplitPos, matchPos - lastSplitPos).trimmed();
             lastSplitPos = match.capturedEnd();
         }
@@ -474,9 +496,14 @@ QStringList SearchQueryParser::splitTopLevelOr(const QString& query) const {
     // capture the final segment
     const QString finalPart = query.mid(lastSplitPos).trimmed();
     if (!finalPart.isEmpty()) {
+        qWarning().noquote() << "     -> finalPart:" << finalPart;
         parts << finalPart;
     }
 
+    qWarning() << "     -> parts: (" << parts.size() << ")";
+    for (const QString& part : std::as_const(parts)) {
+        qWarning().noquote() << "        " << part;
+    }
     return parts;
 }
 

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -23,6 +23,10 @@ class SearchQueryParser {
 
     /// splits the query into a list of terms
     static QStringList splitQueryIntoWords(const QString& query);
+    /// splits the query (part) at ' OR ' or '|' at its top-level
+    /// ie. not inside parenthesis, not inside quotes.
+    /// called for the original query and, if available, isolated parts in parenthesis
+    QStringList splitTopLevelOr(const QString& query) const;
     /// checks if the changed search query is less specific then the original term
     static bool queryIsLessSpecific(const QString& original, const QString& changed);
 

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -1381,3 +1381,66 @@ TEST_F(SearchQueryParserTest, QuotedOrOperator) {
     pTrackI->setComment("house");
     EXPECT_TRUE(pQuery->match(pTrackI));
 }
+
+TEST_F(SearchQueryParserTest, OrOperatorInParenthesis) {
+    m_parser.setSearchColumns({"title"});
+
+    TrackPointer pTrackA = newTestTrack();
+    TrackPointer pTrackB = newTestTrack();
+    TrackPointer pTrackC = newTestTrack();
+    TrackPointer pTrackD = newTestTrack();
+    TrackPointer pTrackE = newTestTrack();
+    TrackPointer pTrackF = newTestTrack();
+    pTrackA->setTitle("purple");
+    pTrackB->setTitle("black shoe");
+    pTrackC->setTitle("red shoe");
+    pTrackD->setTitle("white jacket");
+    pTrackE->setTitle("white");
+    pTrackF->setTitle("jacket");
+
+    // Regular use case
+    auto pQuery = m_parser.parseQuery("shoe (black|purple) | jacket (white|red)", QString());
+    //                                      (-----|------) |        (-----|---)
+    //                               = shoe AND black
+    //                              OR shoe AND purple
+    //                              OR jacket AND white
+    //                              OR jacket AND red
+    EXPECT_FALSE(pQuery->match(pTrackA)); // purple
+    EXPECT_TRUE(pQuery->match(pTrackB));  // black shoe
+    EXPECT_FALSE(pQuery->match(pTrackC)); // red shoe
+    EXPECT_TRUE(pQuery->match(pTrackD));  // white jacket
+    EXPECT_FALSE(pQuery->match(pTrackE)); // white
+    EXPECT_FALSE(pQuery->match(pTrackF)); // jacket
+
+    // Quotes in 2nd level OR node
+    pQuery = m_parser.parseQuery(R"(shoe (black|"purple nose") | "white ja" | red)", QString());
+    //                                   (     |"           ") | "        " |
+    //                                  split here,          here     and here
+    //                          = shoe AND black
+    //                         OR shoe AND "purple nose"
+    //                         OR "white ja"
+    //                         OR red
+    EXPECT_FALSE(pQuery->match(pTrackA)); // purple
+    EXPECT_TRUE(pQuery->match(pTrackB));  // shoe black
+    EXPECT_TRUE(pQuery->match(pTrackC));  // red shoe
+    EXPECT_TRUE(pQuery->match(pTrackD));  // white jacket
+    EXPECT_FALSE(pQuery->match(pTrackE)); // white
+    EXPECT_FALSE(pQuery->match(pTrackF)); // jacket
+
+    // | inside quotes and unclosed parenthesis
+    pQuery = m_parser.parseQuery(R"(shoe (black"|purple) | jacket" (white|"red)", QString());
+    //                                   (     "↑        ↑       " (     ↑"
+    //                            not splitting here or here,            |
+    //                            they're inside quotes                  |
+    //                                                    not splitting here either
+    //                                                    because of missing )
+    //                          = shoe
+    //                        AND (black"|purple) | jacket
+    //                        AND (white|"red
+    EXPECT_FALSE(pQuery->match(pTrackA)); // purple
+    EXPECT_FALSE(pQuery->match(pTrackB)); // black shoe
+    EXPECT_FALSE(pQuery->match(pTrackC)); // red shoe
+    EXPECT_FALSE(pQuery->match(pTrackD)); // white jacket
+    EXPECT_FALSE(pQuery->match(pTrackE)); // white
+    EXPECT_FALSE(pQuery->match(pTrackE)); // jacket
+}


### PR DESCRIPTION
Before we had to do this
`house deep | house minimal | house tech`
which makes BPM/genre OR queries quite long.

Now we can do
`house (deep|minimal|tech)`
`hop (cm:pop|title:hip)`

Quotation detection etc. is also still intact :tada: 
_Theoretically_ it should also work with deeper levels of nesting, but I didn't test this and also don't think it matters in real life, hence we shouldn't add such claims to the docs.

- [x] add tests
- [ ] remove TRACE commit
_____
Disclaimer: I did this with an agent since I wanted this badly but regex and complex parsing is certainly not my cup of tea. First I tried the regex approach, but turned to clean methods for manual splitting (the regex became monstruos when I noticed we also need to cover quotes as well as a few edge cases -- "if a PhD is required to understand the regex, drop it" )
