### PR TITLE
analyzer: skip key storage for silent/empty audio

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,10 +125,6 @@ repos:
     hooks:
       - id: prettier
         types: [yaml]
-  - repo: https://github.com/qarmin/qml_formatter.git
-    rev: 706250038bb565f4c630ca3aab09f764faabae67 # No release tag yet including #9 fix
-    hooks:
-      - id: qml_formatter
   - repo: https://github.com/BlankSpruce/gersemi
     rev: 0.17.1
     hooks:

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -2,6 +2,7 @@
 
 #include <QtDebug>
 
+#include "analyzer/analyzersilence.h"
 #include "analyzer/analyzertrack.h"
 #include "analyzer/constants.h"
 #if defined __KEYFINDER__
@@ -206,7 +207,7 @@ bool AnalyzerKey::processSamples(const CSAMPLE* pIn, SINT count) {
     }
 
     // Track whether any non-silent audio has been seen across all blocks
-    if (SampleUtil::maxAbsAmplitude(pKeyInput, count) >= 1e-6f) {
+    if (SampleUtil::maxAbsAmplitude(pKeyInput, count) >= kSilenceThreshold) {
         m_bHasSignal = true;
     }
 

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -42,7 +42,8 @@ AnalyzerKey::AnalyzerKey(const KeyDetectionSettings& keySettings)
           m_currentFrame(0),
           m_bPreferencesKeyDetectionEnabled(true),
           m_bPreferencesFastAnalysisEnabled(false),
-          m_bPreferencesReanalyzeEnabled(false) {
+          m_bPreferencesReanalyzeEnabled(false),
+          m_bHasSignal(false) {
 }
 
 bool AnalyzerKey::initialize(const AnalyzerTrack& track,
@@ -90,6 +91,9 @@ bool AnalyzerKey::initialize(const AnalyzerTrack& track,
         m_maxFramesToProcess = frameLength;
     }
     m_currentFrame = 0;
+
+    // Reset signal detection for this track
+    m_bHasSignal = false;
 
     // if we can't load a stored track reanalyze it
     bool bShouldAnalyze = shouldAnalyze(track.getTrack());
@@ -201,6 +205,11 @@ bool AnalyzerKey::processSamples(const CSAMPLE* pIn, SINT count) {
         return false;
     }
 
+    // Track whether any non-silent audio has been seen across all blocks
+    if (SampleUtil::maxAbsAmplitude(pKeyInput, count) >= 1e-6f) {
+        m_bHasSignal = true;
+    }
+
     bool ret = m_pPlugin->processSamples(pKeyInput, count);
     if (pHarmonicMixedChannel) {
         SampleUtil::free(pHarmonicMixedChannel);
@@ -214,6 +223,12 @@ void AnalyzerKey::cleanup() {
 
 void AnalyzerKey::storeResults(TrackPointer tio) {
     VERIFY_OR_DEBUG_ASSERT(m_pPlugin) {
+        return;
+    }
+
+    // Do not store a key result if the track had no audio signal
+    if (!m_bHasSignal) {
+        qDebug() << "AnalyzerKey: skipping key storage - track is silent";
         return;
     }
 

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -44,4 +44,5 @@ class AnalyzerKey : public Analyzer {
     bool m_bPreferencesKeyDetectionEnabled;
     bool m_bPreferencesFastAnalysisEnabled;
     bool m_bPreferencesReanalyzeEnabled;
+    bool m_bHasSignal;
 };

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -6,12 +6,6 @@
 
 namespace {
 
-// This threshold must not be changed, because this value is also used to
-// verify that the track samples have not changed since the last analysis
-constexpr CSAMPLE kSilenceThreshold = 0.001f; // -60 dB
-// TODO: Change the above line to:
-//constexpr CSAMPLE kSilenceThreshold = db2ratio(-60.0f);
-
 bool shouldAnalyze(TrackPointer pTrack) {
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
     CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -4,6 +4,8 @@
 #include "preferences/usersettings.h"
 #include "util/span.h"
 
+inline constexpr CSAMPLE kSilenceThreshold = 0.001f;
+
 class AnalyzerTrack;
 class Track;
 


### PR DESCRIPTION
Previously, the analyzer stored false key results for tracks lacking audio signals. I added an m_bHasSignal flag to monitor for non-silent blocks during processSamples. Now, storeResults skips key finalization if no signal is present. So that should leave the key field blank for empty audio files.

Fixes #10199