### PR TITLE
Fix Rekordbox USB Access in macOS Sandbox (#13624)

### DIFF
--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -4,6 +4,7 @@
 #include <rekordbox_anlz.h>
 #include <rekordbox_pdb.h>
 
+#include <QFileDialog>
 #include <QMap>
 #include <QMessageBox>
 #include <QSettings>
@@ -11,7 +12,7 @@
 #include <QTextCodec>
 #include <QtDebug>
 
-#include "engine/engine.h"
+#include "library/dao/settingsdao.h"
 #include "library/dao/trackschema.h"
 #include "library/library.h"
 #include "library/queryutil.h"
@@ -24,11 +25,9 @@
 #include "track/cue.h"
 #include "track/keyfactory.h"
 #include "track/track.h"
-#include "util/color/color.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/db/dbconnectionpooler.h"
 #include "util/sandbox.h"
-#include "waveform/waveform.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarytextbrowser.h"
 
@@ -165,7 +164,8 @@ bool dropTable(QSqlDatabase& database, const QString& tableName) {
 // The returned list owns the pointers, but we can't use a unique_ptr because
 // the result is passed by a const reference inside QFuture and than copied
 // to the main thread requiring a copy-able object.
-QList<TreeItem*> findRekordboxDevices() {
+QList<TreeItem*> findRekordboxDevices(const QString& manualDevicePath = QString()) {
+    Q_UNUSED(manualDevicePath);
     QThread* thisThread = QThread::currentThread();
     thisThread->setPriority(QThread::LowPriority);
 
@@ -231,6 +231,19 @@ QList<TreeItem*> findRekordboxDevices() {
     }
 #else // __APPLE__
     QFileInfoList devices = QDir(QStringLiteral("/Volumes")).entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot);
+
+    if (!manualDevicePath.isEmpty()) {
+        bool alreadyInList = false;
+        foreach (QFileInfo device, devices) {
+            if (device.filePath() == manualDevicePath) {
+                alreadyInList = true;
+                break;
+            }
+        }
+        if (!alreadyInList) {
+            devices.append(QFileInfo(manualDevicePath));
+        }
+    }
 
     foreach (QFileInfo device, devices) {
         QFileInfo rbDBFileInfo(device.filePath() + QStringLiteral("/") + kPdbPath);
@@ -1486,8 +1499,49 @@ void RekordboxFeature::refreshLibraryModels() {
 void RekordboxFeature::activate() {
     qDebug() << "RekordboxFeature::activate()";
 
+    QString manualDevicePath;
+
+#if defined(Q_OS_MACOS)
+    if (Sandbox::enabled()) {
+        SettingsDAO settings(m_pTrackCollection->database());
+        QString savedDbFile(settings.getValue("mixxx.rekordboxfeature.dbpath"));
+
+        bool hasValidDbFile = false;
+
+        if (!savedDbFile.isEmpty()) {
+            mixxx::FileInfo dbFileInfo(savedDbFile);
+            if (Sandbox::canAccess(&dbFileInfo) && dbFileInfo.checkFileExists()) {
+                hasValidDbFile = true;
+            }
+        }
+
+        if (!hasValidDbFile) {
+            QString defaultPath = QDir::homePath();
+            QString newDbFile = QFileDialog::getOpenFileName(nullptr,
+                    tr("Select your Rekordbox external database"),
+                    defaultPath,
+                    "Rekordbox Database (export.pdb)");
+
+            if (!newDbFile.isEmpty()) {
+                mixxx::FileInfo newFileInfo(newDbFile);
+                Sandbox::createSecurityToken(&newFileInfo);
+                settings.setValue("mixxx.rekordboxfeature.dbpath", newDbFile);
+                savedDbFile = newDbFile;
+                hasValidDbFile = true;
+            }
+        }
+
+        if (hasValidDbFile) {
+            QDir dir(savedDbFile);
+            dir.cdUp(); // Up from export.pdb to PIONEER containing folder
+            dir.cdUp(); // Up from PIONEER to root volume folder
+            manualDevicePath = dir.absolutePath();
+        }
+    }
+#endif
+
     // Let a worker thread do the XML parsing
-    m_devicesFuture = QtConcurrent::run(findRekordboxDevices);
+    m_devicesFuture = QtConcurrent::run(findRekordboxDevices, manualDevicePath);
     m_devicesFutureWatcher.setFuture(m_devicesFuture);
     m_title = tr("(loading) Rekordbox");
     //calls a slot in the sidebar model such that 'Rekordbox (isLoading)' is displayed.

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -164,8 +164,8 @@ bool dropTable(QSqlDatabase& database, const QString& tableName) {
 // The returned list owns the pointers, but we can't use a unique_ptr because
 // the result is passed by a const reference inside QFuture and than copied
 // to the main thread requiring a copy-able object.
-QList<TreeItem*> findRekordboxDevices(const QString& manualDevicePath = QString()) {
-    Q_UNUSED(manualDevicePath);
+QList<TreeItem*> findRekordboxDevices(
+        [[maybe_unused]] const QStringList& manualDevicePaths = QStringList()) {
     QThread* thisThread = QThread::currentThread();
     thisThread->setPriority(QThread::LowPriority);
 
@@ -232,16 +232,19 @@ QList<TreeItem*> findRekordboxDevices(const QString& manualDevicePath = QString(
 #else // __APPLE__
     QFileInfoList devices = QDir(QStringLiteral("/Volumes")).entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot);
 
-    if (!manualDevicePath.isEmpty()) {
+    for (const QString& manualPath : manualDevicePaths) {
+        if (manualPath.isEmpty()) {
+            continue;
+        }
         bool alreadyInList = false;
         foreach (QFileInfo device, devices) {
-            if (device.filePath() == manualDevicePath) {
+            if (device.filePath() == manualPath) {
                 alreadyInList = true;
                 break;
             }
         }
         if (!alreadyInList) {
-            devices.append(QFileInfo(manualDevicePath));
+            devices.append(QFileInfo(manualPath));
         }
     }
 
@@ -1499,49 +1502,62 @@ void RekordboxFeature::refreshLibraryModels() {
 void RekordboxFeature::activate() {
     qDebug() << "RekordboxFeature::activate()";
 
-    QString manualDevicePath;
+    QStringList manualDevicePaths;
 
 #if defined(Q_OS_MACOS)
     if (Sandbox::enabled()) {
         SettingsDAO settings(m_pTrackCollection->database());
-        QString savedDbFile(settings.getValue("mixxx.rekordboxfeature.dbpath"));
+        const QString kSettingsKey =
+                QStringLiteral("mixxx.rekordboxfeature.sandboxed_usb_paths");
+        QString savedPaths(settings.getValue(kSettingsKey));
+        QStringList storedDbFiles = savedPaths.isEmpty()
+                ? QStringList()
+                : savedPaths.split(QStringLiteral(";"),
+                          Qt::SkipEmptyParts);
 
-        bool hasValidDbFile = false;
-
-        if (!savedDbFile.isEmpty()) {
-            mixxx::FileInfo dbFileInfo(savedDbFile);
-            if (Sandbox::canAccess(&dbFileInfo) && dbFileInfo.checkFileExists()) {
-                hasValidDbFile = true;
+        // Validate previously stored paths and collect accessible ones
+        QStringList validDbFiles;
+        for (const QString& dbFile : std::as_const(storedDbFiles)) {
+            mixxx::FileInfo dbFileInfo(dbFile);
+            if (Sandbox::canAccess(&dbFileInfo) &&
+                    dbFileInfo.checkFileExists()) {
+                validDbFiles.append(dbFile);
             }
         }
 
-        if (!hasValidDbFile) {
+        // If no valid paths remain, prompt the user to select at least one
+        if (validDbFiles.isEmpty()) {
             QString defaultPath = QDir::homePath();
             QString newDbFile = QFileDialog::getOpenFileName(nullptr,
                     tr("Select your Rekordbox external database"),
                     defaultPath,
-                    "Rekordbox Database (export.pdb)");
+                    tr("Rekordbox Database (export.pdb)"));
 
             if (!newDbFile.isEmpty()) {
                 mixxx::FileInfo newFileInfo(newDbFile);
                 Sandbox::createSecurityToken(&newFileInfo);
-                settings.setValue("mixxx.rekordboxfeature.dbpath", newDbFile);
-                savedDbFile = newDbFile;
-                hasValidDbFile = true;
+                validDbFiles.append(newDbFile);
             }
         }
 
-        if (hasValidDbFile) {
-            QDir dir(savedDbFile);
-            dir.cdUp(); // Up from export.pdb to PIONEER containing folder
-            dir.cdUp(); // Up from PIONEER to root volume folder
-            manualDevicePath = dir.absolutePath();
+        // Persist the updated list of valid paths
+        if (!validDbFiles.isEmpty()) {
+            settings.setValue(kSettingsKey,
+                    validDbFiles.join(QStringLiteral(";")));
+        }
+
+        // Derive volume root paths from each stored db file
+        for (const QString& dbFile : std::as_const(validDbFiles)) {
+            QDir dir(dbFile);
+            dir.cdUp(); // Up from export.pdb to PIONEER folder
+            dir.cdUp(); // Up from PIONEER to volume root
+            manualDevicePaths.append(dir.absolutePath());
         }
     }
 #endif
 
     // Let a worker thread do the XML parsing
-    m_devicesFuture = QtConcurrent::run(findRekordboxDevices, manualDevicePath);
+    m_devicesFuture = QtConcurrent::run(findRekordboxDevices, manualDevicePaths);
     m_devicesFutureWatcher.setFuture(m_devicesFuture);
     m_title = tr("(loading) Rekordbox");
     //calls a slot in the sidebar model such that 'Rekordbox (isLoading)' is displayed.

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -1533,17 +1533,30 @@ void RekordboxFeature::activate() {
                     defaultPath,
                     tr("Rekordbox Database (export.pdb)"));
 
-            if (!newDbFile.isEmpty()) {
-                mixxx::FileInfo newFileInfo(newDbFile);
-                Sandbox::createSecurityToken(&newFileInfo);
-                validDbFiles.append(newDbFile);
+            if (!newDbFile.isEmpty() && newDbFile.endsWith(QStringLiteral("export.pdb"))) {
+                QDir dir(newDbFile);
+                if (dir.cdUp() && dir.dirName() == QStringLiteral("PIONEER")) {
+                    mixxx::FileInfo newFileInfo(newDbFile);
+                    Sandbox::createSecurityToken(&newFileInfo);
+                    validDbFiles.append(newDbFile);
+
+                    if (!storedDbFiles.contains(newDbFile)) {
+                        storedDbFiles.append(newDbFile);
+                    }
+                } else {
+                    qWarning() << "Selected Rekordbox database is not in a "
+                                  "PIONEER directory:"
+                               << newDbFile;
+                }
+            } else if (!newDbFile.isEmpty()) {
+                qWarning() << "Selected file is not export.pdb:" << newDbFile;
             }
         }
 
-        // Persist the updated list of valid paths
-        if (!validDbFiles.isEmpty()) {
+        // Persist the full list of all authorized paths
+        if (!storedDbFiles.isEmpty()) {
             settings.setValue(kSettingsKey,
-                    validDbFiles.join(QStringLiteral(";")));
+                    storedDbFiles.join(QStringLiteral(";")));
         }
 
         // Derive volume root paths from each stored db file


### PR DESCRIPTION
# Fix Rekordbox USB Access in macOS Sandbox (Issue #13624)

### Summary
This PR fixes an issue where Mixxx, when running in a sandboxed macOS environment, was unable to discover Rekordbox USB drives because the `/Volumes` directory is restricted. It implements a manual file picker fallback and uses **Security Scoped Bookmarks** to persist access permissions across multiple devices and restarts. This is based on the ideas used in #16205.

### The Problem
When Mixxx is sandboxed on macOS (e.g., Mac App Store builds or with sandbox entitlements enabled), it does not have permission to read the contents of `/Volumes` by default. As a result, the automatic scanning logic in `findRekordboxDevices()` fails to discover Rekordbox exported databases on external USB or SD devices, leading to a blank interface or "Rekordbox USB not working" issues.

Unlike Traktor (which reads a single, static `collection.nml`), Rekordbox is designed around **multiple external disks**. A DJ commonly has several USB sticks/SD cards plugged in simultaneously. This means the fix needs to handle multiple devices, not just one.

### The Solution
Based on the logic used for the Traktor sandbox fix (#16205):

1. **Manual File Picker Fallback**: Modified `RekordboxFeature::activate()` to prompt the user to manually select their `export.pdb` file via a native `QFileDialog` if no previously bookmarked USB is currently accessible.
2. **OS-Level Permissions**: Selecting the file through the native dialog triggers the macOS `NSOpenPanel`, which explicitly grants Mixxx permission to read the chosen directory.
3. **Security Scoped Bookmarks**: Used `Sandbox::createSecurityToken()` to create a Security Scoped Bookmark per device, ensuring permissions persist across application restarts without re-prompting.
4. **Multi-Device Persistence**: All granted paths are stored as a `;`-delimited list in `SettingsDAO` (`mixxx.rekordboxfeature.sandboxed_usb_paths`). On each `activate()`, all stored paths are validated against the current filesystem — those that are currently plugged in are passed to the scanner, and stale entries are ignored until the device is reconnected.
5. **Enhanced Discovery**: Updated `findRekordboxDevices()` to accept a `QStringList` of manually granted volume roots. All accessible USBs appear in the sidebar simultaneously.

### Changes
- `src/library/rekordbox/rekordboxfeature.cpp`:
  - Added `#include <QFileDialog>` and `SettingsDAO` for configuration and UI.
  - Enhanced `activate()` to validate and iterate all stored USB paths, prompting the picker only when none are currently accessible.
  - Updated `findRekordboxDevices()` to accept a `QStringList` of manual paths instead of a single `QString`, enabling multiple simultaneous Rekordbox USBs in the sidebar.
  - Cleaned up unused headers (`engine.h`, `color.h`, `waveform.h`).

### Verification Required

Fixes: #13624

Direct download for mac ARM(M-series chips): https://github.com/mixxxdj/mixxx/actions/runs/23672026860/artifacts/6154413319