### PR TITLE
(fix) Library scanner: allow resuming canceled scan by clearing hashes of unfinished dirs

### DIFF
--- a/src/library/dao/libraryhashdao.cpp
+++ b/src/library/dao/libraryhashdao.cpp
@@ -101,6 +101,26 @@ void LibraryHashDAO::updateDirectoryHash(const QString& dirPath,
     //qDebug() << getDirectoryHash(dirPath);
 }
 
+void LibraryHashDAO::clearDirectoryHash(const QString& dirPath) {
+    // qDebug() << "LibraryHashDAO::clearDirectoryHash" <<
+    // QThread::currentThread() << m_database.connectionName();
+    QSqlQuery query(m_database);
+    query.prepare(
+            "UPDATE LibraryHashes "
+            "SET hash=:hash, needs_verification=1 "
+            "WHERE directory_path=:directory_path");
+    query.bindValue(":directory_path", dirPath);
+    query.bindValue(":hash", mixxx::invalidCacheKey());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "Clearing existing dirhash for" << dirPath << "failed.";
+    }
+    // qDebug() << "cleared existing hash for" << dirPath;
+
+    // DEBUG: Print out the directory hash we just saved to verify...
+    // qDebug() << "--> test hash:" << getDirectoryHash(dirPath);
+}
+
 void LibraryHashDAO::updateDirectoryStatuses(const QStringList& dirPaths,
                                              const bool deleted,
                                              const bool verified) {

--- a/src/library/dao/libraryhashdao.h
+++ b/src/library/dao/libraryhashdao.h
@@ -16,6 +16,7 @@ class LibraryHashDAO : public DAO {
     void saveDirectoryHash(const QString& dirPath, mixxx::cache_key_t hash);
     void updateDirectoryHash(const QString& dirPath, mixxx::cache_key_t newHash,
                              int dir_deleted);
+    void clearDirectoryHash(const QString& dirPath);
     void markAsExisting(const QString& dirPath);
     void invalidateAllDirectories();
     void markUnverifiedDirectoriesAsDeleted();

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -187,6 +187,7 @@ void LibraryScanner::slotStartScan() {
     kLogger.debug() << "slotStartScan()";
     DEBUG_ASSERT(m_state == STARTING);
 
+    m_canceled = false;
     cleanUpDatabase(m_libraryHashDao.database());
 
     // Recursively scan each directory in the directories table.
@@ -478,7 +479,7 @@ void LibraryScanner::cancelAndQuit() {
 void LibraryScanner::cancel() {
     DEBUG_ASSERT(m_state == CANCELING);
 
-
+    m_canceled = true;
     // we need to make a local copy because cancel is called
     // from any thread but m_scannerGlobal may be cleared
     // in the LibraryScanner thread in the meanwhile
@@ -540,8 +541,23 @@ void LibraryScanner::queueTask(ScannerTask* pTask) {
 void LibraryScanner::slotDirectoryHashedAndScanned(const QString& directoryPath,
                                                bool newDirectory, mixxx::cache_key_t hash) {
     ScopedTimer timer(u"LibraryScanner::slotDirectoryHashedAndScanned");
-    //kLogger.debug() << "sloDirectoryHashedAndScanned" << directoryPath
-    //          << newDirectory << hash;
+    // kLogger.debug() << "sloDirectoryHashedAndScanned" << directoryPath
+    //           << newDirectory << hash;
+    // Don't write dir hashes after the scan has been canceled!
+    // Reason: after canceling we may still receive signals from ImportFilesTask,
+    // eg. addNewTrack() and directoryHashedAndScanned(). However, canceled
+    // means we probably didn't add all tracks. In order to allow "resuming"
+    // the incomplete scan of this directory, we need to keep the old hash
+    // (see slotAddNewTrack) and prevent the directoryHashedAndScanned() signal
+    // from undoing this (what we'd do in this slot by saving a valid hash).
+
+    if (!m_scannerGlobal || m_scannerGlobal->shouldCancel()) {
+        kLogger.warning() << "--> should cancel --> clear hash for" << directoryPath;
+        // Clearing the hash is not strictly required but let's keep it as
+        // safety net in case signals get mixed up?
+        m_libraryHashDao.clearDirectoryHash(directoryPath);
+        return;
+    }
 
     // For statistics tracking -- if we hashed a directory then we scanned it
     // (it was changed or new).

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -120,4 +120,6 @@ class LibraryScanner : public QThread {
 
     QList<mixxx::FileInfo> m_libraryRootDirs;
     QScopedPointer<LibraryScannerDlg> m_pProgressDlg;
+
+    bool m_canceled;
 };


### PR DESCRIPTION
Fixes #16198, a regression from #15320

### The issue:
When canceling a scan, the slot receiving the queued `addNewTrack()` signals just returns.
-> remaining tracks are not added
Though, `ImportFilesTask` also queues a `directoryHashedAndScanned()` signal (after `addNewTrack()`) which makes `LibraryScanner::slotDirectoryHashedAndScanned()` write the new dir hash to the db.
-> on next scan, the dir is considered "clean"/scanned/up-to-date
-> remaining tracks are not added

### Fix:
Like in `slotAddNewTrack()`, reject the dir hash in `slotDirectoryHashedAndScanned()` and clear it instead (just to be safe)
-> a new scan while scan the dir and queue all new tracks
____
### Note1
I didn't test if upgrading (to 2.6) invalidates the hashes and makes the remaining tracks dicoverable.
If not, we should also add such a hash reset function so users don't get stuck with missing tracks forever.
____
### Note2
Please test this thoroughly.
I have an additional / alternative fix ready, just in case something slips through (signals not queued as expected, idk :man_shrugging: )