### PR TITLE
Early return when rendering with a shader that cannot be bound.

### DIFF
--- a/src/rendergraph/opengl/backend/basegeometrynode.cpp
+++ b/src/rendergraph/opengl/backend/basegeometrynode.cpp
@@ -39,13 +39,18 @@ void BaseGeometryNode::render() {
         return;
     }
 
+    QOpenGLShaderProgram& shader = material.shader();
+    VERIFY_OR_DEBUG_ASSERT(shader.bind()) {
+        // if the shader can't be bound, don't try to render with it.
+        // this should only happen if the shader compilation failed,
+        // which shouldn't happen
+        return;
+    }
+
     glEnable(GL_BLEND);
     // Note: Qt scenegraph uses premultiplied alpha color in the shader,
     // so we need to do the same.
     glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
-
-    QOpenGLShaderProgram& shader = material.shader();
-    shader.bind();
 
     if (material.clearUniformsCacheDirty() || !material.isLastModifierOfShader()) {
         material.modifyShader();


### PR DESCRIPTION
This prevents a crash that resulted from shader compilation failure (#16213).

This would not be necessary if context creation were sufficient to ensure shaders will compile, or if rendering backend selection forbade backends which use invalid shaders.