### PR TITLE
Fix invalid row range in Qt model causing assertion in debug builds

### DIFF
--- a/src/preferences/effectmanifesttablemodel.cpp
+++ b/src/preferences/effectmanifesttablemodel.cpp
@@ -23,6 +23,9 @@ EffectManifestTableModel::EffectManifestTableModel(QObject* parent,
 
 void EffectManifestTableModel::setList(const QList<EffectManifestPointer>& newList) {
     removeRows(0, m_manifests.size());
+    if (newList.isEmpty()) {
+        return;
+    }
     beginInsertRows(QModelIndex(), 0, newList.size() - 1);
     m_manifests = newList;
     endInsertRows();


### PR DESCRIPTION
Guard beginInsertRows / beginRemoveRows against empty ranges to ensure last >= first, preventing Qt debug assertion when opening Preferences.

This is a cherry-pick (backport) of #16257 