### PR TITLE
Fix Android HID deny list 

### DIFF
--- a/src/controllers/hid/hiddenylist.h
+++ b/src/controllers/hid/hiddenylist.h
@@ -13,7 +13,7 @@ struct hid_denylist_t {
 };
 
 /// USB HID device that should not be recognized as controllers
-constexpr static hid_denylist_t hid_denylisted[] = {
+constexpr static hid_denylist_t kHidDenyList[] = {
         {0x1157, 0x300, 0x1, 0x2},                  // EKS Otus mouse pad (OS/X,windows)
         {0x1157, 0x300, kAnyValue, kAnyValue, 0x3}, // EKS Otus mouse pad (linux)
         {0x04f3, 0x2d26, kAnyValue, kAnyValue},     // ELAN2D26:00 Touch screen

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -1,6 +1,6 @@
 #include "controllers/hid/hidenumerator.h"
 
-#if defined(Q_OS_ANDROID)
+#ifdef __ANDROID__
 #include <android/api-level.h>
 #include <android/log.h>
 #include <hidapi_libusb.h>
@@ -22,7 +22,7 @@ namespace mixxx {
 
 namespace hid {
 
-#ifndef Q_OS_ANDROID
+#ifndef __ANDROID__
 constexpr unsigned short kGenericDesktopUsagePage = 0x01;
 
 constexpr unsigned short kGenericDesktopMouseUsage = 0x02;
@@ -45,7 +45,7 @@ bool recognizeDevice(unsigned short vendor_id,
         unsigned short usage = 0) {
 // On Android, usage_page and usage are only accessible when permission is
 // granted to the device, so we don't use it for device detection.
-#ifndef Q_OS_ANDROID
+#ifndef __ANDROID__
     // Skip mice and keyboards. Users can accidentally disable their mouse
     // and/or keyboard by enabling them as HID controllers in Mixxx.
     // https://github.com/mixxxdj/mixxx/issues/10498
@@ -86,7 +86,7 @@ bool recognizeDevice(unsigned short vendor_id,
                 interface_number != denylisted.interface_number) {
             continue;
         }
-#ifdef Q_OS_ANDROID
+#ifdef __ANDROID__
         continue;
 #endif
         // Denylist entry based on usage_page and usage (both required)

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -156,7 +156,7 @@ QList<Controller*> HidEnumerator::queryDevices() {
             if (usbInterface.callMethod<jint>("getInterfaceClass") == LIBUSB_CLASS_HID) {
                 auto deviceInfo = mixxx::hid::DeviceInfo(usbDevice, usbInterface);
 
-                if (!recognizeDevice(deviceInfo) {
+                if (!recognizeDevice(deviceInfo)) {
                     qInfo() << "Excluding HID device" << deviceInfo;
                     continue;
                 }

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -41,8 +41,10 @@ namespace {
 bool recognizeDevice(const mixxx::hid::DeviceInfo& deviceInfo) {
     const unsigned short vendor_id = deviceInfo.getVendorId();
     const unsigned short product_id = deviceInfo.getProductId();
-    const int interface_number = deviceInfo.getUsbInterfaceNumber().value_or(
-            kInvalidInterfaceNumber);
+    const auto usbInterfaceNumber = deviceInfo.getUsbInterfaceNumber();
+    const int interface_number = usbInterfaceNumber.has_value()
+            ? static_cast<int>(*usbInterfaceNumber)
+            : kInvalidInterfaceNumber;
 // On Android, usage_page and usage are only accessible when permission is
 // granted to the device, so we don't use it for device detection.
 #ifndef __ANDROID__

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -14,7 +14,6 @@
 
 #include "controllers/hid/hidcontroller.h"
 #include "controllers/hid/hiddenylist.h"
-#include "controllers/hid/hidusagetables.h"
 #include "moc_hidenumerator.cpp"
 #include "util/cmdlineargs.h"
 
@@ -38,14 +37,17 @@ constexpr unsigned short kAppleIncVendorId = 0x004c;
 } // namespace mixxx
 
 namespace {
-bool recognizeDevice(unsigned short vendor_id,
-        unsigned short product_id,
-        int interface_number,
-        unsigned short usage_page = 0,
-        unsigned short usage = 0) {
+
+bool recognizeDevice(const mixxx::hid::DeviceInfo& deviceInfo) {
+    const unsigned short vendor_id = deviceInfo.getVendorId();
+    const unsigned short product_id = deviceInfo.getProductId();
+    const int interface_number = deviceInfo.getUsbInterfaceNumber().value_or(
+            kInvalidInterfaceNumber);
 // On Android, usage_page and usage are only accessible when permission is
 // granted to the device, so we don't use it for device detection.
 #ifndef __ANDROID__
+    const unsigned short usage_page = deviceInfo.getUsagePage();
+    const unsigned short usage = deviceInfo.getUsage();
     // Skip mice and keyboards. Users can accidentally disable their mouse
     // and/or keyboard by enabling them as HID controllers in Mixxx.
     // https://github.com/mixxxdj/mixxx/issues/10498
@@ -88,7 +90,7 @@ bool recognizeDevice(unsigned short vendor_id,
         }
 #ifdef __ANDROID__
         continue;
-#endif
+#else
         // Denylist entry based on usage_page and usage (both required)
         if (denylisted.usage_page != kAnyValue && denylisted.usage != kAnyValue) {
             // If usage_page is different, skip.
@@ -100,19 +102,13 @@ bool recognizeDevice(unsigned short vendor_id,
                 continue;
             }
         }
+#endif
         return false;
     }
     return true;
 }
-} // namespace
 
-bool HidEnumerator::recognizeDevice(const hid_device_info& device_info) const {
-    return ::recognizeDevice(device_info.vendor_id,
-            device_info.product_id,
-            device_info.interface_number,
-            device_info.usage_page,
-            device_info.usage);
-}
+} // namespace
 
 HidEnumerator::~HidEnumerator() {
     qDebug() << "Deleting HID devices...";
@@ -158,27 +154,22 @@ QList<Controller*> HidEnumerator::queryDevices() {
                     "(I)Landroid/hardware/usb/UsbInterface;",
                     ifaceIdx);
             if (usbInterface.callMethod<jint>("getInterfaceClass") == LIBUSB_CLASS_HID) {
-                auto device_info = mixxx::hid::DeviceInfo(usbDevice, usbInterface);
+                auto deviceInfo = mixxx::hid::DeviceInfo(usbDevice, usbInterface);
 
-                if (!::recognizeDevice(device_info.getVendorId(),
-                            device_info.getProductId(),
-                            device_info.getUsbInterfaceNumber().value())) {
-                    qInfo()
-                            << "Excluding HID device"
-                            << device_info;
+                if (!recognizeDevice(deviceInfo) {
+                    qInfo() << "Excluding HID device" << deviceInfo;
                     continue;
                 }
 
-                qInfo() << "Found HID device:"
-                        << device_info;
+                qInfo() << "Found HID device:" << deviceInfo;
 
-                if (!device_info.isValid()) {
+                if (!deviceInfo.isValid()) {
                     qWarning() << "HID device permissions problem or device error."
                                << "Your account needs write access to HID controllers.";
                     continue;
                 }
 
-                HidController* newDevice = new HidController(std::move(device_info));
+                HidController* newDevice = new HidController(std::move(deviceInfo));
                 m_devices.push_back(newDevice);
             }
         }
@@ -186,11 +177,11 @@ QList<Controller*> HidEnumerator::queryDevices() {
 #else
 
     QStringList enumeratedDevices;
-    hid_device_info* device_info_list = hid_enumerate(0x0, 0x0);
-    for (const auto* device_info = device_info_list;
-            device_info;
-            device_info = device_info->next) {
-        auto deviceInfo = mixxx::hid::DeviceInfo(*device_info);
+    hid_device_info* p_device_info_list = hid_enumerate(0x0, 0x0);
+    for (const auto* p_device_info = p_device_info_list;
+            p_device_info;
+            p_device_info = p_device_info->next) {
+        auto deviceInfo = mixxx::hid::DeviceInfo(*p_device_info);
         // The hidraw backend of hidapi on Linux returns many duplicate hid_device_info's from hid_enumerate,
         // so filter them out.
         // https://github.com/libusb/hidapi/issues/298
@@ -200,14 +191,11 @@ QList<Controller*> HidEnumerator::queryDevices() {
         }
         enumeratedDevices.append(QString(deviceInfo.pathRaw()));
 
-        if (!recognizeDevice(*device_info)) {
-            qInfo()
-                    << "Excluding HID device"
-                    << deviceInfo;
+        if (!recognizeDevice(deviceInfo)) {
+            qInfo() << "Excluding HID device" << deviceInfo;
             continue;
         }
-        qInfo() << "Found HID device:"
-                << deviceInfo;
+        qInfo() << "Found HID device:" << deviceInfo;
 
         if (!deviceInfo.isValid()) {
             qWarning() << "HID device permissions problem or device error."
@@ -218,7 +206,7 @@ QList<Controller*> HidEnumerator::queryDevices() {
         HidController* newDevice = new HidController(std::move(deviceInfo));
         m_devices.push_back(newDevice);
     }
-    hid_free_enumeration(device_info_list);
+    hid_free_enumeration(p_device_info_list);
 #endif
 
     return m_devices;

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -88,9 +88,7 @@ bool recognizeDevice(const mixxx::hid::DeviceInfo& deviceInfo) {
                 interface_number != denylisted.interface_number) {
             continue;
         }
-#ifdef __ANDROID__
-        continue;
-#else
+#ifndef __ANDROID__
         // Denylist entry based on usage_page and usage (both required)
         if (denylisted.usage_page != kAnyValue && denylisted.usage != kAnyValue) {
             // If usage_page is different, skip.

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -70,7 +70,7 @@ bool recognizeDevice(const mixxx::hid::DeviceInfo& deviceInfo) {
     }
 
     // Exclude specific devices from the denylist.
-    for (const hid_denylist_t& denylisted : hid_denylisted) {
+    for (const hid_denylist_t& denylisted : kHidDenyList) {
         // If vendor ids are specified and do not match, skip.
         if (denylisted.vendor_id != kAnyValue &&
                 vendor_id != denylisted.vendor_id) {

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -14,7 +14,6 @@
 
 #include "controllers/hid/hidcontroller.h"
 #include "controllers/hid/hiddenylist.h"
-#include "controllers/hid/hidusagetables.h"
 #include "moc_hidenumerator.cpp"
 #include "util/cmdlineargs.h"
 
@@ -38,14 +37,17 @@ constexpr unsigned short kAppleIncVendorId = 0x004c;
 } // namespace mixxx
 
 namespace {
-bool recognizeDevice(unsigned short vendor_id,
-        unsigned short product_id,
-        int interface_number,
-        unsigned short usage_page = 0,
-        unsigned short usage = 0) {
+
+bool recognizeDevice(const mixxx::hid::DeviceInfo& deviceInfo) {
+    const unsigned short vendor_id = deviceInfo.getVendorId();
+    const unsigned short product_id = deviceInfo.getProductId();
+    const int interface_number = deviceInfo.getUsbInterfaceNumber().value_or(
+            kInvalidInterfaceNumber);
 // On Android, usage_page and usage are only accessible when permission is
 // granted to the device, so we don't use it for device detection.
 #ifndef __ANDROID__
+    const unsigned short usage_page = deviceInfo.getUsagePage();
+    const unsigned short usage = deviceInfo.getUsage();
     // Skip mice and keyboards. Users can accidentally disable their mouse
     // and/or keyboard by enabling them as HID controllers in Mixxx.
     // https://github.com/mixxxdj/mixxx/issues/10498
@@ -88,7 +90,7 @@ bool recognizeDevice(unsigned short vendor_id,
         }
 #ifdef __ANDROID__
         continue;
-#endif
+#else
         // Denylist entry based on usage_page and usage (both required)
         if (denylisted.usage_page != kAnyValue && denylisted.usage != kAnyValue) {
             // If usage_page is different, skip.
@@ -100,19 +102,13 @@ bool recognizeDevice(unsigned short vendor_id,
                 continue;
             }
         }
+#endif
         return false;
     }
     return true;
 }
-} // namespace
 
-bool HidEnumerator::recognizeDevice(const hid_device_info& device_info) const {
-    return ::recognizeDevice(device_info.vendor_id,
-            device_info.product_id,
-            device_info.interface_number,
-            device_info.usage_page,
-            device_info.usage);
-}
+} // namespace
 
 HidEnumerator::~HidEnumerator() {
     qDebug() << "Deleting HID devices...";
@@ -158,27 +154,22 @@ QList<Controller*> HidEnumerator::queryDevices() {
                     "(I)Landroid/hardware/usb/UsbInterface;",
                     ifaceIdx);
             if (usbInterface.callMethod<jint>("getInterfaceClass") == LIBUSB_CLASS_HID) {
-                auto device_info = mixxx::hid::DeviceInfo(usbDevice, usbInterface);
+                auto deviceInfo = mixxx::hid::DeviceInfo(usbDevice, usbInterface);
 
-                if (!::recognizeDevice(device_info.getVendorId(),
-                            device_info.getProductId(),
-                            device_info.getUsbInterfaceNumber().value())) {
-                    qInfo()
-                            << "Excluding HID device"
-                            << device_info;
+                if (!recognizeDevice(deviceInfo)) {
+                    qInfo() << "Excluding HID device" << deviceInfo;
                     continue;
                 }
 
-                qInfo() << "Found HID device:"
-                        << device_info;
+                qInfo() << "Found HID device:" << deviceInfo;
 
-                if (!device_info.isValid()) {
+                if (!deviceInfo.isValid()) {
                     qWarning() << "HID device permissions problem or device error."
                                << "Your account needs write access to HID controllers.";
                     continue;
                 }
 
-                HidController* newDevice = new HidController(std::move(device_info));
+                HidController* newDevice = new HidController(std::move(deviceInfo));
                 m_devices.push_back(newDevice);
             }
         }
@@ -186,11 +177,11 @@ QList<Controller*> HidEnumerator::queryDevices() {
 #else
 
     QStringList enumeratedDevices;
-    hid_device_info* device_info_list = hid_enumerate(0x0, 0x0);
-    for (const auto* device_info = device_info_list;
-            device_info;
-            device_info = device_info->next) {
-        auto deviceInfo = mixxx::hid::DeviceInfo(*device_info);
+    hid_device_info* p_device_info_list = hid_enumerate(0x0, 0x0);
+    for (const auto* p_device_info = p_device_info_list;
+            p_device_info;
+            p_device_info = p_device_info->next) {
+        auto deviceInfo = mixxx::hid::DeviceInfo(*p_device_info);
         // The hidraw backend of hidapi on Linux returns many duplicate hid_device_info's from hid_enumerate,
         // so filter them out.
         // https://github.com/libusb/hidapi/issues/298
@@ -200,14 +191,11 @@ QList<Controller*> HidEnumerator::queryDevices() {
         }
         enumeratedDevices.append(QString(deviceInfo.pathRaw()));
 
-        if (!recognizeDevice(*device_info)) {
-            qInfo()
-                    << "Excluding HID device"
-                    << deviceInfo;
+        if (!recognizeDevice(deviceInfo)) {
+            qInfo() << "Excluding HID device" << deviceInfo;
             continue;
         }
-        qInfo() << "Found HID device:"
-                << deviceInfo;
+        qInfo() << "Found HID device:" << deviceInfo;
 
         if (!deviceInfo.isValid()) {
             qWarning() << "HID device permissions problem or device error."
@@ -218,7 +206,7 @@ QList<Controller*> HidEnumerator::queryDevices() {
         HidController* newDevice = new HidController(std::move(deviceInfo));
         m_devices.push_back(newDevice);
     }
-    hid_free_enumeration(device_info_list);
+    hid_free_enumeration(p_device_info_list);
 #endif
 
     return m_devices;

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -73,6 +73,13 @@ bool recognizeDevice(const mixxx::hid::DeviceInfo& deviceInfo) {
 
     // Exclude specific devices from the denylist.
     for (const hid_denylist_t& denylisted : kHidDenyList) {
+#ifdef __ANDROID__
+        if (denylisted.vendor_id == kAnyValue &&
+                denylisted.product_id == kAnyValue) {
+            // these wildcard entries would deny any devices on Android, skip
+            continue;
+        }
+#endif
         // If vendor ids are specified and do not match, skip.
         if (denylisted.vendor_id != kAnyValue &&
                 vendor_id != denylisted.vendor_id) {

--- a/src/controllers/hid/hidenumerator.h
+++ b/src/controllers/hid/hidenumerator.h
@@ -8,7 +8,6 @@
 class HidEnumerator : public ControllerEnumerator {
     Q_OBJECT
   public:
-    bool recognizeDevice(const hid_device_info& device_info) const;
     HidEnumerator() = default;
     ~HidEnumerator() override;
 


### PR DESCRIPTION
In that last commit, this fixes a logic inversion that leads to bypassing the HID list. 

The earlier commits fix confusing naming and a "grown" control flow. Now Android and Desktop code aligns better. 
It is pure refactoring and shall not cause a logic change.  

This is however not tested. (No Android Dev environment and and no HID controller) 