### PR TITLE
fix(QML): Remove unused QtQuick.Dialogs import breaking Windows builds

### DIFF
--- a/res/qml/Settings/Interface.qml
+++ b/res/qml/Settings/Interface.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
-import QtQuick.Dialogs
 import Qt5Compat.GraphicalEffects
 import Mixxx 1.0 as Mixxx
 import "." as Setting


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR fixes a critical Windows startup crash when launching with `--new-ui`.

A recent PR (#14887) introduced `res/qml/Settings/Interface.qml` which contained an unused `import QtQuick.Dialogs`. Because the Dialogs module is not actually utilized anywhere in the QML or C++ codebase, `windeployqt` correctly omits the heavyweight `qtquickdialogsplugin.dll` from the Windows portable build bundle. 

However, the QML engine blindly attempts to resolve the module upon initialization, failing with a fatal `Module not found` error on Windows. Removing this dangling import restores Windows compatibility.

*(Note: This was identified while debugging failures in #15380. See [this comment](https://github.com/mixxxdj/mixxx/pull/15380#issuecomment-4216443650) for context).*