### PR TITLE
(fix) WOverview: ignore leave event if left mouse is still pressed

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -2,6 +2,7 @@
 
 #include <QBrush>
 #include <QColor>
+#include <QGuiApplication>
 #include <QMouseEvent>
 #include <QPaintEvent>
 #include <QPainter>
@@ -669,6 +670,18 @@ void WOverview::slotCueMenuPopupAboutToHide() {
 
 void WOverview::leaveEvent(QEvent* pEvent) {
     Q_UNUSED(pEvent);
+    // Reset our dragging only if the left button is not pressed.
+    // This works around a Qt mouse event change after Qt 6.5 which causes
+    // leaveEvents to be emitted when we hover another widget which has set the
+    // acceptDrops() property true (eg. WSpinnyBase) -- even if we explicitly
+    // setMouseTracking(true) and the left button is still pressed.
+    // See https://github.com/mixxxdj/mixxx/issues/16306
+    // We still get another leave event when we release outside WOverview.
+    // Note: casting to QMouseEvent works, but buttons are not reported correctly,
+    // QGuiApplication::mouseButtons() is the way to go here.
+    if (QGuiApplication::mouseButtons() & Qt::LeftButton) {
+        return;
+    }
     if (!m_pCueMenuPopup->isVisible()) {
         m_pHoveredMark.clear();
     }

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -141,12 +141,12 @@ class WOverview : public WWidget, public TrackDropTarget {
         }
     }
 
-    // Hold the last visual sample processed to generate the pixmap
 
     const QString m_group;
     UserSettingsPointer m_pConfig;
 
     mixxx::OverviewType m_type;
+    // Hold the last visual sample processed to generate the pixmap
     int m_actualCompletion;
     bool m_pixmapDone;
     float m_waveformPeak;


### PR DESCRIPTION
Fixes #16306
This works around a Drag'n'drop event handling improvement added in Qt 6.5 or later, which causes leaveEvents to be emitted when we hover another widget which has set the acceptDrops() property true (eg. WSpinnyBase)
-- even if we've explicitly `setMouseTracking(true)` in the overview and the left button is still pressed.
We still get a second leave event when we actually release the cursor outside WOverview.

~~Second commits also resets dragging and hover states when the window loses focus or is hidden.~~ not mature, removed. will try again if there's demand