### PR TITLE
Remove unused includes from trackinfo.h and keyutils.h

### DIFF
--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -1,6 +1,6 @@
 #include "analyzer/analyzerkey.h"
 
-#include <QtDebug>
+#include <QDebug>
 
 #include "analyzer/analyzertrack.h"
 #include "analyzer/constants.h"

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -11,6 +11,7 @@
 #include "proto/keys.pb.h"
 #include "track/keyfactory.h"
 #include "track/track.h"
+#include "util/sample.h"
 
 namespace {
 constexpr int excludeFirstChannelMask = 0x1;

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -8,6 +8,7 @@
 #include "engine/filters/enginefilterbessel4.h"
 #include "track/track.h"
 #include "util/logger.h"
+#include "util/sample.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformfactory.h"
 

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -8,7 +8,6 @@
 #include "engine/filters/enginefilterbessel4.h"
 #include "track/track.h"
 #include "util/logger.h"
-#include "util/sample.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformfactory.h"
 

--- a/src/dialog/dlgkeywheel.h
+++ b/src/dialog/dlgkeywheel.h
@@ -1,9 +1,7 @@
 #ifndef DLGKEYWHEEL_H
 #define DLGKEYWHEEL_H
 
-#include <QDialog>
 #include <QDomDocument>
-#include <QSvgWidget>
 
 #include "dialog/ui_dlgkeywheel.h"
 #include "preferences/usersettings.h"

--- a/src/dialog/dlgkeywheel.h
+++ b/src/dialog/dlgkeywheel.h
@@ -6,6 +6,7 @@
 #include <QSvgWidget>
 
 #include "dialog/ui_dlgkeywheel.h"
+#include "preferences/usersettings.h"
 #include "track/keyutils.h"
 
 class DlgKeywheel : public QDialog, public Ui::DlgKeywheel {

--- a/src/mixer/samplerbank.cpp
+++ b/src/mixer/samplerbank.cpp
@@ -4,6 +4,7 @@
 #include <QMessageBox>
 #include <QStandardPaths>
 
+#include "control/controlproxy.h"
 #include "control/controlpushbutton.h"
 #include "mixer/playermanager.h"
 #include "mixer/sampler.h"

--- a/src/preferences/dialog/dlgprefkey.h
+++ b/src/preferences/dialog/dlgprefkey.h
@@ -10,6 +10,7 @@
 #include "preferences/usersettings.h"
 #include "track/keyutils.h"
 
+class ControlProxy;
 class QWidget;
 
 class DlgPrefKey : public DlgPreferencePage, Ui::DlgPrefKeyDlg {

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -5,7 +5,6 @@
 #include <QString>
 
 #include "audio/types.h"
-#include "control/controlproxy.h"
 #include "proto/keys.pb.h"
 #include "track/keys.h"
 #include "util/color/colorpalette.h"

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -3,7 +3,6 @@
 #include <QString>
 #include <QUuid>
 
-#include "sources/audiosource.h"
 #include "track/bpm.h"
 #include "track/replaygain.h"
 #include "track/serato/tags.h"


### PR DESCRIPTION
Part of a broader effort to clean up include dependencies as a step towards a modular build.

See https://mixxx.zulipchat.com/#narrow/channel/109171-development/topic/towards.20a.20modular.20build.20system/with/585505636

Removed include `sources/audiosource.h` from `track/trackinfo.h` as no type from that header was used anywhere in the file or its .cpp. This required adding a direct `#include "util/sample.h"` to `analyzerkey.cpp` and `analyzerwaveform.cpp`, which were relying on `util/sample.h` to be included transitively (for `SampleUtil`).

Removed include `control/controlproxy.h` from `track/keyutils.h` as no type from that header was used anywhere in the file or its .cpp. This required adding direct includes to three files which were relying on `control/controlproxy.h` to be included transitively (for `ControlProxy`):
- `dialog/dlgkeywheel.h`: add direct `#include "preferences/usersettings.h"` for `UserSettingsPointer`
- `mixer/samplerbank.cpp`: add direct `#include "control/controlproxy.h"` for the `new ControlProxy(…)` call
- `preferences/dialog/dlgprefkey.h`: add `class ControlProxy;` forward declaration (pointer member only, full definition not needed in header)