### PR TITLE
avoid corrupting WaveformMarkSet

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -283,6 +283,8 @@ void allshader::WaveformRenderMark::update() {
         return;
     }
 
+    m_marks.updateSafe();
+
     // For each WaveformMark we create a GeometryNode with Texture
     // (in updateMarkImage). Of these GeometryNodes, we append the
     // the ones that need to be shown on screen as children to

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -134,6 +134,8 @@ void WaveformMarkSet::update() {
             }
         }
     }
+    
+    const auto locker = lockMutex(&m_mutex);
 
     m_marksToRender.clear();
     m_marksToRender.reserve(static_cast<QList<WaveformMarkPointer>::size_type>(map.size()));
@@ -155,6 +157,11 @@ void WaveformMarkSet::update() {
         }
         pMark->setLevel(levels[pMark->m_align]++);
     }
+}
+
+void WaveformMarkSet::updateSafe() {
+    const auto locker = lockMutex(&m_mutex);
+    m_marksToRenderSafe = m_marksToRender;
 }
 
 WaveformMarkPointer WaveformMarkSet::findHoveredMark(

--- a/src/waveform/renderers/waveformmarkset.h
+++ b/src/waveform/renderers/waveformmarkset.h
@@ -61,16 +61,16 @@ class WaveformMarkSet {
     }
 
     inline QList<WaveformMarkPointer>::const_iterator begin() const {
-        return m_marksToRender.begin();
+        return m_marksToRenderSafe.begin();
     }
     inline QList<WaveformMarkPointer>::const_iterator end() const {
-        return m_marksToRender.end();
+        return m_marksToRenderSafe.end();
     }
     inline QList<WaveformMarkPointer>::const_iterator cbegin() const {
-        return m_marksToRender.cbegin();
+        return m_marksToRenderSafe.cbegin();
     }
     inline QList<WaveformMarkPointer>::const_iterator cend() const {
-        return m_marksToRender.cend();
+        return m_marksToRenderSafe.cend();
     }
 
     // hotCue must be valid (>= 0 and < kMaxNumberOfHotcues)
@@ -80,10 +80,13 @@ class WaveformMarkSet {
 
     void update();
 
+    void updateSafe();
+
     void setBreadth(float breadth);
 
     void clear() {
         m_marks.clear();
+        const auto locker = lockMutex(&m_mutex);
         m_marksToRender.clear();
     }
 
@@ -98,8 +101,12 @@ class WaveformMarkSet {
   private:
     WaveformMarkPointer m_pDefaultMark;
     QList<WaveformMarkPointer> m_marks;
+
+    QMutex m_mutex;
     // List of visible WaveformMarks sorted by the order they appear in the track
     QList<WaveformMarkPointer> m_marksToRender;
+    // Copy of m_marksToRender, guaranteed to not change during rendering
+    QList<WaveformMarkPointer> m_marksToRenderSafe;
 
     QMap<int, WaveformMarkPointer> m_hotCueMarks;
 

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -28,6 +28,8 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
     painter->setWorldMatrixEnabled(false);
 
+    m_marks.updateSafe();
+
     for (const auto& pMark : std::as_const(m_marks)) {
         const QImage& image = static_cast<ImageGraphics*>(pMark->m_pGraphics.get())->image();
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -726,6 +726,8 @@ void WOverview::paintEvent(QPaintEvent* pEvent) {
             const float offset = 1.0f;
             const auto gain = static_cast<CSAMPLE_GAIN>(length() - 2) /
                     static_cast<CSAMPLE_GAIN>(trackSamples);
+    
+            m_marks.updateSafe();
 
             drawRangeMarks(&painter, offset, gain);
             drawMarks(&painter, offset, gain);


### PR DESCRIPTION
Analyzing https://github.com/mixxxdj/mixxx/issues/15954 , my suspicion is that the problem lies in modifying the `WaveformMarkSet` member `QList<WaveformMarkPointer> m_marksToRender;` while it is being iterated. I don't think that @acolombier suspicion about "to send to a slot... which may have just been deleted" is actually the case: `WaveformMarkSet::update()` does not actually delete anything.

This fix protects `m_marksToRender` with a mutex. A function `updateSafe()` makes a copy (also protected by the mutex) to `m_marksToRenderSafe`, which is in turn used for the iteration (through `WaveformMarkSet::begin()` e.a.) during rendering.

Note that this is purely based on reading the code and having a strong suspicion of what is going on; I have not been able to reproduce this as I don't have an s4 and couldn't figure out how to emulate controller screens in software.
