### PR TITLE
build: Update Qt policy QTP0004 to suppress deprecation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3781,11 +3781,11 @@ endif()
 if(QML)
   if(QT_KNOWN_POLICY_QTP0004)
     # See: https://doc.qt.io/qt-6/qt-cmake-policy-qtp0004.html
-    # OLD (Qt < 6.8) requires to import qml modules with a folder e.g.:
+    # OLD requires to import qml modules with a folder e.g.:
     # fragmentShader: "qrc:/shaders/rgbsignal_qml.frag.qsb"
-    # For using NEW, we need to back-port:
+    # We keep OLD for Qt < 6.8 because using NEW would require a backport:
     # https://github.com/qt/qtdeclarative/commit/6314d305ee0d9064ca848980ef2dab1793c191b8
-    # until Qt 6.8 lands in all supported distros
+    # For Qt >= 6.8, we use NEW to match current Qt behavior and suppress the deprecation warning.
     if(QT_VERSION VERSION_GREATER_EQUAL 6.8)
       qt6_policy(SET QTP0004 NEW)
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3786,7 +3786,11 @@ if(QML)
     # For using NEW, we need to back-port:
     # https://github.com/qt/qtdeclarative/commit/6314d305ee0d9064ca848980ef2dab1793c191b8
     # until Qt 6.8 lands in all supported distros
-    qt6_policy(SET QTP0004 OLD)
+    if(QT_VERSION VERSION_GREATER_EQUAL 6.8)
+      qt6_policy(SET QTP0004 NEW)
+    else()
+      qt6_policy(SET QTP0004 OLD)
+    endif()
   endif()
 
   add_subdirectory(res/shaders)


### PR DESCRIPTION
# build: Update Qt policy QTP0004 to suppress deprecation warnings

## Bug / Issue Summary

Fixes a persistent CMake deprecation warning (`Qt policy QTP0004 is set to OLD. Support for the old behavior will be removed in a future major version of Qt.`) encountered when configuring with Qt 6.8+.

Qt introduced policy `QTP0004` (originally in Qt 6.4) which controls the automatic calling of `qt_import_qml_plugins` by `qt_add_executable`. Setting this to `OLD` is now deprecated in Qt 6.8. While Mixxx previously set this to `OLD` to preserve legacy QML module folder imports (as documented in code comments), this is no longer desirable or necessary for modern Qt versions.

This PR conditionalizes the policy:
- Uses **NEW** behavior for Qt 6.8 and above to silence the deprecation warning.
- Retains **OLD** behavior for versions earlier than 6.8 to maintain compatibility for supported distributions using older Qt.

## Changes:
- `CMakeLists.txt`: Replaced the fixed `OLD` setting with a version-dependent block using `QT_VERSION VERSION_GREATER_EQUAL 6.8`.
