### PR TITLE
Break control/ ↔ preferences/ include cycle

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -2,6 +2,7 @@
 
 #include "control/controlobject.h"
 #include "moc_control.cpp"
+#include "preferences/usersettings.h"
 #include "util/mutex.h"
 #include "util/stat.h"
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -8,7 +8,8 @@
 
 #include "control/controlbehavior.h"
 #include "control/controlvalue.h"
-#include "preferences/usersettings.h"
+#include "preferences/usersettings_fwd.h"
+#include "util/assert.h"
 
 class ControlObject;
 

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -4,6 +4,7 @@
 
 #include "control/control.h"
 #include "moc_controlobject.cpp"
+#include "preferences/usersettings.h"
 
 ControlObject::ControlObject()
         : m_pControl(ControlDoublePrivate::getDefaultControl()) {

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <QObject>
 #include <QEvent>
+#include <QObject>
 
-#include "preferences/usersettings.h"
-#include "controllers/midi/midimessage.h"
 #include "control/control.h"
+#include "controllers/midi/midimessage.h"
+#include "preferences/usersettings_fwd.h"
 
 class ControlObject : public QObject {
     Q_OBJECT

--- a/src/control/controlproxy.cpp
+++ b/src/control/controlproxy.cpp
@@ -2,6 +2,7 @@
 
 #include "control/control.h"
 #include "moc_controlproxy.cpp"
+#include "preferences/usersettings.h"
 
 ControlProxy::ControlProxy(const QString& g, const QString& i, QObject* pParent, ControlFlags flags)
         : ControlProxy(ConfigKey(g, i), pParent, flags) {

--- a/src/control/controlproxy.h
+++ b/src/control/controlproxy.h
@@ -5,7 +5,7 @@
 #include <QString>
 
 #include "control/control.h"
-#include "preferences/usersettings.h"
+#include "preferences/usersettings_fwd.h"
 
 //// This class is the successor of ControlObjectThread. It should be used for
 /// new code to avoid unnecessary locking during send if no slot is connected.

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QKeyEvent>
 #include <QObject>
 #include <memory>
 

--- a/src/preferences/configkey.h
+++ b/src/preferences/configkey.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <QHash>
+#include <QMetaType>
+#include <QString>
+#include <QtDebug>
+
+#include "util/compatibility/qhash.h"
+
+// Class for the key for a specific configuration element. A key consists of a
+// group and an item.
+//
+// NOTE: new ConfigKey's item should use the `snake_case` formatting
+class ConfigKey final {
+  public:
+    ConfigKey() = default; // is required for qMetaTypeConstructHelper()
+    ConfigKey(QString group, QString item)
+            : group(std::move(group)),
+              item(std::move(item)) {
+    }
+
+    static ConfigKey parseCommaSeparated(const QString& key);
+
+    bool isValid() const {
+        return !group.isEmpty() && !item.isEmpty();
+    }
+
+    QString group;
+    QString item;
+};
+Q_DECLARE_METATYPE(ConfigKey);
+
+// comparison function for ConfigKeys. Used by a QHash in ControlObject
+inline bool operator==(const ConfigKey& lhs, const ConfigKey& rhs) {
+    return lhs.group == rhs.group &&
+            lhs.item == rhs.item;
+}
+
+// comparison function for ConfigKeys. Used by a QHash in ControlObject
+inline bool operator!=(const ConfigKey& lhs, const ConfigKey& rhs) {
+    return !(lhs == rhs);
+}
+
+// comparison function for ConfigKeys. Used by a QMap in ControlObject
+inline bool operator<(const ConfigKey& lhs, const ConfigKey& rhs) {
+    int groupResult = lhs.group.compare(rhs.group);
+    if (groupResult == 0) {
+        return lhs.item < rhs.item;
+    }
+    return (groupResult < 0);
+}
+
+// stream operator function for trivial qDebug()ing of ConfigKeys
+inline QDebug operator<<(QDebug stream, const ConfigKey& configKey) {
+    stream << configKey.group << "," << configKey.item;
+    return stream;
+}
+
+// QHash hash function for ConfigKey objects.
+inline qhash_seed_t qHash(
+        const ConfigKey& key,
+        qhash_seed_t seed = 0) {
+    return qHash(key.group, seed) ^
+            qHash(key.item, seed);
+}

--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -9,66 +9,9 @@
 #include <QString>
 #include <type_traits>
 
+#include "preferences/configkey.h"
 #include "util/assert.h"
-#include "util/compatibility/qhash.h"
 #include "util/debug.h"
-
-// Class for the key for a specific configuration element. A key consists of a
-// group and an item.
-//
-// NOTE: new ConfigKey's item should use the `snake_case` formatting
-class ConfigKey final {
-  public:
-    ConfigKey() = default; // is required for qMetaTypeConstructHelper()
-    ConfigKey(QString group, QString item)
-            : group(std::move(group)),
-              item(std::move(item)) {
-    }
-
-    static ConfigKey parseCommaSeparated(const QString& key);
-
-    bool isValid() const {
-        return !group.isEmpty() && !item.isEmpty();
-    }
-
-    QString group;
-    QString item;
-};
-Q_DECLARE_METATYPE(ConfigKey);
-
-// comparison function for ConfigKeys. Used by a QHash in ControlObject
-inline bool operator==(const ConfigKey& lhs, const ConfigKey& rhs) {
-    return lhs.group == rhs.group &&
-            lhs.item == rhs.item;
-}
-
-// comparison function for ConfigKeys. Used by a QHash in ControlObject
-inline bool operator!=(const ConfigKey& lhs, const ConfigKey& rhs) {
-    return !(lhs == rhs);
-}
-
-// comparison function for ConfigKeys. Used by a QMap in ControlObject
-inline bool operator<(const ConfigKey& lhs, const ConfigKey& rhs) {
-    int groupResult = lhs.group.compare(rhs.group);
-    if (groupResult == 0) {
-        return lhs.item < rhs.item;
-    }
-    return (groupResult < 0);
-}
-
-// stream operator function for trivial qDebug()ing of ConfigKeys
-inline QDebug operator<<(QDebug stream, const ConfigKey& configKey) {
-    stream << configKey.group << "," << configKey.item;
-    return stream;
-}
-
-// QHash hash function for ConfigKey objects.
-inline qhash_seed_t qHash(
-        const ConfigKey& key,
-        qhash_seed_t seed = 0) {
-    return qHash(key.group, seed) ^
-            qHash(key.item, seed);
-}
 
 // The value corresponding to a key. The basic value is a string, but can be
 // subclassed to more specific needs.

--- a/src/preferences/usersettings_fwd.h
+++ b/src/preferences/usersettings_fwd.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QSharedPointer>
+#include <QWeakPointer>
+
+#include "preferences/configkey.h"
+
+// Forward declaration of ConfigObject to allow using UserSettingsPointer
+// without pulling in the full configobject.h template.
+template<typename T>
+class ConfigObject;
+class ConfigValue;
+
+typedef ConfigObject<ConfigValue> UserSettings;
+typedef QSharedPointer<UserSettings> UserSettingsPointer;
+typedef QWeakPointer<UserSettings> UserSettingsWeakPointer;


### PR DESCRIPTION
Part of a broader effort to clean up include dependencies as a step towards a modular build.

Extracted `ConfigKey` from `preferences/configobject.h` into a new `preferences/configkey.h` (no logic change, pure relocation).

Created `preferences/usersettings_fwd.h` containing only the forward declarations of `ConfigObject<T>` / `ConfigValue` and the `UserSettingsPointer` / `UserSettingsWeakPointer` typedefs.

Replaced `#include "preferences/usersettings.h"` with `#include "preferences/usersettings_fwd.h"` in:
- `control/control.h`
- `control/controlobject.h`
- `control/controlproxy.h`

Added direct `#include "preferences/usersettings.h"` to `control/control.cpp`, `control/controlobject.cpp`, and `control/controlproxy.cpp`, which need the full template definition.

Added direct `#include <QKeyEvent>` to `library/librarycontrol.h`, which was relying on QKeyEvent being included transitively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)