### PR TITLE
Backend Infrastructure for Track Linking & CMRT Caching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1399,6 +1399,7 @@ add_library(
   src/library/dao/playlistdao.cpp
   src/library/dao/settingsdao.cpp
   src/library/dao/trackdao.cpp
+  src/library/dao/tracklinkdao.cpp
   src/library/dao/trackschema.cpp
   src/library/tabledelegates/defaultdelegate.cpp
   src/library/dlgcoverartfullsize.cpp
@@ -2939,6 +2940,7 @@ if(BUILD_TESTING)
     src/test/tableview_test.cpp
     src/test/taglibtest.cpp
     src/test/trackdao_test.cpp
+    src/test/tracklinkdao_test.cpp
     src/test/trackexport_test.cpp
     src/test/trackmetadata_test.cpp
     src/test/trackmetadataexport_test.cpp

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -593,4 +593,22 @@ reapplying those migrations.
       ALTER TABLE library ADD COLUMN tuning_frequency_hz FLOAT DEFAULT 0.0;
     </sql>
   </revision>
+  <revision version="41" min_compatible="3">
+    <description>
+      Add track_links table for stem linking and future CMRT features.
+    </description>
+    <sql>
+      CREATE TABLE IF NOT EXISTS track_links (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          track_id INTEGER NOT NULL REFERENCES library(id) ON DELETE CASCADE,
+          target_track_id INTEGER NOT NULL REFERENCES library(id) ON DELETE CASCADE,
+          offset_ms REAL DEFAULT 0.0,
+          link_type INTEGER NOT NULL
+      );
+
+      -- Ensure a track isn't linked to the same target twice in the same way
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_track_links_unique
+          ON track_links(track_id, target_track_id, link_type);
+    </sql>
+  </revision>
 </schema>

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -14,7 +14,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 40;
+const int MixxxDb::kRequiredSchemaVersion = 41;
 
 namespace {
 

--- a/src/library/dao/tracklinkdao.cpp
+++ b/src/library/dao/tracklinkdao.cpp
@@ -1,0 +1,137 @@
+#include "library/dao/tracklinkdao.h"
+
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QtDebug>
+
+bool TrackLinkDao::linkTracks(TrackId trackId,
+        TrackId targetTrackId,
+        double offsetMs,
+        TrackLink::Type type) {
+    if (!trackId.isValid() || !targetTrackId.isValid()) {
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(
+            "INSERT INTO track_links (track_id, target_track_id, offset_ms, link_type) "
+            "VALUES (:track_id, :target_track_id, :offset_ms, :link_type) "
+            "ON CONFLICT(track_id, target_track_id, link_type) DO UPDATE SET "
+            "offset_ms = excluded.offset_ms");
+    query.bindValue(":track_id", trackId.toVariant());
+    query.bindValue(":target_track_id", targetTrackId.toVariant());
+    query.bindValue(":offset_ms", offsetMs);
+    query.bindValue(":link_type", static_cast<int>(type));
+
+    if (!query.exec()) {
+        qWarning() << "TrackLinkDao::linkTracks failed:" << query.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+bool TrackLinkDao::unlinkTracks(TrackId trackId,
+        TrackId targetTrackId,
+        TrackLink::Type type) {
+    if (!trackId.isValid() || !targetTrackId.isValid()) {
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(
+            "DELETE FROM track_links "
+            "WHERE track_id = :track_id AND target_track_id = :target_track_id "
+            "AND link_type = :link_type");
+    query.bindValue(":track_id", trackId.toVariant());
+    query.bindValue(":target_track_id", targetTrackId.toVariant());
+    query.bindValue(":link_type", static_cast<int>(type));
+
+    if (!query.exec()) {
+        qWarning() << "TrackLinkDao::unlinkTracks failed:" << query.lastError().text();
+        return false;
+    }
+    return true;
+}
+
+QList<TrackLink> TrackLinkDao::getLinksForTrack(TrackId trackId) {
+    QList<TrackLink> links;
+    if (!trackId.isValid()) {
+        return links;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(
+            "SELECT id, track_id, target_track_id, offset_ms, link_type "
+            "FROM track_links WHERE track_id = :track_id");
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        qWarning() << "TrackLinkDao::getLinksForTrack failed:" << query.lastError().text();
+        return links;
+    }
+
+    while (query.next()) {
+        TrackLink link;
+        link.id = query.value(0).toInt();
+        link.trackId = TrackId(query.value(1));
+        link.targetTrackId = TrackId(query.value(2));
+        link.offsetMs = query.value(3).toDouble();
+        link.type = static_cast<TrackLink::Type>(query.value(4).toInt());
+        links.append(link);
+    }
+    return links;
+}
+
+QList<TrackLink> TrackLinkDao::getLinksToTarget(TrackId targetTrackId) {
+    QList<TrackLink> links;
+    if (!targetTrackId.isValid()) {
+        return links;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(
+            "SELECT id, track_id, target_track_id, offset_ms, link_type "
+            "FROM track_links WHERE target_track_id = :target_track_id");
+    query.bindValue(":target_track_id", targetTrackId.toVariant());
+
+    if (!query.exec()) {
+        qWarning() << "TrackLinkDao::getLinksToTarget failed:" << query.lastError().text();
+        return links;
+    }
+
+    while (query.next()) {
+        TrackLink link;
+        link.id = query.value(0).toInt();
+        link.trackId = TrackId(query.value(1));
+        link.targetTrackId = TrackId(query.value(2));
+        link.offsetMs = query.value(3).toDouble();
+        link.type = static_cast<TrackLink::Type>(query.value(4).toInt());
+        links.append(link);
+    }
+    return links;
+}
+
+bool TrackLinkDao::updateOffset(TrackId trackId,
+        TrackId targetTrackId,
+        TrackLink::Type type,
+        double offsetMs) {
+    if (!trackId.isValid() || !targetTrackId.isValid()) {
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(
+            "UPDATE track_links SET offset_ms = :offset_ms "
+            "WHERE track_id = :track_id AND target_track_id = :target_track_id "
+            "AND link_type = :link_type");
+    query.bindValue(":offset_ms", offsetMs);
+    query.bindValue(":track_id", trackId.toVariant());
+    query.bindValue(":target_track_id", targetTrackId.toVariant());
+    query.bindValue(":link_type", static_cast<int>(type));
+
+    if (!query.exec()) {
+        qWarning() << "TrackLinkDao::updateOffset failed:" << query.lastError().text();
+        return false;
+    }
+    return query.numRowsAffected() > 0;
+}

--- a/src/library/dao/tracklinkdao.h
+++ b/src/library/dao/tracklinkdao.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <QList>
+
+#include "library/dao/dao.h"
+#include "track/trackid.h"
+
+class TrackLink {
+  public:
+    enum class Type {
+        Unknown = 0,
+        Stem = 1,
+        Duplicate = 2,
+        Canonical = 3,
+    };
+
+    TrackLink()
+            : id(-1),
+              trackId(TrackId()),
+              targetTrackId(TrackId()),
+              offsetMs(0.0),
+              type(Type::Unknown) {
+    }
+
+    int id;
+    TrackId trackId;
+    TrackId targetTrackId;
+    double offsetMs;
+    Type type;
+};
+
+class TrackLinkDao : public DAO {
+  public:
+    explicit TrackLinkDao() = default;
+    ~TrackLinkDao() override = default;
+
+    bool linkTracks(TrackId trackId,
+            TrackId targetTrackId,
+            double offsetMs,
+            TrackLink::Type type);
+
+    bool unlinkTracks(TrackId trackId,
+            TrackId targetTrackId,
+            TrackLink::Type type);
+
+    QList<TrackLink> getLinksForTrack(TrackId trackId);
+    QList<TrackLink> getLinksToTarget(TrackId targetTrackId);
+
+    bool updateOffset(TrackId trackId,
+            TrackId targetTrackId,
+            TrackLink::Type type,
+            double offsetMs);
+};

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -73,6 +73,7 @@ void TrackCollection::connectDatabase(const QSqlDatabase& database) {
     m_database = database;
     m_trackDao.initialize(database);
     m_playlistDao.initialize(database);
+    m_trackLinkDao.initialize(database);
     m_cueDao.initialize(database);
     m_directoryDao.initialize(database);
     m_analysisDao.initialize(database);

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -12,6 +12,7 @@
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
+#include "library/dao/tracklinkdao.h"
 #include "library/trackset/crate/cratestorage.h"
 #include "preferences/usersettings.h"
 #include "util/thread_affinity.h"
@@ -59,6 +60,10 @@ class TrackCollection : public QObject,
     PlaylistDAO& getPlaylistDAO() {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
         return m_playlistDao;
+    }
+    TrackLinkDao& getTrackLinkDAO() {
+        DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+        return m_trackLinkDao;
     }
     const DirectoryDAO& getDirectoryDAO() const {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
@@ -176,6 +181,7 @@ class TrackCollection : public QObject,
     AnalysisDao m_analysisDao;
     LibraryHashDAO m_libraryHashDao;
     TrackDAO m_trackDao;
+    TrackLinkDao m_trackLinkDao;
 
     QSharedPointer<BaseTrackCache> m_pTrackSource;
 };

--- a/src/test/tracklinkdao_test.cpp
+++ b/src/test/tracklinkdao_test.cpp
@@ -1,0 +1,104 @@
+#include "library/dao/tracklinkdao.h"
+
+#include <gtest/gtest.h>
+
+#include <QTemporaryDir>
+
+#include "library/trackcollection.h"
+#include "test/librarytest.h"
+#include "track/track.h"
+
+class TrackLinkDaoTest : public LibraryTest {
+  protected:
+    TrackLinkDao& dao() {
+        return internalCollection()->getTrackLinkDAO();
+    }
+
+    // Add a temporary track file and return its library TrackId.
+    TrackId addTrack(const QString& filename) {
+        const QString path = m_tempDir.filePath(filename);
+        // Create the file so the library accepts it.
+        QFile f(path);
+        f.open(QIODevice::WriteOnly);
+        f.close();
+        const auto pTrack = getOrAddTrackByLocation(path);
+        EXPECT_TRUE(pTrack != nullptr);
+        if (!pTrack) {
+            return TrackId{};
+        }
+        return pTrack->getId();
+    }
+
+    QTemporaryDir m_tempDir;
+};
+
+TEST_F(TrackLinkDaoTest, LinkAndGetLinks) {
+    TrackId trackId = addTrack(QStringLiteral("stem_track.stem.mp4"));
+    TrackId targetId = addTrack(QStringLiteral("source_track.flac"));
+    ASSERT_TRUE(trackId.isValid());
+    ASSERT_TRUE(targetId.isValid());
+
+    const double offset = 10.5;
+    const TrackLink::Type type = TrackLink::Type::Stem;
+
+    EXPECT_TRUE(dao().linkTracks(trackId, targetId, offset, type));
+
+    QList<TrackLink> links = dao().getLinksForTrack(trackId);
+    ASSERT_EQ(links.size(), 1);
+    EXPECT_EQ(links[0].trackId, trackId);
+    EXPECT_EQ(links[0].targetTrackId, targetId);
+    EXPECT_DOUBLE_EQ(links[0].offsetMs, offset);
+    EXPECT_EQ(links[0].type, type);
+
+    QList<TrackLink> targetLinks = dao().getLinksToTarget(targetId);
+    ASSERT_EQ(targetLinks.size(), 1);
+    EXPECT_EQ(targetLinks[0].trackId, trackId);
+}
+
+TEST_F(TrackLinkDaoTest, UpdateOffset) {
+    TrackId trackId = addTrack(QStringLiteral("stem_update.stem.mp4"));
+    TrackId targetId = addTrack(QStringLiteral("source_update.flac"));
+    ASSERT_TRUE(trackId.isValid());
+    ASSERT_TRUE(targetId.isValid());
+
+    const TrackLink::Type type = TrackLink::Type::Stem;
+
+    ASSERT_TRUE(dao().linkTracks(trackId, targetId, 10.0, type));
+    EXPECT_TRUE(dao().updateOffset(trackId, targetId, type, 20.0));
+
+    QList<TrackLink> links = dao().getLinksForTrack(trackId);
+    ASSERT_EQ(links.size(), 1);
+    EXPECT_DOUBLE_EQ(links[0].offsetMs, 20.0);
+}
+
+TEST_F(TrackLinkDaoTest, Unlink) {
+    TrackId trackId = addTrack(QStringLiteral("stem_unlink.stem.mp4"));
+    TrackId targetId = addTrack(QStringLiteral("source_unlink.flac"));
+    ASSERT_TRUE(trackId.isValid());
+    ASSERT_TRUE(targetId.isValid());
+
+    const TrackLink::Type type = TrackLink::Type::Stem;
+
+    ASSERT_TRUE(dao().linkTracks(trackId, targetId, 10.0, type));
+    EXPECT_TRUE(dao().unlinkTracks(trackId, targetId, type));
+
+    QList<TrackLink> links = dao().getLinksForTrack(trackId);
+    EXPECT_EQ(links.size(), 0);
+}
+
+TEST_F(TrackLinkDaoTest, DuplicateLinkUpsert) {
+    TrackId trackId = addTrack(QStringLiteral("stem_upsert.stem.mp4"));
+    TrackId targetId = addTrack(QStringLiteral("source_upsert.flac"));
+    ASSERT_TRUE(trackId.isValid());
+    ASSERT_TRUE(targetId.isValid());
+
+    const TrackLink::Type type = TrackLink::Type::Stem;
+
+    EXPECT_TRUE(dao().linkTracks(trackId, targetId, 10.0, type));
+    // Upsert: linking again should update the offset.
+    EXPECT_TRUE(dao().linkTracks(trackId, targetId, 30.0, type));
+
+    QList<TrackLink> links = dao().getLinksForTrack(trackId);
+    ASSERT_EQ(links.size(), 1);
+    EXPECT_DOUBLE_EQ(links[0].offsetMs, 30.0);
+}


### PR DESCRIPTION
# PR Title: Backend Infrastructure for Track Linking & CMRT Caching

## Summary

This PR establishes the core database schema and DAO (Data Access Object) to store time-offset relationships between tracks. 

This was originally conceived as the backend for a manual stem-linking UI (Issue #14758). However, following discussions with the team about the upcoming **CMRT (Canonical Master Release Track)** project, manual linking is expected to be superseded by automatic linking.

This generic `track_links` table is still necessary logic. It serves as a **highly efficient caching layer**. When CMRT identifies a Stem track and calculates its sub-millisecond offset from the original lossless track (using the 5th mastering channel), that relationship will be cached here. This prevents Mixxx from having to re-fingerprint and recalculate offsets on every load.

It supports:
1. **Stem-to-Source links** (Stems phase)
2. **Duplicate track links** (CMRT phase)
3. **Canonical track links** (CMRT phase)

## Technical Changes

- **Database Schema (Revision 41)**: Added `track_links` table with foreign key constraints, `ON DELETE CASCADE`, and a unique index on `(track_id, target_track_id, link_type)`.
- **MixxxDb**: Bumped `kRequiredSchemaVersion` to `41` to enable the table on migration.
- **TrackLinkDao**: Implemented CRUD operations for track links, including an upsert method `linkTracks()` to safely handle re-linking.
- **TrackCollection**: Integrated the new DAO into the library storage engine.
- **Testing**: Added `src/test/tracklinkdao_test.cpp` with 100% pass rate for core link operations.

## GUI Changes

*This is a backend-only PR. It operates entirely as an infrastructure and caching layer.*

## Verification

- **Unit Tests**: Ran `ctest -R TrackLinkDao` - All tests passed successfully.
- **Database Inspection**: Verified schema migration to version 41 in a fresh local library database.

## Approach Forward

- **Manual Linking UI**: Scrapped per team alignment.
- **Next Steps**: Focus shifts to reading the 5th channel of Stem files to generate full-track Chromaprint fingerprints automatically, laying the foundation for CMRT integration.

## Additions to SQLite Schema
<img width="1470" height="129" alt="Screenshot 2026-04-06 at 7 32 31 PM" src="https://github.com/user-attachments/assets/88ca5590-3ac9-4592-9e51-519c9be627e6" />
<img width="1470" height="82" alt="Screenshot 2026-04-06 at 7 32 48 PM" src="https://github.com/user-attachments/assets/82b385b7-5c5b-46cd-a287-b4c77ebaff6d" />

