### PR TITLE
Dependabot: Use 2.5 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "2.6"
+    target-branch: "2.5"
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "2.6"
+    target-branch: "2.5"


### PR DESCRIPTION
This branch is still our stable (until 2.6.0 is released)

This has been changed in #16161. 
Lets keep 2.5 maintained for now. 