### PR TITLE
Fix flaky test, due to not waiting for a fully loaded EngineBufferE2ETest

### DIFF
--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -94,12 +94,6 @@ void EngineControl::seekExact(mixxx::audio::FramePos position) {
     }
 }
 
-void EngineControl::seek(double fractionalPosition) {
-    if (m_pEngineBuffer) {
-        m_pEngineBuffer->slotControlSeek(fractionalPosition);
-    }
-}
-
 EngineBuffer* EngineControl::pickSyncTarget() {
     EngineMixer* pEngineMixer = getEngineMixer();
     if (!pEngineMixer) {

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -101,7 +101,6 @@ class EngineControl : public QObject {
     FrameInfo frameInfo() const {
         return m_frameInfo.getValue();
     }
-    void seek(double fractionalPosition);
     void seekAbs(mixxx::audio::FramePos position);
     // Seek to an exact sample and don't allow quantizing adjustment.
     void seekExact(mixxx::audio::FramePos position);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -725,10 +725,9 @@ void EngineBuffer::doSeekFractional(double fractionalPos, enum SeekRequest seekT
     VERIFY_OR_DEBUG_ASSERT(!util_isnan(fractionalPos)) {
         return;
     }
-
-    // FIXME: Use maybe invalid here
     const mixxx::audio::FramePos trackEndPosition = getTrackEndPosition();
-    VERIFY_OR_DEBUG_ASSERT(trackEndPosition.isValid()) {
+    if (!trackEndPosition.isValid()) {
+        // happens if no track is loaded
         return;
     }
     const auto seekPosition = trackEndPosition * fractionalPos;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1189,8 +1189,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     m_pScaleRB->setSampleRate(m_sampleRate);
 #endif
 
-    bool hasStableTrack = m_pTrackLoaded->toBool() && m_iTrackLoading.loadAcquire() == 0;
-    if (hasStableTrack && m_pause.tryLock()) {
+    if (isTrackLoaded() && m_pause.tryLock()) {
         processTrackLocked(pOutput, iBufferSize, m_sampleRate);
         // release the pauselock
         m_pause.unlock();
@@ -1550,10 +1549,7 @@ void EngineBuffer::addControl(EngineControl* pControl) {
 }
 
 bool EngineBuffer::isTrackLoaded() const {
-    if (m_pCurrentTrack) {
-        return true;
-    }
-    return false;
+    return (m_pCurrentTrack && atomicLoadAcquire(m_iTrackLoading) == 0);
 }
 
 TrackPointer EngineBuffer::getLoadedTrack() const {

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -157,9 +157,6 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
 
     void loadTrack(Deck* pDeck, TrackPointer pTrack) {
         EngineDeck* pEngineDeck = pDeck->getEngineDeck();
-        if (pEngineDeck->getEngineBuffer()->isTrackLoaded()) {
-            pEngineDeck->getEngineBuffer()->ejectTrack();
-        }
         pDeck->slotLoadTrack(pTrack, false);
 
         // Wait for the track to load.


### PR DESCRIPTION
This aims to fix #12554. Test that are loading tracks but start processing too early before the engine is processing it and fail consequently. I was able to reproduce the issue by a sleep just after setting `m_pCurrentTrack`

This does hover not explain all failure. Especially where the output buffer to compare is not completely zero.  
