### PR TITLE
Move engine channel-count constants and StemChannel to audio/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,7 +620,7 @@ if(MSVC)
   # Microsoft Visual Studio Compiler
   add_compile_options(/UTF8)
   if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x64|x86_64|AMD64)$")
-    # Target architecture is x64 -> x64 has alsways SSE and SSE2 instruction sets
+    # Target architecture is x64 -> x64 has always SSE and SSE2 instruction sets
     message(STATUS "x64 Enabling SSE2 CPU optimizations (>= Pentium 4)")
     # Define gcc/clang style defines for SSE and SSE2 for compatibility
     add_compile_definitions("__SSE__" "__SSE2__")
@@ -1174,6 +1174,7 @@ add_library(
   src/controllers/midi/midicontroller.cpp
   src/controllers/midi/midienumerator.cpp
   src/controllers/midi/midimessage.cpp
+  src/controllers/midi/midiopcode.cpp
   src/controllers/midi/midioutputhandler.cpp
   src/controllers/midi/midiutils.cpp
   src/controllers/scripting/colormapper.cpp

--- a/src/analyzer/constants.h
+++ b/src/analyzer/constants.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "engine/engine.h"
+#include "audio/enginechannelcount.h"
 
 namespace mixxx {
 

--- a/src/audio/enginechannelcount.h
+++ b/src/audio/enginechannelcount.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <QFlags>
+
+#include "audio/types.h"
+
+// Audio signal-path channel-count constants and stem-channel types.
+//
+// These describe the fixed channel configuration used throughout the engine
+// and analysis pipeline. They live in audio/ because they are properties of
+// the audio signal path, not of the engine subsystem.
+
+namespace mixxx {
+
+static constexpr audio::ChannelCount kEngineChannelOutputCount =
+        audio::ChannelCount::stereo();
+static constexpr audio::ChannelCount kMaxEngineChannelInputCount =
+        audio::ChannelCount::stem();
+// Always defined (not gated on __STEM__) because the waveform data struct
+// must stay consistent regardless of whether STEM support is compiled in.
+constexpr int kMaxSupportedStems = 4;
+
+#ifdef __STEM__
+enum class StemChannel {
+    First = 0x1,
+    Second = 0x2,
+    Third = 0x4,
+    Fourth = 0x8,
+
+    None = 0,
+    All = First | Second | Third | Fourth
+};
+Q_DECLARE_FLAGS(StemChannelSelection, StemChannel);
+#endif
+
+} // namespace mixxx

--- a/src/audio/frame.h
+++ b/src/audio/frame.h
@@ -4,7 +4,8 @@
 #include <cmath>
 #include <limits>
 
-#include "engine/engine.h"
+#include "audio/enginechannelcount.h"
+#include "audio/signalinfo.h"
 #include "util/compatibility/qhash.h"
 #include "util/fpclassify.h"
 

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -2,6 +2,7 @@
 
 #include "control/controlobject.h"
 #include "moc_control.cpp"
+#include "preferences/usersettings.h"
 #include "util/mutex.h"
 #include "util/stat.h"
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -8,7 +8,8 @@
 
 #include "control/controlbehavior.h"
 #include "control/controlvalue.h"
-#include "preferences/usersettings.h"
+#include "preferences/usersettings_fwd.h"
+#include "util/assert.h"
 
 class ControlObject;
 

--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -4,7 +4,7 @@
 #include <QTimer>
 
 #include "control/controlbuttonmode.h"
-#include "controllers/midi/midimessage.h"
+#include "controllers/midi/midiopcode.h"
 
 class ControlDoublePrivate;
 

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -4,6 +4,7 @@
 
 #include "control/control.h"
 #include "moc_controlobject.cpp"
+#include "preferences/usersettings.h"
 
 ControlObject::ControlObject()
         : m_pControl(ControlDoublePrivate::getDefaultControl()) {

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <QObject>
 #include <QEvent>
+#include <QObject>
 
-#include "preferences/usersettings.h"
-#include "controllers/midi/midimessage.h"
 #include "control/control.h"
+#include "controllers/midi/midiopcode.h"
+#include "preferences/usersettings.h"
 
 class ControlObject : public QObject {
     Q_OBJECT

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -5,7 +5,7 @@
 
 #include "control/control.h"
 #include "controllers/midi/midiopcode.h"
-#include "preferences/usersettings.h"
+#include "preferences/usersettings_fwd.h"
 
 class ControlObject : public QObject {
     Q_OBJECT

--- a/src/control/controlproxy.cpp
+++ b/src/control/controlproxy.cpp
@@ -2,6 +2,7 @@
 
 #include "control/control.h"
 #include "moc_controlproxy.cpp"
+#include "preferences/usersettings.h"
 
 ControlProxy::ControlProxy(const QString& g, const QString& i, QObject* pParent, ControlFlags flags)
         : ControlProxy(ConfigKey(g, i), pParent, flags) {

--- a/src/control/controlproxy.h
+++ b/src/control/controlproxy.h
@@ -5,7 +5,7 @@
 #include <QString>
 
 #include "control/control.h"
-#include "preferences/usersettings.h"
+#include "preferences/usersettings_fwd.h"
 
 //// This class is the successor of ControlObjectThread. It should be used for
 /// new code to avoid unnecessary locking during send if no slot is connected.

--- a/src/controllers/midi/midimessage.cpp
+++ b/src/controllers/midi/midimessage.cpp
@@ -1,14 +1,5 @@
 #include "controllers/midi/midiutils.h"
 
-QDebug operator<<(QDebug debug, MidiOpCode midiOpCode) {
-    debug << static_cast<uint8_t>(midiOpCode);
-    return debug;
-}
-
-qhash_seed_t qHash(MidiOpCode key, qhash_seed_t seed) {
-    return qHash(static_cast<uint8_t>(key), seed);
-}
-
 MidiKey::MidiKey()
         : status(0),
           control(0) {

--- a/src/controllers/midi/midimessage.h
+++ b/src/controllers/midi/midimessage.h
@@ -11,98 +11,10 @@
 #include <memory>
 #include <variant>
 
+#include "controllers/midi/midiopcode.h"
 #include "preferences/usersettings.h"
 #include "util/always_false_v.h"
 #include "util/compatibility/qhash.h"
-
-// The second value of each OpCode will be the channel number the message
-// corresponds to.  So 0xB0 is a CC on the first channel, and 0xB1 is a CC
-// on the second channel.  When working with incoming midi data, first call
-// MidiUtils::opCodeFromStatus to translate from raw status values to opcodes,
-// then compare to these enums.
-enum class MidiOpCode : uint8_t {
-    /// Note Off event.
-    /// This message is sent when a note is released (ended).
-    NoteOff = 0x80,
-    /// Note On event.
-    /// This message is sent when a note is depressed (start).
-    NoteOn = 0x90,
-    /// Polyphonic Key Pressure (Aftertouch). This message is most often sent
-    /// by pressing down on the key after it "bottoms out".
-    PolyphonicKeyPressure = 0xA0,
-    /// Control Change. This message is sent when a controller value changes.
-    /// Controllers include devices such as pedals and levers. Controller
-    /// numbers 120-127 are reserved as "Channel Mode Messages" (below).
-    ControlChange = 0xB0,
-    /// Program Change. This message sent when the patch number changes.
-    ProgramChange = 0xC0,
-    /// Channel Pressure (After-touch). This message is most often sent by
-    /// pressing down on the key after it "bottoms out". This message is
-    /// different from polyphonic after-touch. Use this message to send the
-    /// single greatest pressure value (of all the current depressed keys).
-    ChannelPressure = 0xD0,
-    /// Pitch Bend Change. This message is sent to indicate a change in the
-    /// pitch bender (wheel or lever, typically). The pitch bender is measured
-    /// by a fourteen bit value. Center (no pitch change) is 2000H. Sensitivity
-    /// is a function of the receiver, but may be set using RPN 0.
-    PitchBendChange = 0xE0,
-    /// System Exclusive. This message type allows manufacturers to create
-    /// their own messages (such as bulk dumps, patch parameters, and other
-    /// non-spec data) and provides a mechanism for creating additional MIDI
-    /// Specification messages. The Manufacturer's ID code (assigned by MMA or
-    /// AMEI) is either 1 byte (0iiiiiii) or 3 bytes (0iiiiiii 0iiiiiii
-    /// 0iiiiiii). Two of the 1 Byte IDs are reserved for extensions called
-    /// Universal Exclusive Messages, which are not manufacturer-specific. If a
-    /// device recognizes the ID code as its own (or as a supported Universal
-    /// message) it will listen to the rest of the message (0ddddddd).
-    /// Otherwise, the message will be ignored. (Note: Only Real-Time messages
-    /// may be interleaved with a System Exclusive.)
-    SystemExclusive = 0xF0,
-    /// MIDI Time Code Quarter Frame.
-    TimeCodeQuarterFrame = 0xF1,
-    /// Song Position Pointer.
-    /// This is an internal 14 bit register that holds the number of MIDI beats
-    //  (1 beat = six MIDI clocks) since the start of the song.
-    SongPosition = 0xF2,
-    /// Song Select. The Song Select specifies which sequence or song is to be
-    /// played.
-    SongSelect = 0xF3,
-    /// Undefined. (Reserved)
-    Undefined1 = 0xF4,
-    /// Undefined. (Reserved)
-    Undefined2 = 0xF5,
-    /// Tune Request. Upon receiving a Tune Request, all analog synthesizers
-    /// should tune their oscillators.
-    TuneRequest = 0xF6,
-    /// End of Exclusive. Used to terminate a System Exclusive dump (see
-    /// above).
-    EndOfExclusive = 0xF7,
-    /// Timing Clock. Sent 24 times per quarter note when synchronization
-    /// is required.
-    TimingClock = 0xF8,
-    /// Undefined. (Reserved)
-    Undefined3 = 0xF9,
-    /// Start. Start the current sequence playing.
-    /// (This message will be followed with Timing Clocks).
-    Start = 0xFA,
-    /// Continue. Continue at the point the sequence was stopped
-    Continue = 0xFB,
-    /// Stop. Stop the current sequence.
-    Stop = 0xFC,
-    /// Undefined. (Reserved)
-    Undefined4 = 0xFD,
-    /// Active Sensing. This message is intended to be sent repeatedly to tell the receiver that a
-    /// connection is alive. Use of this message is optional. When initially received, the receiver
-    /// will expect to receive another Active Sensing message each 300ms (max), and if it does not
-    /// then it will assume that the connection has been terminated. At termination, the receiver
-    /// will turn off all voices and return to normal (non- active sensing) operation.
-    ActiveSensing = 0xFE,
-    /// Reset. Reset all receivers in the system to power-up status. This should be used sparingly,
-    /// preferably under manual control. In particular, it should not be sent on power-up.
-    SystemReset = 0xFF,
-};
-QDebug operator<<(QDebug debug, MidiOpCode midiOpCode);
-qhash_seed_t qHash(MidiOpCode key, qhash_seed_t seed);
 
 enum class MidiOption : uint16_t {
     None = 0x0000,

--- a/src/controllers/midi/midiopcode.cpp
+++ b/src/controllers/midi/midiopcode.cpp
@@ -1,0 +1,10 @@
+#include "controllers/midi/midiopcode.h"
+
+QDebug operator<<(QDebug debug, MidiOpCode midiOpCode) {
+    debug << static_cast<uint8_t>(midiOpCode);
+    return debug;
+}
+
+qhash_seed_t qHash(MidiOpCode key, qhash_seed_t seed) {
+    return qHash(static_cast<uint8_t>(key), seed);
+}

--- a/src/controllers/midi/midiopcode.h
+++ b/src/controllers/midi/midiopcode.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <QtDebug>
+#include <cstdint>
+
+#include "util/compatibility/qhash.h"
+
+// The second value of each OpCode will be the channel number the message
+// corresponds to.  So 0xB0 is a CC on the first channel, and 0xB1 is a CC
+// on the second channel.  When working with incoming midi data, first call
+// MidiUtils::opCodeFromStatus to translate from raw status values to opcodes,
+// then compare to these enums.
+enum class MidiOpCode : uint8_t {
+    /// Note Off event.
+    /// This message is sent when a note is released (ended).
+    NoteOff = 0x80,
+    /// Note On event.
+    /// This message is sent when a note is depressed (start).
+    NoteOn = 0x90,
+    /// Polyphonic Key Pressure (Aftertouch). This message is most often sent
+    /// by pressing down on the key after it "bottoms out".
+    PolyphonicKeyPressure = 0xA0,
+    /// Control Change. This message is sent when a controller value changes.
+    /// Controllers include devices such as pedals and levers. Controller
+    /// numbers 120-127 are reserved as "Channel Mode Messages" (below).
+    ControlChange = 0xB0,
+    /// Program Change. This message sent when the patch number changes.
+    ProgramChange = 0xC0,
+    /// Channel Pressure (After-touch). This message is most often sent by
+    /// pressing down on the key after it "bottoms out". This message is
+    /// different from polyphonic after-touch. Use this message to send the
+    /// single greatest pressure value (of all the current depressed keys).
+    ChannelPressure = 0xD0,
+    /// Pitch Bend Change. This message is sent to indicate a change in the
+    /// pitch bender (wheel or lever, typically). The pitch bender is measured
+    /// by a fourteen bit value. Center (no pitch change) is 2000H. Sensitivity
+    /// is a function of the receiver, but may be set using RPN 0.
+    PitchBendChange = 0xE0,
+    /// System Exclusive. This message type allows manufacturers to create
+    /// their own messages (such as bulk dumps, patch parameters, and other
+    /// non-spec data) and provides a mechanism for creating additional MIDI
+    /// Specification messages. The Manufacturer's ID code (assigned by MMA or
+    /// AMEI) is either 1 byte (0iiiiiii) or 3 bytes (0iiiiiii 0iiiiiii
+    /// 0iiiiiii). Two of the 1 Byte IDs are reserved for extensions called
+    /// Universal Exclusive Messages, which are not manufacturer-specific. If a
+    /// device recognizes the ID code as its own (or as a supported Universal
+    /// message) it will listen to the rest of the message (0ddddddd).
+    /// Otherwise, the message will be ignored. (Note: Only Real-Time messages
+    /// may be interleaved with a System Exclusive.)
+    SystemExclusive = 0xF0,
+    /// MIDI Time Code Quarter Frame.
+    TimeCodeQuarterFrame = 0xF1,
+    /// Song Position Pointer.
+    /// This is an internal 14 bit register that holds the number of MIDI beats
+    //  (1 beat = six MIDI clocks) since the start of the song.
+    SongPosition = 0xF2,
+    /// Song Select. The Song Select specifies which sequence or song is to be
+    /// played.
+    SongSelect = 0xF3,
+    /// Undefined. (Reserved)
+    Undefined1 = 0xF4,
+    /// Undefined. (Reserved)
+    Undefined2 = 0xF5,
+    /// Tune Request. Upon receiving a Tune Request, all analog synthesizers
+    /// should tune their oscillators.
+    TuneRequest = 0xF6,
+    /// End of Exclusive. Used to terminate a System Exclusive dump (see
+    /// above).
+    EndOfExclusive = 0xF7,
+    /// Timing Clock. Sent 24 times per quarter note when synchronization
+    /// is required.
+    TimingClock = 0xF8,
+    /// Undefined. (Reserved)
+    Undefined3 = 0xF9,
+    /// Start. Start the current sequence playing.
+    /// (This message will be followed with Timing Clocks).
+    Start = 0xFA,
+    /// Continue. Continue at the point the sequence was stopped
+    Continue = 0xFB,
+    /// Stop. Stop the current sequence.
+    Stop = 0xFC,
+    /// Undefined. (Reserved)
+    Undefined4 = 0xFD,
+    /// Active Sensing. This message is intended to be sent repeatedly to tell the receiver that a
+    /// connection is alive. Use of this message is optional. When initially received, the receiver
+    /// will expect to receive another Active Sensing message each 300ms (max), and if it does not
+    /// then it will assume that the connection has been terminated. At termination, the receiver
+    /// will turn off all voices and return to normal (non- active sensing) operation.
+    ActiveSensing = 0xFE,
+    /// Reset. Reset all receivers in the system to power-up status. This should be used sparingly,
+    /// preferably under manual control. In particular, it should not be sent on power-up.
+    SystemReset = 0xFF,
+};
+
+QDebug operator<<(QDebug debug, MidiOpCode midiOpCode);
+qhash_seed_t qHash(MidiOpCode key, qhash_seed_t seed);

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -1,29 +1,9 @@
 #pragma once
 
+#include "audio/enginechannelcount.h"
 #include "audio/signalinfo.h"
 
-
 namespace mixxx {
-static constexpr audio::ChannelCount kEngineChannelOutputCount =
-        audio::ChannelCount::stereo();
-static constexpr audio::ChannelCount kMaxEngineChannelInputCount =
-        audio::ChannelCount::stem();
-// The following constant is always defined as it used for the waveform data
-// struct, which must stay consistent, whether the STEM feature is enabled or
-// not.
-constexpr int kMaxSupportedStems = 4;
-#ifdef __STEM__
-enum class StemChannel {
-    First = 0x1,
-    Second = 0x2,
-    Third = 0x4,
-    Fourth = 0x8,
-
-    None = 0,
-    All = First | Second | Third | Fourth
-};
-Q_DECLARE_FLAGS(StemChannelSelection, StemChannel);
-#endif
 
 // Contains the information needed to process a buffer of audio
 class EngineParameters final {

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QKeyEvent>
 #include <QObject>
 #include <memory>
 

--- a/src/preferences/configkey.h
+++ b/src/preferences/configkey.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <QHash>
+#include <QMetaType>
+#include <QString>
+#include <QtDebug>
+
+#include "util/compatibility/qhash.h"
+
+// Class for the key for a specific configuration element. A key consists of a
+// group and an item.
+//
+// NOTE: new ConfigKey's item should use the `snake_case` formatting
+class ConfigKey final {
+  public:
+    ConfigKey() = default; // is required for qMetaTypeConstructHelper()
+    ConfigKey(QString group, QString item)
+            : group(std::move(group)),
+              item(std::move(item)) {
+    }
+
+    static ConfigKey parseCommaSeparated(const QString& key);
+
+    bool isValid() const {
+        return !group.isEmpty() && !item.isEmpty();
+    }
+
+    QString group;
+    QString item;
+};
+Q_DECLARE_METATYPE(ConfigKey);
+
+// comparison function for ConfigKeys. Used by a QHash in ControlObject
+inline bool operator==(const ConfigKey& lhs, const ConfigKey& rhs) {
+    return lhs.group == rhs.group &&
+            lhs.item == rhs.item;
+}
+
+// comparison function for ConfigKeys. Used by a QHash in ControlObject
+inline bool operator!=(const ConfigKey& lhs, const ConfigKey& rhs) {
+    return !(lhs == rhs);
+}
+
+// comparison function for ConfigKeys. Used by a QMap in ControlObject
+inline bool operator<(const ConfigKey& lhs, const ConfigKey& rhs) {
+    int groupResult = lhs.group.compare(rhs.group);
+    if (groupResult == 0) {
+        return lhs.item < rhs.item;
+    }
+    return (groupResult < 0);
+}
+
+// stream operator function for trivial qDebug()ing of ConfigKeys
+inline QDebug operator<<(QDebug stream, const ConfigKey& configKey) {
+    stream << configKey.group << "," << configKey.item;
+    return stream;
+}
+
+// QHash hash function for ConfigKey objects.
+inline qhash_seed_t qHash(
+        const ConfigKey& key,
+        qhash_seed_t seed = 0) {
+    return qHash(key.group, seed) ^
+            qHash(key.item, seed);
+}

--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -9,66 +9,9 @@
 #include <QString>
 #include <type_traits>
 
+#include "preferences/configkey.h"
 #include "util/assert.h"
-#include "util/compatibility/qhash.h"
 #include "util/debug.h"
-
-// Class for the key for a specific configuration element. A key consists of a
-// group and an item.
-//
-// NOTE: new ConfigKey's item should use the `snake_case` formatting
-class ConfigKey final {
-  public:
-    ConfigKey() = default; // is required for qMetaTypeConstructHelper()
-    ConfigKey(QString group, QString item)
-            : group(std::move(group)),
-              item(std::move(item)) {
-    }
-
-    static ConfigKey parseCommaSeparated(const QString& key);
-
-    bool isValid() const {
-        return !group.isEmpty() && !item.isEmpty();
-    }
-
-    QString group;
-    QString item;
-};
-Q_DECLARE_METATYPE(ConfigKey);
-
-// comparison function for ConfigKeys. Used by a QHash in ControlObject
-inline bool operator==(const ConfigKey& lhs, const ConfigKey& rhs) {
-    return lhs.group == rhs.group &&
-            lhs.item == rhs.item;
-}
-
-// comparison function for ConfigKeys. Used by a QHash in ControlObject
-inline bool operator!=(const ConfigKey& lhs, const ConfigKey& rhs) {
-    return !(lhs == rhs);
-}
-
-// comparison function for ConfigKeys. Used by a QMap in ControlObject
-inline bool operator<(const ConfigKey& lhs, const ConfigKey& rhs) {
-    int groupResult = lhs.group.compare(rhs.group);
-    if (groupResult == 0) {
-        return lhs.item < rhs.item;
-    }
-    return (groupResult < 0);
-}
-
-// stream operator function for trivial qDebug()ing of ConfigKeys
-inline QDebug operator<<(QDebug stream, const ConfigKey& configKey) {
-    stream << configKey.group << "," << configKey.item;
-    return stream;
-}
-
-// QHash hash function for ConfigKey objects.
-inline qhash_seed_t qHash(
-        const ConfigKey& key,
-        qhash_seed_t seed = 0) {
-    return qHash(key.group, seed) ^
-            qHash(key.item, seed);
-}
 
 // The value corresponding to a key. The basic value is a string, but can be
 // subclassed to more specific needs.

--- a/src/preferences/usersettings_fwd.h
+++ b/src/preferences/usersettings_fwd.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QSharedPointer>
+#include <QWeakPointer>
+
+#include "preferences/configkey.h"
+
+// Forward declaration of ConfigObject to allow using UserSettingsPointer
+// without pulling in the full configobject.h template.
+template<typename T>
+class ConfigObject;
+class ConfigValue;
+
+typedef ConfigObject<ConfigValue> UserSettings;
+typedef QSharedPointer<UserSettings> UserSettingsPointer;
+typedef QWeakPointer<UserSettings> UserSettingsWeakPointer;


### PR DESCRIPTION
Part of a broader effort to clean up include dependencies as a step towards a modular build.

Created `audio/enginechannelcount.h` containing:
- `kEngineChannelOutputCount`, `kMaxEngineChannelInputCount`, `kMaxSupportedStems` (signal-path channel-count constants)
- `StemChannel` enum and `StemChannelSelection` flags type (previously in `engine/engine.h` under `#ifdef __STEM__`)

These are properties of the audio signal path, not of the engine subsystem, so `audio/` is the correct home.

Removed the duplicate definitions from `engine/engine.h`, which now includes `audio/enginechannelcount.h` to re-export the symbols.

Replaced `#include "engine/engine.h"` with `#include "audio/enginechannelcount.h"` in:
- `audio/frame.h` (added direct `audio/signalinfo.h` which it was previously getting transitively)
- `analyzer/constants.h`

This removes the `waveform/ → engine/` and `analyzer/ → engine/` include paths, allowing those modules to depend only on `audio/` instead of the full engine/ subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)