### PR TITLE
Refactor: fix typos and unify naming consistency in effects and engine

### DIFF
--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -422,7 +422,7 @@ void EffectChain::enableForInputChannel(const ChannelHandleAndGroup& handleGroup
     // avoid allocating memory in the realtime audio callback thread.
 
     for (int i = 0; i < m_effectSlots.size(); ++i) {
-        m_effectSlots[i]->initalizeInputChannel(handleGroup.handle());
+        m_effectSlots[i]->initializeInputChannel(handleGroup.handle());
     }
 
     m_pMessenger->writeRequest(request);

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -196,11 +196,11 @@ void EffectSlot::updateEngineState() {
     }
 }
 
-void EffectSlot::initalizeInputChannel(ChannelHandle inputChannel) {
+void EffectSlot::initializeInputChannel(ChannelHandle inputChannel) {
     if (!m_pEngineEffect) {
         return;
     }
-    m_pEngineEffect->initalizeInputChannel(inputChannel);
+    m_pEngineEffect->initializeInputChannel(inputChannel);
 };
 
 EffectManifestPointer EffectSlot::getManifest() const {

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -117,7 +117,7 @@ class EffectSlot : public QObject {
         return m_group;
     }
 
-    void initalizeInputChannel(ChannelHandle inputChannel);
+    void initializeInputChannel(ChannelHandle inputChannel);
 
     EffectManifestPointer getManifest() const;
 

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -53,7 +53,7 @@ EngineEffect::~EngineEffect() {
     }
 }
 
-void EngineEffect::initalizeInputChannel(ChannelHandle inputChannel) {
+void EngineEffect::initializeInputChannel(ChannelHandle inputChannel) {
     if (m_pProcessor->hasStatesForInputChannel(inputChannel)) {
         // already initialized for this input channel
         return;

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -30,7 +30,7 @@ class EngineEffect final : public EffectsRequestHandler {
     ~EngineEffect();
 
     /// Called from the main thread to make sure that the channel already has states
-    void initalizeInputChannel(ChannelHandle inputChannel);
+    void initializeInputChannel(ChannelHandle inputChannel);
 
     /// Called in audio thread
     bool processEffectsRequest(


### PR DESCRIPTION
Hi @ronso0, @daschuer.

Following your feedback in #16251, I've isolated the naming consistency and typo fixes into this clean PR. I've removed the redundant trimming logic to avoid metadata round-trip issues.

This serves as my environment verification and initial contribution for GSoC 2026. Ready for review!