### PR TITLE
packaging/macos: entitlements to actually load third-party Audio Units

### DIFF
--- a/packaging/macos/Mixxx.entitlements
+++ b/packaging/macos/Mixxx.entitlements
@@ -51,5 +51,25 @@
       -->
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <!-- Allow loading Audio Unit plugins signed by third parties
+         Audio Unit v2 plugins are loaded in-process as dylibs. Under the
+         hardened runtime, macOS' library validation refuses to load dylibs
+         signed by any team other than Mixxx's own, so without this entitlement
+         every third-party AU (e.g. Universal Audio, iZotope, FabFilter, etc.)
+         fails to instantiate and the user sees "you must lower your security
+         preferences to use Audio Units" — which is misleading, since the
+         restriction comes from the app's own entitlements, not system SIP or
+         Gatekeeper.
+      -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <!-- App Sandbox temporary exception: host Audio Unit plugins
+         Sandboxed apps cannot host arbitrary Audio Units by default. This
+         temporary exception permits AU hosting; without it, AU enumeration
+         may succeed via AVAudioUnitComponentManager but instantiation is
+         silently blocked by the sandbox.
+      -->
+    <key>com.apple.security.temporary-exception.audio-unit-host</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
Mixxx ships with the hardened runtime enabled and the App Sandbox entitlement set, but without the two entitlements required to actually host third-party Audio Unit plugins:

1. com.apple.security.cs.disable-library-validation AU v2 plugins are loaded in-process as dylibs. Hardened runtime's library validation refuses to load any dylib not signed by the same team as the host app, so every third-party AU (Universal Audio, iZotope, FabFilter, etc.) fails to load. The error surfaces to the user as "you must lower your security preferences to use Audio Units", which is misleading — the restriction is enforced by AMFI based on the app's own entitlements and is independent of SIP, Gatekeeper, or csrutil status.

2. com.apple.security.temporary-exception.audio-unit-host App Sandbox blocks AU hosting by default. Plugins may enumerate via AVAudioUnitComponentManager but instantiation is blocked without this temporary exception.

Both are standard entitlements for DAWs and other AU hosts on macOS.