### PR TITLE
Fix flaky test ControllerScriptEngineLegacyTimerTest.beginTimer_repeatedTimer

### DIFF
--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -70,18 +70,18 @@ class ControllerScriptEngineLegacyTest : public MixxxTest {
 
 class ControllerScriptEngineLegacyTimerTest : public ControllerScriptEngineLegacyTest {
   protected:
-    std::unique_ptr<ControlPotmeter> co;
-    std::unique_ptr<ControlPotmeter> coTimerId;
+    std::unique_ptr<ControlPotmeter> m_pCo;
+    std::unique_ptr<ControlPotmeter> m_pCoTimerId;
 
     void SetUp() override {
         ControllerScriptEngineLegacyTest::SetUp();
-        co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"), -10.0, 10.0);
-        co->setParameter(0.0);
-        coTimerId = std::make_unique<ControlPotmeter>(
+        m_pCo = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"), -10.0, 10.0);
+        m_pCo->setParameter(0.0);
+        m_pCoTimerId = std::make_unique<ControlPotmeter>(
                 ConfigKey("[Test]", "coTimerId"), -10.0, 50.0);
-        coTimerId->setParameter(0.0);
+        m_pCoTimerId->setParameter(0.0);
         EXPECT_TRUE(evaluateAndAssert("engine.setValue('[Test]', 'co', 0.0);"));
-        EXPECT_DOUBLE_EQ(0.0, co->get());
+        EXPECT_DOUBLE_EQ(0.0, m_pCo->get());
     }
 };
 TEST_F(ControllerScriptEngineLegacyTest, commonScriptHasNoErrors) {
@@ -640,7 +640,7 @@ TEST_F(ControllerScriptEngineLegacyTest, connectionExecutesWithCorrectThisObject
 TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_repeatedTimer) {
     EXPECT_TRUE(evaluateAndAssert(
             "engine.setValue('[Test]', 'co', 0.0);"));
-    EXPECT_DOUBLE_EQ(0.0, co->get());
+    EXPECT_DOUBLE_EQ(0.0, m_pCo->get());
 
     EXPECT_TRUE(
             evaluateAndAssert(R"(engine.beginTimer(50, function() {
@@ -649,23 +649,23 @@ TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_repeatedTimer) {
                                     engine.setValue('[Test]', 'co', x);
                                  }, false);)"));
     processEvents();
-    EXPECT_DOUBLE_EQ(0.0, co->get());
+    EXPECT_DOUBLE_EQ(0.0, m_pCo->get());
 
     cEngine->thread()->msleep(70);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(1.0, co->get());
+    EXPECT_DOUBLE_EQ(1.0, m_pCo->get());
 
     cEngine->thread()->msleep(140);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(2.0, co->get());
+    EXPECT_DOUBLE_EQ(2.0, m_pCo->get());
 }
 
 TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimer) {
     EXPECT_TRUE(evaluateAndAssert(
             "engine.setValue('[Test]', 'co', 0.0);"));
-    EXPECT_DOUBLE_EQ(0.0, co->get());
+    EXPECT_DOUBLE_EQ(0.0, m_pCo->get());
 
     // Single shot timer with minimum allowed interval of 20ms
     EXPECT_TRUE(evaluateAndAssert(
@@ -673,12 +673,12 @@ TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimer) {
                    engine.setValue('[Test]', 'co', 1.0);
                }, true);)"));
     processEvents();
-    EXPECT_DOUBLE_EQ(0.0, co->get());
+    EXPECT_DOUBLE_EQ(0.0, m_pCo->get());
 
     cEngine->thread()->msleep(35);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(1.0, co->get());
+    EXPECT_DOUBLE_EQ(1.0, m_pCo->get());
 }
 
 TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimerBindFunction) {
@@ -692,19 +692,19 @@ TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimerBindFunc
             }.bind(this), true);            
             engine.setValue('[Test]', 'coTimerId', timerId);)"));
     processEvents();
-    EXPECT_DOUBLE_EQ(0.0, co->get());
-    double timerId = coTimerId->get();
+    EXPECT_DOUBLE_EQ(0.0, m_pCo->get());
+    double timerId = m_pCoTimerId->get();
     EXPECT_TRUE(timerId > 0);
 
     cEngine->thread()->msleep(35);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(timerId + 10, coTimerId->get());
-    EXPECT_DOUBLE_EQ(7.0, co->get());
+    EXPECT_DOUBLE_EQ(timerId + 10, m_pCoTimerId->get());
+    EXPECT_DOUBLE_EQ(7.0, m_pCo->get());
     EXPECT_TRUE(evaluateAndAssert("engine.setValue('[Test]', 'co', this.globVar);"));
     processEvents();
 
-    EXPECT_DOUBLE_EQ(8.0, co->get());
+    EXPECT_DOUBLE_EQ(8.0, m_pCo->get());
 }
 
 TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimerArrowFunction) {
@@ -718,19 +718,19 @@ TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimerArrowFun
             }, true);            
             engine.setValue('[Test]', 'coTimerId', timerId);)"));
     processEvents();
-    EXPECT_DOUBLE_EQ(0.0, co->get());
-    double timerId = coTimerId->get();
+    EXPECT_DOUBLE_EQ(0.0, m_pCo->get());
+    double timerId = m_pCoTimerId->get();
     EXPECT_TRUE(timerId > 0);
 
     cEngine->thread()->msleep(35);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(timerId + 10, coTimerId->get());
-    EXPECT_DOUBLE_EQ(7.0, co->get());
+    EXPECT_DOUBLE_EQ(timerId + 10, m_pCoTimerId->get());
+    EXPECT_DOUBLE_EQ(7.0, m_pCo->get());
     EXPECT_TRUE(evaluateAndAssert("engine.setValue('[Test]', 'co', this.globVar);"));
     processEvents();
 
-    EXPECT_DOUBLE_EQ(8.0, co->get());
+    EXPECT_DOUBLE_EQ(8.0, m_pCo->get());
 }
 
 TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimerBindFunctionInClass) {
@@ -754,19 +754,19 @@ TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimerBindFunc
             var MyMapping = new MyClass();
             MyMapping.runTimer();)"));
     processEvents();
-    EXPECT_DOUBLE_EQ(0.0, co->get());
-    double timerId = coTimerId->get();
+    EXPECT_DOUBLE_EQ(0.0, m_pCo->get());
+    double timerId = m_pCoTimerId->get();
     EXPECT_TRUE(timerId > 0);
 
     cEngine->thread()->msleep(35);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(timerId + 10, coTimerId->get());
-    EXPECT_DOUBLE_EQ(7.0, co->get());
+    EXPECT_DOUBLE_EQ(timerId + 10, m_pCoTimerId->get());
+    EXPECT_DOUBLE_EQ(7.0, m_pCo->get());
     EXPECT_TRUE(evaluateAndAssert("engine.setValue('[Test]', 'co', MyMapping.globVar);"));
     processEvents();
 
-    EXPECT_DOUBLE_EQ(8.0, co->get());
+    EXPECT_DOUBLE_EQ(8.0, m_pCo->get());
 }
 
 TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimerArrowFunctionInClass) {
@@ -792,19 +792,19 @@ TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimerArrowFun
             var MyMapping = new MyClass();
             MyMapping.runTimer();)"));
     processEvents();
-    EXPECT_DOUBLE_EQ(0.0, co->get());
-    double timerId = coTimerId->get();
+    EXPECT_DOUBLE_EQ(0.0, m_pCo->get());
+    double timerId = m_pCoTimerId->get();
     EXPECT_TRUE(timerId > 0);
 
     cEngine->thread()->msleep(35);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(timerId + 10, coTimerId->get());
-    EXPECT_DOUBLE_EQ(7.0, co->get());
+    EXPECT_DOUBLE_EQ(timerId + 10, m_pCoTimerId->get());
+    EXPECT_DOUBLE_EQ(7.0, m_pCo->get());
     EXPECT_TRUE(evaluateAndAssert("engine.setValue('[Test]', 'co', MyMapping.globVar);"));
     processEvents();
 
-    EXPECT_DOUBLE_EQ(8.0, co->get());
+    EXPECT_DOUBLE_EQ(8.0, m_pCo->get());
 }
 
 TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_repeatedTimerArrowFunctionCallInClass) {
@@ -831,19 +831,19 @@ TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_repeatedTimerArrowFunct
             var MyMapping = new MyClass();
             MyMapping.runTimer();)"));
     processEvents();
-    EXPECT_DOUBLE_EQ(7.0, co->get());
-    double timerId = coTimerId->get();
+    EXPECT_DOUBLE_EQ(7.0, m_pCo->get());
+    double timerId = m_pCoTimerId->get();
     EXPECT_TRUE(timerId > 0);
 
     cEngine->thread()->msleep(35);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(20, coTimerId->get());
+    EXPECT_DOUBLE_EQ(20, m_pCoTimerId->get());
 
     cEngine->thread()->msleep(35);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(20, coTimerId->get());
+    EXPECT_DOUBLE_EQ(20, m_pCoTimerId->get());
 }
 TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_repeatedTimerThisFunctionCallInClass) {
     // Single shot timer with minimum allowed interval of 20ms
@@ -869,17 +869,17 @@ TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_repeatedTimerThisFuncti
             var MyMapping = new MyClass();
             MyMapping.runTimer();)"));
     processEvents();
-    EXPECT_DOUBLE_EQ(7.0, co->get());
-    double timerId = coTimerId->get();
+    EXPECT_DOUBLE_EQ(7.0, m_pCo->get());
+    double timerId = m_pCoTimerId->get();
     EXPECT_TRUE(timerId > 0);
 
     cEngine->thread()->msleep(35);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(20, coTimerId->get());
+    EXPECT_DOUBLE_EQ(20, m_pCoTimerId->get());
 
     cEngine->thread()->msleep(35);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(20, coTimerId->get());
+    EXPECT_DOUBLE_EQ(20, m_pCoTimerId->get());
 }

--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -654,12 +654,12 @@ TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_repeatedTimer) {
     cEngine->thread()->msleep(70);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(1.0, m_pCo->get());
+    EXPECT_LE(1.0, m_pCo->get());
 
     cEngine->thread()->msleep(140);
     processEvents();
 
-    EXPECT_DOUBLE_EQ(2.0, m_pCo->get());
+    EXPECT_LE(2.0, m_pCo->get());
 }
 
 TEST_F(ControllerScriptEngineLegacyTimerTest, beginTimer_singleShotTimer) {


### PR DESCRIPTION
in overload situations

like here: 
https://github.com/daschuer/mixxx/actions/runs/24372014844/job/71177549953