### PR TITLE
Request security scoped bookmark for files in imported playlists on macOS

### DIFF
--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -492,7 +492,42 @@ void BasePlaylistFeature::slotImportPlaylistFile(const QString& playlistFile,
             Qt::AscendingOrder);
     pPlaylistTableModel->select();
 
-    QList<QString> locations = Parser::parse(playlistFile);
+    const QList<QString> allLocations = Parser::parseAllLocations(playlistFile);
+    const QString basePath = QFileInfo(playlistFile).canonicalPath();
+
+    QList<QString> locations;
+    for (const auto& rawLocation : allLocations) {
+        if (rawLocation.trimmed().isEmpty()) {
+            continue;
+        }
+        mixxx::FileInfo trackFile =
+                Parser::playlistEntryToFileInfo(rawLocation, basePath);
+
+#if defined(__APPLE__)
+        if (Sandbox::enabled() && !trackFile.isReadable() &&
+                !Sandbox::canAccess(&trackFile)) {
+            // The file may be inaccessible due to macOS App Sandbox rather
+            // than genuinely missing. Request access to the containing
+            // directory to obtain a security-scoped bookmark, then retry.
+            mixxx::FileInfo dirInfo(trackFile.locationPath());
+            if (Sandbox::askForAccess(&dirInfo)) {
+                trackFile.refresh();
+            } else {
+                // User cancelled — stop prompting to avoid repeated dialogs.
+                qWarning() << "Sandbox access denied or cancelled for"
+                           << trackFile.locationPath();
+                break;
+            }
+        }
+#endif
+
+        if (trackFile.checkFileExists()) {
+            locations.append(trackFile.location());
+        } else {
+            qInfo() << "File" << trackFile.location() << "from playlist"
+                    << playlistFile << "does not exist.";
+        }
+    }
     // Iterate over the List that holds locations of playlist entries
     pPlaylistTableModel->addTracks(QModelIndex(), locations);
 }


### PR DESCRIPTION
When importing a playlist on macOS with App Sandbox enabled, Mixxx previously lacked permissions to read the files referenced inside the playlist, resulting in missing or inaccessible tracks.

This PR resolves the issue by iterating over the imported track locations and checking `Sandbox::canAccess()` for each. If a track is inaccessible, Mixxx automatically prompts the user via `Sandbox::askForAccess()` for permission to the file's parent directory, creating a persistent security-scoped bookmark before iterating through the rest. If the user cancels the permission prompt, the loop breaks to respectfully avoid repeatedly annoying them.

## **Changes:**

- Added `#include "util/sandbox.h"` to `baseplaylistfeature.cpp`.
- Implemented macOS Sandbox permission checking and prompt logic within `BasePlaylistFeature::slotImportPlaylistFile`.



## Verification

I created a playlist file `play.m3u` located at my Desktop folder and proceeded to import the playlist inside Mixxx.

- First, the system prompt to give access:
<img width="262" height="320" alt="Screenshot 2026-04-22 at 6 55 13 PM" src="https://github.com/user-attachments/assets/772c1f18-d189-4870-af55-8a6049ee816d">

- Then, the native file picker opens, expecting the user to press `Open` to grant access to the folder.
<img width="729" height="388" alt="Screenshot 2026-04-22 at 9 34 44 PM" src="https://github.com/user-attachments/assets/c3e91636-d962-4a00-ad26-64c6e60cdb48">

- Finally, the playlist gets imported into mixxx.
<img width="1452" height="130" alt="Screenshot 2026-04-22 at 9 35 16 PM" src="https://github.com/user-attachments/assets/ec9295ab-3a9d-4800-ad32-f6b1e8a4f396">


Closes #7309 
