### PR TITLE
Effect preferences: Fix invalid row range in Qt model causing assertion in debug builds

### DIFF
--- a/src/preferences/effectmanifesttablemodel.cpp
+++ b/src/preferences/effectmanifesttablemodel.cpp
@@ -23,6 +23,9 @@ EffectManifestTableModel::EffectManifestTableModel(QObject* parent,
 
 void EffectManifestTableModel::setList(const QList<EffectManifestPointer>& newList) {
     removeRows(0, m_manifests.size());
+    if (newList.isEmpty()) {
+        return;
+    }
     beginInsertRows(QModelIndex(), 0, newList.size() - 1);
     m_manifests = newList;
     endInsertRows();


### PR DESCRIPTION
Fixes a Qt assertion ("last >= first") triggered in debug builds when opening Preferences.

Cause:
A model called beginInsertRows with an invalid range when the underlying list was empty (last < first).

Solution:
Added a guard to ensure valid row ranges before calling Qt model functions.

Result:
- Debug assertion no longer occurs
- No change in behavior in Release builds

Tested on:
- Windows (Visual Studio, Qt 6.8.3)
- Debug build