### PR TITLE
Fix Android build with external libdjinterop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3232,7 +3232,8 @@ if(LOCALECOMPARE)
     target_link_libraries(mixxx-lib PRIVATE SQLite::SQLite3)
   endif()
 elseif(SQLite3_FOUND)
-  # in the static case we need to link SQLite3 uncoditionally
+  # When LOCALECOMPARE is OFF (manually set) but SQLite3 is found (static Qt builds),
+  # we still need to link SQLite3 unconditionally
   target_link_libraries(mixxx-lib PRIVATE SQLite::SQLite3)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3211,7 +3211,10 @@ cmake_dependent_option(
 )
 if(LOCALECOMPARE)
   target_compile_definitions(mixxx-lib PUBLIC __SQLITE3__)
-  if(ANDROID AND TARGET unofficial::sqlite3::sqlite3)
+  if(
+    NOT VCPKG_TARGET_TRIPLET MATCHES "-release$"
+    AND TARGET unofficial::sqlite3::sqlite3
+  )
     get_target_property(
       _sqlite3_location
       unofficial::sqlite3::sqlite3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3200,37 +3200,38 @@ target_link_libraries(mixxx-lib PRIVATE Chromaprint::Chromaprint)
 find_package(SQLite3)
 # For LOCALECOMPARE we call directly sqlite functions to the database opened by
 # Qt. It only works without crashing when Mixxx links to the same sqlite
-# library as Qt.
-# This is difficult on macOS where system the SQLite can be installed and linked
-# dynamically from various locations. There is no issue in case of static
-# linking which would result in a duplicate symbol error.
-if(NOT SQLite3_FOUND)
-  set(LOCALECOMPARE_DEFAULT OFF)
-else()
-  is_static_library(SQLite3_IS_STATIC SQLite::SQLite3)
-  if(SQLite3_IS_STATIC OR NOT APPLE)
-    set(LOCALECOMPARE_DEFAULT ON)
-  else()
-    set(LOCALECOMPARE_DEFAULT OFF)
-  endif()
-endif()
+# library as Qt. On vcpkg builds, the custom FindSQLite3.cmake wrapper ensures
+# that both Qt and Mixxx resolve to the same vcpkg-provided SQLite library.
 cmake_dependent_option(
   LOCALECOMPARE
   "Locale Aware Compare support for SQLite"
   ON
-  "LOCALECOMPARE_DEFAULT"
+  "SQLite3_FOUND"
   OFF
 )
 if(LOCALECOMPARE)
-  if(NOT SQLite3_FOUND)
-    message(
-      FATAL_ERROR
-      "Locale Aware Compare for SQLite requires libsqlite and its development headers."
-    )
-  endif()
   target_compile_definitions(mixxx-lib PUBLIC __SQLITE3__)
-  target_link_libraries(mixxx-lib PRIVATE SQLite::SQLite3)
-elseif(SQLite3_IS_STATIC)
+  if(ANDROID AND TARGET unofficial::sqlite3::sqlite3)
+    get_target_property(
+      _sqlite3_location
+      unofficial::sqlite3::sqlite3
+      IMPORTED_LOCATION_RELEASE
+    )
+    if(NOT _sqlite3_location)
+      get_target_property(
+        _sqlite3_location
+        unofficial::sqlite3::sqlite3
+        IMPORTED_LOCATION
+      )
+    endif()
+    if(_sqlite3_location)
+      message(STATUS "Forcing link to SQLite3 library: ${_sqlite3_location}")
+      target_link_libraries(mixxx-lib PRIVATE "${_sqlite3_location}")
+    endif()
+  else()
+    target_link_libraries(mixxx-lib PRIVATE SQLite::SQLite3)
+  endif()
+elseif(SQLite3_FOUND)
   # in the static case we need to link SQLite3 uncoditionally
   target_link_libraries(mixxx-lib PRIVATE SQLite::SQLite3)
 endif()
@@ -3252,9 +3253,7 @@ if(ENGINEPRIME)
     message(STATUS "STATIC link existing system installation of libdjinterop")
     target_link_libraries(mixxx-lib PUBLIC DjInterop::DjInterop)
   else()
-    # On MacOS, Mixxx does not use system SQLite, so we will use libdjinterop's
-    # embedded SQLite in such a case.
-    if(APPLE AND NOT SQLite3_IS_STATIC)
+    if(NOT SQLite3_FOUND)
       message(
         STATUS
         "Building libdjinterop sources (with embedded SQLite) fetched from GitHub"
@@ -3310,10 +3309,12 @@ if(ENGINEPRIME)
       INSTALL_DIR ${DJINTEROP_INSTALL_DIR}
       LIST_SEPARATOR "|"
       CMAKE_ARGS
-        -DBUILD_SHARED_LIBS=OFF -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON
+        -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+        -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
         -DCMAKE_PREFIX_PATH=${PIPE_DELIMITED_CMAKE_PREFIX_PATH}
+        -DCMAKE_FIND_ROOT_PATH=${PIPE_DELIMITED_CMAKE_PREFIX_PATH}
         -DCMAKE_INSTALL_LIBDIR:PATH=lib
         -DCMAKE_MODULE_PATH:PATH=${CMAKE_MODULE_PATH}
         -$<IF:$<BOOL:${CMAKE_TOOLCHAIN_FILE}>,D,U>CMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}

--- a/cmake/modules/FindSQLite3.cmake
+++ b/cmake/modules/FindSQLite3.cmake
@@ -1,0 +1,104 @@
+#[=======================================================================[.rst:
+FindSQLite3
+-----------
+
+Finds the SQLite3 library.
+
+vcpkg uses an ``unofficial-`` prefix for ports where upstream does not ship
+CMake config files. This module tries vcpkg's ``unofficial-sqlite3`` first,
+then falls back to CMake's built-in ``FindSQLite3`` module.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``SQLite::SQLite3``
+  The SQLite3 library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+``SQLite3_FOUND``
+  True if the system has the SQLite3 library.
+``SQLite3_INCLUDE_DIRS``
+  Include directories needed to use SQLite3.
+``SQLite3_VERSION``
+  The version of SQLite3 found.
+
+#]=======================================================================]
+
+# Avoid repeated processing
+if(TARGET SQLite::SQLite3)
+  set(SQLite3_FOUND TRUE)
+  return()
+endif()
+
+# Try vcpkg's unofficial-sqlite3 package first (CONFIG mode only)
+find_package(unofficial-sqlite3 CONFIG QUIET)
+
+if(TARGET unofficial::sqlite3::sqlite3)
+  # Extract the include directory from the imported target
+  get_target_property(
+    SQLite3_INCLUDE_DIR
+    unofficial::sqlite3::sqlite3
+    INTERFACE_INCLUDE_DIRECTORIES
+  )
+  if(SQLite3_INCLUDE_DIR)
+    # INTERFACE_INCLUDE_DIRECTORIES may be a list; use the first entry
+    list(GET SQLite3_INCLUDE_DIR 0 SQLite3_INCLUDE_DIR)
+  endif()
+
+  # Detect version from sqlite3.h
+  if(SQLite3_INCLUDE_DIR AND EXISTS "${SQLite3_INCLUDE_DIR}/sqlite3.h")
+    file(
+      STRINGS
+      "${SQLite3_INCLUDE_DIR}/sqlite3.h"
+      _sqlite3_version_str
+      REGEX "^#[\t ]*define[\t ]+SQLITE_VERSION[\t ]+\"[^\"]+\""
+    )
+    string(
+      REGEX REPLACE
+      "^#[\t ]*define[\t ]+SQLITE_VERSION[\t ]+\"([^\"]+)\".*$"
+      "\\1"
+      SQLite3_VERSION
+      "${_sqlite3_version_str}"
+    )
+    unset(_sqlite3_version_str)
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(
+    SQLite3
+    REQUIRED_VARS SQLite3_INCLUDE_DIR
+    VERSION_VAR SQLite3_VERSION
+  )
+
+  if(SQLite3_FOUND AND NOT TARGET SQLite::SQLite3)
+    # Use an IMPORTED INTERFACE target instead of ALIAS so that vcpkg's
+    # vcpkg-cmake-wrapper.cmake can call set_target_properties() on it.
+    # ALIAS targets do not support set_target_properties(), which causes
+    # the Android (and potentially other) vcpkg builds to fail.
+    add_library(SQLite::SQLite3 INTERFACE IMPORTED GLOBAL)
+    target_link_libraries(
+      SQLite::SQLite3
+      INTERFACE unofficial::sqlite3::sqlite3
+    )
+    set(SQLite3_INCLUDE_DIRS "${SQLite3_INCLUDE_DIR}")
+  endif()
+
+  if(SQLite3_FOUND AND TARGET unofficial::sqlite3::sqlite3)
+    # Ensure that the actual library is linked, not just INTERFACE
+    get_target_property(
+      _sqlite3_libs
+      unofficial::sqlite3::sqlite3
+      INTERFACE_LINK_LIBRARIES
+    )
+    # _sqlite3_libs should contain the actual library, but on Android (static linked build) it may not.
+    # Force linking the real library if needed.
+    if(_sqlite3_libs)
+      target_link_libraries(SQLite::SQLite3 INTERFACE ${_sqlite3_libs})
+    endif()
+  endif()
+else()
+  # If VCPKG's unofficial-sqlite3 package is not found, fall back to CMake's built-in FindSQLite3 module
+  include("${CMAKE_ROOT}/Modules/FindSQLite3.cmake")
+endif()

--- a/cmake/modules/FindSQLite3.cmake
+++ b/cmake/modules/FindSQLite3.cmake
@@ -53,7 +53,8 @@ if(TARGET unofficial::sqlite3::sqlite3)
       STRINGS
       "${SQLite3_INCLUDE_DIR}/sqlite3.h"
       _sqlite3_version_str
-      REGEX "^#[\t ]*define[\t ]+SQLITE_VERSION[\t ]+\"[^\"]+\""
+      REGEX "SQLITE_VERSION[\t ]+\""
+      LIMIT_COUNT 1
     )
     string(REGEX MATCH "\"([^\"]+)\"" _unused "${_sqlite3_version_str}")
     set(SQLite3_VERSION "${CMAKE_MATCH_1}")

--- a/cmake/modules/FindSQLite3.cmake
+++ b/cmake/modules/FindSQLite3.cmake
@@ -33,6 +33,9 @@ if(TARGET SQLite::SQLite3)
 endif()
 
 # Try vcpkg's unofficial-sqlite3 package first (CONFIG mode only)
+# vcpkg prefixes packages with "unofficial-" when upstream doesn't provide
+# CMake config files. These packages expose only a target for linking;
+# so we extract the version from sqlite3.h below.
 find_package(unofficial-sqlite3 CONFIG QUIET)
 
 if(TARGET unofficial::sqlite3::sqlite3)

--- a/cmake/modules/FindSQLite3.cmake
+++ b/cmake/modules/FindSQLite3.cmake
@@ -55,13 +55,8 @@ if(TARGET unofficial::sqlite3::sqlite3)
       _sqlite3_version_str
       REGEX "^#[\t ]*define[\t ]+SQLITE_VERSION[\t ]+\"[^\"]+\""
     )
-    string(
-      REGEX REPLACE
-      "^#[\t ]*define[\t ]+SQLITE_VERSION[\t ]+\"([^\"]+)\".*$"
-      "\\1"
-      SQLite3_VERSION
-      "${_sqlite3_version_str}"
-    )
+    string(REGEX MATCH "\"([^\"]+)\"" _unused "${_sqlite3_version_str}")
+    set(SQLite3_VERSION "${CMAKE_MATCH_1}")
     unset(_sqlite3_version_str)
   endif()
 


### PR DESCRIPTION
- For VCPKG based builds, ensure that we always use the VCPKG provided SQLite3 version with prefix `unofficial-`
- Unify behavior for static linking as for dynamic linking
- Handle SQLite3 linking on Android with VCPKG target unofficial-SQLite3
- Enable Position Independend Code (PIC) and set CMAKE_FIND_ROOT for libdjinterop external build