### PR TITLE
remove PreferencesPage from m_allPages in DlgPreferences::removePageWidget

### DIFF
--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -177,8 +177,9 @@ void DlgPrefControllers::destroyControllerWidgets() {
     }
     while (!m_controllerPages.isEmpty()) {
         DlgPrefController* pControllerDlg = m_controllerPages.takeLast();
+
+        // this triggers the deletion of pControllerDlg, it no longer may be used
         m_pDlgPreferences->removePageWidget(pControllerDlg);
-        delete pControllerDlg;
     }
 
     m_controllerTreeItems.clear();

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -272,10 +272,9 @@ DlgPreferences::~DlgPreferences() {
     }
 
     // When DlgPrefControllers is deleted it manually deletes the controller tree items,
-    // which makes QTreeWidgetItem trigger this signal. If we don't disconnect,
-    // &DlgPreferences::changePage iterates on the PreferencesPage instances in m_allPages,
-    // but the pDlg objects of the controller items are already destroyed by DlgPrefControllers,
-    // which causes a crash when accessed.
+    // which makes QTreeWidgetItem trigger this signal. Currently PreferencesPage
+    // instances in m_allPages are destroyed along with pDlg objects. This disconnect
+    // is kept as a safety measure.
     disconnect(contentsTreeWidget, &QTreeWidget::currentItemChanged, this, &DlgPreferences::changePage);
     // Need to explicitly delete rather than relying on child auto-deletion
     // because otherwise the QStackedWidget will delete the controller
@@ -515,7 +514,24 @@ DlgPreferencePage* DlgPreferences::currentPage() {
 }
 
 void DlgPreferences::removePageWidget(DlgPreferencePage* pWidget) {
-    pagesWidget->removeWidget(pWidget->parentWidget()->parentWidget());
+    QWidget* pParent = pWidget->parentWidget();
+    VERIFY_OR_DEBUG_ASSERT(pParent) {
+        return;
+    }
+
+    QWidget* pScrollArea = pParent->parentWidget();
+    VERIFY_OR_DEBUG_ASSERT(pScrollArea) {
+        return;
+    }
+
+    const int index = pagesWidget->indexOf(pScrollArea);
+    VERIFY_OR_DEBUG_ASSERT(index >= 0 && index < m_allPages.size()) {
+        return;
+    }
+
+    m_allPages.removeAt(index);
+    pagesWidget->removeWidget(pScrollArea);
+    delete pScrollArea;
 }
 
 void DlgPreferences::expandTreeItem(QTreeWidgetItem* pItem) {


### PR DESCRIPTION
Fixes #16235

This assumes m_allPages and pagesWidget contents have 1-1 correspondence, which isn't communicated explicitly. Can this be done some other way? There is also a [comment](https://github.com/mixxxdj/mixxx/blob/4cc9db6f8394e27fb149603fca5d4faee1b7443a/src/preferences/dialog/dlgpreferences.cpp#L274) related to this.