### PR TITLE
Add support for beat subdivisions

### DIFF
--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -21,11 +21,25 @@ WaveformRenderBeat::WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget,
           m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip) {
     initForRectangles<UniColorMaterial>(0);
     setUsePreprocess(true);
+
+    auto pSubNode = std::make_unique<GeometryNode>();
+    m_pSubNode = pSubNode.get();
+    m_pSubNode->initForRectangles<UniColorMaterial>(0);
+    appendChildNode(std::move(pSubNode));
 }
 
 void WaveformRenderBeat::setup(const QDomNode& node, const SkinContext& skinContext) {
     m_color = QColor(skinContext.selectString(node, QStringLiteral("BeatColor")));
     m_color = WSkinColor::getCorrectColor(m_color).toRgb();
+
+    m_subColor = QColor(skinContext.selectString(
+            node, QStringLiteral("BeatSubdivisionColor")));
+    if (m_subColor.isValid()) {
+        m_subColor = WSkinColor::getCorrectColor(m_subColor).toRgb();
+    }
+
+    m_beatThickness = skinContext.selectDouble(
+            node, QStringLiteral("BeatThickness"), 1.0);
 }
 
 void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* event) {
@@ -38,6 +52,8 @@ void WaveformRenderBeat::preprocess() {
     if (!preprocessInner()) {
         geometry().allocate(0);
         markDirtyGeometry();
+        m_pSubNode->geometry().allocate(0);
+        m_pSubNode->markDirtyGeometry();
     }
 }
 
@@ -56,16 +72,20 @@ bool WaveformRenderBeat::preprocessInner() {
         return false;
     }
 
+    const bool showSubdivisions = m_subColor.isValid();
 #ifndef __SCENEGRAPH__
     int alpha = m_waveformRenderer->getBeatGridAlpha();
     if (alpha == 0) {
         return false;
     }
     m_color.setAlphaF(alpha / 100.0f);
+    if (showSubdivisions) {
+        m_subColor.setAlphaF(alpha / 100.0f);
+    }
 #endif
 
-    if (!m_color.alpha()) {
-        // Don't render the beatgrid lines is there are fully transparent
+    if (!m_color.alpha() && !(showSubdivisions && m_subColor.alpha())) {
+        // Don't render the beatgrid lines if they are fully transparent
         return true;
     }
 
@@ -105,33 +125,64 @@ bool WaveformRenderBeat::preprocessInner() {
         numBeatsInRange++;
     }
 
-    const int reserved = numBeatsInRange * numVerticesPerLine;
-    geometry().allocate(reserved);
+    const int onBeatVertices = numBeatsInRange * numVerticesPerLine;
+    const int subVertices = showSubdivisions ? numBeatsInRange * 3 * numVerticesPerLine : 0;
+    geometry().allocate(onBeatVertices);
+    m_pSubNode->geometry().allocate(subVertices);
 
-    VertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::Point2D>()};
+    VertexUpdater beatUpdater{geometry().vertexDataAs<Geometry::Point2D>()};
+    VertexUpdater subUpdater{m_pSubNode->geometry().vertexDataAs<Geometry::Point2D>()};
+
+    const float breadth = m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth;
+    const float subBreadth = breadth * 0.5f;
+    const float subStart = (breadth - subBreadth) * 0.5f;
+    const float subEnd = subStart + subBreadth;
+    const float halfThickness = static_cast<float>(m_beatThickness * 0.5);
 
     for (auto it = trackBeats->iteratorFrom(startPosition);
             it != trackBeats->cend() && *it <= endPosition;
             ++it) {
-        double beatPosition = it->toEngineSamplePos();
+        const auto beatPos = *it;
+        const auto beatLength = it.beatLengthFrames();
         double xBeatPoint =
                 m_waveformRenderer->transformSamplePositionInRendererWorld(
-                        beatPosition, positionType);
+                        beatPos.toEngineSamplePos(), positionType);
 
         xBeatPoint = qRound(xBeatPoint * devicePixelRatio) / devicePixelRatio;
 
         const float x1 = static_cast<float>(xBeatPoint);
-        const float x2 = x1 + 1.f;
+        // On-beat: m_beatThickness wide, full breadth, centered on the beat.
+        beatUpdater.addRectangle(
+                {x1 + 0.5f - halfThickness, 0.f},
+                {x1 + 0.5f + halfThickness, breadth});
 
-        vertexUpdater.addRectangle({x1, 0.f},
-                {x2, m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth});
+        if (!showSubdivisions) {
+            continue;
+        }
+
+        // 3 subdivisions at +1/4, +1/2, +3/4 of this beat's length:
+        // 1px wide, centered half-breadth.
+        for (int i = 1; i <= 3; ++i) {
+            const auto subPos = beatPos + beatLength * i / 4.0;
+            double xSub = m_waveformRenderer->transformSamplePositionInRendererWorld(
+                    subPos.toEngineSamplePos(), positionType);
+            xSub = qRound(xSub * devicePixelRatio) / devicePixelRatio;
+            const float sx1 = static_cast<float>(xSub);
+            subUpdater.addRectangle({sx1, subStart}, {sx1 + 1.f, subEnd});
+        }
     }
     markDirtyGeometry();
+    m_pSubNode->markDirtyGeometry();
 
-    DEBUG_ASSERT(reserved == vertexUpdater.index());
+    DEBUG_ASSERT(onBeatVertices == beatUpdater.index());
+    DEBUG_ASSERT(subVertices == subUpdater.index());
 
     material().setUniform(1, m_color);
     markDirtyMaterial();
+    if (showSubdivisions) {
+        m_pSubNode->material().setUniform(1, m_subColor);
+        m_pSubNode->markDirtyMaterial();
+    }
 
     return true;
 }

--- a/src/waveform/renderers/allshader/waveformrenderbeat.h
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.h
@@ -38,7 +38,10 @@ class allshader::WaveformRenderBeat final
 
   private:
     QColor m_color;
+    QColor m_subColor;
+    double m_beatThickness{1.0};
     bool m_isSlipRenderer;
+    rendergraph::GeometryNode* m_pSubNode{};
 
     bool preprocessInner();
 

--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -12,6 +12,7 @@ class QPaintEvent;
 WaveformRenderBeat::WaveformRenderBeat(WaveformWidgetRenderer* waveformWidgetRenderer)
         : WaveformRendererAbstract(waveformWidgetRenderer) {
     m_beats.resize(128);
+    m_subdivisions.resize(128 * 3);
 }
 
 WaveformRenderBeat::~WaveformRenderBeat() {
@@ -20,6 +21,13 @@ WaveformRenderBeat::~WaveformRenderBeat() {
 void WaveformRenderBeat::setup(const QDomNode& node, const SkinContext& context) {
     m_beatColor = QColor(context.selectString(node, "BeatColor"));
     m_beatColor = WSkinColor::getCorrectColor(m_beatColor).toRgb();
+
+    m_subBeatColor = QColor(context.selectString(node, "BeatSubdivisionColor"));
+    if (m_subBeatColor.isValid()) {
+        m_subBeatColor = WSkinColor::getCorrectColor(m_subBeatColor).toRgb();
+    }
+
+    m_beatThickness = context.selectDouble(node, "BeatThickness", 1.0);
 }
 
 void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
@@ -38,13 +46,20 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
     if (alpha == 0) {
         return;
     }
+    const bool showSubdivisions = m_subBeatColor.isValid();
 #ifdef MIXXX_USE_QOPENGL
     // Using alpha transparency with drawLines causes a graphical issue when
     // drawing with QPainter on the QOpenGLWindow: instead of individual lines
     // a large rectangle encompassing all beatlines is drawn.
     m_beatColor.setAlphaF(1.f);
+    if (showSubdivisions) {
+        m_subBeatColor.setAlphaF(1.f);
+    }
 #else
     m_beatColor.setAlphaF(alpha/100.0);
+    if (showSubdivisions) {
+        m_subBeatColor.setAlphaF(alpha/100.0);
+    }
 #endif
 
     const double trackSamples = m_waveformRenderer->getTrackSamples();
@@ -78,20 +93,23 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
     painter->setRenderHint(QPainter::Antialiasing);
 
-    QPen beatPen(m_beatColor);
-    beatPen.setWidthF(std::max(1.0, scaleFactor()));
-    painter->setPen(beatPen);
-
     const Qt::Orientation orientation = m_waveformRenderer->getOrientation();
     const float rendererWidth = m_waveformRenderer->getWidth();
     const float rendererHeight = m_waveformRenderer->getHeight();
+    const float rendererBreadth =
+            (orientation == Qt::Horizontal) ? rendererHeight : rendererWidth;
+    const float subBreadth = rendererBreadth * 0.5f;
+    const float subStart = (rendererBreadth - subBreadth) * 0.5f;
+    const float subEnd = subStart + subBreadth;
 
     int beatCount = 0;
+    int subCount = 0;
 
     for (; it != trackBeats->cend() && *it <= endPosition; ++it) {
-        double beatPosition = it->toEngineSamplePos();
-        double xBeatPoint =
-                m_waveformRenderer->transformSamplePositionInRendererWorld(beatPosition);
+        const auto beatPos = *it;
+        const auto beatLength = it.beatLengthFrames();
+        double xBeatPoint = m_waveformRenderer->transformSamplePositionInRendererWorld(
+                beatPos.toEngineSamplePos());
 
         xBeatPoint = qRound(xBeatPoint * devicePixelRatio) / devicePixelRatio;
 
@@ -105,8 +123,39 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
         } else {
             m_beats[beatCount++].setLine(0.0f, xBeatPoint, rendererWidth, xBeatPoint);
         }
+
+        if (!showSubdivisions) {
+            continue;
+        }
+
+        if (subCount + 3 > m_subdivisions.size()) {
+            m_subdivisions.resize(m_subdivisions.size() * 2);
+        }
+
+        for (int i = 1; i <= 3; ++i) {
+            const auto subPos = beatPos + beatLength * i / 4.0;
+            double xSubPoint = m_waveformRenderer->transformSamplePositionInRendererWorld(
+                    subPos.toEngineSamplePos());
+            xSubPoint = qRound(xSubPoint * devicePixelRatio) / devicePixelRatio;
+
+            if (orientation == Qt::Horizontal) {
+                m_subdivisions[subCount++].setLine(xSubPoint, subStart, xSubPoint, subEnd);
+            } else {
+                m_subdivisions[subCount++].setLine(subStart, xSubPoint, subEnd, xSubPoint);
+            }
+        }
     }
 
-    // Make sure to use constData to prevent detaches!
+    // Subdivisions first (thinner, shorter) so on-beat lines draw on top.
+    if (showSubdivisions) {
+        QPen subPen(m_subBeatColor);
+        subPen.setWidthF(std::max(1.0, scaleFactor()));
+        painter->setPen(subPen);
+        painter->drawLines(m_subdivisions.constData(), subCount);
+    }
+
+    QPen beatPen(m_beatColor);
+    beatPen.setWidthF(m_beatThickness * std::max(1.0, scaleFactor()));
+    painter->setPen(beatPen);
     painter->drawLines(m_beats.constData(), beatCount);
 }

--- a/src/waveform/renderers/waveformrenderbeat.h
+++ b/src/waveform/renderers/waveformrenderbeat.h
@@ -16,7 +16,10 @@ class WaveformRenderBeat : public WaveformRendererAbstract {
 
   private:
     QColor m_beatColor;
+    QColor m_subBeatColor;
+    double m_beatThickness{1.0};
     QVector<QLineF> m_beats;
+    QVector<QLineF> m_subdivisions;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderBeat);
 };


### PR DESCRIPTION
  * BeatSubdivisionColor if set enables 4/4 subdivisions in waveform with color set separately from the main beat bar
  * BeatThickness changes the line thickness of the main beat bar, scaling proportionally to DPI

With neither option set in `waveform.xml`:
<img width="783" height="477" alt="Screenshot 2026-04-16 191541" src="https://github.com/user-attachments/assets/46b410d2-8454-4dcf-ba36-51e9f2700d5c" />

With `BeatSubdivisionColor` set to `#fff` and `BeatThickness` set to `3.0`:
<img width="674" height="495" alt="Screenshot 2026-04-16 191454" src="https://github.com/user-attachments/assets/485f3aad-a066-4e3d-9eb5-0825cf1bc50a" />
