### PR TITLE
Extract MidiOpCode enum into controllers/midi/midiopcode.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,7 +620,7 @@ if(MSVC)
   # Microsoft Visual Studio Compiler
   add_compile_options(/UTF8)
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x64|x86_64|AMD64)$")
-    # Target architecture is x64 -> x64 has alsways SSE and SSE2 instruction sets
+    # Target architecture is x64 -> x64 has always SSE and SSE2 instruction sets
     message(STATUS "x64 Enabling SSE2 CPU optimizations (>= Pentium 4)")
     # Define gcc/clang style defines for SSE and SSE2 for compatibility
     add_compile_definitions("__SSE__" "__SSE2__")
@@ -1174,6 +1174,7 @@ add_library(
   src/controllers/midi/midicontroller.cpp
   src/controllers/midi/midienumerator.cpp
   src/controllers/midi/midimessage.cpp
+  src/controllers/midi/midiopcode.cpp
   src/controllers/midi/midioutputhandler.cpp
   src/controllers/midi/midiutils.cpp
   src/controllers/scripting/colormapper.cpp

--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -4,7 +4,7 @@
 #include <QTimer>
 
 #include "control/controlbuttonmode.h"
-#include "controllers/midi/midimessage.h"
+#include "controllers/midi/midiopcode.h"
 
 class ControlDoublePrivate;
 

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <QObject>
 #include <QEvent>
+#include <QObject>
 
-#include "preferences/usersettings.h"
-#include "controllers/midi/midimessage.h"
 #include "control/control.h"
+#include "controllers/midi/midiopcode.h"
+#include "preferences/usersettings.h"
 
 class ControlObject : public QObject {
     Q_OBJECT

--- a/src/controllers/midi/midimessage.cpp
+++ b/src/controllers/midi/midimessage.cpp
@@ -1,14 +1,5 @@
 #include "controllers/midi/midiutils.h"
 
-QDebug operator<<(QDebug debug, MidiOpCode midiOpCode) {
-    debug << static_cast<uint8_t>(midiOpCode);
-    return debug;
-}
-
-qhash_seed_t qHash(MidiOpCode key, qhash_seed_t seed) {
-    return qHash(static_cast<uint8_t>(key), seed);
-}
-
 MidiKey::MidiKey()
         : status(0),
           control(0) {

--- a/src/controllers/midi/midimessage.h
+++ b/src/controllers/midi/midimessage.h
@@ -11,98 +11,10 @@
 #include <memory>
 #include <variant>
 
+#include "controllers/midi/midiopcode.h"
 #include "preferences/usersettings.h"
 #include "util/always_false_v.h"
 #include "util/compatibility/qhash.h"
-
-// The second value of each OpCode will be the channel number the message
-// corresponds to.  So 0xB0 is a CC on the first channel, and 0xB1 is a CC
-// on the second channel.  When working with incoming midi data, first call
-// MidiUtils::opCodeFromStatus to translate from raw status values to opcodes,
-// then compare to these enums.
-enum class MidiOpCode : uint8_t {
-    /// Note Off event.
-    /// This message is sent when a note is released (ended).
-    NoteOff = 0x80,
-    /// Note On event.
-    /// This message is sent when a note is depressed (start).
-    NoteOn = 0x90,
-    /// Polyphonic Key Pressure (Aftertouch). This message is most often sent
-    /// by pressing down on the key after it "bottoms out".
-    PolyphonicKeyPressure = 0xA0,
-    /// Control Change. This message is sent when a controller value changes.
-    /// Controllers include devices such as pedals and levers. Controller
-    /// numbers 120-127 are reserved as "Channel Mode Messages" (below).
-    ControlChange = 0xB0,
-    /// Program Change. This message sent when the patch number changes.
-    ProgramChange = 0xC0,
-    /// Channel Pressure (After-touch). This message is most often sent by
-    /// pressing down on the key after it "bottoms out". This message is
-    /// different from polyphonic after-touch. Use this message to send the
-    /// single greatest pressure value (of all the current depressed keys).
-    ChannelPressure = 0xD0,
-    /// Pitch Bend Change. This message is sent to indicate a change in the
-    /// pitch bender (wheel or lever, typically). The pitch bender is measured
-    /// by a fourteen bit value. Center (no pitch change) is 2000H. Sensitivity
-    /// is a function of the receiver, but may be set using RPN 0.
-    PitchBendChange = 0xE0,
-    /// System Exclusive. This message type allows manufacturers to create
-    /// their own messages (such as bulk dumps, patch parameters, and other
-    /// non-spec data) and provides a mechanism for creating additional MIDI
-    /// Specification messages. The Manufacturer's ID code (assigned by MMA or
-    /// AMEI) is either 1 byte (0iiiiiii) or 3 bytes (0iiiiiii 0iiiiiii
-    /// 0iiiiiii). Two of the 1 Byte IDs are reserved for extensions called
-    /// Universal Exclusive Messages, which are not manufacturer-specific. If a
-    /// device recognizes the ID code as its own (or as a supported Universal
-    /// message) it will listen to the rest of the message (0ddddddd).
-    /// Otherwise, the message will be ignored. (Note: Only Real-Time messages
-    /// may be interleaved with a System Exclusive.)
-    SystemExclusive = 0xF0,
-    /// MIDI Time Code Quarter Frame.
-    TimeCodeQuarterFrame = 0xF1,
-    /// Song Position Pointer.
-    /// This is an internal 14 bit register that holds the number of MIDI beats
-    //  (1 beat = six MIDI clocks) since the start of the song.
-    SongPosition = 0xF2,
-    /// Song Select. The Song Select specifies which sequence or song is to be
-    /// played.
-    SongSelect = 0xF3,
-    /// Undefined. (Reserved)
-    Undefined1 = 0xF4,
-    /// Undefined. (Reserved)
-    Undefined2 = 0xF5,
-    /// Tune Request. Upon receiving a Tune Request, all analog synthesizers
-    /// should tune their oscillators.
-    TuneRequest = 0xF6,
-    /// End of Exclusive. Used to terminate a System Exclusive dump (see
-    /// above).
-    EndOfExclusive = 0xF7,
-    /// Timing Clock. Sent 24 times per quarter note when synchronization
-    /// is required.
-    TimingClock = 0xF8,
-    /// Undefined. (Reserved)
-    Undefined3 = 0xF9,
-    /// Start. Start the current sequence playing.
-    /// (This message will be followed with Timing Clocks).
-    Start = 0xFA,
-    /// Continue. Continue at the point the sequence was stopped
-    Continue = 0xFB,
-    /// Stop. Stop the current sequence.
-    Stop = 0xFC,
-    /// Undefined. (Reserved)
-    Undefined4 = 0xFD,
-    /// Active Sensing. This message is intended to be sent repeatedly to tell the receiver that a
-    /// connection is alive. Use of this message is optional. When initially received, the receiver
-    /// will expect to receive another Active Sensing message each 300ms (max), and if it does not
-    /// then it will assume that the connection has been terminated. At termination, the receiver
-    /// will turn off all voices and return to normal (non- active sensing) operation.
-    ActiveSensing = 0xFE,
-    /// Reset. Reset all receivers in the system to power-up status. This should be used sparingly,
-    /// preferably under manual control. In particular, it should not be sent on power-up.
-    SystemReset = 0xFF,
-};
-QDebug operator<<(QDebug debug, MidiOpCode midiOpCode);
-qhash_seed_t qHash(MidiOpCode key, qhash_seed_t seed);
 
 enum class MidiOption : uint16_t {
     None = 0x0000,

--- a/src/controllers/midi/midiopcode.cpp
+++ b/src/controllers/midi/midiopcode.cpp
@@ -1,0 +1,10 @@
+#include "controllers/midi/midiopcode.h"
+
+QDebug operator<<(QDebug debug, MidiOpCode midiOpCode) {
+    debug << static_cast<uint8_t>(midiOpCode);
+    return debug;
+}
+
+qhash_seed_t qHash(MidiOpCode key, qhash_seed_t seed) {
+    return qHash(static_cast<uint8_t>(key), seed);
+}

--- a/src/controllers/midi/midiopcode.h
+++ b/src/controllers/midi/midiopcode.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <QtDebug>
+#include <cstdint>
+
+#include "util/compatibility/qhash.h"
+
+// The second value of each OpCode will be the channel number the message
+// corresponds to.  So 0xB0 is a CC on the first channel, and 0xB1 is a CC
+// on the second channel.  When working with incoming midi data, first call
+// MidiUtils::opCodeFromStatus to translate from raw status values to opcodes,
+// then compare to these enums.
+enum class MidiOpCode : uint8_t {
+    /// Note Off event.
+    /// This message is sent when a note is released (ended).
+    NoteOff = 0x80,
+    /// Note On event.
+    /// This message is sent when a note is depressed (start).
+    NoteOn = 0x90,
+    /// Polyphonic Key Pressure (Aftertouch). This message is most often sent
+    /// by pressing down on the key after it "bottoms out".
+    PolyphonicKeyPressure = 0xA0,
+    /// Control Change. This message is sent when a controller value changes.
+    /// Controllers include devices such as pedals and levers. Controller
+    /// numbers 120-127 are reserved as "Channel Mode Messages" (below).
+    ControlChange = 0xB0,
+    /// Program Change. This message sent when the patch number changes.
+    ProgramChange = 0xC0,
+    /// Channel Pressure (After-touch). This message is most often sent by
+    /// pressing down on the key after it "bottoms out". This message is
+    /// different from polyphonic after-touch. Use this message to send the
+    /// single greatest pressure value (of all the current depressed keys).
+    ChannelPressure = 0xD0,
+    /// Pitch Bend Change. This message is sent to indicate a change in the
+    /// pitch bender (wheel or lever, typically). The pitch bender is measured
+    /// by a fourteen bit value. Center (no pitch change) is 2000H. Sensitivity
+    /// is a function of the receiver, but may be set using RPN 0.
+    PitchBendChange = 0xE0,
+    /// System Exclusive. This message type allows manufacturers to create
+    /// their own messages (such as bulk dumps, patch parameters, and other
+    /// non-spec data) and provides a mechanism for creating additional MIDI
+    /// Specification messages. The Manufacturer's ID code (assigned by MMA or
+    /// AMEI) is either 1 byte (0iiiiiii) or 3 bytes (0iiiiiii 0iiiiiii
+    /// 0iiiiiii). Two of the 1 Byte IDs are reserved for extensions called
+    /// Universal Exclusive Messages, which are not manufacturer-specific. If a
+    /// device recognizes the ID code as its own (or as a supported Universal
+    /// message) it will listen to the rest of the message (0ddddddd).
+    /// Otherwise, the message will be ignored. (Note: Only Real-Time messages
+    /// may be interleaved with a System Exclusive.)
+    SystemExclusive = 0xF0,
+    /// MIDI Time Code Quarter Frame.
+    TimeCodeQuarterFrame = 0xF1,
+    /// Song Position Pointer.
+    /// This is an internal 14 bit register that holds the number of MIDI beats
+    //  (1 beat = six MIDI clocks) since the start of the song.
+    SongPosition = 0xF2,
+    /// Song Select. The Song Select specifies which sequence or song is to be
+    /// played.
+    SongSelect = 0xF3,
+    /// Undefined. (Reserved)
+    Undefined1 = 0xF4,
+    /// Undefined. (Reserved)
+    Undefined2 = 0xF5,
+    /// Tune Request. Upon receiving a Tune Request, all analog synthesizers
+    /// should tune their oscillators.
+    TuneRequest = 0xF6,
+    /// End of Exclusive. Used to terminate a System Exclusive dump (see
+    /// above).
+    EndOfExclusive = 0xF7,
+    /// Timing Clock. Sent 24 times per quarter note when synchronization
+    /// is required.
+    TimingClock = 0xF8,
+    /// Undefined. (Reserved)
+    Undefined3 = 0xF9,
+    /// Start. Start the current sequence playing.
+    /// (This message will be followed with Timing Clocks).
+    Start = 0xFA,
+    /// Continue. Continue at the point the sequence was stopped
+    Continue = 0xFB,
+    /// Stop. Stop the current sequence.
+    Stop = 0xFC,
+    /// Undefined. (Reserved)
+    Undefined4 = 0xFD,
+    /// Active Sensing. This message is intended to be sent repeatedly to tell the receiver that a
+    /// connection is alive. Use of this message is optional. When initially received, the receiver
+    /// will expect to receive another Active Sensing message each 300ms (max), and if it does not
+    /// then it will assume that the connection has been terminated. At termination, the receiver
+    /// will turn off all voices and return to normal (non- active sensing) operation.
+    ActiveSensing = 0xFE,
+    /// Reset. Reset all receivers in the system to power-up status. This should be used sparingly,
+    /// preferably under manual control. In particular, it should not be sent on power-up.
+    SystemReset = 0xFF,
+};
+
+QDebug operator<<(QDebug debug, MidiOpCode midiOpCode);
+qhash_seed_t qHash(MidiOpCode key, qhash_seed_t seed);


### PR DESCRIPTION
Part of a broader effort to clean up include dependencies as a step towards a modular build.

Moved the `MidiOpCode` enum class and its `operator<<` and `qHash` declarations from `controllers/midi/midimessage.h` into a new thin header `controllers/midi/midiopcode.h`, with the implementations in `midiopcode.cpp`. `midimessage.h` now includes `midiopcode.h` so all existing code continues to work unchanged.

Updated `control/controlbehavior.h` and `control/controlobject.h` to include `midiopcode.h` directly instead of the full `midimessage.h`. This breaks the dependency from the control module on the controllers module, which was the only reason control headers were pulling in `Qt::Qml` transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)