### PR TITLE
NS4FX: use EQ knobs to control stem volumes

### DIFF
--- a/res/controllers/Numark NS4FX.midi.xml
+++ b/res/controllers/Numark NS4FX.midi.xml
@@ -28,6 +28,25 @@
             <option type="boolean" variable="useFadercutsAsStems" label="Control stems with Fader Cuts pads" default="false" description="When enabled, the 'Fader Cuts' pad mode is replaced with a mode to control Stems (mute, volume, and quick effects)."/>
             <option type="boolean" variable="useAdditionalHotcues" label="Add hotcues 5-8 to the second row of pads" default="false" description="When enabled, the bottom row of transport pads (CUE, START, BACK, FWD) will function as hotcues 5-8 when the pad mode is set to 'Hot Cue'."/>
         </group>
+        <group label="Mixer">
+            <option
+                type="enum"
+                variable="useEQsAs"
+                label="Select the mode for EQ knobs"
+                description="Select whether the EQ knobs should work normally or assign extended behaviour to them.">
+                <value label="Normal EQs" default="true">normal</value>
+                <value label="Stem Control (Simple)">stemSimple</value>
+                <value label="Stem Control (SoftMax)">stemSoftMax</value>
+                <value label="Stem Control (Gated Attenuation)">stemGatedAttenuation</value>
+                <value label="Stem Control (Triangle)">stemTriangle</value>
+            </option>
+            <option
+                type="boolean"
+                default="false"
+                variable="useEQs34asStemEffects"
+                label="Control stems effects with EQ knobs"
+                description="When enabled, the EQ knobs of decks 3 and 4 control stem effects of decks 1 and 2."/>
+        </group>
     </settings>
     <controller id="NS4FX">
         <scriptfiles>

--- a/res/controllers/Numark-NS4FX-scripts.js
+++ b/res/controllers/Numark-NS4FX-scripts.js
@@ -1,3 +1,8 @@
+/**
+ * The main controller object.
+ */
+function NS4FX() { };
+
 /******************
  * CONFIG OPTIONS *
  ******************/
@@ -9,6 +14,8 @@ const defaultPadMode = engine.getSetting("defaultPadMode");
 const useFadercutsAsStems = engine.getSetting("useFadercutsAsStems");
 const useAdditionalHotcues = engine.getSetting("useAdditionalHotcues");
 const exitSlipmodeAfterScratching = engine.getSetting("exitSlipmodeAfterScratching");
+const useEQsAs = engine.getSetting("useEQsAs");
+const useEQs34asStemEffects = engine.getSetting("useEQs34asStemEffects");
 
 /**
  * Creates a configuration object for a performance pad to be used for stem control.
@@ -158,12 +165,30 @@ const createTransportPad = function(deck, padNumber, defaultKey, momentary) {
 };
 
 
-var NS4FX = {};
-
 NS4FX.dbg = function(str) {
     if (NS4FX.debug) {
         print(str);
     }
+};
+
+/**
+ * Normalizes a set of stem volumes so the loudest stem is at 1.0 (full volume),
+ * preserving the relative ratio between them, and applies them to the deck.
+ * @param {object} deck - The deck object to apply volumes to.
+ * @param {object} volumes - An object with v_v, v_m, and v_d volume properties.
+ */
+NS4FX.normalizeAndApplyStemVolumes = function(deck, volumes) {
+    const max_vol = Math.max(volumes.v_v, volumes.v_m, volumes.v_d);
+
+    if (max_vol > 0) {
+        volumes.v_v /= max_vol;
+        volumes.v_m /= max_vol;
+        volumes.v_d /= max_vol;
+    }
+    engine.setValue(`[Channel${deck.number}_Stem4]`, "volume", volumes.v_v); // Vocals
+    engine.setValue(`[Channel${deck.number}_Stem3]`, "volume", volumes.v_m); // Music/Melody
+    engine.setValue(`[Channel${deck.number}_Stem1]`, "volume", volumes.v_d); // Drums
+    engine.setValue(`[Channel${deck.number}_Stem2]`, "volume", volumes.v_d); // Bass
 };
 
 NS4FX.testMidi = function(status, control, value) {
@@ -691,8 +716,231 @@ NS4FX.Deck = function(number, midi_chan) {
         this.stemPad4 = {timerId: null, isHeldForVolume: false};
     }
 
-
     components.Deck.call(this, number);
+
+    // decide whether the current deck holds a track with separated stems
+    this.trackHasStems = function() {
+        if (engine.getValue(deck.currentDeck, "passthrough")) {
+            return false;
+        }
+        return engine.getValue(deck.currentDeck, "stem_count") > 0;
+    };
+
+    /**
+     * Configures the behavior of the high, mid, and low EQ knobs.
+     * Depending on the 'useEQsAs' setting in the controller script, these knobs can either
+     * control the standard EQs or be repurposed to control stems in various modes
+     * (e.g., simple volume, softmax balancing, gated attenuation, or triangle balancing).
+     * If a stem mode is selected but the current track does not have stems,
+     * the function defaults to the standard EQ behavior for that track.
+     * This function is called when a track is loaded or when the deck becomes active
+     * to ensure the EQs are correctly mapped for the current context.
+     */
+    this.updateEQs = function() {
+        const isStemEffectMode = useEQs34asStemEffects &&
+            (deck.number === 3 || deck.number === 4) &&
+            (!engine.getValue(deck.currentDeck, "track_loaded") ||
+                engine.getValue(deck.currentDeck, "passthrough"));
+
+        if (isStemEffectMode) {
+            const targetDeckNumber = deck.number - 2;
+            NS4FX.dbg(`Deck ${deck.number} is controlling stem effects for Deck ${targetDeckNumber}`);
+
+            const eq_group = `[EqualizerRack1_${deck.currentDeck}_Effect1]`;
+            engine.setValue(eq_group, "enabled", false); // Disable standard EQ for this deck
+            NS4FX.dbg(`Disabled EQ effect unit ${eq_group} for stem effect control on Deck ${deck.number}.`);
+
+            const createStemEffectInput = function(stemNumbers, eq_param) {
+                const stems = Array.isArray(stemNumbers) ? stemNumbers : [stemNumbers];
+                return function(_channel, _control, value, _status) {
+                    const paramValue = value / 127;
+                    // Set the EQ parameter for the current deck to provide visual feedback in the Mixxx UI
+                    engine.setParameter(eq_group, eq_param, paramValue);
+                    stems.forEach(function(stemNumber) {
+                        const quickEffectGroup = `[QuickEffectRack1_[Channel${targetDeckNumber}_Stem${stemNumber}]]`;
+                        engine.setValue(quickEffectGroup, "super1", paramValue);
+                    });
+                };
+            };
+
+            deck.high_eq = new components.Pot({input: createStemEffectInput(4, "parameter3")});      // Vocals effect
+            deck.mid_eq = new components.Pot({input: createStemEffectInput(3, "parameter2")});       // Melody effect
+            deck.low_eq = new components.Pot({input: createStemEffectInput([1, 2], "parameter1")});  // Drums & Bass effect
+            return; // Exit to prevent running the standard EQ/stem logic
+        }
+
+        let currentEQsAs = useEQsAs;
+        NS4FX.dbg(`trackHasStems: ${deck.trackHasStems()}`);
+        // If a stem mode is selected but the track has no stems, fall back to normal EQ mode.
+        if (useEQsAs !== "normal" && !deck.trackHasStems()) {
+            NS4FX.dbg(`Deck ${deck.number}: Track has no stems, falling back to normal EQ mode.`);
+            currentEQsAs = "normal";
+        }
+
+        const eq_group = `[EqualizerRack1_${deck.currentDeck}_Effect1]`;
+
+        if (currentEQsAs === "normal") {
+            // If 'normal' mode, enable the EQ effect unit and map knobs to standard EQs.
+            engine.setValue(eq_group, "enabled", true);
+            deck.high_eq = new components.Pot({group: eq_group, inKey: "parameter3"});
+            deck.mid_eq = new components.Pot({group: eq_group, inKey: "parameter2"});
+            deck.low_eq = new components.Pot({group: eq_group, inKey: "parameter1"});
+        } else {
+            // If not 'normal', EQs are used for stem control.
+            NS4FX.dbg(`Deck ${deck.number}: EQs are configured as Stems in '${currentEQsAs}' mode.`);
+            // Disable the standard EQ effect unit to prevent interference.
+            engine.setValue(eq_group, "enabled", false);
+            NS4FX.dbg(`Disabled EQ effect unit ${eq_group} for stem control on Deck ${deck.number}.`);
+            let highEQInput, midEQInput, lowEQInput;
+
+            // 'stemSimple' mode: Each EQ knob directly controls the volume of one or more stems.
+            if (currentEQsAs === "stemSimple") {
+                const createStemInput = function(stemNumbers, eq_param) {
+                    const stems = Array.isArray(stemNumbers) ? stemNumbers : [stemNumbers];
+                    return function(_channel, _control, value, _status) {
+                        const paramValue = value / 127;
+                        engine.setParameter(eq_group, eq_param, paramValue);
+                        stems.forEach(function(stemNumber) {
+                            engine.setValue(`[Channel${deck.number}_Stem${stemNumber}]`, "volume", paramValue);
+                        });
+                    };
+                };
+                highEQInput = createStemInput(4, "parameter3");      // Vocals
+                midEQInput = createStemInput(3, "parameter2");       // Melody
+                lowEQInput = createStemInput([1, 2], "parameter1");  // Drums & Bass
+                // 'stemSoftMax' mode: Uses a softmax function to balance stem volumes. Turning one knob up turns others down.
+            } else if (currentEQsAs === "stemSoftMax") {
+                deck.logits = {z_v: 1, z_m: 1, z_d: 1};
+
+                const updateStemVolumes = function(deckToUpdate) {
+                    const {z_v, z_m, z_d} = deckToUpdate.logits;
+
+                    const exp_zv = Math.exp(z_v);
+                    const exp_zm = Math.exp(z_m);
+                    const exp_zd = Math.exp(z_d);
+
+                    // Denominator for the softmax calculation. Drums and bass are weighted together.
+                    const denominator = exp_zv + exp_zm + 2 * exp_zd;
+
+                    if (denominator === 0) { return; } // Avoid division by zero.
+
+                    const volumes = {
+                        v_v: exp_zv / denominator,
+                        v_m: exp_zm / denominator,
+                        v_d: exp_zd / denominator // This volume is used for both drums and bass.
+                    };
+                    NS4FX.normalizeAndApplyStemVolumes(deckToUpdate, volumes);
+                };
+                updateStemVolumes(deck);
+
+                const createSoftmaxInput = function(logitKey, eq_param) {
+                    return function(_channel, _control, value, _status) {
+                        const LOGIT_RANGE = 5;
+                        deck.logits[logitKey] = (value / 127) * LOGIT_RANGE;
+                        updateStemVolumes(deck);
+                        engine.setParameter(eq_group, eq_param, value / 127);
+                    };
+                };
+                highEQInput = createSoftmaxInput("z_v", "parameter3");
+                midEQInput = createSoftmaxInput("z_m", "parameter2");
+                lowEQInput = createSoftmaxInput("z_d", "parameter1");
+                // 'stemGatedAttenuation' mode: A more complex model where knobs can attenuate their own stem or focus it while attenuating others.
+            } else if (currentEQsAs === "stemGatedAttenuation") {
+                deck.attenuation = {x_v: 0.5, x_m: 0.5, x_d: 0.5}; // Centered
+                const GAMMA = 2;
+
+                const updateStemVolumes = function(deckToUpdate) {
+                    const {x_v, x_m, x_d} = deckToUpdate.attenuation;
+                    // The knob's right side (0.5 to 1) controls focus, increasing the stem's volume relative to others.
+
+                    // --- Focus (right side: 0 → 1) ---
+                    const focus_v = Math.pow(Math.max(0, 2 * (x_v - 0.5)), GAMMA);
+                    const focus_m = Math.pow(Math.max(0, 2 * (x_m - 0.5)), GAMMA);
+                    const focus_d = Math.pow(Math.max(0, 2 * (x_d - 0.5)), GAMMA);
+
+                    // The knob's left side (0 to 0.5) controls self-attenuation, reducing the stem's own volume.
+                    // --- Self attenuation (left side) ---
+                    const self_v = 1 - Math.pow(Math.max(0, 2 * (0.5 - x_v)), GAMMA);
+                    const self_m = 1 - Math.pow(Math.max(0, 2 * (0.5 - x_m)), GAMMA);
+                    const self_d = 1 - Math.pow(Math.max(0, 2 * (0.5 - x_d)), GAMMA);
+
+                    // Calculates the final volume for each stem based on self-attenuation and the focus levels of other stems.
+                    // --- Cooperative attenuation (FIXED) ---
+                    const volumes = {
+                        v_v: self_v *
+                            (1 - focus_m * (1 - focus_v)) *
+                            (1 - focus_d * (1 - focus_v)),
+                        v_m: self_m *
+                            (1 - focus_v * (1 - focus_m)) *
+                            (1 - focus_d * (1 - focus_m)),
+                        v_d: self_d *
+                            (1 - focus_v * (1 - focus_d)) *
+                            (1 - focus_m * (1 - focus_d))
+                    };
+                    NS4FX.normalizeAndApplyStemVolumes(deckToUpdate, volumes);
+                };
+                updateStemVolumes(deck);
+
+                const createGatedAttenuationInput = function(attenuationKey, eq_param) {
+                    return function(_channel, _control, value, _status) {
+                        deck.attenuation[attenuationKey] = value / 127;
+                        updateStemVolumes(deck);
+                        engine.setParameter(eq_group, eq_param, value / 127);
+                    };
+                };
+
+                highEQInput = createGatedAttenuationInput("x_v", "parameter3");
+                midEQInput = createGatedAttenuationInput("x_m", "parameter2");
+                lowEQInput = createGatedAttenuationInput("x_d", "parameter1");
+                // 'stemTriangle' mode: A volume balancing model based on a triangular function.
+            } else if (currentEQsAs === "stemTriangle") {
+                deck.triangle = {x_v: 0.5, x_m: 0.5, x_d: 0.5}; // Centered at 0.5
+                const GAMMA = 2;
+
+                const updateStemVolumes = function(deckToUpdate) {
+                    const {x_v, x_m, x_d} = deckToUpdate.triangle;
+                    // This function processes the knob value to create a non-linear response.
+
+                    const processKnob = function(x) {
+                        const d = 2 * (x - 0.5);
+                        const a = Math.max(0, d);
+                        const r = Math.max(0, -d);
+                        return 1 + Math.pow(a, GAMMA) - Math.pow(r, GAMMA);
+                    };
+
+                    const w_v = Math.max(0, processKnob(x_v));
+                    const w_m = Math.max(0, processKnob(x_m));
+                    const w_d = Math.max(0, processKnob(x_d));
+
+                    // The denominator is the sum of all weighted volumes, used for normalization.
+                    const denominator = w_v + w_m + w_d;
+
+                    const V_v = (denominator > 0) ? w_v / denominator : 0;
+                    const V_m = (denominator > 0) ? w_m / denominator : 0;
+                    const V_d = (denominator > 0) ? w_d / denominator : 0;
+                    const volumes = {v_v: V_v, v_m: V_m, v_d: V_d};
+                    NS4FX.normalizeAndApplyStemVolumes(deckToUpdate, volumes);
+                };
+                updateStemVolumes(deck);
+
+                const createTriangleInput = function(triangleKey, eq_param) {
+                    return function(_channel, _control, value, _status) {
+                        deck.triangle[triangleKey] = value / 127;
+                        updateStemVolumes(deck);
+                        engine.setParameter(eq_group, eq_param, value / 127);
+                    };
+                };
+
+                highEQInput = createTriangleInput("x_v", "parameter3");
+                midEQInput = createTriangleInput("x_m", "parameter2");
+                lowEQInput = createTriangleInput("x_d", "parameter1");
+            }
+            // Assign the created input handlers to the EQ knob components.
+            deck.high_eq = new components.Pot({input: highEQInput});
+            deck.mid_eq = new components.Pot({input: midEQInput});
+            deck.low_eq = new components.Pot({input: lowEQInput});
+        }
+    };
 
     this.bpm = new components.Component({
         outKey: "bpm",
@@ -729,6 +977,7 @@ NS4FX.Deck = function(number, midi_chan) {
             NS4FX.sendScreenDurationMidi(number, duration * 1000);
 
             // when the duration changes, we need to update the play position
+            deck.updateEQs();
 
             deck.position.trigger();
             // When a new track loads, the hotcue_enabled states can flicker, causing the LEDs to blink.
@@ -1589,10 +1838,7 @@ NS4FX.Deck = function(number, midi_chan) {
             })
         });
 
-        const eq_group = `[EqualizerRack1_${this.currentDeck}_Effect1]`;
-        this.high_eq = new components.Pot({group: eq_group, inKey: "parameter3"});
-        this.mid_eq = new components.Pot({group: eq_group, inKey: "parameter2"});
-        this.low_eq = new components.Pot({group: eq_group, inKey: "parameter1"});
+
 
         this.filter = new components.Pot({
             group: `[QuickEffectRack1_${this.currentDeck}]`,
@@ -1614,12 +1860,19 @@ NS4FX.Deck = function(number, midi_chan) {
         this.setActive = function(active) {
             this.active = active;
 
+            if (active) {
+                deck.updateEQs();
+            }
+
             if (!active) {
                 // trigger soft takeover on the pitch control
                 this.pitch.disconnect();
             }
         };
     };
+    this.updateEQs();
+    engine.makeConnection(this.currentDeck, "track_loaded", function() { deck.updateEQs(); });
+    engine.makeConnection(this.currentDeck, "passthrough", function() { deck.updateEQs(); });
 };
 
 NS4FX.Deck.prototype = new components.Deck();


### PR DESCRIPTION
Checklist:

- [x] apply EQ stems only if a track with stems is loaded, otherwise fall back to normal EQ functions - even for PASSTHROUGH mode