### PR TITLE
EffectsBackend: fix crash when AU manifest loading times out

### DIFF
--- a/src/effects/backends/audiounit/audiounitbackend.mm
+++ b/src/effects/backends/audiounit/audiounitbackend.mm
@@ -33,20 +33,22 @@ class AudioUnitBackend : public EffectsBackend {
     };
 
     const QList<QString> getEffectIds() const override {
-        QList<QString> effectIds;
-
-        for (NSString* effectId in m_componentsById) {
-            effectIds.append(QString::fromNSString(effectId));
-        }
-
-        return effectIds;
+        // Only report effects whose manifest actually finished loading.
+        // If loadAudioUnitsOfType() timed out, some components in
+        // m_componentsById may not have a corresponding manifest yet, and
+        // callers would get a null EffectManifestPointer from getManifest(),
+        // which crashes downstream (e.g. EffectManifest::sortLexigraphically).
+        auto locker = lockMutex(&m_mutex);
+        return m_manifestsById.keys();
     }
 
     EffectManifestPointer getManifest(const QString& effectId) const override {
-        return m_manifestsById[effectId];
+        auto locker = lockMutex(&m_mutex);
+        return m_manifestsById.value(effectId);
     }
 
     const QList<EffectManifestPointer> getManifests() const override {
+        auto locker = lockMutex(&m_mutex);
         return m_manifestsById.values();
     }
 
@@ -64,7 +66,7 @@ class AudioUnitBackend : public EffectsBackend {
   private:
     NSMutableDictionary<NSString*, AVAudioUnitComponent*>* m_componentsById;
     QHash<QString, EffectManifestPointer> m_manifestsById;
-    QMutex m_mutex;
+    mutable QMutex m_mutex;
 
     void loadAudioUnits() {
         qDebug() << "Loading audio units...";

--- a/src/effects/backends/effectmanifest.cpp
+++ b/src/effects/backends/effectmanifest.cpp
@@ -16,6 +16,15 @@ bool EffectManifest::hasMetaKnobLinking() const {
 
 bool EffectManifest::sortLexigraphically(
         EffectManifestPointer pManifest1, EffectManifestPointer pManifest2) {
+    // Defensive: null manifests sort to the end. A backend whose async
+    // manifest loading times out may briefly expose null entries; crashing
+    // std::sort on them is worse than a transiently misordered list.
+    if (!pManifest1) {
+        return false;
+    }
+    if (!pManifest2) {
+        return true;
+    }
     // Sort built-in effects first before external plugins
     int backendNameComparision = static_cast<int>(pManifest1->backendType()) -
             static_cast<int>(pManifest2->backendType());

--- a/src/effects/backends/effectmanifest.cpp
+++ b/src/effects/backends/effectmanifest.cpp
@@ -16,13 +16,13 @@ bool EffectManifest::hasMetaKnobLinking() const {
 
 bool EffectManifest::sortLexigraphically(
         EffectManifestPointer pManifest1, EffectManifestPointer pManifest2) {
-    // Defensive: null manifests sort to the end. A backend whose async
-    // manifest loading times out may briefly expose null entries; crashing
-    // std::sort on them is worse than a transiently misordered list.
-    if (!pManifest1) {
+    // Defensive: null manifests should no longer occur here, but
+    // this check is retained to prevent std::sort from crashing if an
+    // unexpected null pointer ever reaches this comparator. Nulls sort to the end.
+    VERIFY_OR_DEBUG_ASSERT(pManifest1) {
         return false;
     }
-    if (!pManifest2) {
+    VERIFY_OR_DEBUG_ASSERT(pManifest2) {
         return true;
     }
     // Sort built-in effects first before external plugins


### PR DESCRIPTION
AudioUnitBackend loads manifests asynchronously via dispatch_group_async with a 6-second timeout. If the timeout fires, m_manifestsById is only partially populated, but getEffectIds() was iterating m_componentsById (populated synchronously for every discovered AU). Callers would then receive null EffectManifestPointers from getManifest(), and the next std::sort on the combined manifest list would dereference null in EffectManifest::sortLexigraphically and segfault.

Fix:
- AudioUnitBackend::getEffectIds() now returns keys from m_manifestsById so only fully loaded manifests are reported. The three map accessors also take m_mutex (now mutable) to stop racing the loader threads.
- EffectManifest::sortLexigraphically null-checks both arguments as defensive insurance for any other backend that might expose a null.