### PR TITLE
Pref sound: add button to reset underflow counter

### DIFF
--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -334,6 +334,11 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                     tr("Find details in the Mixxx user manual"),
                     MIXXX_MANUAL_OUTPUT_AND_INPUT_DEVICES);
     deckBusHint->setText(deckBusHintStr);
+
+    // Append a ':' to separate latency/underflow labels from values.
+    // (append here to keep existing tr strings)
+    latencyLabel->setText(latencyLabel->text() + ':');
+    underflowLabel->setText(underflowLabel->text() + ':');
 }
 
 /// Slot called when the preferences dialog is opened.

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -263,6 +263,11 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             kAppGroup, QStringLiteral("output_latency_ms"), this);
     m_pOutputLatencyMs->connectValueChanged(this, &DlgPrefSound::outputLatencyChanged);
 
+    connect(btnResetBufferUnderflowCount,
+            &QPushButton::clicked,
+            this,
+            &DlgPrefSound::slotResetUnderflowCounter);
+
     // TODO: remove this option by automatically disabling/enabling the main mix
     // when recording, broadcasting, headphone, and main outputs are enabled/disabled
     m_pMainEnabled =
@@ -968,6 +973,10 @@ void DlgPrefSound::slotResetToDefaults() {
 void DlgPrefSound::bufferUnderflow(double count) {
     bufferUnderflowCount->setText(QString::number(count));
     update();
+}
+
+void DlgPrefSound::slotResetUnderflowCounter() {
+    m_pSoundManager->resetUnderflowCount();
 }
 
 void DlgPrefSound::outputLatencyChanged(double latency) {

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -50,6 +50,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void slotApply() override;  // called on ok button
     void slotResetToDefaults() override;
     void bufferUnderflow(double count);
+    void slotResetUnderflowCounter();
     void outputLatencyChanged(double latency);
     void latencyCompensationSpinboxChanged(double value);
     void mainDelaySpinboxChanged(double value);

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QGridLayout" name="gridLayout">
+    <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
      <item row="0" column="0">
       <widget class="QLabel" name="apiLabel">
        <property name="text">
@@ -344,7 +344,7 @@
      <property name="title">
       <string>Hints and Diagnostics</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_6">
+     <layout class="QGridLayout" name="gridLayout_6" columnstretch="0,1">
       <item row="0" column="0" colspan="2">
        <widget class="QLabel" name="deckBusHint">
         <property name="text">

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -344,8 +344,8 @@
      <property name="title">
       <string>Hints and Diagnostics</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_6" columnstretch="0,1">
-      <item row="0" column="0" colspan="2">
+     <layout class="QGridLayout" name="gridLayout_6" columnstretch="0,0,0,1">
+      <item row="0" column="0" colspan="4">
        <widget class="QLabel" name="deckBusHint">
         <property name="text">
          <string>Deck and Bus outputs are for external mixers. They are post-fader and include effects and crossfader (for Auto DJ). For external mixing, make sure all Mixxx faders and EQ knobs are set to their default position (right- or double-click). </string>
@@ -358,7 +358,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="1" column="0" colspan="4">
        <widget class="QLabel" name="underflowCounterHint">
         <property name="text">
          <string>Enlarge your audio buffer if the underflow counter is increasing or you hear pops during playback.</string>
@@ -368,7 +368,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="2" column="0" colspan="4">
        <widget class="QLabel" name="audioBufferHint">
         <property name="text">
          <string>Downsize your audio buffer to improve Mixxx's responsiveness.</string>
@@ -378,7 +378,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="3" column="0" colspan="4">
        <widget class="QLabel" name="realtimeHint">
         <property name="wordWrap">
          <bool>true</bool>
@@ -388,7 +388,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="4" column="0" colspan="4">
        <widget class="QLabel" name="hardwareGuide">
         <property name="wordWrap">
          <bool>true</bool>
@@ -398,7 +398,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="2">
+      <item row="5" column="0" colspan="4">
        <widget class="Line" name="line">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -436,6 +436,13 @@
        <widget class="QLabel" name="bufferUnderflowCount">
         <property name="text">
          <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="2">
+       <widget class="QPushButton" name="btnResetBufferUnderflowCount">
+        <property name="text">
+         <string>Reset</string>
         </property>
        </widget>
       </item>

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -116,6 +116,10 @@ class SoundManager : public QObject {
         return m_pConfig;
     }
 
+    void resetUnderflowCount() {
+        m_audioLatencyOverloadCount.set(0);
+    }
+
   signals:
     void devicesUpdated(); // emitted when pointers to SoundDevices go stale
     void devicesSetup(); // emitted when the sound devices have been set up


### PR DESCRIPTION
based on #16184

Lately, when using the SignalSmith engine I wanted to track where the (now rare) underflows stem from.
Since I didn't hear them I suspected it's #8693 or #9006
To be sure I need to check the counter and Reset helps a lot with that.

<img width="464" height="125" alt="image" src="https://github.com/user-attachments/assets/fd7f0f7c-bad5-4fdd-9633-90d6f942d956" />
