### PR TITLE
build: Add --no-net to appstreamcli validate

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -80,4 +80,4 @@ jobs:
       # AppStream metadata has been generated/updated by a pre-commit hook
       - name: "Validate AppStream metadata"
         if: runner.os == 'Linux'
-        run: appstreamcli validate res/linux/org.mixxx.Mixxx.metainfo.xml
+        run: appstreamcli validate --no-net res/linux/org.mixxx.Mixxx.metainfo.xml


### PR DESCRIPTION
Fixes flakiness in the metainfo hook. The 403 Forbidden errors for https://mixxx.org/donate/ during appstreamcli validate are likely due to server-side bot protection. Adding the --no-net flag prevents these network checks during pre-commit validation. Fixes https://github.com/mixxxdj/mixxx/issues/16162