### PR TITLE
Overview + Spinny TRACE mouse move events

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -513,6 +513,7 @@ void WOverview::receiveCuesUpdated() {
 
 void WOverview::mouseMoveEvent(QMouseEvent* e) {
     if (m_bLeftClickDragging) {
+        qWarning() << "WOverview::mouseMoveEvent -> m_bLeftClickDragging" << e->pos();
         if (isPosInAllowedPosDragZone(e->pos())) {
             m_bTimeRulerActive = true;
             m_timeRulerPos = e->pos();
@@ -535,6 +536,8 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
         } else {
             m_iPickupPos = math_clamp(e->pos().y(), 0, height() - 1);
         }
+    } else {
+        qWarning() << "WOverview::mouseMoveEvent -> no button or right button" << e->pos();
     }
 
     // Do not activate cue hovering while right click is held down and the
@@ -555,6 +558,7 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
 }
 
 void WOverview::mouseReleaseEvent(QMouseEvent* e) {
+    qWarning() << "WOverview::mouseReleaseEvent";
     mouseMoveEvent(e);
     if (m_bPassthroughEnabled) {
         m_bLeftClickDragging = false;
@@ -590,7 +594,7 @@ void WOverview::mouseReleaseEvent(QMouseEvent* e) {
 }
 
 void WOverview::mousePressEvent(QMouseEvent* e) {
-    //qDebug() << "WOverview::mousePressEvent" << e->pos();
+    qWarning() << "WOverview::mousePressEvent" << e->pos();
     mouseMoveEvent(e);
     if (m_bPassthroughEnabled) {
         m_bLeftClickDragging = false;
@@ -668,6 +672,7 @@ void WOverview::slotCueMenuPopupAboutToHide() {
 }
 
 void WOverview::leaveEvent(QEvent* pEvent) {
+    qWarning() << "WOverview --> LEAVE";
     Q_UNUSED(pEvent);
     if (!m_pCueMenuPopup->isVisible()) {
         m_pHoveredMark.clear();

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -2,6 +2,7 @@
 
 #include <QBrush>
 #include <QColor>
+#include <QGuiApplication>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
@@ -691,6 +692,16 @@ void WOverview::leaveEvent(QEvent* pEvent) {
     if (!m_pCueMenuPopup->isVisible()) {
         m_pHoveredMark.clear();
     }
+    // Reset our dragging only if the left button is not pressed.
+    // With Qt 6.5x and newer (TODO verify) leaveEvents are also emitted when
+    // we hover a widget that has setAcceptDrops(true) -- even if we explicitly
+    // setMouseTracking(true). That's why we may get two or more leave events
+    // when hovering WSpinny(Base) for example: 1st when we enter the spinny,
+    // 2nd when we release the mouse (anywhere)
+    if (QGuiApplication::mouseButtons() & Qt::LeftButton) {
+        return;
+    }
+
     m_bLeftClickDragging = false;
     m_bTimeRulerActive = false;
     update();

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -558,7 +558,21 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
 }
 
 void WOverview::mouseReleaseEvent(QMouseEvent* e) {
-    qWarning() << "WOverview::mouseReleaseEvent";
+    qWarning() << "WOverview::mouseReleaseEvent" << e->pos() << e->button();
+    if (e->button() == Qt::NoButton) {
+        qWarning() << "--> ! no button, synth new event";
+        e = new QMouseEvent(e->type(),
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+                e->pos(),
+                e->globalPosition(),
+#else
+                e->position(),
+                e->globalPosition(),
+#endif
+                Qt::LeftButton,
+                Qt::MouseButtons{Qt::LeftButton},
+                Qt::NoModifier);
+    }
     mouseMoveEvent(e);
     if (m_bPassthroughEnabled) {
         m_bLeftClickDragging = false;

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -11,6 +11,9 @@ WSpinny::WSpinny(
         VinylControlManager* pVCMan,
         BaseTrackPlayer* pPlayer)
         : WSpinnyBase(pParent, group, pConfig, pVCMan, pPlayer) {
+    qWarning() << ".";
+    qWarning() << ". WSpinny" << group;
+    qWarning() << ".";
 }
 
 void WSpinny::draw() {

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -490,6 +490,7 @@ void WSpinnyBase::updateSlipEnabled(double enabled) {
 }
 
 void WSpinnyBase::mouseMoveEvent(QMouseEvent* e) {
+    qWarning() << "WSpinnyBase::mouseMoveEvent";
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     int y = static_cast<int>(e->position().y());
     int x = static_cast<int>(e->position().x());
@@ -627,6 +628,7 @@ void WSpinnyBase::hideEvent(QHideEvent* event) {
 }
 
 bool WSpinnyBase::event(QEvent* pEvent) {
+    qWarning() << "WSpinnyBase  event:" << pEvent;
     if (pEvent->type() == QEvent::ToolTip) {
         updateTooltip();
     }


### PR DESCRIPTION
adds some qwarnings to WOverview and WSpinnybase in order to debug #16306

It can certainly be that the OpenGL spinny (now default when being built with QOPENGL flag) has issues passing events to the base class (WSpinnyBase) -- but with `--enable-legacy-spinny` -> using legacy QWidget-based WSpinny it should just work.

So, for testing:
get the build of this PR from ...
0. first run Mixxx with default flags (none, unless you want to point it to a certain settings dir for example)
1. use LateNight, enable big spinnies, load a track
2. in the overview, move the play pos to the middle of the track
3. try to drag the overview's play position left outside the overview, hovering the spinny
(don't go too far, you should not see the 'Forbidden' cursor)
-> does the play pos snap to 0 (track start)?
or do you see the same behavior as in the screencast in #16306?

If you see the same buggy behavior, start Mixxx from the command line with `--enable-legacy-spinny`.
repeat 1. - 3., does dragging work as expected?

Please leave a comment with
* result summary
* your operating system + version
* your Qt version

Thank you!