### PR TITLE
Move AnalyzerPluginInfo to analyzer/analyzer_plugin_info.h

### DIFF
--- a/src/analyzer/analyzer_plugin_info.h
+++ b/src/analyzer/analyzer_plugin_info.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QString>
+
+namespace mixxx {
+
+// Plain data class describing an analyzer plugin.
+// Extracted from analyzer/plugins/analyzerplugin.h so that preference
+// dialogs can hold a QList<AnalyzerPluginInfo> without pulling in the
+// full analyzer plugin hierarchy.
+class AnalyzerPluginInfo {
+  public:
+    AnalyzerPluginInfo(const QString& id,
+            const QString& author,
+            const QString& name,
+            bool isConstantTempoSupported)
+            : m_id(id),
+              m_author(author),
+              m_name(name),
+              m_isConstantTempoSupported(isConstantTempoSupported) {
+    }
+
+    const QString& id() const {
+        return m_id;
+    }
+
+    const QString& author() const {
+        return m_author;
+    }
+
+    const QString& name() const {
+        return m_name;
+    }
+
+    bool isConstantTempoSupported() const {
+        return m_isConstantTempoSupported;
+    }
+
+  private:
+    QString m_id;
+    QString m_author;
+    QString m_name;
+    bool m_isConstantTempoSupported;
+};
+
+} // namespace mixxx

--- a/src/analyzer/plugins/analyzerplugin.h
+++ b/src/analyzer/plugins/analyzerplugin.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <QString>
-
+#include "analyzer/analyzer_plugin_info.h"
 #include "audio/frame.h"
 #include "track/beats.h"
 #include "track/bpm.h"
@@ -9,41 +8,6 @@
 #include "util/types.h"
 
 namespace mixxx {
-
-class AnalyzerPluginInfo {
-  public:
-    AnalyzerPluginInfo(const QString& id,
-            const QString& author,
-            const QString& name,
-            bool isConstantTempoSupported)
-            : m_id(id),
-              m_author(author),
-              m_name(name),
-              m_isConstantTempoSupported(isConstantTempoSupported) {
-    }
-
-    const QString& id() const {
-        return m_id;
-    }
-
-    const QString& author() const {
-        return m_author;
-    }
-
-    const QString& name() const {
-        return m_name;
-    }
-
-    bool isConstantTempoSupported() const {
-        return m_isConstantTempoSupported;
-    }
-
-  private:
-    QString m_id;
-    QString m_author;
-    QString m_name;
-    bool m_isConstantTempoSupported;
-};
 
 class AnalyzerPlugin {
   public:

--- a/src/preferences/dialog/dlgprefbeats.h
+++ b/src/preferences/dialog/dlgprefbeats.h
@@ -3,7 +3,7 @@
 #include <QList>
 #include <QString>
 
-#include "analyzer/plugins/analyzerplugin.h"
+#include "analyzer/analyzer_plugin_info.h"
 #include "preferences/beatdetectionsettings.h"
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgprefbeatsdlg.h"

--- a/src/preferences/dialog/dlgprefkey.h
+++ b/src/preferences/dialog/dlgprefkey.h
@@ -3,7 +3,7 @@
 #include <QList>
 #include <QMap>
 
-#include "analyzer/plugins/analyzerplugin.h"
+#include "analyzer/analyzer_plugin_info.h"
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgprefkeydlg.h"
 #include "preferences/keydetectionsettings.h"

--- a/src/preferences/keydetectionsettings.h
+++ b/src/preferences/keydetectionsettings.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "preferences/usersettings.h"
+#include "proto/keys.pb.h"
 
 #define VAMP_CONFIG_KEY "[Vamp]"
 


### PR DESCRIPTION
Part of a broader effort to clean up include dependencies as a step towards a modular build.

Created `analyzer/analyzer_plugin_info.h` containing only `AnalyzerPluginInfo` (a plain data class). The new header depends solely on `<QString>`.

Removed the `AnalyzerPluginInfo` definition from `analyzer/plugins/analyzerplugin.h`, replacing it with an include of the new thin header.

Replaced `#include "analyzer/plugins/analyzerplugin.h"` with `#include "analyzer/analyzer_plugin_info.h"` in:
- `preferences/dialog/dlgprefbeats.h`
- `preferences/dialog/dlgprefkey.h`

These headers only need the `AnalyzerPluginInfo` type (for a `QList<AnalyzerPluginInfo>` member). They no longer drag in the full analyzer plugin hierarchy (`audio/frame.h`, `track/beats.h`, `track/keys.h`, etc.).

Added a direct `#include "proto/keys.pb.h"` to `preferences/keydetectionsettings.h`, which was relying on `mixxx::track::io::key::ChromaticKey` being included transitively through `analyzerplugin.h → track/keys.h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)