### PR TITLE
EngineBuffer: Reset sample counter after indicator update

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -80,6 +80,7 @@ EngineBuffer::EngineBuffer(const QString& group,
           m_baserate_old(0),
           m_rate_old(0.),
           m_trackEndPositionOld(mixxx::audio::kInvalidFramePos),
+          m_iSamplesSinceLastIndicatorUpdate(0),
           m_slipPos(mixxx::audio::kStartFramePos),
           m_dSlipRate(1.0),
           m_bSlipEnabledProcessing(false),
@@ -1479,6 +1480,7 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
                     kPlaypositionUpdateRate)) {
         m_playposSlider->set(fFractionalPlaypos);
         m_pCueControl->updateIndicators();
+        m_iSamplesSinceLastIndicatorUpdate = 0;
     }
 
     // Update visual control object, this needs to be done more often than the

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -2710,7 +2710,8 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     ProcessBuffer();
 
     EXPECT_DOUBLE_EQ(0.025154950869236584, ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
-    EXPECT_DOUBLE_EQ(0.0023219954648526077, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
+    EXPECT_DOUBLE_EQ(0.0023219954648526077,
+            m_pChannel1->getEngineBuffer()->getVisualPlayPos());
 
     ControlObject::set(ConfigKey(m_sGroup1, "playposition"), 0.2);
     ProcessBuffer();
@@ -2718,7 +2719,8 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     // We expect to be two buffers ahead in a beat near 0.2
     EXPECT_DOUBLE_EQ(0.050309901738473162,
             ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
-    EXPECT_DOUBLE_EQ(0.18925937554508981, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
+    EXPECT_DOUBLE_EQ(0.18925937554508981,
+            m_pChannel1->getEngineBuffer()->getVisualPlayPos());
 
     // The same again with a stopped track loaded in Channel 2
     ControlObject::set(ConfigKey(m_sGroup1, "playposition"), 0.0);
@@ -2735,7 +2737,7 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     EXPECT_DOUBLE_EQ(0.025154950869236584,
             ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
     EXPECT_DOUBLE_EQ(0.0023219954648526077,
-            ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
+            m_pChannel1->getEngineBuffer()->getVisualPlayPos());
 
     ControlObject::set(ConfigKey(m_sGroup1, "playposition"), 0.2);
     ProcessBuffer();
@@ -2743,7 +2745,8 @@ TEST_F(EngineSyncTest, SeekStayInPhase) {
     // We expect to be two buffers ahead in a beat near 0.2
     EXPECT_DOUBLE_EQ(0.050309901738473162,
             ControlObject::get(ConfigKey(m_sGroup1, "beat_distance")));
-    EXPECT_DOUBLE_EQ(0.18925937554508981, ControlObject::get(ConfigKey(m_sGroup1, "playposition")));
+    EXPECT_DOUBLE_EQ(0.18925937554508981,
+            m_pChannel1->getEngineBuffer()->getVisualPlayPos());
 }
 
 TEST_F(EngineSyncTest, ScratchEndOtherStoppedTrackStayInPhase) {
@@ -3115,6 +3118,6 @@ TEST_F(EngineSyncTest, BeatContextRounding) {
     ProcessBuffer();
 
     EXPECT_NEAR(-0.021112622826908536,
-            ControlObject::get(ConfigKey(m_sGroup1, "playposition")),
+            m_pChannel1->getEngineBuffer()->getVisualPlayPos(),
             kMaxFloatingPointErrorHighPrecision);
 }

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -3,10 +3,12 @@
 #include "control/controlproxy.h"
 #include "moc_vinylcontrol.cpp"
 #include "vinylcontrol/defs_vinylcontrol.h"
+#include "waveform/visualplayposition.h"
 
 VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
         : m_pConfig(pConfig),
           m_group(group),
+          m_visualPlayPos(VisualPlayPosition::getVisualPlayPosition(group)),
           m_passthroughEnabled(PollingControlProxy(m_group, QStringLiteral("passthrough"))),
           m_scratchPositionEnabled(PollingControlProxy(
                   m_group, QStringLiteral("scratch_position_enable"))),
@@ -22,9 +24,6 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     double gain = m_pConfig->getValueString(ConfigKey(VINYL_PREF_KEY, "gain"))
             .toDouble(&gainOk);
     m_pVinylControlInputGain->set(gainOk ? gain : 1.0);
-
-    // Range: 0 to 1.0
-    playPos = new ControlProxy(group, "playposition", this);
     trackSamples = new ControlProxy(group, "track_samples", this);
     trackSampleRate = new ControlProxy(group, "track_samplerate", this);
     vinylSeek = new ControlProxy(group, "vinylcontrol_seek", this);

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QSharedPointer>
 #include <QString>
 
 #include "control/pollingcontrolproxy.h"
@@ -9,6 +10,7 @@
 
 class PollingControlProxy;
 class ControlProxy;
+class VisualPlayPosition;
 struct VinylSignalQualityReport;
 
 class VinylControl : public QObject {
@@ -33,8 +35,9 @@ class VinylControl : public QObject {
 
     //The ControlObject used to start/stop playback of the song.
     ControlProxy* playButton;
-    //The ControlObject used to read the playback position in the song.
-    ControlProxy* playPos;
+    // Playback position in the song. VisualPlayPosition is updated at engine
+    // rate, unlike the rate-limited playposition CO.
+    QSharedPointer<VisualPlayPosition> m_visualPlayPos;
     ControlProxy* trackSamples;
     ControlProxy* trackSampleRate;
     //The ControlObject used to change the playback position in the song.

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -12,6 +12,7 @@
 #include "vinylcontrol/defs_vinylcontrol.h"
 #include "vinylcontrol/steadypitch.h"
 #include "vinylcontrol/vinylsignalquality.h"
+#include "waveform/visualplayposition.h"
 
 /****** TODO *******
    Stuff to maybe implement here
@@ -293,7 +294,8 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
     }
 
     // Get the playback position in the file in seconds.
-    double filePosition = playPos->get() * m_dOldDuration;
+    const double fractionalPos = m_visualPlayPos->getEnginePlayPos();
+    const double filePosition = fractionalPos * m_dOldDuration;
 
     int reportedMode = static_cast<int>(mode->get());
     bool reportedPlayButton = playButton->toBool();
@@ -446,7 +448,7 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
                 //qDebug() << "CDJ resync position (>0.1 sec)";
                 syncPosition();
                 resetSteadyPitch(dVinylPitch, m_dVinylPosition);
-            } else if (playPos->get() >= 1.0 && dVinylPitch > 0) {
+            } else if (fractionalPos >= 1.0 && dVinylPitch > 0) {
                 //end of track, force stop
                 togglePlayButton(false);
                 resetSteadyPitch(0.0, 0.0);
@@ -464,7 +466,7 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
             //if we don't have valid position, we're not playing so reset time to current
             //estimate vinyl position
 
-            if (playPos->get() >= 1.0 && dVinylPitch > 0) {
+            if (fractionalPos >= 1.0 && dVinylPitch > 0) {
                 //end of track, force stop
                 togglePlayButton(false);
                 resetSteadyPitch(0.0, 0.0);


### PR DESCRIPTION
Playpos indicator updates in EngineBuffer are supposed to happen with a rate of 15 Hz:

https://github.com/mixxxdj/mixxx/blob/3ebac449e7e5fe2a0186596657696e87ce8b0e56/src/engine/enginebuffer.cpp#L53

There is a counter that takes track of this:

https://github.com/mixxxdj/mixxx/blob/3ebac449e7e5fe2a0186596657696e87ce8b0e56/src/engine/enginebuffer.h#L379

but it is never reset after an update:

https://github.com/mixxxdj/mixxx/blob/3ebac449e7e5fe2a0186596657696e87ce8b0e56/src/engine/enginebuffer.cpp#L1477-L1482

As a result, playpos updates are issued at a rate much faster than 15 Hz. I noticed this because the DDJ-SX mapping relies on those 15 Hz to blink the jog dial when the end of a track approaches, and the blinking was way too fast and erratic.

It seems that the counter reset was accidentally removed in 5a4444d520. I added it back. The issue is present both in 2.5 and 2.6, so the fix targets 2.5.