### PR TITLE
Add Pioneer DDJ SX2 Mapping

### DIFF
--- a/res/controllers/PIONEER-DDJ-SX2.midi.xml
+++ b/res/controllers/PIONEER-DDJ-SX2.midi.xml
@@ -4,10 +4,15 @@
     <name>Pioneer DDJ-SX2</name>
     <author>Krafting, hrudham, tildearrow, eXWoLL1</author>
     <description>Pioneer DDJ-SX2 mapping for Mixxx</description>
+    <manual>pioneer_ddj_sx2</manual>
+    <forums>https://mixxx.discourse.group/t/pioneer-ddj-sx2-mapping/33575/8</forums>
   </info>
   <settings>
     <group label="General Settings">
       <option variable="NeedleSearchBehaviour" type="boolean" default="0" label="Allow to use needle search when a song is playing. If disabled, you can use :hwbtn:`Shift` + :hwbtn:`NeedleSearch` to use the needle search when a song is playing." />
+      <option variable="LoadBehaviour" type="boolean" default="0" label="When loading a track onto a deck, disabled all headphone cues from all deck and enable the headphone cue from the loaded deck" />
+      <option variable="KeySyncBehaviour" type="boolean" default="0" label="Enable Alternative Deck Key Sync (Flip Slot Button): Syncs track´s key to the opposite side loaded deck. Gives more control over which deck the key is taken from, useful for multi-deck mixing" />
+      <option variable="SoftTakeoverBehaviour" type="boolean" default="0" label="Disable soft takeover of sliders and knobs when launching Mixxx or switching tracks. Checking this will activate instant updates of the target Mixxx control to the hardware position." />
     </group>
     <group label="Scratch Settings">
       <option variable="safeScratchTimeout" default="20" min="20" max="1000" step="10" type="integer" label="Safe Scratch Timeout (ms) (20ms is the minimum allowed)" />
@@ -25,7 +30,6 @@
   </settings>
   <controller id="PIONEER DDJ-SX2">
     <scriptfiles>
-      <file filename="lodash.mixxx.js" />
       <file filename="midi-components-0.0.js" />
       <file functionprefix="PioneerDDJSX2" filename="PIONEER-DDJ-SX2.scripts.js" />
     </scriptfiles>
@@ -394,7 +398,7 @@
         <key>PioneerDDJSX2.NeedleSearch</key>
         <description>Needle search for Deck 2 when Shifting</description>
         <status>0xB1</status>
-        <midino>0x03</midino>
+        <midino>0x28</midino>
         <options>
           <script-binding />
         </options>
@@ -404,7 +408,7 @@
         <key>PioneerDDJSX2.NeedleSearch</key>
         <description>Needle search for Deck 3 when Shifting</description>
         <status>0xB2</status>
-        <midino>0x03</midino>
+        <midino>0x28</midino>
         <options>
           <script-binding />
         </options>
@@ -414,7 +418,7 @@
         <key>PioneerDDJSX2.NeedleSearch</key>
         <description>Needle search for Deck 4 when Shifting</description>
         <status>0xB3</status>
-        <midino>0x03</midino>
+        <midino>0x28</midino>
         <options>
           <script-binding />
         </options>
@@ -4328,11 +4332,38 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>LoadSelectedTrack</key>
+        <key>PioneerDDJSX2.LoadSelectedTrack</key>
         <status>0x96</status>
         <midino>0x46</midino>
         <options>
-          <normal />
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.LoadSelectedTrack</key>
+        <status>0x96</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.LoadSelectedTrack</key>
+        <status>0x96</status>
+        <midino>0x48</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.LoadSelectedTrack</key>
+        <status>0x96</status>
+        <midino>0x49</midino>
+        <options>
+          <script-binding />
         </options>
       </control>
       <control>
@@ -4506,15 +4537,6 @@
         </options>
       </control>
       <control>
-        <group>[Channel2]</group>
-        <key>LoadSelectedTrack</key>
-        <status>0x96</status>
-        <midino>0x47</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
         <group>[Channel1]</group>
         <description>Activate Hotcue Loop 16 on channel 1</description>
         <key>hotcue_16_activateloop</key>
@@ -4609,15 +4631,6 @@
         </options>
       </control>
       <control>
-        <group>[Channel3]</group>
-        <key>LoadSelectedTrack</key>
-        <status>0x96</status>
-        <midino>0x48</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
         <group>[Channel1]</group>
         <key>hotcue_9_clear</key>
         <status>0x97</status>
@@ -4656,7 +4669,7 @@
       <control>
         <group>[Channel1]</group>
         <key>PioneerDDJSX2.FlipStart</key>
-        <description>Toggle Loop Anchor with the Flip Start button on Deck 1</description>
+        <description>Set the pitch of the track up on Deck 1</description>
         <status>0x90</status>
         <midino>0x4B</midino>
         <options>
@@ -4666,7 +4679,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.FlipStart</key>
-        <description>Toggle Loop Anchor with the Flip Start button on Deck 2</description>
+        <description>Set the pitch of the track up on Deck 2</description>
         <status>0x91</status>
         <midino>0x4B</midino>
         <options>
@@ -4676,7 +4689,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.FlipStart</key>
-        <description>Toggle Loop Anchor with the Flip Start button on Deck 3</description>
+        <description>Set the pitch of the track up on Deck 3</description>
         <status>0x92</status>
         <midino>0x4B</midino>
         <options>
@@ -4686,7 +4699,7 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.FlipStart</key>
-        <description>Toggle Loop Anchor with the Flip Start button on Deck 4</description>
+        <description>Set the pitch of the track up on Deck 4</description>
         <status>0x93</status>
         <midino>0x4B</midino>
         <options>
@@ -4696,7 +4709,7 @@
       <control>
         <group>[Channel1]</group>
         <key>PioneerDDJSX2.FlipRec</key>
-        <description>Toggle Quantize with the Flip Rec button on Deck 1</description>
+        <description>Set the pitch of the track down Deck 1</description>
         <status>0x90</status>
         <midino>0x4A</midino>
         <options>
@@ -4706,7 +4719,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.FlipRec</key>
-        <description>Toggle Quantize with the Flip Rec button on Deck 2</description>
+        <description>Set the pitch of the track down Deck 2</description>
         <status>0x91</status>
         <midino>0x4A</midino>
         <options>
@@ -4716,7 +4729,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.FlipRec</key>
-        <description>Toggle Quantize with the Flip Rec button on Deck 3</description>
+        <description>Set the pitch of the track down Deck 3</description>
         <status>0x92</status>
         <midino>0x4A</midino>
         <options>
@@ -4726,7 +4739,7 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.FlipRec</key>
-        <description>Toggle Quantize with the Flip Rec button on Deck 4</description>
+        <description>Set the pitch of the track down Deck 4</description>
         <status>0x93</status>
         <midino>0x4A</midino>
         <options>
@@ -4736,7 +4749,7 @@
       <control>
         <group>[Channel1]</group>
         <key>PioneerDDJSX2.FlipSlot</key>
-        <description>Reset current track key Flip Slot button on Deck 1</description>
+        <description>Key Sync Deck 1</description>
         <status>0x90</status>
         <midino>0x49</midino>
         <options>
@@ -4746,7 +4759,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.FlipSlot</key>
-        <description>Reset current track key Flip Slot button on Deck 2</description>
+        <description>Key Sync Deck 2</description>
         <status>0x91</status>
         <midino>0x49</midino>
         <options>
@@ -4756,7 +4769,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.FlipSlot</key>
-        <description>Reset current track key Flip Slot button on Deck 3</description>
+        <description>Key Sync Deck 3</description>
         <status>0x92</status>
         <midino>0x49</midino>
         <options>
@@ -4766,7 +4779,7 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.FlipSlot</key>
-        <description>Reset current track key Flip Slot button on Deck 4</description>
+        <description>Key Sync Deck 4</description>
         <status>0x93</status>
         <midino>0x49</midino>
         <options>
@@ -4856,7 +4869,7 @@
       <control>
         <group>[Channel1]</group>
         <key>PioneerDDJSX2.FlipSave</key>
-        <description>Set the Key DOWN for the track on Deck 1 with the SHIFT + SLOT button</description>
+        <description>Resets track key to original</description>
         <status>0x90</status>
         <midino>0x59</midino>
         <options>
@@ -4866,7 +4879,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.FlipSave</key>
-        <description>Set the Key DOWN for the track on Deck 2 with the SHIFT + SLOT button</description>
+        <description>Resets track key to original</description>
         <status>0x91</status>
         <midino>0x59</midino>
         <options>
@@ -4876,7 +4889,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.FlipSave</key>
-        <description>Set the Key DOWN for the track on Deck 3 with the SHIFT + SLOT button</description>
+        <description>Resets track key to original</description>
         <status>0x92</status>
         <midino>0x59</midino>
         <options>
@@ -4886,7 +4899,7 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.FlipSave</key>
-        <description>Set the Key DOWN for the track on Deck 4 with the SHIFT + SLOT button</description>
+        <description>Resets track key to original</description>
         <status>0x93</status>
         <midino>0x59</midino>
         <options>
@@ -4909,15 +4922,6 @@
         <midino>0x49</midino>
         <options>
           <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>LoadSelectedTrack</key>
-        <status>0x96</status>
-        <midino>0x49</midino>
-        <options>
-          <normal />
         </options>
       </control>
       <control>
@@ -5093,38 +5097,38 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>reloop_exit</key>
+        <key>PioneerDDJSX2.ReloopExit</key>
         <status>0x90</status>
         <midino>0x4D</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>reloop_exit</key>
+        <key>PioneerDDJSX2.ReloopExit</key>
         <status>0x91</status>
         <midino>0x4D</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>reloop_exit</key>
+        <key>PioneerDDJSX2.ReloopExit</key>
         <status>0x92</status>
         <midino>0x4D</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>reloop_exit</key>
+        <key>PioneerDDJSX2.ReloopExit</key>
         <status>0x93</status>
         <midino>0x4D</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
@@ -5727,7 +5731,7 @@
         </options>
       </control>
       <control>
-        <group>0</group>
+        <group>[Channel1]</group>
         <key>PioneerDDJSX2.SyncEnable</key>
         <status>0x90</status>
         <midino>0x58</midino>
@@ -5736,7 +5740,7 @@
         </options>
       </control>
       <control>
-        <group>1</group>
+        <group>[Channel2]</group>
         <key>PioneerDDJSX2.SyncEnable</key>
         <status>0x91</status>
         <midino>0x58</midino>
@@ -5745,7 +5749,7 @@
         </options>
       </control>
       <control>
-        <group>2</group>
+        <group>[Channel3]</group>
         <key>PioneerDDJSX2.SyncEnable</key>
         <status>0x92</status>
         <midino>0x58</midino>
@@ -5754,7 +5758,7 @@
         </options>
       </control>
       <control>
-        <group>3</group>
+        <group>[Channel4]</group>
         <key>PioneerDDJSX2.SyncEnable</key>
         <status>0x93</status>
         <midino>0x58</midino>
@@ -5764,150 +5768,6 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>hotcue_17_clear</key>
-        <status>0x97</status>
-        <midino>0x58</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>hotcue_17_clear</key>
-        <status>0x98</status>
-        <midino>0x58</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>hotcue_17_clear</key>
-        <status>0x99</status>
-        <midino>0x58</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>hotcue_17_clear</key>
-        <status>0x9A</status>
-        <midino>0x58</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>hotcue_18_clear</key>
-        <status>0x97</status>
-        <midino>0x59</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>hotcue_18_clear</key>
-        <status>0x98</status>
-        <midino>0x59</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>hotcue_18_clear</key>
-        <status>0x99</status>
-        <midino>0x59</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>hotcue_18_clear</key>
-        <status>0x9A</status>
-        <midino>0x59</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>hotcue_19_clear</key>
-        <status>0x97</status>
-        <midino>0x5A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>hotcue_19_clear</key>
-        <status>0x98</status>
-        <midino>0x5A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>hotcue_19_clear</key>
-        <status>0x99</status>
-        <midino>0x5A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>hotcue_19_clear</key>
-        <status>0x9A</status>
-        <midino>0x5A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>hotcue_20_clear</key>
-        <status>0x97</status>
-        <midino>0x5B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>hotcue_20_clear</key>
-        <status>0x98</status>
-        <midino>0x5B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>hotcue_20_clear</key>
-        <status>0x99</status>
-        <midino>0x5B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>hotcue_20_clear</key>
-        <status>0x9A</status>
-        <midino>0x5B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>0</group>
         <key>PioneerDDJSX2.SyncDisable</key>
         <status>0x90</status>
         <midino>0x5C</midino>
@@ -5916,7 +5776,7 @@
         </options>
       </control>
       <control>
-        <group>1</group>
+        <group>[Channel2]</group>
         <key>PioneerDDJSX2.SyncDisable</key>
         <status>0x91</status>
         <midino>0x5C</midino>
@@ -5925,7 +5785,7 @@
         </options>
       </control>
       <control>
-        <group>2</group>
+        <group>[Channel3]</group>
         <key>PioneerDDJSX2.SyncDisable</key>
         <status>0x92</status>
         <midino>0x5C</midino>
@@ -5934,12 +5794,156 @@
         </options>
       </control>
       <control>
-        <group>3</group>
+        <group>[Channel4]</group>
         <key>PioneerDDJSX2.SyncDisable</key>
         <status>0x93</status>
         <midino>0x5C</midino>
         <options>
           <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_17_clear</key>
+        <status>0x97</status>
+        <midino>0x58</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_17_clear</key>
+        <status>0x98</status>
+        <midino>0x58</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_17_clear</key>
+        <status>0x99</status>
+        <midino>0x58</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_17_clear</key>
+        <status>0x9A</status>
+        <midino>0x58</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_18_clear</key>
+        <status>0x97</status>
+        <midino>0x59</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_18_clear</key>
+        <status>0x98</status>
+        <midino>0x59</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_18_clear</key>
+        <status>0x99</status>
+        <midino>0x59</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_18_clear</key>
+        <status>0x9A</status>
+        <midino>0x59</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_19_clear</key>
+        <status>0x97</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_19_clear</key>
+        <status>0x98</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_19_clear</key>
+        <status>0x99</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_19_clear</key>
+        <status>0x9A</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_20_clear</key>
+        <status>0x97</status>
+        <midino>0x5B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_20_clear</key>
+        <status>0x98</status>
+        <midino>0x5B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_20_clear</key>
+        <status>0x99</status>
+        <midino>0x5B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_20_clear</key>
+        <status>0x9A</status>
+        <midino>0x5B</midino>
+        <options>
+          <normal />
         </options>
       </control>
       <control>
@@ -7073,6 +7077,46 @@
         <key>PioneerDDJSX2.SetSampleGain</key>
         <status>0xBA</status>
         <midino>0x71</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.DeckToggle</key>
+        <description>Deck 1 select button (Side A)</description>
+        <status>0x90</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.DeckToggle</key>
+        <description>Deck 2 select button (Side B)</description>
+        <status>0x91</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.DeckToggle</key>
+        <description>Deck 3 select button (Side A)</description>
+        <status>0x92</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.DeckToggle</key>
+        <description>Deck 4 select button (Side B)</description>
+        <status>0x93</status>
+        <midino>0x72</midino>
         <options>
           <script-binding />
         </options>

--- a/res/controllers/PIONEER-DDJ-SX2.midi.xml
+++ b/res/controllers/PIONEER-DDJ-SX2.midi.xml
@@ -1,0 +1,7746 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.5.0+">
+  <info>
+    <name>Pioneer DDJ-SX2</name>
+    <author>Krafting, hrudham, tildearrow, eXWoLL1</author>
+    <description>Pioneer DDJ-SX2 mapping for Mixxx</description>
+  </info>
+  <settings>
+    <group label="Scratch Settings">
+      <option variable="safeScratchTimeout" default="20" min="20" max="1000" step="10" type="integer" label="Safe Scratch Timeout (ms) (20ms is the minimum allowed)" />
+    </group>
+    <group label="Brake and Soft Start">
+      <option variable="UseShiftToBreak" type="boolean" default="0" label="Use :hwbtn:`Play` instead of :hwbtn:`Shift` + :hwbtn:`Play` to brake/soft start." />
+      <option variable="SoftStartTime" min="-1" default="15" max="10000" step="10" type="integer" label="Soft Start Factor (Higher is faster) (disable with -1)" />
+      <option variable="BrakeTime" min="-1" default="15" max="10000" step="10" type="integer" label="Brake Factor (Higher is faster) (disable with -1)" />
+    </group>
+    <group label="Lights Settings">
+      <option variable="CenterRedLightsBehavior" type="boolean" default="0" label="Bar-by-bar central red LED counter (Beat-By-Beat if unchecked)" />
+      <option variable="CenterWhiteLightsBehavior" type="boolean" default="0" label="Show track progression instead of rotation in the center white lights." />
+      <option variable="DoNotTrickController" type="boolean" default="0" label="Do not send Serato mode keep-alive when enabled. Note that center lights, spin alignment and slip flash will not be available." />
+    </group>
+  </settings>
+  <controller id="PIONEER DDJ-SX2">
+    <scriptfiles>
+      <file filename="lodash.mixxx.js" />
+      <file filename="midi-components-0.0.js" />
+      <file functionprefix="PioneerDDJSX2" filename="PIONEER-DDJ-SX2.scripts.js" />
+    </scriptfiles>
+    <controls>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Hotcue 1 for channel 1</description>
+        <key>hotcue_1_activatecue</key>
+        <status>0x97</status>
+        <midino>0x00</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Hotcue 1 for channel 2</description>
+        <key>hotcue_1_activatecue</key>
+        <status>0x98</status>
+        <midino>0x00</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Hotcue 1 for channel 3</description>
+        <key>hotcue_1_activatecue</key>
+        <status>0x99</status>
+        <midino>0x00</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Hotcue 1 for channel 4</description>
+        <key>hotcue_1_activatecue</key>
+        <status>0x9A</status>
+        <midino>0x00</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Set Tempo Slider for channel 1</description>
+        <key>PioneerDDJSX2.RateSlider</key>
+        <status>0xB0</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Set Tempo Slider for channel 2</description>
+        <key>PioneerDDJSX2.RateSlider</key>
+        <status>0xB1</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Set Tempo Slider for channel 3</description>
+        <key>PioneerDDJSX2.RateSlider</key>
+        <status>0xB2</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Set Tempo Slider for channel 4</description>
+        <key>PioneerDDJSX2.RateSlider</key>
+        <status>0xB3</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Set Tempo Slider for channel 1</description>
+        <key>PioneerDDJSX2.RateSlider</key>
+        <status>0xB0</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Set Tempo Slider for channel 2</description>
+        <key>PioneerDDJSX2.RateSlider</key>
+        <status>0xB1</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Set Tempo Slider for channel 3</description>
+        <key>PioneerDDJSX2.RateSlider</key>
+        <status>0xB2</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Set Tempo Slider for channel 4</description>
+        <key>PioneerDDJSX2.RateSlider</key>
+        <status>0xB3</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.EffectJog</key>
+        <status>0xB4</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.EffectJog</key>
+        <status>0xB5</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_2_activatecue</key>
+        <status>0x97</status>
+        <midino>0x01</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_2_activatecue</key>
+        <status>0x98</status>
+        <midino>0x01</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_2_activatecue</key>
+        <status>0x99</status>
+        <midino>0x01</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_2_activatecue</key>
+        <status>0x9A</status>
+        <midino>0x01</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Mixer Profile]</group>
+        <key>PioneerDDJSX2.CrossfaderCurve</key>
+        <status>0xB6</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_3_activatecue</key>
+        <status>0x97</status>
+        <midino>0x02</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_3_activatecue</key>
+        <status>0x98</status>
+        <midino>0x02</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_3_activatecue</key>
+        <status>0x99</status>
+        <midino>0x02</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_3_activatecue</key>
+        <status>0x9A</status>
+        <midino>0x02</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.EffectKnob</key>
+        <status>0xB4</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>3</group>
+        <key>PioneerDDJSX2.EffectKnob</key>
+        <status>0xB5</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[BeatJump]</group>
+        <key>prev</key>
+        <status>0x90</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[BeatJump]</group>
+        <key>prev</key>
+        <status>0x91</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[BeatJump]</group>
+        <key>prev</key>
+        <status>0x92</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[BeatJump]</group>
+        <key>prev</key>
+        <status>0x93</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_4_activatecue</key>
+        <status>0x97</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_4_activatecue</key>
+        <status>0x98</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_4_activatecue</key>
+        <status>0x99</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_4_activatecue</key>
+        <status>0x9A</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>playposition</key>
+        <status>0xB0</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>playposition</key>
+        <status>0xB1</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>playposition</key>
+        <status>0xB2</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>playposition</key>
+        <status>0xB3</status>
+        <midino>0x03</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SetSamplerVol</key>
+        <status>0xB6</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_5_activatecue</key>
+        <status>0x97</status>
+        <midino>0x04</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_5_activatecue</key>
+        <status>0x98</status>
+        <midino>0x04</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_5_activatecue</key>
+        <status>0x99</status>
+        <midino>0x04</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_5_activatecue</key>
+        <status>0x9A</status>
+        <midino>0x04</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.Pregain</key>
+        <status>0xB0</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.Pregain</key>
+        <status>0xB1</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.Pregain</key>
+        <status>0xB2</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.Pregain</key>
+        <status>0xB3</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.Pregain</key>
+        <status>0xB0</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.Pregain</key>
+        <status>0xB1</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.Pregain</key>
+        <status>0xB2</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.Pregain</key>
+        <status>0xB3</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.EffectKnob</key>
+        <status>0xB4</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>4</group>
+        <key>PioneerDDJSX2.EffectKnob</key>
+        <status>0xB5</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_6_activatecue</key>
+        <status>0x97</status>
+        <midino>0x05</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_6_activatecue</key>
+        <status>0x98</status>
+        <midino>0x05</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_6_activatecue</key>
+        <status>0x99</status>
+        <midino>0x05</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_6_activatecue</key>
+        <status>0x9A</status>
+        <midino>0x05</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_7_activatecue</key>
+        <status>0x97</status>
+        <midino>0x06</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_7_activatecue</key>
+        <status>0x98</status>
+        <midino>0x06</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_7_activatecue</key>
+        <status>0x99</status>
+        <midino>0x06</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_7_activatecue</key>
+        <status>0x9A</status>
+        <midino>0x06</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>2</group>
+        <key>PioneerDDJSX2.EffectKnob</key>
+        <status>0xB4</status>
+        <midino>0x06</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>5</group>
+        <key>PioneerDDJSX2.EffectKnob</key>
+        <status>0xB5</status>
+        <midino>0x06</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_8_activatecue</key>
+        <status>0x97</status>
+        <midino>0x07</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_8_activatecue</key>
+        <status>0x98</status>
+        <midino>0x07</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_8_activatecue</key>
+        <status>0x99</status>
+        <midino>0x07</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_8_activatecue</key>
+        <status>0x9A</status>
+        <midino>0x07</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>PioneerDDJSX2.EQHigh</key>
+        <status>0xB0</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>PioneerDDJSX2.EQHigh</key>
+        <status>0xB1</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel3]_Effect1]</group>
+        <key>PioneerDDJSX2.EQHigh</key>
+        <status>0xB2</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel4]_Effect1]</group>
+        <key>PioneerDDJSX2.EQHigh</key>
+        <status>0xB3</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>PioneerDDJSX2.EQHigh</key>
+        <status>0xB0</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>PioneerDDJSX2.EQHigh</key>
+        <status>0xB1</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel3]_Effect1]</group>
+        <key>PioneerDDJSX2.EQHigh</key>
+        <status>0xB2</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel4]_Effect1]</group>
+        <key>PioneerDDJSX2.EQHigh</key>
+        <status>0xB3</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_1_clear</key>
+        <status>0x97</status>
+        <midino>0x08</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_1_clear</key>
+        <status>0x98</status>
+        <midino>0x08</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_1_clear</key>
+        <status>0x99</status>
+        <midino>0x08</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_1_clear</key>
+        <status>0x9A</status>
+        <midino>0x08</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_2_clear</key>
+        <status>0x97</status>
+        <midino>0x09</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_2_clear</key>
+        <status>0x98</status>
+        <midino>0x09</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_2_clear</key>
+        <status>0x99</status>
+        <midino>0x09</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_2_clear</key>
+        <status>0x9A</status>
+        <midino>0x09</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SetGridSlide</key>
+        <status>0x90</status>
+        <midino>0x0A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.SetGridSlide</key>
+        <status>0x91</status>
+        <midino>0x0A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>2</group>
+        <key>PioneerDDJSX2.SetGridSlide</key>
+        <status>0x92</status>
+        <midino>0x0A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>3</group>
+        <key>PioneerDDJSX2.SetGridSlide</key>
+        <status>0x93</status>
+        <midino>0x0A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_3_clear</key>
+        <status>0x97</status>
+        <midino>0x0A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_3_clear</key>
+        <status>0x98</status>
+        <midino>0x0A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_3_clear</key>
+        <status>0x99</status>
+        <midino>0x0A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_3_clear</key>
+        <status>0x9A</status>
+        <midino>0x0A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.Play</key>
+        <description>Play Button for channel 1</description>
+        <status>0x90</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.Play</key>
+        <description>Play Button for channel 2</description>
+        <status>0x91</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.Play</key>
+        <description>Play Button for channel 3</description>
+        <status>0x92</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.Play</key>
+        <description>Play Button for channel 4</description>
+        <status>0x93</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_4_clear</key>
+        <status>0x97</status>
+        <midino>0x0B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_4_clear</key>
+        <status>0x98</status>
+        <midino>0x0B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_4_clear</key>
+        <status>0x99</status>
+        <midino>0x0B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_4_clear</key>
+        <status>0x9A</status>
+        <midino>0x0B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>PioneerDDJSX2.EQMid</key>
+        <status>0xB0</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>PioneerDDJSX2.EQMid</key>
+        <status>0xB1</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel3]_Effect1]</group>
+        <key>PioneerDDJSX2.EQMid</key>
+        <status>0xB2</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel4]_Effect1]</group>
+        <key>PioneerDDJSX2.EQMid</key>
+        <status>0xB3</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>PioneerDDJSX2.EQMid</key>
+        <status>0xB0</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>PioneerDDJSX2.EQMid</key>
+        <status>0xB1</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel3]_Effect1]</group>
+        <key>PioneerDDJSX2.EQMid</key>
+        <status>0xB2</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel4]_Effect1]</group>
+        <key>PioneerDDJSX2.EQMid</key>
+        <status>0xB3</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>cue_default</key>
+        <status>0x90</status>
+        <midino>0x0C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>cue_default</key>
+        <status>0x91</status>
+        <midino>0x0C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>cue_default</key>
+        <status>0x92</status>
+        <midino>0x0C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>cue_default</key>
+        <status>0x93</status>
+        <midino>0x0C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_5_clear</key>
+        <status>0x97</status>
+        <midino>0x0C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_5_clear</key>
+        <status>0x98</status>
+        <midino>0x0C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_5_clear</key>
+        <status>0x99</status>
+        <midino>0x0C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_5_clear</key>
+        <status>0x9A</status>
+        <midino>0x0C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_6_clear</key>
+        <status>0x97</status>
+        <midino>0x0D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_6_clear</key>
+        <status>0x98</status>
+        <midino>0x0D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_6_clear</key>
+        <status>0x99</status>
+        <midino>0x0D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_6_clear</key>
+        <status>0x9A</status>
+        <midino>0x0D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_7_clear</key>
+        <status>0x97</status>
+        <midino>0x0E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_7_clear</key>
+        <status>0x98</status>
+        <midino>0x0E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_7_clear</key>
+        <status>0x99</status>
+        <midino>0x0E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_7_clear</key>
+        <status>0x9A</status>
+        <midino>0x0E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_8_clear</key>
+        <status>0x97</status>
+        <midino>0x0F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_8_clear</key>
+        <status>0x98</status>
+        <midino>0x0F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_8_clear</key>
+        <status>0x99</status>
+        <midino>0x0F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_8_clear</key>
+        <status>0x9A</status>
+        <midino>0x0F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>PioneerDDJSX2.EQLow</key>
+        <status>0xB0</status>
+        <midino>0x0F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>PioneerDDJSX2.EQLow</key>
+        <status>0xB1</status>
+        <midino>0x0F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel3]_Effect1]</group>
+        <key>PioneerDDJSX2.EQLow</key>
+        <status>0xB2</status>
+        <midino>0x0F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel4]_Effect1]</group>
+        <key>PioneerDDJSX2.EQLow</key>
+        <status>0xB3</status>
+        <midino>0x0F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>PioneerDDJSX2.EQLow</key>
+        <status>0xB0</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>PioneerDDJSX2.EQLow</key>
+        <status>0xB1</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel3]_Effect1]</group>
+        <key>PioneerDDJSX2.EQLow</key>
+        <status>0xB2</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel4]_Effect1]</group>
+        <key>PioneerDDJSX2.EQLow</key>
+        <status>0xB3</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.LoopIn</key>
+        <status>0x90</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.LoopIn</key>
+        <status>0x91</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.LoopIn</key>
+        <status>0x92</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.LoopIn</key>
+        <status>0x93</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x97</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x98</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x99</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x9A</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>loop_out</key>
+        <status>0x90</status>
+        <midino>0x11</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>loop_out</key>
+        <status>0x91</status>
+        <midino>0x11</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>loop_out</key>
+        <status>0x92</status>
+        <midino>0x11</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>loop_out</key>
+        <status>0x93</status>
+        <midino>0x11</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x97</status>
+        <midino>0x11</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x98</status>
+        <midino>0x11</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x99</status>
+        <midino>0x11</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x9A</status>
+        <midino>0x11</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>loop_halve</key>
+        <status>0x90</status>
+        <midino>0x12</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>loop_halve</key>
+        <status>0x91</status>
+        <midino>0x12</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>loop_halve</key>
+        <status>0x92</status>
+        <midino>0x12</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>loop_halve</key>
+        <status>0x93</status>
+        <midino>0x12</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x97</status>
+        <midino>0x12</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x98</status>
+        <midino>0x12</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x99</status>
+        <midino>0x12</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x9A</status>
+        <midino>0x12</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>loop_double</key>
+        <status>0x90</status>
+        <midino>0x13</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>loop_double</key>
+        <status>0x91</status>
+        <midino>0x13</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>loop_double</key>
+        <status>0x92</status>
+        <midino>0x13</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>loop_double</key>
+        <status>0x93</status>
+        <midino>0x13</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x97</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x98</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x99</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x9A</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.VolumeSlider</key>
+        <status>0xB0</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.VolumeSlider</key>
+        <status>0xB1</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.VolumeSlider</key>
+        <status>0xB2</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.VolumeSlider</key>
+        <status>0xB3</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.VolumeSlider</key>
+        <status>0xB0</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.VolumeSlider</key>
+        <status>0xB1</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.VolumeSlider</key>
+        <status>0xB2</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.VolumeSlider</key>
+        <status>0xB3</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.AutoLoop</key>
+        <status>0x90</status>
+        <midino>0x14</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.AutoLoop</key>
+        <status>0x91</status>
+        <midino>0x14</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.AutoLoop</key>
+        <status>0x92</status>
+        <midino>0x14</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.AutoLoop</key>
+        <status>0x93</status>
+        <midino>0x14</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x97</status>
+        <midino>0x14</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x98</status>
+        <midino>0x14</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x99</status>
+        <midino>0x14</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x9A</status>
+        <midino>0x14</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.ReverseHold</key>
+        <status>0x90</status>
+        <midino>0x15</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.ReverseHold</key>
+        <status>0x91</status>
+        <midino>0x15</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.ReverseHold</key>
+        <status>0x92</status>
+        <midino>0x15</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.ReverseHold</key>
+        <status>0x93</status>
+        <midino>0x15</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x97</status>
+        <midino>0x15</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x98</status>
+        <midino>0x15</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x99</status>
+        <midino>0x15</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x9A</status>
+        <midino>0x15</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>orientation_left</key>
+        <status>0x90</status>
+        <midino>0x16</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>orientation_left</key>
+        <status>0x91</status>
+        <midino>0x16</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>orientation_left</key>
+        <status>0x92</status>
+        <midino>0x16</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>orientation_left</key>
+        <status>0x93</status>
+        <midino>0x16</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x97</status>
+        <midino>0x16</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x98</status>
+        <midino>0x16</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x99</status>
+        <midino>0x16</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x9A</status>
+        <midino>0x16</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.ToggleVinyl</key>
+        <status>0x90</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.ToggleVinyl</key>
+        <status>0x91</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.ToggleVinyl</key>
+        <status>0x92</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.ToggleVinyl</key>
+        <status>0x93</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x97</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x98</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x99</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollPerformancePad</key>
+        <status>0x9A</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel1]]</group>
+        <key>PioneerDDJSX2.Filter</key>
+        <status>0xB6</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel1]]</group>
+        <key>PioneerDDJSX2.Filter</key>
+        <status>0xB6</status>
+        <midino>0x37</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>orientation_right</key>
+        <status>0x90</status>
+        <midino>0x18</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>orientation_right</key>
+        <status>0x91</status>
+        <midino>0x18</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>orientation_right</key>
+        <status>0x92</status>
+        <midino>0x18</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>orientation_right</key>
+        <status>0x93</status>
+        <midino>0x18</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel2]]</group>
+        <key>PioneerDDJSX2.Filter</key>
+        <status>0xB6</status>
+        <midino>0x18</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel2]]</group>
+        <key>PioneerDDJSX2.Filter</key>
+        <status>0xB6</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.InputSelect</key>
+        <status>0x90</status>
+        <midino>0x19</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.InputSelect</key>
+        <status>0x91</status>
+        <midino>0x19</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.InputSelect</key>
+        <status>0x92</status>
+        <midino>0x19</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.InputSelect</key>
+        <status>0x93</status>
+        <midino>0x19</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel3]]</group>
+        <key>PioneerDDJSX2.Filter</key>
+        <status>0xB6</status>
+        <midino>0x19</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel3]]</group>
+        <key>PioneerDDJSX2.Filter</key>
+        <status>0xB6</status>
+        <midino>0x39</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>keylock</key>
+        <status>0x90</status>
+        <midino>0x1A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>keylock</key>
+        <status>0x91</status>
+        <midino>0x1A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>keylock</key>
+        <status>0x92</status>
+        <midino>0x1A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>keylock</key>
+        <status>0x93</status>
+        <midino>0x1A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel4]]</group>
+        <key>PioneerDDJSX2.Filter</key>
+        <status>0xB6</status>
+        <midino>0x1A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel4]]</group>
+        <key>PioneerDDJSX2.Filter</key>
+        <status>0xB6</status>
+        <midino>0x3A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SetHotCueMode</key>
+        <status>0x90</status>
+        <midino>0x1B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SetHotCueMode</key>
+        <status>0x91</status>
+        <midino>0x1B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SetHotCueMode</key>
+        <status>0x92</status>
+        <midino>0x1B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SetHotCueMode</key>
+        <status>0x93</status>
+        <midino>0x1B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>rate_set_default</key>
+        <status>0x90</status>
+        <midino>0x1C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>rate_set_default</key>
+        <status>0x91</status>
+        <midino>0x1C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>rate_set_default</key>
+        <status>0x92</status>
+        <midino>0x1C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>rate_set_default</key>
+        <status>0x93</status>
+        <midino>0x1C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>orientation_center</key>
+        <status>0x90</status>
+        <midino>0x1D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>orientation_center</key>
+        <status>0x91</status>
+        <midino>0x1D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>orientation_center</key>
+        <status>0x92</status>
+        <midino>0x1D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>orientation_center</key>
+        <status>0x93</status>
+        <midino>0x1D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SetRollMode</key>
+        <status>0x90</status>
+        <midino>0x1E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SetRollMode</key>
+        <status>0x91</status>
+        <midino>0x1E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SetRollMode</key>
+        <status>0x92</status>
+        <midino>0x1E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SetRollMode</key>
+        <status>0x93</status>
+        <midino>0x1E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>crossfader</key>
+        <status>0xB6</status>
+        <midino>0x1F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SetSlicerMode</key>
+        <status>0x90</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SetSlicerMode</key>
+        <status>0x91</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SetSlicerMode</key>
+        <status>0x92</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SetSlicerMode</key>
+        <status>0x93</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.jogPitchBend</key>
+        <status>0xB0</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.jogPitchBend</key>
+        <status>0xB1</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.jogPitchBend</key>
+        <status>0xB2</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.jogPitchBend</key>
+        <status>0xB3</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SetSamplerMode</key>
+        <status>0x90</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SetSamplerMode</key>
+        <status>0x91</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SetSamplerMode</key>
+        <status>0x92</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SetSamplerMode</key>
+        <status>0x93</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.jogScratchTurn</key>
+        <status>0xB0</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.jogScratchTurn</key>
+        <status>0xB1</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.jogScratchTurn</key>
+        <status>0xB2</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.jogScratchTurn</key>
+        <status>0xB3</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.jogSeekTurn</key>
+        <status>0xB0</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.jogSeekTurn</key>
+        <status>0xB1</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.jogSeekTurn</key>
+        <status>0xB2</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.jogSeekTurn</key>
+        <status>0xB3</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>rate_temp_down</key>
+        <status>0x90</status>
+        <midino>0x24</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>rate_temp_down</key>
+        <status>0x91</status>
+        <midino>0x24</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>rate_temp_down</key>
+        <status>0x92</status>
+        <midino>0x24</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>rate_temp_down</key>
+        <status>0x93</status>
+        <midino>0x24</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollParam1L</key>
+        <status>0x90</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollParam1L</key>
+        <status>0x91</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollParam1L</key>
+        <status>0x92</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollParam1L</key>
+        <status>0x93</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SlicerParam1L</key>
+        <status>0x90</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SlicerParam1L</key>
+        <status>0x91</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SlicerParam1L</key>
+        <status>0x92</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SlicerParam1L</key>
+        <status>0x93</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.jogSeek</key>
+        <status>0xB0</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.jogSeek</key>
+        <status>0xB1</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.jogSeek</key>
+        <status>0xB2</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.jogSeek</key>
+        <status>0xB3</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SamplerParam1L</key>
+        <status>0x90</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SamplerParam1L</key>
+        <status>0x91</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SamplerParam1L</key>
+        <status>0x92</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SamplerParam1L</key>
+        <status>0x93</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.CueLoopParam1L</key>
+        <status>0x90</status>
+        <midino>0x28</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.CueLoopParam1L</key>
+        <status>0x91</status>
+        <midino>0x28</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.CueLoopParam1L</key>
+        <status>0x92</status>
+        <midino>0x28</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.CueLoopParam1L</key>
+        <status>0x93</status>
+        <midino>0x28</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SamplerParam1L</key>
+        <status>0x90</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SamplerParam1L</key>
+        <status>0x91</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SamplerParam1L</key>
+        <status>0x92</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SamplerParam1L</key>
+        <status>0x93</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>rate_temp_up</key>
+        <status>0x90</status>
+        <midino>0x2C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>rate_temp_up</key>
+        <status>0x91</status>
+        <midino>0x2C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>rate_temp_up</key>
+        <status>0x92</status>
+        <midino>0x2C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>rate_temp_up</key>
+        <status>0x93</status>
+        <midino>0x2C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollParam1R</key>
+        <status>0x90</status>
+        <midino>0x2D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollParam1R</key>
+        <status>0x91</status>
+        <midino>0x2D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollParam1R</key>
+        <status>0x92</status>
+        <midino>0x2D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollParam1R</key>
+        <status>0x93</status>
+        <midino>0x2D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SlicerParam1R</key>
+        <status>0x90</status>
+        <midino>0x2E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SlicerParam1R</key>
+        <status>0x91</status>
+        <midino>0x2E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SlicerParam1R</key>
+        <status>0x92</status>
+        <midino>0x2E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SlicerParam1R</key>
+        <status>0x93</status>
+        <midino>0x2E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SamplerParam1R</key>
+        <status>0x90</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SamplerParam1R</key>
+        <status>0x91</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SamplerParam1R</key>
+        <status>0x92</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SamplerParam1R</key>
+        <status>0x93</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.CueLoopParam1R</key>
+        <status>0x90</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.CueLoopParam1R</key>
+        <status>0x91</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.CueLoopParam1R</key>
+        <status>0x92</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.CueLoopParam1R</key>
+        <status>0x93</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x31</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x31</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x31</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x31</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x32</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x32</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x32</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x32</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SamplerParam1R</key>
+        <status>0x90</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SamplerParam1R</key>
+        <status>0x91</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SamplerParam1R</key>
+        <status>0x92</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SamplerParam1R</key>
+        <status>0x93</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x34</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x34</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x34</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x34</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.jogSeekTouch</key>
+        <status>0x90</status>
+        <midino>0x35</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.jogSeekTouch</key>
+        <status>0x91</status>
+        <midino>0x35</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.jogSeekTouch</key>
+        <status>0x92</status>
+        <midino>0x35</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.jogSeekTouch</key>
+        <status>0x93</status>
+        <midino>0x35</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x35</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x35</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x35</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x35</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.jogScratchTouch</key>
+        <status>0x90</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.jogScratchTouch</key>
+        <status>0x91</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.jogScratchTouch</key>
+        <status>0x92</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.jogScratchTouch</key>
+        <status>0x93</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x37</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x37</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x37</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x37</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.Reverse</key>
+        <status>0x90</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.Reverse</key>
+        <status>0x91</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.Reverse</key>
+        <status>0x92</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.Reverse</key>
+        <status>0x93</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x39</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x39</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x39</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x39</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x3A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x3A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x3A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x3A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x3B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x3B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x3B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x3B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x3C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x3C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x3C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x3C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x3D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x3D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x3D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x3D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x3E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x3E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x3E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x3E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.Shift</key>
+        <status>0x90</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.Shift</key>
+        <status>0x91</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.Shift</key>
+        <status>0x92</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.Shift</key>
+        <status>0x93</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SlipEnabled</key>
+        <status>0x90</status>
+        <midino>0x40</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SlipEnabled</key>
+        <status>0x91</status>
+        <midino>0x40</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SlipEnabled</key>
+        <status>0x92</status>
+        <midino>0x40</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SlipEnabled</key>
+        <status>0x93</status>
+        <midino>0x40</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.ShiftBeatsPressFX</key>
+        <status>0x94</status>
+        <midino>0x40</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.ShiftBeatsPressFX</key>
+        <status>0x95</status>
+        <midino>0x40</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Hotcue Loop 9 on channel 1</description>
+        <key>hotcue_9_activateloop</key>
+        <status>0x97</status>
+        <midino>0x40</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Hotcue Loop 9 on channel 2</description>
+        <key>hotcue_9_activateloop</key>
+        <status>0x98</status>
+        <midino>0x40</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Hotcue Loop 9 on channel 3</description>
+        <key>hotcue_9_activateloop</key>
+        <status>0x99</status>
+        <midino>0x40</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Hotcue Loop 9 on channel 4</description>
+        <key>hotcue_9_activateloop</key>
+        <status>0x9A</status>
+        <midino>0x40</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Playlist]</group>
+        <description>The rotary selector to select item and songs</description>
+        <key>PioneerDDJSX2.RotarySelector</key>
+        <status>0xB6</status>
+        <midino>0x40</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Playlist]</group>
+        <description>The rotary selector to select used with SHIFT</description>
+        <key>PioneerDDJSX2.RotarySelector</key>
+        <status>0xB6</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Playlist]</group>
+        <description>The rotary selector when clicked</description>
+        <key>PioneerDDJSX2.RotarySelectorClick</key>
+        <status>0x96</status>
+        <midino>0x41</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Playlist]</group>
+        <description>The rotary selector when clicked with SHIFT</description>
+        <key>PioneerDDJSX2.RotarySelectorClick</key>
+        <status>0x96</status>
+        <midino>0x42</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Hotcue Loop 10 on channel 1</description>
+        <key>hotcue_10_activateloop</key>
+        <status>0x97</status>
+        <midino>0x41</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Hotcue Loop 10 on channel 2</description>
+        <key>hotcue_10_activateloop</key>
+        <status>0x98</status>
+        <midino>0x41</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Hotcue Loop 10 on channel 3</description>
+        <key>hotcue_10_activateloop</key>
+        <status>0x99</status>
+        <midino>0x41</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Hotcue Loop 10 on channel 4</description>
+        <key>hotcue_10_activateloop</key>
+        <status>0x9A</status>
+        <midino>0x41</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Hotcue Loop 11 on channel 1</description>
+        <key>hotcue_11_activateloop</key>
+        <status>0x97</status>
+        <midino>0x42</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Hotcue Loop 11 on channel 2</description>
+        <key>hotcue_11_activateloop</key>
+        <status>0x98</status>
+        <midino>0x42</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Hotcue Loop 11 on channel 3</description>
+        <key>hotcue_11_activateloop</key>
+        <status>0x99</status>
+        <midino>0x42</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Hotcue Loop 11 on channel 4</description>
+        <key>hotcue_11_activateloop</key>
+        <status>0x9A</status>
+        <midino>0x42</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.BeatsPressFX</key>
+        <status>0x94</status>
+        <midino>0x43</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.BeatsPressFX</key>
+        <key>PioneerDDJSX2.BeatsPressFX</key>
+        <status>0x95</status>
+        <midino>0x43</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Hotcue Loop 12 on channel 1</description>
+        <key>hotcue_12_activateloop</key>
+        <status>0x97</status>
+        <midino>0x43</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Hotcue Loop 12 on channel 2</description>
+        <key>hotcue_12_activateloop</key>
+        <status>0x98</status>
+        <midino>0x43</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Hotcue Loop 12 on channel 3</description>
+        <key>hotcue_12_activateloop</key>
+        <status>0x99</status>
+        <midino>0x43</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Hotcue Loop 12 on channel 4</description>
+        <key>hotcue_12_activateloop</key>
+        <status>0x9A</status>
+        <midino>0x43</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Hotcue Loop 13 on channel 1</description>
+        <key>hotcue_13_activateloop</key>
+        <status>0x97</status>
+        <midino>0x44</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Hotcue Loop 13 on channel 2</description>
+        <key>hotcue_13_activateloop</key>
+        <status>0x98</status>
+        <midino>0x44</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Hotcue Loop 13 on channel 3</description>
+        <key>hotcue_13_activateloop</key>
+        <status>0x99</status>
+        <midino>0x44</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Hotcue Loop 13 on channel 4</description>
+        <key>hotcue_13_activateloop</key>
+        <status>0x9A</status>
+        <midino>0x44</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.FourBeat</key>
+        <status>0x90</status>
+        <midino>0x45</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.FourBeat</key>
+        <status>0x91</status>
+        <midino>0x45</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.FourBeat</key>
+        <status>0x92</status>
+        <midino>0x45</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.FourBeat</key>
+        <status>0x93</status>
+        <midino>0x45</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Hotcue Loop 14 on channel 1</description>
+        <key>hotcue_14_activateloop</key>
+        <status>0x97</status>
+        <midino>0x45</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Hotcue Loop 14 on channel 2</description>
+        <key>hotcue_14_activateloop</key>
+        <status>0x98</status>
+        <midino>0x45</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Hotcue Loop 14 on channel 3</description>
+        <key>hotcue_14_activateloop</key>
+        <status>0x99</status>
+        <midino>0x45</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Hotcue Loop 14 on channel 4</description>
+        <key>hotcue_14_activateloop</key>
+        <status>0x9A</status>
+        <midino>0x45</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>LoadSelectedTrack</key>
+        <status>0x96</status>
+        <midino>0x46</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SortLibrary</key>
+        <status>0x96</status>
+        <midino>0x58</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Library]</group>
+        <key>PioneerDDJSX2.SortLibrary</key>
+        <status>0x96</status>
+        <midino>0x59</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Library]</group>
+        <key>PioneerDDJSX2.SortLibrary</key>
+        <status>0x96</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Library]</group>
+        <key>PioneerDDJSX2.SortLibrary</key>
+        <status>0x96</status>
+        <midino>0x61</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Hotcue Loop 15 on channel 1</description>
+        <key>hotcue_15_activateloop</key>
+        <status>0x97</status>
+        <midino>0x46</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Hotcue Loop 15 on channel 2</description>
+        <key>hotcue_15_activateloop</key>
+        <status>0x98</status>
+        <midino>0x46</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Hotcue Loop 15 on channel 3</description>
+        <key>hotcue_15_activateloop</key>
+        <status>0x99</status>
+        <midino>0x46</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Hotcue Loop 15 on channel 4</description>
+        <key>hotcue_15_activateloop</key>
+        <status>0x9A</status>
+        <midino>0x46</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>stop</key>
+        <status>0x80</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>stop</key>
+        <status>0x81</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>stop</key>
+        <status>0x82</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>stop</key>
+        <status>0x83</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.Play</key>
+        <description>Shift + Play on channel 1</description>
+        <status>0x90</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.Play</key>
+        <description>Shift + Play on channel 2</description>
+        <status>0x91</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.Play</key>
+        <description>Shift + Play on channel 3</description>
+        <status>0x92</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.Play</key>
+        <description>Shift + Play on channel 4</description>
+        <status>0x93</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.EffectButton</key>
+        <status>0x94</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.EffectButton</key>
+        <status>0x95</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>LoadSelectedTrack</key>
+        <status>0x96</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Hotcue Loop 16 on channel 1</description>
+        <key>hotcue_16_activateloop</key>
+        <status>0x97</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Hotcue Loop 16 on channel 2</description>
+        <key>hotcue_16_activateloop</key>
+        <status>0x98</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Hotcue Loop 16 on channel 3</description>
+        <key>hotcue_16_activateloop</key>
+        <status>0x99</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Hotcue Loop 16 on channel 4</description>
+        <key>hotcue_16_activateloop</key>
+        <status>0x9A</status>
+        <midino>0x47</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>start</key>
+        <status>0x90</status>
+        <midino>0x48</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>start</key>
+        <status>0x91</status>
+        <midino>0x48</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>start</key>
+        <status>0x92</status>
+        <midino>0x48</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>start</key>
+        <status>0x93</status>
+        <midino>0x48</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.EffectButton</key>
+        <status>0x94</status>
+        <midino>0x48</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.EffectButton</key>
+        <status>0x95</status>
+        <midino>0x48</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>LoadSelectedTrack</key>
+        <status>0x96</status>
+        <midino>0x48</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_9_clear</key>
+        <status>0x97</status>
+        <midino>0x48</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_9_clear</key>
+        <status>0x98</status>
+        <midino>0x48</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_9_clear</key>
+        <status>0x99</status>
+        <midino>0x48</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_9_clear</key>
+        <status>0x9A</status>
+        <midino>0x48</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>pitch_adjust_set_zero</key>
+        <status>0x90</status>
+        <midino>0x49</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>pitch_adjust_set_zero</key>
+        <status>0x91</status>
+        <midino>0x49</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>pitch_adjust_set_zero</key>
+        <status>0x92</status>
+        <midino>0x49</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>pitch_adjust_set_zero</key>
+        <status>0x93</status>
+        <midino>0x49</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.EffectButton</key>
+        <status>0x94</status>
+        <midino>0x49</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.EffectButton</key>
+        <status>0x95</status>
+        <midino>0x49</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>LoadSelectedTrack</key>
+        <status>0x96</status>
+        <midino>0x49</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_10_clear</key>
+        <status>0x97</status>
+        <midino>0x49</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_10_clear</key>
+        <status>0x98</status>
+        <midino>0x49</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_10_clear</key>
+        <status>0x99</status>
+        <midino>0x49</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_10_clear</key>
+        <status>0x9A</status>
+        <midino>0x49</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>pitch_down</key>
+        <status>0x90</status>
+        <midino>0x4A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>pitch_down</key>
+        <status>0x91</status>
+        <midino>0x4A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>pitch_down</key>
+        <status>0x92</status>
+        <midino>0x4A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>pitch_down</key>
+        <status>0x93</status>
+        <midino>0x4A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[OK]</group>
+        <key>PioneerDDJSX2.EffectTap</key>
+        <status>0x94</status>
+        <midino>0x4A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[OK]</group>
+        <key>PioneerDDJSX2.EffectTap</key>
+        <status>0x95</status>
+        <midino>0x4A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_11_clear</key>
+        <status>0x97</status>
+        <midino>0x4A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_11_clear</key>
+        <status>0x98</status>
+        <midino>0x4A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_11_clear</key>
+        <status>0x99</status>
+        <midino>0x4A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_11_clear</key>
+        <status>0x9A</status>
+        <midino>0x4A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>pitch_up</key>
+        <status>0x90</status>
+        <midino>0x4B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>pitch_up</key>
+        <status>0x91</status>
+        <midino>0x4B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>pitch_up</key>
+        <status>0x92</status>
+        <midino>0x4B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>pitch_up</key>
+        <status>0x93</status>
+        <midino>0x4B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_12_clear</key>
+        <status>0x97</status>
+        <midino>0x4B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_12_clear</key>
+        <status>0x98</status>
+        <midino>0x4B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_12_clear</key>
+        <status>0x99</status>
+        <midino>0x4B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_12_clear</key>
+        <status>0x9A</status>
+        <midino>0x4B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit1]</group>
+        <key>group_[Channel1]_enable</key>
+        <status>0x96</status>
+        <midino>0x4C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_13_clear</key>
+        <status>0x97</status>
+        <midino>0x4C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_13_clear</key>
+        <status>0x98</status>
+        <midino>0x4C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_13_clear</key>
+        <status>0x99</status>
+        <midino>0x4C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_13_clear</key>
+        <status>0x9A</status>
+        <midino>0x4C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>reloop_exit</key>
+        <status>0x90</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>reloop_exit</key>
+        <status>0x91</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>reloop_exit</key>
+        <status>0x92</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>reloop_exit</key>
+        <status>0x93</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit1]</group>
+        <key>group_[Channel2]_enable</key>
+        <status>0x96</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_14_clear</key>
+        <status>0x97</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_14_clear</key>
+        <status>0x98</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_14_clear</key>
+        <status>0x99</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_14_clear</key>
+        <status>0x9A</status>
+        <midino>0x4D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit1]</group>
+        <key>group_[Channel3]_enable</key>
+        <status>0x96</status>
+        <midino>0x4E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_15_clear</key>
+        <status>0x97</status>
+        <midino>0x4E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_15_clear</key>
+        <status>0x98</status>
+        <midino>0x4E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_15_clear</key>
+        <status>0x99</status>
+        <midino>0x4E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_15_clear</key>
+        <status>0x9A</status>
+        <midino>0x4E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit1]</group>
+        <key>group_[Channel4]_enable</key>
+        <status>0x96</status>
+        <midino>0x4F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_16_clear</key>
+        <status>0x97</status>
+        <midino>0x4F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_16_clear</key>
+        <status>0x98</status>
+        <midino>0x4F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_16_clear</key>
+        <status>0x99</status>
+        <midino>0x4F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_16_clear</key>
+        <status>0x9A</status>
+        <midino>0x4F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>reloop_exit</key>
+        <status>0x90</status>
+        <midino>0x50</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>reloop_exit</key>
+        <status>0x91</status>
+        <midino>0x50</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>reloop_exit</key>
+        <status>0x92</status>
+        <midino>0x50</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>reloop_exit</key>
+        <status>0x93</status>
+        <midino>0x50</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit2]</group>
+        <key>group_[Channel1]_enable</key>
+        <status>0x96</status>
+        <midino>0x50</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Saved Loop (Pad 1) on channel 1</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x97</status>
+        <midino>0x50</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Saved Loop  (Pad 1) on channel 2</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x98</status>
+        <midino>0x50</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Saved Loop  (Pad 1) on channel 3</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x99</status>
+        <midino>0x50</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Saved Loop  (Pad 1) on channel 4</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x9A</status>
+        <midino>0x50</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit2]</group>
+        <key>group_[Channel2]_enable</key>
+        <status>0x96</status>
+        <midino>0x51</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Saved Loop  (Pad 2) on channel 1</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x97</status>
+        <midino>0x51</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Saved Loop  (Pad 2) on channel 2</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x98</status>
+        <midino>0x51</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Saved Loop  (Pad 2) on channel 3</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x99</status>
+        <midino>0x51</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Saved Loop  (Pad 2) on channel 4</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x9A</status>
+        <midino>0x51</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>cue_gotoandstop</key>
+        <status>0x90</status>
+        <midino>0x52</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>cue_gotoandstop</key>
+        <status>0x91</status>
+        <midino>0x52</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>cue_gotoandstop</key>
+        <status>0x92</status>
+        <midino>0x52</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>cue_gotoandstop</key>
+        <status>0x93</status>
+        <midino>0x52</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit2]</group>
+        <key>group_[Channel3]_enable</key>
+        <status>0x96</status>
+        <midino>0x52</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Saved Loop  (Pad 3) on channel 1</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x97</status>
+        <midino>0x52</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Saved Loop  (Pad 3) on channel 2</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x98</status>
+        <midino>0x52</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Saved Loop  (Pad 3) on channel 3</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x99</status>
+        <midino>0x52</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Saved Loop  (Pad 3) on channel 4</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x9A</status>
+        <midino>0x52</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit2]</group>
+        <key>group_[Channel4]_enable</key>
+        <status>0x96</status>
+        <midino>0x53</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Saved Loop  (Pad 4) on channel 1</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x97</status>
+        <midino>0x53</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Saved Loop  (Pad 4) on channel 2</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x98</status>
+        <midino>0x53</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Saved Loop  (Pad 4) on channel 3</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x99</status>
+        <midino>0x53</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Saved Loop  (Pad 4) on channel 4</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x9A</status>
+        <midino>0x53</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>pfl</key>
+        <status>0x90</status>
+        <midino>0x54</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>pfl</key>
+        <status>0x91</status>
+        <midino>0x54</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>pfl</key>
+        <status>0x92</status>
+        <midino>0x54</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>pfl</key>
+        <status>0x93</status>
+        <midino>0x54</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Saved Loop  (Pad 5) on channel 1</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x97</status>
+        <midino>0x54</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Saved Loop  (Pad 5) on channel 2</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x98</status>
+        <midino>0x54</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Saved Loop  (Pad 5) on channel 3</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x99</status>
+        <midino>0x54</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Saved Loop  (Pad 5) on channel 4</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x9A</status>
+        <midino>0x54</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Saved Loop  (Pad 6) on channel 1</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x97</status>
+        <midino>0x55</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Saved Loop  (Pad 6) on channel 2</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x98</status>
+        <midino>0x55</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Saved Loop  (Pad 6) on channel 3</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x99</status>
+        <midino>0x55</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Saved Loop  (Pad 6) on channel 4</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x9A</status>
+        <midino>0x55</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Saved Loop  (Pad 7) on channel 1</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x97</status>
+        <midino>0x56</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Saved Loop  (Pad 7) on channel 2</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x98</status>
+        <midino>0x56</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Saved Loop  (Pad 7) on channel 3</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x99</status>
+        <midino>0x56</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Saved Loop  (Pad 7) on channel 4</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x9A</status>
+        <midino>0x56</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Activate Saved Loop  (Pad 8) on channel 1</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x97</status>
+        <midino>0x57</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Activate Saved Loop  (Pad 8) on channel 2</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x98</status>
+        <midino>0x57</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Activate Saved Loop  (Pad 8) on channel 3</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x99</status>
+        <midino>0x57</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Activate Saved Loop  (Pad 8) on channel 4</description>
+        <key>PioneerDDJSX2.SavedLoop</key>
+        <status>0x9A</status>
+        <midino>0x57</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SyncEnable</key>
+        <status>0x90</status>
+        <midino>0x58</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.SyncEnable</key>
+        <status>0x91</status>
+        <midino>0x58</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>2</group>
+        <key>PioneerDDJSX2.SyncEnable</key>
+        <status>0x92</status>
+        <midino>0x58</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>3</group>
+        <key>PioneerDDJSX2.SyncEnable</key>
+        <status>0x93</status>
+        <midino>0x58</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_17_clear</key>
+        <status>0x97</status>
+        <midino>0x58</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_17_clear</key>
+        <status>0x98</status>
+        <midino>0x58</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_17_clear</key>
+        <status>0x99</status>
+        <midino>0x58</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_17_clear</key>
+        <status>0x9A</status>
+        <midino>0x58</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_18_clear</key>
+        <status>0x97</status>
+        <midino>0x59</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_18_clear</key>
+        <status>0x98</status>
+        <midino>0x59</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_18_clear</key>
+        <status>0x99</status>
+        <midino>0x59</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_18_clear</key>
+        <status>0x9A</status>
+        <midino>0x59</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>repeat</key>
+        <status>0x90</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>repeat</key>
+        <status>0x91</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>repeat</key>
+        <status>0x92</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>repeat</key>
+        <status>0x93</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_19_clear</key>
+        <status>0x97</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_19_clear</key>
+        <status>0x98</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_19_clear</key>
+        <status>0x99</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_19_clear</key>
+        <status>0x9A</status>
+        <midino>0x5A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_20_clear</key>
+        <status>0x97</status>
+        <midino>0x5B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_20_clear</key>
+        <status>0x98</status>
+        <midino>0x5B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_20_clear</key>
+        <status>0x99</status>
+        <midino>0x5B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_20_clear</key>
+        <status>0x9A</status>
+        <midino>0x5B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SyncDisable</key>
+        <status>0x90</status>
+        <midino>0x5C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.SyncDisable</key>
+        <status>0x91</status>
+        <midino>0x5C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>2</group>
+        <key>PioneerDDJSX2.SyncDisable</key>
+        <status>0x92</status>
+        <midino>0x5C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>3</group>
+        <key>PioneerDDJSX2.SyncDisable</key>
+        <status>0x93</status>
+        <midino>0x5C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_21_clear</key>
+        <status>0x97</status>
+        <midino>0x5C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_21_clear</key>
+        <status>0x98</status>
+        <midino>0x5C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_21_clear</key>
+        <status>0x99</status>
+        <midino>0x5C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_21_clear</key>
+        <status>0x9A</status>
+        <midino>0x5C</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_22_clear</key>
+        <status>0x97</status>
+        <midino>0x5D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_22_clear</key>
+        <status>0x98</status>
+        <midino>0x5D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_22_clear</key>
+        <status>0x99</status>
+        <midino>0x5D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_22_clear</key>
+        <status>0x9A</status>
+        <midino>0x5D</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_23_clear</key>
+        <status>0x97</status>
+        <midino>0x5E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_23_clear</key>
+        <status>0x98</status>
+        <midino>0x5E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_23_clear</key>
+        <status>0x99</status>
+        <midino>0x5E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_23_clear</key>
+        <status>0x9A</status>
+        <midino>0x5E</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>hotcue_24_clear</key>
+        <status>0x97</status>
+        <midino>0x5F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>hotcue_24_clear</key>
+        <status>0x98</status>
+        <midino>0x5F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>hotcue_24_clear</key>
+        <status>0x99</status>
+        <midino>0x5F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>hotcue_24_clear</key>
+        <status>0x9A</status>
+        <midino>0x5F</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <description>Button for the Tempo range in channel 1</description>
+        <key>PioneerDDJSX2.SetTempoRange</key>
+        <status>0x90</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <description>Button for the Tempo range in channel 2</description>
+        <key>PioneerDDJSX2.SetTempoRange</key>
+        <status>0x91</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <description>Button for the Tempo range in channel 3</description>
+        <key>PioneerDDJSX2.SetTempoRange</key>
+        <status>0x92</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <description>Button for the Tempo range in channel 4</description>
+        <key>PioneerDDJSX2.SetTempoRange</key>
+        <status>0x93</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>loop_move_4_backward</key>
+        <status>0x90</status>
+        <midino>0x61</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>loop_move_4_backward</key>
+        <status>0x91</status>
+        <midino>0x61</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>loop_move_4_backward</key>
+        <status>0x92</status>
+        <midino>0x61</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>loop_move_4_backward</key>
+        <status>0x93</status>
+        <midino>0x61</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x61</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x61</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x61</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x61</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>loop_move_4_forward</key>
+        <status>0x90</status>
+        <midino>0x62</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>loop_move_4_forward</key>
+        <status>0x91</status>
+        <midino>0x62</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>loop_move_4_forward</key>
+        <status>0x92</status>
+        <midino>0x62</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>loop_move_4_forward</key>
+        <status>0x93</status>
+        <midino>0x62</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x62</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x62</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x62</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x62</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.EffectSelect</key>
+        <status>0x94</status>
+        <midino>0x63</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.EffectSelect</key>
+        <status>0x95</status>
+        <midino>0x63</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x63</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x63</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x63</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x63</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>beats_translate_curpos</key>
+        <status>0x90</status>
+        <midino>0x64</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>beats_translate_curpos</key>
+        <status>0x91</status>
+        <midino>0x64</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>beats_translate_curpos</key>
+        <status>0x92</status>
+        <midino>0x64</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>beats_translate_curpos</key>
+        <status>0x93</status>
+        <midino>0x64</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>2</group>
+        <key>PioneerDDJSX2.EffectSelect</key>
+        <status>0x94</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>2</group>
+        <key>PioneerDDJSX2.EffectSelect</key>
+        <status>0x95</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.ClearGrid</key>
+        <status>0x90</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.ClearGrid</key>
+        <status>0x91</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>2</group>
+        <key>PioneerDDJSX2.ClearGrid</key>
+        <status>0x92</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>3</group>
+        <key>PioneerDDJSX2.ClearGrid</key>
+        <status>0x93</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>3</group>
+        <key>PioneerDDJSX2.EffectSelect</key>
+        <status>0x94</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>3</group>
+        <key>PioneerDDJSX2.EffectSelect</key>
+        <status>0x95</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Playlist]</group>
+        <key>PioneerDDJSX2.BackButton</key>
+        <status>0x96</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>play</key>
+        <description>Shift + Volume Up play song on channel 1</description>
+        <status>0x90</status>
+        <midino>0x66</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>play</key>
+        <description>Shift + Volume Up play song on channel 2</description>
+        <status>0x91</status>
+        <midino>0x66</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>play</key>
+        <description>Shift + Volume Up play song on channel 3</description>
+        <status>0x92</status>
+        <midino>0x66</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>play</key>
+        <description>Shift + Volume Up play song on channel 4</description>
+        <status>0x93</status>
+        <midino>0x66</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit1]</group>
+        <key>show_parameters</key>
+        <status>0x94</status>
+        <midino>0x66</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[EffectRack1_EffectUnit2]</group>
+        <key>show_parameters</key>
+        <status>0x95</status>
+        <midino>0x66</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.ViewButton</key>
+        <status>0x96</status>
+        <midino>0x66</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x66</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x66</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x66</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x66</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[PreviewDeck1]</group>
+        <key>LoadSelectedTrack</key>
+        <status>0x96</status>
+        <midino>0x67</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x97</status>
+        <midino>0x67</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x98</status>
+        <midino>0x67</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x99</status>
+        <midino>0x67</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.BeatJump</key>
+        <status>0x9A</status>
+        <midino>0x67</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>bpm_tap</key>
+        <status>0x90</status>
+        <midino>0x68</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>bpm_tap</key>
+        <status>0x91</status>
+        <midino>0x68</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>bpm_tap</key>
+        <status>0x92</status>
+        <midino>0x68</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>bpm_tap</key>
+        <status>0x93</status>
+        <midino>0x68</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <description>AREA Button, maximize the library</description>
+        <key>maximize_library</key>
+        <status>0x96</status>
+        <midino>0x68</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <description>Splits headphone stereo cueing into right (main mono) and left (PFL mono) using Shift + Master Cue</description>
+        <key>headSplit</key>
+        <status>0x96</status>
+        <midino>0x62</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SetCueLoopMode</key>
+        <status>0x90</status>
+        <midino>0x69</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SetCueLoopMode</key>
+        <status>0x91</status>
+        <midino>0x69</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SetCueLoopMode</key>
+        <status>0x92</status>
+        <midino>0x69</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SetCueLoopMode</key>
+        <status>0x93</status>
+        <midino>0x69</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>quantize</key>
+        <status>0x90</status>
+        <midino>0x6A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>quantize</key>
+        <status>0x91</status>
+        <midino>0x6A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>quantize</key>
+        <status>0x92</status>
+        <midino>0x6A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>quantize</key>
+        <status>0x93</status>
+        <midino>0x6A</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SetSavedLoopMode</key>
+        <status>0x90</status>
+        <midino>0x6B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SetSavedLoopMode</key>
+        <status>0x91</status>
+        <midino>0x6B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SetSavedLoopMode</key>
+        <status>0x92</status>
+        <midino>0x6B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SetSavedLoopMode</key>
+        <status>0x93</status>
+        <midino>0x6B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SetSlicerLoopMode</key>
+        <status>0x90</status>
+        <midino>0x6D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SetSlicerLoopMode</key>
+        <status>0x91</status>
+        <midino>0x6D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SetSlicerLoopMode</key>
+        <status>0x92</status>
+        <midino>0x6D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SetSlicerLoopMode</key>
+        <status>0x93</status>
+        <midino>0x6D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SetVelocitySamplerMode</key>
+        <status>0x90</status>
+        <midino>0x6F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SetVelocitySamplerMode</key>
+        <status>0x91</status>
+        <midino>0x6F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SetVelocitySamplerMode</key>
+        <status>0x92</status>
+        <midino>0x6F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SetVelocitySamplerMode</key>
+        <status>0x93</status>
+        <midino>0x6F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x70</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x70</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x70</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x70</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler1]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB7</status>
+        <midino>0x70</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler1]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB8</status>
+        <midino>0x70</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler1]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB9</status>
+        <midino>0x70</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler1]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xBA</status>
+        <midino>0x70</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x71</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x71</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x71</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x71</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler2]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB7</status>
+        <midino>0x71</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler2]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB8</status>
+        <midino>0x71</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler2]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB9</status>
+        <midino>0x71</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler2]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xBA</status>
+        <midino>0x71</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler3]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB7</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler3]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB8</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler3]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB9</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler3]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xBA</status>
+        <midino>0x72</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x73</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x73</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x73</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x73</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler4]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB7</status>
+        <midino>0x73</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler4]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB8</status>
+        <midino>0x73</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler4]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB9</status>
+        <midino>0x73</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler4]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xBA</status>
+        <midino>0x73</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x74</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x74</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x74</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x74</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler5]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB7</status>
+        <midino>0x74</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler5]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB8</status>
+        <midino>0x74</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler5]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB9</status>
+        <midino>0x74</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler5]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xBA</status>
+        <midino>0x74</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x75</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x75</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x75</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x75</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler6]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB7</status>
+        <midino>0x75</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler6]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB8</status>
+        <midino>0x75</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler6]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB9</status>
+        <midino>0x75</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler6]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xBA</status>
+        <midino>0x75</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x76</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x76</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x76</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x76</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler7]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB7</status>
+        <midino>0x76</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler7]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB8</status>
+        <midino>0x76</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler7]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB9</status>
+        <midino>0x76</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler7]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xBA</status>
+        <midino>0x76</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x97</status>
+        <midino>0x77</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x98</status>
+        <midino>0x77</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x99</status>
+        <midino>0x77</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerPlay</key>
+        <status>0x9A</status>
+        <midino>0x77</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler8]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB7</status>
+        <midino>0x77</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler8]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB8</status>
+        <midino>0x77</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler8]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xB9</status>
+        <midino>0x77</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Sampler8]</group>
+        <key>PioneerDDJSX2.SetSampleGain</key>
+        <status>0xBA</status>
+        <midino>0x77</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.PanelSelect</key>
+        <status>0x96</status>
+        <midino>0x78</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x78</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x78</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x78</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x78</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SetGridAdjust</key>
+        <status>0x90</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>1</group>
+        <key>PioneerDDJSX2.SetGridAdjust</key>
+        <status>0x91</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>2</group>
+        <key>PioneerDDJSX2.SetGridAdjust</key>
+        <status>0x92</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>3</group>
+        <key>PioneerDDJSX2.SetGridAdjust</key>
+        <status>0x93</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.PanelSelect</key>
+        <status>0x96</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x79</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x7A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x7A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x7A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x7A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[BeatJump]</group>
+        <key>next</key>
+        <status>0x90</status>
+        <midino>0x7B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[BeatJump]</group>
+        <key>next</key>
+        <status>0x91</status>
+        <midino>0x7B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[BeatJump]</group>
+        <key>next</key>
+        <status>0x92</status>
+        <midino>0x7B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>[BeatJump]</group>
+        <key>next</key>
+        <status>0x93</status>
+        <midino>0x7B</midino>
+        <options>
+          <normal />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x7B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x7B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x7B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x7B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x7C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x7C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x7C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x7C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x7D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x7D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x7D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x7D</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x7E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x7E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x7E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x7E</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x97</status>
+        <midino>0x7F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x98</status>
+        <midino>0x7F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x99</status>
+        <midino>0x7F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>0</group>
+        <key>PioneerDDJSX2.SamplerStop</key>
+        <status>0x9A</status>
+        <midino>0x7F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+    </controls>
+    <outputs />
+  </controller>
+</MixxxControllerPreset>

--- a/res/controllers/PIONEER-DDJ-SX2.midi.xml
+++ b/res/controllers/PIONEER-DDJ-SX2.midi.xml
@@ -6,6 +6,9 @@
     <description>Pioneer DDJ-SX2 mapping for Mixxx</description>
   </info>
   <settings>
+    <group label="General Settings">
+      <option variable="NeedleSearchBehaviour" type="boolean" default="0" label="Allow to use needle search when a song is playing. If disabled, you can use :hwbtn:`Shift` + :hwbtn:`NeedleSearch` to use the needle search when a song is playing." />
+    </group>
     <group label="Scratch Settings">
       <option variable="safeScratchTimeout" default="20" min="20" max="1000" step="10" type="integer" label="Safe Scratch Timeout (ms) (20ms is the minimum allowed)" />
     </group>
@@ -338,38 +341,82 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>playposition</key>
+        <key>PioneerDDJSX2.NeedleSearch</key>
+        <description>Needle search for Deck 1</description>
         <status>0xB0</status>
         <midino>0x03</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>playposition</key>
+        <key>PioneerDDJSX2.NeedleSearch</key>
+        <description>Needle search for Deck 2</description>
         <status>0xB1</status>
         <midino>0x03</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>playposition</key>
+        <key>PioneerDDJSX2.NeedleSearch</key>
+        <description>Needle search for Deck 3</description>
         <status>0xB2</status>
         <midino>0x03</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>playposition</key>
+        <key>PioneerDDJSX2.NeedleSearch</key>
+        <description>Needle search for Deck 4</description>
         <status>0xB3</status>
         <midino>0x03</midino>
         <options>
-          <normal />
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.NeedleSearch</key>
+        <description>Needle search for Deck 1 when Shifting</description>
+        <status>0xB0</status>
+        <midino>0x28</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.NeedleSearch</key>
+        <description>Needle search for Deck 2 when Shifting</description>
+        <status>0xB1</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.NeedleSearch</key>
+        <description>Needle search for Deck 3 when Shifting</description>
+        <status>0xB2</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.NeedleSearch</key>
+        <description>Needle search for Deck 4 when Shifting</description>
+        <status>0xB3</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding />
         </options>
       </control>
       <control>
@@ -2556,42 +2603,6 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>rate_temp_down</key>
-        <status>0x90</status>
-        <midino>0x24</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>rate_temp_down</key>
-        <status>0x91</status>
-        <midino>0x24</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>rate_temp_down</key>
-        <status>0x92</status>
-        <midino>0x24</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>rate_temp_down</key>
-        <status>0x93</status>
-        <midino>0x24</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
         <key>PioneerDDJSX2.BeatJump</key>
         <status>0x97</status>
         <midino>0x24</midino>
@@ -2628,42 +2639,6 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>PioneerDDJSX2.RollParam1L</key>
-        <status>0x90</status>
-        <midino>0x25</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>PioneerDDJSX2.RollParam1L</key>
-        <status>0x91</status>
-        <midino>0x25</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>PioneerDDJSX2.RollParam1L</key>
-        <status>0x92</status>
-        <midino>0x25</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>PioneerDDJSX2.RollParam1L</key>
-        <status>0x93</status>
-        <midino>0x25</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
         <key>PioneerDDJSX2.BeatJump</key>
         <status>0x97</status>
         <midino>0x25</midino>
@@ -2694,42 +2669,6 @@
         <key>PioneerDDJSX2.BeatJump</key>
         <status>0x9A</status>
         <midino>0x25</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>PioneerDDJSX2.SlicerParam1L</key>
-        <status>0x90</status>
-        <midino>0x26</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>PioneerDDJSX2.SlicerParam1L</key>
-        <status>0x91</status>
-        <midino>0x26</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>PioneerDDJSX2.SlicerParam1L</key>
-        <status>0x92</status>
-        <midino>0x26</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>PioneerDDJSX2.SlicerParam1L</key>
-        <status>0x93</status>
-        <midino>0x26</midino>
         <options>
           <script-binding />
         </options>
@@ -2808,42 +2747,6 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>PioneerDDJSX2.SamplerParam1L</key>
-        <status>0x90</status>
-        <midino>0x27</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>PioneerDDJSX2.SamplerParam1L</key>
-        <status>0x91</status>
-        <midino>0x27</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>PioneerDDJSX2.SamplerParam1L</key>
-        <status>0x92</status>
-        <midino>0x27</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>PioneerDDJSX2.SamplerParam1L</key>
-        <status>0x93</status>
-        <midino>0x27</midino>
-        <options>
-          <script-binding />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
         <key>PioneerDDJSX2.BeatJump</key>
         <status>0x97</status>
         <midino>0x27</midino>
@@ -2880,7 +2783,88 @@
       </control>
       <control>
         <group>[Channel1]</group>
+        <key>PioneerDDJSX2.RollParam1L</key>
+        <description>Parameter 1 Left, when pads are in ROLL mode for Deck 1</description>
+        <status>0x90</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.RollParam1L</key>
+        <description>Parameter 1 Left, when pads are in ROLL mode for Deck 2</description>
+        <status>0x91</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.RollParam1L</key>
+        <description>Parameter 1 Left, when pads are in ROLL mode for Deck 3</description>
+        <status>0x92</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.RollParam1L</key>
+        <description>Parameter 1 Left, when pads are in ROLL mode for Deck 4</description>
+        <status>0x93</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.SlicerParam1L</key>
+        <description>Parameter 1 Left, when pads are in SLICER mode for Deck 1</description>
+        <status>0x90</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.SlicerParam1L</key>
+        <description>Parameter 1 Left, when pads are in SLICER mode for Deck 2</description>
+        <status>0x91</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.SlicerParam1L</key>
+        <description>Parameter 1 Left, when pads are in SLICER mode for Deck 3</description>
+        <status>0x92</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.SlicerParam1L</key>
+        <description>Parameter 1 Left, when pads are in SLICER mode for Deck 4</description>
+        <status>0x93</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
         <key>PioneerDDJSX2.CueLoopParam1L</key>
+        <description>Parameter 1 Left, when pads are in CUE LOOP mode for Deck 1</description>
         <status>0x90</status>
         <midino>0x28</midino>
         <options>
@@ -2890,6 +2874,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.CueLoopParam1L</key>
+        <description>Parameter 1 Left, when pads are in CUE LOOP mode for Deck 2</description>
         <status>0x91</status>
         <midino>0x28</midino>
         <options>
@@ -2899,6 +2884,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.CueLoopParam1L</key>
+        <description>Parameter 1 Left, when pads are in CUE LOOP mode for Deck 3</description>
         <status>0x92</status>
         <midino>0x28</midino>
         <options>
@@ -2908,6 +2894,7 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.CueLoopParam1L</key>
+        <description>Parameter 1 Left, when pads are in CUE LOOP mode for Deck 4</description>
         <status>0x93</status>
         <midino>0x28</midino>
         <options>
@@ -2917,6 +2904,7 @@
       <control>
         <group>[Channel1]</group>
         <key>PioneerDDJSX2.SamplerParam1L</key>
+        <description>Parameter 1 Left, when pads are in SAMPLER mode for Deck 1</description>
         <status>0x90</status>
         <midino>0x2B</midino>
         <options>
@@ -2926,6 +2914,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.SamplerParam1L</key>
+        <description>Parameter 1 Left, when pads are in SAMPLER mode for Deck 2</description>
         <status>0x91</status>
         <midino>0x2B</midino>
         <options>
@@ -2935,6 +2924,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.SamplerParam1L</key>
+        <description>Parameter 1 Left, when pads are in SAMPLER mode for Deck 3</description>
         <status>0x92</status>
         <midino>0x2B</midino>
         <options>
@@ -2944,6 +2934,7 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.SamplerParam1L</key>
+        <description>Parameter 1 Left, when pads are in SAMPLER mode for Deck 4</description>
         <status>0x93</status>
         <midino>0x2B</midino>
         <options>
@@ -2952,43 +2943,48 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>rate_temp_up</key>
+        <key>PioneerDDJSX2.CueParam1L</key>
+        <description>Parameter 1 Left, when pads are in CUE mode for Deck 1</description>
         <status>0x90</status>
-        <midino>0x2C</midino>
+        <midino>0x24</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>rate_temp_up</key>
+        <key>PioneerDDJSX2.CueParam1L</key>
+        <description>Parameter 1 Left, when pads are in CUE mode for Deck 2</description>
         <status>0x91</status>
-        <midino>0x2C</midino>
+        <midino>0x24</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>rate_temp_up</key>
+        <key>PioneerDDJSX2.CueParam1L</key>
+        <description>Parameter 1 Left, when pads are in CUE mode for Deck 3</description>
         <status>0x92</status>
-        <midino>0x2C</midino>
+        <midino>0x24</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>rate_temp_up</key>
+        <key>PioneerDDJSX2.CueParam1L</key>
+        <description>Parameter 1 Left, when pads are in CUE mode for Deck 4</description>
         <status>0x93</status>
-        <midino>0x2C</midino>
+        <midino>0x24</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel1]</group>
         <key>PioneerDDJSX2.RollParam1R</key>
+        <description>Parameter 1 Right, when pads are in ROLL mode for Deck 1</description>
         <status>0x90</status>
         <midino>0x2D</midino>
         <options>
@@ -2998,6 +2994,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.RollParam1R</key>
+        <description>Parameter 1 Right, when pads are in ROLL mode for Deck 2</description>
         <status>0x91</status>
         <midino>0x2D</midino>
         <options>
@@ -3007,6 +3004,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.RollParam1R</key>
+        <description>Parameter 1 Right, when pads are in ROLL mode for Deck 3</description>
         <status>0x92</status>
         <midino>0x2D</midino>
         <options>
@@ -3016,6 +3014,7 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.RollParam1R</key>
+        <description>Parameter 1 Right, when pads are in ROLL mode for Deck 4</description>
         <status>0x93</status>
         <midino>0x2D</midino>
         <options>
@@ -3025,6 +3024,7 @@
       <control>
         <group>[Channel1]</group>
         <key>PioneerDDJSX2.SlicerParam1R</key>
+        <description>Parameter 1 Right, when pads are in SLICER mode for Deck 1</description>
         <status>0x90</status>
         <midino>0x2E</midino>
         <options>
@@ -3034,6 +3034,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.SlicerParam1R</key>
+        <description>Parameter 1 Right, when pads are in SLICER mode for Deck 2</description>
         <status>0x91</status>
         <midino>0x2E</midino>
         <options>
@@ -3043,6 +3044,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.SlicerParam1R</key>
+        <description>Parameter 1 Right, when pads are in SLICER mode for Deck 3</description>
         <status>0x92</status>
         <midino>0x2E</midino>
         <options>
@@ -3052,6 +3054,7 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.SlicerParam1R</key>
+        <description>Parameter 1 Right, when pads are in SLICER mode for Deck 4</description>
         <status>0x93</status>
         <midino>0x2E</midino>
         <options>
@@ -3061,6 +3064,7 @@
       <control>
         <group>[Channel1]</group>
         <key>PioneerDDJSX2.SamplerParam1R</key>
+        <description>Parameter 1 Right, when pads are in SAMPLER mode for Deck 1</description>
         <status>0x90</status>
         <midino>0x2F</midino>
         <options>
@@ -3070,6 +3074,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.SamplerParam1R</key>
+        <description>Parameter 1 Right, when pads are in SAMPLER mode for Deck 2</description>
         <status>0x91</status>
         <midino>0x2F</midino>
         <options>
@@ -3079,6 +3084,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.SamplerParam1R</key>
+        <description>Parameter 1 Right, when pads are in SAMPLER mode for Deck 3</description>
         <status>0x92</status>
         <midino>0x2F</midino>
         <options>
@@ -3088,6 +3094,7 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.SamplerParam1R</key>
+        <description>Parameter 1 Right, when pads are in SAMPLER mode for Deck 4</description>
         <status>0x93</status>
         <midino>0x2F</midino>
         <options>
@@ -3097,6 +3104,7 @@
       <control>
         <group>[Channel1]</group>
         <key>PioneerDDJSX2.CueLoopParam1R</key>
+        <description>Parameter 1 Right, when pads are in CUE LOOP mode for Deck 1</description>
         <status>0x90</status>
         <midino>0x30</midino>
         <options>
@@ -3106,6 +3114,7 @@
       <control>
         <group>[Channel2]</group>
         <key>PioneerDDJSX2.CueLoopParam1R</key>
+        <description>Parameter 1 Right, when pads are in CUE LOOP mode for Deck 2</description>
         <status>0x91</status>
         <midino>0x30</midino>
         <options>
@@ -3115,6 +3124,7 @@
       <control>
         <group>[Channel3]</group>
         <key>PioneerDDJSX2.CueLoopParam1R</key>
+        <description>Parameter 1 Right, when pads are in CUE LOOP mode for Deck 3</description>
         <status>0x92</status>
         <midino>0x30</midino>
         <options>
@@ -3124,8 +3134,49 @@
       <control>
         <group>[Channel4]</group>
         <key>PioneerDDJSX2.CueLoopParam1R</key>
+        <description>Parameter 1 Right, when pads are in CUE LOOP mode for Deck 4</description>
         <status>0x93</status>
         <midino>0x30</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.CueParam1R</key>
+        <description>Parameter 1 Right, when pads are in CUE mode for Deck 1</description>
+        <status>0x90</status>
+        <midino>0x2C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.CueParam1R</key>
+        <description>Parameter 1 Right, when pads are in CUE mode for Deck 2</description>
+        <status>0x91</status>
+        <midino>0x2C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.CueParam1R</key>
+        <description>Parameter 1 Right, when pads are in CUE mode for Deck 3</description>
+        <status>0x92</status>
+        <midino>0x2C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.CueParam1R</key>
+        <description>Parameter 1 Right, when pads are in CUE mode for Deck 4</description>
+        <status>0x93</status>
+        <midino>0x2C</midino>
         <options>
           <script-binding />
         </options>
@@ -4604,38 +4655,242 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>pitch_adjust_set_zero</key>
+        <key>PioneerDDJSX2.FlipStart</key>
+        <description>Toggle Loop Anchor with the Flip Start button on Deck 1</description>
         <status>0x90</status>
-        <midino>0x49</midino>
+        <midino>0x4B</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>pitch_adjust_set_zero</key>
+        <key>PioneerDDJSX2.FlipStart</key>
+        <description>Toggle Loop Anchor with the Flip Start button on Deck 2</description>
         <status>0x91</status>
-        <midino>0x49</midino>
+        <midino>0x4B</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel3]</group>
-        <key>pitch_adjust_set_zero</key>
+        <key>PioneerDDJSX2.FlipStart</key>
+        <description>Toggle Loop Anchor with the Flip Start button on Deck 3</description>
         <status>0x92</status>
-        <midino>0x49</midino>
+        <midino>0x4B</midino>
         <options>
-          <normal />
+          <script-binding />
         </options>
       </control>
       <control>
         <group>[Channel4]</group>
-        <key>pitch_adjust_set_zero</key>
+        <key>PioneerDDJSX2.FlipStart</key>
+        <description>Toggle Loop Anchor with the Flip Start button on Deck 4</description>
+        <status>0x93</status>
+        <midino>0x4B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.FlipRec</key>
+        <description>Toggle Quantize with the Flip Rec button on Deck 1</description>
+        <status>0x90</status>
+        <midino>0x4A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.FlipRec</key>
+        <description>Toggle Quantize with the Flip Rec button on Deck 2</description>
+        <status>0x91</status>
+        <midino>0x4A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.FlipRec</key>
+        <description>Toggle Quantize with the Flip Rec button on Deck 3</description>
+        <status>0x92</status>
+        <midino>0x4A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.FlipRec</key>
+        <description>Toggle Quantize with the Flip Rec button on Deck 4</description>
+        <status>0x93</status>
+        <midino>0x4A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.FlipSlot</key>
+        <description>Reset current track key Flip Slot button on Deck 1</description>
+        <status>0x90</status>
+        <midino>0x49</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.FlipSlot</key>
+        <description>Reset current track key Flip Slot button on Deck 2</description>
+        <status>0x91</status>
+        <midino>0x49</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.FlipSlot</key>
+        <description>Reset current track key Flip Slot button on Deck 3</description>
+        <status>0x92</status>
+        <midino>0x49</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.FlipSlot</key>
+        <description>Reset current track key Flip Slot button on Deck 4</description>
         <status>0x93</status>
         <midino>0x49</midino>
         <options>
-          <normal />
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.FlipLoop</key>
+        <status>0x90</status>
+        <midino>0x5A</midino>
+        <description>Set the Repeat setting for the track on Deck 1 with the SHIFT + REC button</description>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.FlipLoop</key>
+        <description>Set the Repeat setting for the track on Deck 2 with the SHIFT + REC button</description>
+        <status>0x91</status>
+        <midino>0x5A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.FlipLoop</key>
+        <description>Set the Repeat setting for the track on Deck 3 with the SHIFT + REC button</description>
+        <status>0x92</status>
+        <midino>0x5A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.FlipLoop</key>
+        <description>Set the Repeat setting for the track on Deck 4 with the SHIFT + REC button</description>
+        <status>0x93</status>
+        <midino>0x5A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.FlipOnOff</key>
+        <description>Set the Key UP for the track on Deck 1 with the SHIFT + START button</description>
+        <status>0x90</status>
+        <midino>0x5B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.FlipOnOff</key>
+        <description>Set the Key UP for the track on Deck 2 with the SHIFT + START button</description>
+        <status>0x91</status>
+        <midino>0x5B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.FlipOnOff</key>
+        <description>Set the Key UP for the track on Deck 3 with the SHIFT + START button</description>
+        <status>0x92</status>
+        <midino>0x5B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.FlipOnOff</key>
+        <description>Set the Key UP for the track on Deck 4 with the SHIFT + START button</description>
+        <status>0x93</status>
+        <midino>0x5B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>PioneerDDJSX2.FlipSave</key>
+        <description>Set the Key DOWN for the track on Deck 1 with the SHIFT + SLOT button</description>
+        <status>0x90</status>
+        <midino>0x59</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>PioneerDDJSX2.FlipSave</key>
+        <description>Set the Key DOWN for the track on Deck 2 with the SHIFT + SLOT button</description>
+        <status>0x91</status>
+        <midino>0x59</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>PioneerDDJSX2.FlipSave</key>
+        <description>Set the Key DOWN for the track on Deck 3 with the SHIFT + SLOT button</description>
+        <status>0x92</status>
+        <midino>0x59</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>PioneerDDJSX2.FlipSave</key>
+        <description>Set the Key DOWN for the track on Deck 4 with the SHIFT + SLOT button</description>
+        <status>0x93</status>
+        <midino>0x59</midino>
+        <options>
+          <script-binding />
         </options>
       </control>
       <control>
@@ -4702,42 +4957,6 @@
         </options>
       </control>
       <control>
-        <group>[Channel1]</group>
-        <key>pitch_down</key>
-        <status>0x90</status>
-        <midino>0x4A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>pitch_down</key>
-        <status>0x91</status>
-        <midino>0x4A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>pitch_down</key>
-        <status>0x92</status>
-        <midino>0x4A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>pitch_down</key>
-        <status>0x93</status>
-        <midino>0x4A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
         <group>[OK]</group>
         <key>PioneerDDJSX2.EffectTap</key>
         <status>0x94</status>
@@ -4787,42 +5006,6 @@
         <key>hotcue_11_clear</key>
         <status>0x9A</status>
         <midino>0x4A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>pitch_up</key>
-        <status>0x90</status>
-        <midino>0x4B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>pitch_up</key>
-        <status>0x91</status>
-        <midino>0x4B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>pitch_up</key>
-        <status>0x92</status>
-        <midino>0x4B</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>pitch_up</key>
-        <status>0x93</status>
-        <midino>0x4B</midino>
         <options>
           <normal />
         </options>
@@ -5647,42 +5830,6 @@
         <key>hotcue_18_clear</key>
         <status>0x9A</status>
         <midino>0x59</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>repeat</key>
-        <status>0x90</status>
-        <midino>0x5A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel2]</group>
-        <key>repeat</key>
-        <status>0x91</status>
-        <midino>0x5A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel3]</group>
-        <key>repeat</key>
-        <status>0x92</status>
-        <midino>0x5A</midino>
-        <options>
-          <normal />
-        </options>
-      </control>
-      <control>
-        <group>[Channel4]</group>
-        <key>repeat</key>
-        <status>0x93</status>
-        <midino>0x5A</midino>
         <options>
           <normal />
         </options>

--- a/res/controllers/PIONEER-DDJ-SX2.scripts.js
+++ b/res/controllers/PIONEER-DDJ-SX2.scripts.js
@@ -1,8 +1,10 @@
-/* eslint-disable no-var */
 /* eslint-disable no-undef */
-// Pioneer DDJ-SX2 mapping for Mixxx - WIP
-// Based on hrudham's mapping for the DDJ-SR
-// Modifications by tildearrow, Krafting, eXWoLL
+/* eslint-disable no-var */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// Pioneer DDJ-SX2 mapping for Mixxx
+// Based on tildearrow's mapping for the DDJ-SX2
+// Modifications by Krafting, eXWoLL(+Assistant)
 
 // Thanks to:
 // 		hrudham for making the DDJ-SR mapping
@@ -19,6 +21,7 @@
 // 6.  LIGHTING & FEEDBACK .......................
 // 7.  JOGWHEEL & SCRATCHING .....................
 // 8.  MIXER & TRANSPORT (14-bit Support) ........
+// 8b. KNOB KILL FUNCTIONS (Shift+Knob Down) .....
 // 9.  FX SECTION ................................
 // 10. VIEW, GRID, & PANELS ......................
 // 11. SAMPLER & PAD PARAMETERS ..................
@@ -34,7 +37,7 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
 //
@@ -48,18 +51,26 @@
 
 var PioneerDDJSX2 = {};
 
+// Guidelines :
+// Buttons function should have these variables as their parameters, in this order :
+//      channel, control, value, status, group
+// For MIDI control (LEDs) with makeConnections :
+//      value, group, control
+// CC function should have these instead :
+//      channel, control, value
+
 // =============================================================================
 // 1. CONSTANTS, DEBUGGING & HELPERS
 // =============================================================================
 
 // SysEx constants for Controller Initialization & Keep Alive.
-// The SX2 requires a "Keep Alive" signal periodically to prevent it from 
+// The SX2 requires a "Keep Alive" signal periodically to prevent it from
 // falling back to a standby/demo state or locking the jog wheels.
-PioneerDDJSX2.keepAlive = [0xF0, 0x00, 0x20, 0x7f, 0x50, 0x01, 0xF7];
-PioneerDDJSX2.recallState = [0xF0, 0x00, 0x20, 0x7f, 0x03, 0x01, 0xF7];
+PioneerDDJSX2.keepAlive = [0xF0, 0x00, 0x20, 0x7F, 0x50, 0x01, 0xF7];
+PioneerDDJSX2.recallState = [0xF0, 0x00, 0x20, 0x7F, 0x03, 0x01, 0xF7];
 
 // Performance pad colors (Hex to MIDI value mapping)
-// Maps standard HTML-style Hex codes to the specific MIDI velocity values 
+// Maps standard HTML-style Hex codes to the specific MIDI velocity values
 // required by the Pioneer RGB pads.
 // 0: Off, 1-127: Various colors and brightness levels.
 
@@ -167,7 +178,7 @@ PioneerDDJSX2.channels = {
 };
 
 // Deck & Pad State
-PioneerDDJSX2.shift = [0, 0, 0, 0]; // Shift button state per deck
+PioneerDDJSX2.shiftState = [0, 0, 0, 0]; // Shift button state per deck
 PioneerDDJSX2.reverse = [0, 0, 0, 0]; // Reverse playback state
 PioneerDDJSX2.vinylOn = [1, 1, 1, 1]; // Vinyl Mode enabled
 PioneerDDJSX2.padMode = [0, 0, 0, 0]; // Current Pad Mode (Hotcue, Roll, Slicer, etc.)
@@ -188,6 +199,10 @@ PioneerDDJSX2.lastLightUpdate = [0, 0, 0, 0];
 PioneerDDJSX2.currentBeat = [0, 0, 0, 0];
 PioneerDDJSX2.blinkState = 0; // Toggles every timer tick for blinking LEDs
 
+// Hotcue Warning Red Center Lights LED
+PioneerDDJSX2.HotCueLEDStatus = {};
+PioneerDDJSX2.isThereHotCue = [];
+
 // View & Layout
 PioneerDDJSX2.curPanel = 0; // Tracks visible GUI panels
 PioneerDDJSX2.curView = 0; // Tracks visible waveform views
@@ -202,14 +217,65 @@ PioneerDDJSX2.samplerVolume = 1.0;
 PioneerDDJSX2.sampleVolume = new Array(64).fill(0.9);
 PioneerDDJSX2.samplerBank = [0, 0, 0, 0]; // Offset for sampler banks (0=1-8, 1=9-16, etc)
 
+// LOAD button hold state per channel.
+// Set true on press, false on release.
+// Used to intercept rotary input for QuickEffect cycling.
+PioneerDDJSX2.loadHeld = [false, false, false, false];
+
+// Tracks whether the rotary was turned while LOAD was held.
+// If true on LOAD release, the normal track-load is suppressed.
+PioneerDDJSX2.loadRotaryUsed = [false, false, false, false];
+
 // Effects State
 PioneerDDJSX2.currentEffect = [3, 3]; // Selected FX unit
 PioneerDDJSX2.currentEffectparamset = [0, 0, 0, 0, 0, 0, 0, 0];
-PioneerDDJSX2.linkTypeTimer = 0;
-PioneerDDJSX2.linkType = [
-    [],
-    []
-];
+
+// Kill/mute state for EQ and Filter knobs, per deck (0-3).
+// Each knob tracks:
+//   killed        — whether the kill is currently active
+//   anchor        — the knob position at the start of the current shift gesture,
+//                   used to measure how far the knob has moved
+//   lastToggleDir — the direction ("up"/"down") of the most recent toggle,
+//                   used to prevent re-triggering while continuing the same movement
+PioneerDDJSX2.killState = {};
+for (let i = 0; i < 4; i++) {
+    PioneerDDJSX2.killState[i] = {
+        eqHigh: {
+            killed: false,
+            anchor: null,
+            lastToggleDir: null,
+        },
+        eqMid: {
+            killed: false,
+            anchor: null,
+            lastToggleDir: null,
+        },
+        eqLow: {
+            killed: false,
+            anchor: null,
+            lastToggleDir: null,
+        },
+        filter: {
+            killed: false,
+            anchor: null,
+            lastToggleDir: null,
+        },
+    };
+}
+
+// Snap window for position-based restores (center and minimum detection).
+PioneerDDJSX2.KillTolerance = 0.005;
+
+// Minimum knob travel (as a 0.0-1.0 fraction of the full range) required
+// to trigger or restore a kill while shift is held. Prevents MIDI jitter
+// and the MSB/LSB message pairs the SX2 sends per tick from double-firing.
+PioneerDDJSX2.KillThreshold = 0.005;
+
+// Returns true if any of the four shift buttons is currently held.
+// Used so kills can be triggered from either side of the controller.
+PioneerDDJSX2.anyShiftHeld = function() {
+    return PioneerDDJSX2.shiftState.some(function(v) { return v > 0; });
+};
 
 // 14-bit MIDI Cache
 // Stores the MSB (Most Significant Byte) to combine with LSB for high-res control
@@ -264,34 +330,31 @@ PioneerDDJSX2.settings = {
     beta: (1.0 / 8) / 32,
     jogResolution: 2054, // Resolution per rotation for scratching
     vinylSpeed: 33 + 1 / 3,
-    loopIntervals: ['0.03125', '0.0625', '0.125', '0.25', '0.5', '1', '2', '4', '8', '16', '32', '64'],
+    loopIntervals: ["0.03125", "0.0625", "0.125", "0.25", "0.5", "1", "2", "4", "8", "16", "32", "64"],
     tempoRanges: [0.08, 0.16, 0.32, 0.64],
     rollColors: [0x19, 0x20, 0x13, 0x0e, 0x05],
-    beatjumpColors: [0x3c, 0x3a, 0x38, 0x36, 0x34, 0x32, 0x30, 0x2e, 0x2c, 0x2a, 0x28],
-    cueLoopColors: [0x30, 0x35, 0x3a, 0x01, 0x05, 0x0a, 0x10, 0x15, 0x1a, 0x24, 0x27, 0x2a],
-    safeScratchTimeout: engine.getSetting('safeScratchTimeout'),
-    CenterRedLightsBehavior: engine.getSetting('CenterRedLightsBehavior'),
-    CenterWhiteLightsBehavior: engine.getSetting('CenterWhiteLightsBehavior'), // 0 for rotations, 1 for duration
+    beatjumpColors: [0x3c, 0x3A, 0x38, 0x36, 0x34, 0x32, 0x30, 0x2e, 0x2c, 0x2a, 0x28],
+    cueLoopColors: [0x30, 0x35, 0x3A, 0x01, 0x05, 0x0a, 0x10, 0x15, 0x1a, 0x24, 0x27, 0x2a],
     NeedleSearchBehaviour: engine.getSetting("NeedleSearchBehaviour"),
-    DoNotTrickController: engine.getSetting('DoNotTrickController'),
-    SoftStartTime: engine.getSetting('SoftStartTime'),
-    BrakeTime: engine.getSetting('BrakeTime'),
-    UseShiftToBreak: engine.getSetting('UseShiftToBreak')
+    LoadBehaviour: engine.getSetting("LoadBehaviour"),
+    KeySyncBehaviour: engine.getSetting("KeySyncBehaviour"),
+    SoftTakeoverBehaviour: engine.getSetting("SoftTakeoverBehaviour"),
+    safeScratchTimeout: engine.getSetting("safeScratchTimeout"),
+    CenterRedLightsBehavior: engine.getSetting("CenterRedLightsBehavior"),
+    CenterWhiteLightsBehavior: engine.getSetting("CenterWhiteLightsBehavior"), // 0 for rotations, 1 for duration
+    DoNotTrickController: engine.getSetting("DoNotTrickController"),
+    SoftStartTime: engine.getSetting("SoftStartTime"),
+    BrakeTime: engine.getSetting("BrakeTime"),
+    UseShiftToBreak: engine.getSetting("UseShiftToBreak")
 };
 
-// Enums for efficient lookup
-PioneerDDJSX2.enums = {
-    rotarySelector: {
-        targets: {
-            libraries: 0,
-            tracklist: 1
-        }
-    },
+// Groups for efficient lookup
+PioneerDDJSX2.groups = {
     channelGroups: {
-        '[Channel1]': 0x00,
-        '[Channel2]': 0x01,
-        '[Channel3]': 0x02,
-        '[Channel4]': 0x03
+        "[Channel1]": 0x00,
+        "[Channel2]": 0x01,
+        "[Channel3]": 0x02,
+        "[Channel4]": 0x03
     },
     samplerGroups: {},
     hotcueIndex: {}
@@ -299,13 +362,16 @@ PioneerDDJSX2.enums = {
 
 // Populate Enums dynamically
 for (var i = 0; i < 64; i++) {
-    PioneerDDJSX2.enums.samplerGroups['[Sampler' + (i + 1) + ']'] = i;
+    PioneerDDJSX2.groups.samplerGroups[`[Sampler${  i + 1  }]`] = i;
 }
-for (var i = 1; i <= 24; i++) {
-    PioneerDDJSX2.enums.hotcueIndex['hotcue_' + i + '_status'] = i;
+for (let i = 1; i <= 24; i++) {
+    PioneerDDJSX2.groups.hotcueIndex[`hotcue_${  i  }_status`] = i;
 }
 
-PioneerDDJSX2.status = {rotarySelector: {target: PioneerDDJSX2.enums.rotarySelector.targets.tracklist}};
+// Tracks which channel is currently active on each physical side
+// Side A (left deck):  ch1 or ch3
+// Side B (right deck): ch2 or ch4
+PioneerDDJSX2.activeDeck = {A: 1, B: 2};
 
 // =============================================================================
 // 3. INITIALIZATION & SHUTDOWN
@@ -316,54 +382,88 @@ PioneerDDJSX2.init = function(id) {
     // Send Serato Recall Sysex (Forces controller into correct mode)
     midi.sendSysexMsg(PioneerDDJSX2.recallState, PioneerDDJSX2.recallState.length);
 
-    PioneerDDJSX2.channels = {
-        0x00: {},
-        0x01: {},
-        0x02: {},
-        0x03: {}
-    };
+    // Enable soft-takeover for all CC controls.
+    if (PioneerDDJSX2.settings.SoftTakeoverBehaviour === false) {
+        // Waits 3 seconds for the hardware position's burst, then enable soft takeover
+        engine.beginTimer(3000, function() {
+
+            // -- FX Knobs --
+            for (var j = 1; j <= 4; j++) {
+                engine.softTakeover("[EffectRack1_EffectUnit1_Effect1]", `parameter${  j}`, true);
+                engine.softTakeover("[EffectRack1_EffectUnit2_Effect1]", `parameter${  j}`, true);
+                engine.softTakeover("[EffectRack1_EffectUnit1_Effect2]", `parameter${  j}`, true);
+                engine.softTakeover("[EffectRack1_EffectUnit2_Effect2]", `parameter${  j}`, true);
+                engine.softTakeover("[EffectRack1_EffectUnit1_Effect3]", `parameter${  j}`, true);
+                engine.softTakeover("[EffectRack1_EffectUnit2_Effect3]", `parameter${  j}`, true);
+            }
+
+            // -- META Knobs --
+            engine.softTakeover("[EffectRack1_EffectUnit1_Effect1]", "meta", true);
+            engine.softTakeover("[EffectRack1_EffectUnit2_Effect1]", "meta", true);
+            engine.softTakeover("[EffectRack1_EffectUnit1_Effect2]", "meta", true);
+            engine.softTakeover("[EffectRack1_EffectUnit2_Effect2]", "meta", true);
+            engine.softTakeover("[EffectRack1_EffectUnit1_Effect3]", "meta", true);
+            engine.softTakeover("[EffectRack1_EffectUnit2_Effect3]", "meta", true);
+
+            // -- Per Channel Controls --
+            for (var i = 1; i <= 4; i++) {
+
+                // Filter Knobs
+                engine.softTakeover(`[QuickEffectRack1_[Channel${  i  }]]`, "super1", true);
+
+                // Channel Faders
+                engine.softTakeover(`[Channel${  i  }]`, "volume", true);
+
+                // EQ Knobs
+                engine.softTakeover(`[EqualizerRack1_[Channel${  i  }]_Effect1]`, "parameter1", true);
+                engine.softTakeover(`[EqualizerRack1_[Channel${  i  }]_Effect1]`, "parameter2", true);
+                engine.softTakeover(`[EqualizerRack1_[Channel${  i  }]_Effect1]`, "parameter3", true);
+
+                // Pregain/Trim
+                engine.softTakeover(`[Channel${  i  }]`, "pregain", true);
+
+                // Tempo Slider
+                engine.softTakeover(`[Channel${  i  }]`, "rate", true);
+            }
+
+            //--Crossfader--
+            engine.softTakeover("[Master]", "crossfader", true);
+        }, true);
+    }
 
     // Startup Animation (Sends lights to the Master Level Meter)
-    midi.sendShortMsg(0x90, 0x0b, 0x10);
-    midi.sendShortMsg(0x91, 0x0b, 0x10);
-    midi.sendShortMsg(0x92, 0x0b, 0x10);
-    midi.sendShortMsg(0x93, 0x0b, 0x10);
-    midi.sendShortMsg(0x90, 0x1b, 0x7f);
-    midi.sendShortMsg(0x91, 0x1b, 0x7f);
-    midi.sendShortMsg(0x92, 0x1b, 0x7f);
-    midi.sendShortMsg(0x93, 0x1b, 0x7f);
+    midi.sendShortMsg(0x90, 0x0B, 0x10);
+    midi.sendShortMsg(0x91, 0x0B, 0x10);
+    midi.sendShortMsg(0x92, 0x0B, 0x10);
+    midi.sendShortMsg(0x93, 0x0B, 0x10);
 
     // Bind Mixxx Controls to JS functions using engine.makeConnection
     PioneerDDJSX2.BindControlConnections();
 
-    // Reset Hardware state (Quick Effects default to Filter)
-    engine.setValue("[QuickEffectRack1_[Channel1]_Effect1]", "parameter2", 4);
-    engine.setValue("[QuickEffectRack1_[Channel2]_Effect1]", "parameter2", 4);
-    engine.setValue("[QuickEffectRack1_[Channel3]_Effect1]", "parameter2", 4);
-    engine.setValue("[QuickEffectRack1_[Channel4]_Effect1]", "parameter2", 4);
-
     // Turn off Deck Lights initially to ensure clean state
     for (var i = 0; i < 8; i++) {
-        midi.sendShortMsg(0xbb, i, 0);
+        midi.sendShortMsg(0xBB, i, 0);
     }
 
     // Initialize Deck defaults (Vinyl mode on, Tempo range reset)
-    for (var i = 0; i < 4; i++) {
-        midi.sendShortMsg(0x90 + i, 0x0d, 0x7f);
-        engine.setValue("[Channel" + (i + 1) + "]", "rateRange", PioneerDDJSX2.settings.tempoRanges[PioneerDDJSX2.tempoRange[i]]);
+    for (let i = 0; i < 4; i++) {
+        // Slip LED
+        midi.sendShortMsg(0x90 + i, 0x0D, 0x7F);
+        engine.setValue(`[Channel${  i + 1  }]`, "rateRange", PioneerDDJSX2.settings.tempoRanges[PioneerDDJSX2.tempoRange[i]]);
         PioneerDDJSX2.RepaintSampler(i);
     }
 
     PioneerDDJSX2.FXLeds();
 
     // Restore Hotcues LED state from engine
-    for (var i = 1; i <= 4; i++) {
+    for (let i = 1; i <= 4; i++) {
         for (var j = 1; j <= 16; j++) {
-            PioneerDDJSX2.HotCuePerformancePadLed(engine.getValue("[Channel" + i + "]", "hotcue_" + j + "_status"), "[Channel" + i + "]", "hotcue_" + j + "_status");
+            PioneerDDJSX2.HotCuePerformancePadLed(engine.getValue(`[Channel${  i  }]`, `hotcue_${  j  }_status`), `[Channel${  i  }]`, `hotcue_${  j  }_status`);
         }
     }
 
     // Enable Effects Units for all channels by default
+    // Left Deck : only effect bank no. 1  --  Right Deck : only effect bank no. 2
     engine.setValue("[EffectRack1_EffectUnit1]", "group_[Channel1]_enable", 1);
     engine.setValue("[EffectRack1_EffectUnit1]", "group_[Channel3]_enable", 1);
     engine.setValue("[EffectRack1_EffectUnit2]", "group_[Channel2]_enable", 1);
@@ -373,27 +473,52 @@ PioneerDDJSX2.init = function(id) {
     PioneerDDJSX2.lightsTimer = engine.beginTimer(250, PioneerDDJSX2.doTimer, 0);
 
     // Initialize 14-bit cache structures if undefined
-    if (typeof PioneerDDJSX2.midi14bit === 'undefined') {
+    if (typeof PioneerDDJSX2.midi14bit === "undefined") {
         PioneerDDJSX2.midi14bit = {};
     }
-    if (typeof PioneerDDJSX2.midi14bit.pregain === 'undefined') {
+    if (typeof PioneerDDJSX2.midi14bit.pregain === "undefined") {
         PioneerDDJSX2.midi14bit.pregain = [0, 0, 0, 0]; // For 4 channels
     }
 
-}
+};
 
 // Called when the controller is disconnected or script is stopped.
 PioneerDDJSX2.shutdown = function() {
     PioneerDDJSX2.UnbindControlConnections();
-    // Turn off lights
+    // Turn off center lights
     for (var i = 0; i < 8; i++) {
-        midi.sendShortMsg(0xbb, i, 0);
+        midi.sendShortMsg(0xBB, i, 0);
     };
+
+    // Reset Load Lights
+    midi.sendShortMsg(0x96, 0x46, 0x7F);
+    midi.sendShortMsg(0x96, 0x47, 0x7F);
+    midi.sendShortMsg(0x96, 0x48, 0x00);
+    midi.sendShortMsg(0x96, 0x49, 0x00);
+
+    // Reset to HOT CUE Mode + LED
+    // For All Channel
+    midi.sendShortMsg(0x90, 0x1B, 0x7F);
+    midi.sendShortMsg(0x91, 0x1B, 0x7F);
+    midi.sendShortMsg(0x92, 0x1B, 0x7F);
+    midi.sendShortMsg(0x93, 0x1B, 0x7F);
+
+    // Reset All Pad LEDs
+    // For All 4 channels
+    for (let i = 0; i < 8; i++) {
+        midi.sendShortMsg(0x97, 0x00 + i, 0x00);
+        midi.sendShortMsg(0x98, 0x00 + i, 0x00);
+        midi.sendShortMsg(0x99, 0x00 + i, 0x00);
+        midi.sendShortMsg(0x9A, 0x00 + i, 0x00);
+    }
+
     // Stop main timer
     if (PioneerDDJSX2.lightsTimer) {
         engine.stopTimer(PioneerDDJSX2.lightsTimer);
     };
 };
+
+
 
 // =============================================================================
 // 4. TIMER & BLINKING
@@ -409,7 +534,7 @@ PioneerDDJSX2.doTimer = function() {
     // Handle blinking LEDs (Slip Mode and Reverse) for each Deck
     for (var i = 0; i < 4; i++) {
         // Slip Blink
-        if (engine.getValue("[Channel" + (i + 1) + "]", "slip_enabled")) {
+        if (engine.getValue(`[Channel${  i + 1  }]`, "slip_enabled")) {
             midi.sendShortMsg(0x90 + i, 0x40, PioneerDDJSX2.blinkState ? 0x7F : 0x00); // Slip Button normal
         } else {
             midi.sendShortMsg(0x90 + i, 0x40, 0x00); // Slip Button normal
@@ -417,8 +542,8 @@ PioneerDDJSX2.doTimer = function() {
 
         // Reverse Blink
         if (PioneerDDJSX2.reverse[i]) {
-            midi.sendShortMsg(0x90 + i, 0x38, PioneerDDJSX2.blinkState ? 0x7f : 0x00); // Reverse Button when shifting
-            midi.sendShortMsg(0x90 + i, 0x15, PioneerDDJSX2.blinkState ? 0x7f : 0x00); // Reverse Button normal
+            midi.sendShortMsg(0x90 + i, 0x38, PioneerDDJSX2.blinkState ? 0x7F : 0x00); // Reverse Button when shifting
+            midi.sendShortMsg(0x90 + i, 0x15, PioneerDDJSX2.blinkState ? 0x7F : 0x00); // Reverse Button normal
         } else {
             midi.sendShortMsg(0x90 + i, 0x38, 0x00); // Reverse Button when shifting
             midi.sendShortMsg(0x90 + i, 0x15, 0x00); // Reverse Button normal
@@ -426,74 +551,74 @@ PioneerDDJSX2.doTimer = function() {
     }
     // Toggle blink state for next tick
     PioneerDDJSX2.blinkState = !PioneerDDJSX2.blinkState;
-}
+};
 
 // =============================================================================
 // 5. CONNECTIONS (Signals)
 // =============================================================================
 
-// Binds Mixxx Engine signals (e.g., 'play', 'vu_meter') to script functions.
+// Binds Mixxx Engine signals (e.g., "play", "vu_meter") to script functions.
 // This allows the controller LEDs to react to changes in the software UI.
 PioneerDDJSX2.BindControlConnections = function() {
     for (var i = 1; i <= 4; i++) {
-        var group = '[Channel' + i + ']';
+        var group = `[Channel${  i  }]`;
 
         // CRITICAL: JOGWHEEL & SLICER FEEDBACK
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'playposition', PioneerDDJSX2.deckLights));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'beat_next', PioneerDDJSX2.SlicerLights));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'beat_active', PioneerDDJSX2.UpdateCenterBeatLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "playposition", PioneerDDJSX2.DeckLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "beat_next", PioneerDDJSX2.SlicerLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "beat_active", PioneerDDJSX2.UpdateCenterBeatLights));
 
         // NEW: Reset beat counter when playposition changes (needle drop, hotcue jumps)
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'playposition', PioneerDDJSX2.ResetBeatCounter));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "playposition", PioneerDDJSX2.ResetBeatCounter));
 
         // STANDARD INDICATORS
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'vu_meter', PioneerDDJSX2.VuMeter));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'play_indicator', PioneerDDJSX2.PlayLeds));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'sync_enabled', PioneerDDJSX2.SyncLights));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'cue_indicator', PioneerDDJSX2.CueLeds));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'pfl', PioneerDDJSX2.HeadphoneCueLed));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'keylock', PioneerDDJSX2.KeyLockLeds));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_double', PioneerDDJSX2.LoopDouble));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_halve', PioneerDDJSX2.LoopHalve));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'rate', PioneerDDJSX2.RateLights));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'eject', PioneerDDJSX2.UnloadLights));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_enabled', PioneerDDJSX2.ReloopExit));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_in', PioneerDDJSX2.ReloopExit));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_out", PioneerDDJSX2.ReloopExit));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'track_samples', PioneerDDJSX2.LoadActions));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'pitch_adjust', PioneerDDJSX2.PitchAdjust));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, "quantize", PioneerDDJSX2.ParamLights));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_anchor", PioneerDDJSX2.ParamLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "vu_meter", PioneerDDJSX2.VuMeter));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "play_indicator", PioneerDDJSX2.PlayLeds));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "sync_enabled", PioneerDDJSX2.SyncLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "cue_indicator", PioneerDDJSX2.CueLeds));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "pfl", PioneerDDJSX2.HeadphoneCueLed));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "keylock", PioneerDDJSX2.KeyLockLeds));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_double", PioneerDDJSX2.LoopDouble));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_halve", PioneerDDJSX2.LoopHalve));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "rate", PioneerDDJSX2.RateLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "eject", PioneerDDJSX2.UnloadLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_enabled", PioneerDDJSX2.LoopLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_in", PioneerDDJSX2.LoopLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_out", PioneerDDJSX2.LoopLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_anchor", PioneerDDJSX2.LoopLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "track_samples", PioneerDDJSX2.LoadActions));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "pitch_adjust", PioneerDDJSX2.PitchAdjust));
         PioneerDDJSX2.conns.push(engine.makeConnection(group, "repeat", PioneerDDJSX2.ParamLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "quantize", PioneerDDJSX2.QuantizeLights));
 
         // HOTCUES (Status and Color)
         for (var j = 1; j <= 16; j++) {
-            PioneerDDJSX2.conns.push(engine.makeConnection(group, 'hotcue_' + j + '_status', PioneerDDJSX2.HotCuePerformancePadLed));
-            PioneerDDJSX2.conns.push(engine.makeConnection(group, 'hotcue_' + j + '_color', PioneerDDJSX2.HotCuePerformancePadLed));
+            PioneerDDJSX2.conns.push(engine.makeConnection(group, `hotcue_${  j  }_status`, PioneerDDJSX2.HotCuePerformancePadLed));
+            PioneerDDJSX2.conns.push(engine.makeConnection(group, `hotcue_${  j  }_color`, PioneerDDJSX2.HotCuePerformancePadLed));
         }
     }
 
     // FX Connections (Enable/Disable LEDs)
-    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel1]_enable', PioneerDDJSX2.FX1CH1));
-    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel1]_enable', PioneerDDJSX2.FX2CH1));
+    PioneerDDJSX2.conns.push(engine.makeConnection("[EffectRack1_EffectUnit1]", "group_[Channel1]_enable", PioneerDDJSX2.FX1CH1));
+    PioneerDDJSX2.conns.push(engine.makeConnection("[EffectRack1_EffectUnit2]", "group_[Channel1]_enable", PioneerDDJSX2.FX2CH1));
     PioneerDDJSX2.conns.push(engine.makeConnection("[EffectRack1_EffectUnit1]", "group_[Channel2]_enable", PioneerDDJSX2.FX1CH2));
-    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel2]_enable', PioneerDDJSX2.FX2CH2));
-    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel3]_enable', PioneerDDJSX2.FX1CH3));
-    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel3]_enable', PioneerDDJSX2.FX2CH3));
-    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel4]_enable', PioneerDDJSX2.FX1CH4));
-    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel4]_enable', PioneerDDJSX2.FX2CH4));
+    PioneerDDJSX2.conns.push(engine.makeConnection("[EffectRack1_EffectUnit2]", "group_[Channel2]_enable", PioneerDDJSX2.FX2CH2));
+    PioneerDDJSX2.conns.push(engine.makeConnection("[EffectRack1_EffectUnit1]", "group_[Channel3]_enable", PioneerDDJSX2.FX1CH3));
+    PioneerDDJSX2.conns.push(engine.makeConnection("[EffectRack1_EffectUnit2]", "group_[Channel3]_enable", PioneerDDJSX2.FX2CH3));
+    PioneerDDJSX2.conns.push(engine.makeConnection("[EffectRack1_EffectUnit1]", "group_[Channel4]_enable", PioneerDDJSX2.FX1CH4));
+    PioneerDDJSX2.conns.push(engine.makeConnection("[EffectRack1_EffectUnit2]", "group_[Channel4]_enable", PioneerDDJSX2.FX2CH4));
 
     // Effect Leds
-    for (var i = 1; i <= 3; i++) {
-        PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1_Effect' + i + ']', 'enabled', PioneerDDJSX2.FXLeds));
-        PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2_Effect' + i + ']', 'enabled', PioneerDDJSX2.FXLeds));
+    for (let i = 1; i <= 3; i++) {
+        PioneerDDJSX2.conns.push(engine.makeConnection(`[EffectRack1_EffectUnit1_Effect${  i  }]`, "enabled", PioneerDDJSX2.FXLeds));
+        PioneerDDJSX2.conns.push(engine.makeConnection(`[EffectRack1_EffectUnit2_Effect${  i  }]`, "enabled", PioneerDDJSX2.FXLeds));
     }
 
     // Sampler Connections (Play/Load state)
-    var numSamplers = engine.getValue('[App]', 'num_samplers');
-    for (var i = 1; i <= numSamplers; i++) {
-        PioneerDDJSX2.conns.push(engine.makeConnection('[Sampler' + i + ']', 'play', PioneerDDJSX2.SamplerLight));
-        PioneerDDJSX2.conns.push(engine.makeConnection('[Sampler' + i + ']', 'track_loaded', PioneerDDJSX2.SamplerLight));
+    var numSamplers = engine.getValue("[App]", "num_samplers");
+    for (let i = 1; i <= numSamplers; i++) {
+        PioneerDDJSX2.conns.push(engine.makeConnection(`[Sampler${  i  }]`, "play", PioneerDDJSX2.SamplerLight));
+        PioneerDDJSX2.conns.push(engine.makeConnection(`[Sampler${  i  }]`, "track_loaded", PioneerDDJSX2.SamplerLight));
     }
 };
 
@@ -514,9 +639,9 @@ PioneerDDJSX2.UnbindControlConnections = function() {
 // INCLUDES THROTTLING: The SX2 can freeze if too many MIDI messages are sent
 // rapidly to the jog rings. This function limits updates to ~30ms.
 
-// 1. Handles WHITE outer ring ONLY
-PioneerDDJSX2.deckLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+// Handles WHITE outer ring ONLY
+PioneerDDJSX2.DeckLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
 
     // THROTTLE: Limit update rate to ~30ms to prevent controller freeze
     var now = Date.now();
@@ -548,113 +673,142 @@ PioneerDDJSX2.deckLights = function(value, group, control) {
 
         // END-OF-TRACK WARNING BLINK (WHITE outer ring)
         if (isEndOfTrack === 1 && !engine.isScratching(channel + 1)) {
-            if (PioneerDDJSX2.settings.CenterWhiteLightsBehavior === 1) {
-                midi.sendShortMsg(0xbb, channel, PioneerDDJSX2.blinkState ? trackProgression : 0x00);
+            if (PioneerDDJSX2.settings.CenterWhiteLightsBehavior === true) {
+                midi.sendShortMsg(0xBB, channel, PioneerDDJSX2.blinkState ? trackProgression : 0x00);
             } else {
-                midi.sendShortMsg(0xbb, channel, PioneerDDJSX2.blinkState ? finalPos : 0x00);
+                midi.sendShortMsg(0xBB, channel, PioneerDDJSX2.blinkState ? finalPos : 0x00);
             }
         } else {
             // Normal playback - steady white ring rotation
-            if (PioneerDDJSX2.settings.CenterWhiteLightsBehavior === 1) {
-                midi.sendShortMsg(0xbb, channel, trackProgression);
+            if (PioneerDDJSX2.settings.CenterWhiteLightsBehavior === true) {
+                midi.sendShortMsg(0xBB, channel, trackProgression);
             } else {
-                midi.sendShortMsg(0xbb, channel, finalPos);
+                midi.sendShortMsg(0xBB, channel, finalPos);
             }
         }
     }
 };
 
-
 // CENTER RED JOGWHEEL LIGHTS (4 LEDs - 2 MODES ONLY)
 // =============================================================================
-// 2. Handles BOTH beat modes for RED center LEDs
+// Handles BOTH beat modes for RED center LEDs
 // MODE 0 (Checkbox OFF): Beat-by-beat - 1 LED per beat, 4 beat cycle
 // MODE 1 (Checkbox ON):  Bar-by-bar - 1 LED per bar (4 beats), 4 bar cycle (16 beats)
 PioneerDDJSX2.UpdateCenterBeatLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+
     if (value === 0) {
-        return
+        return;
     };
+
+    // WIP: This handles the whole red center light blinking when a hot cue is getting close (It will blink 4 times, meaning the hotcue is close by 8 beats)
+    // The code is there, the blinking happens, this could probably be better, maybe also be put in a setting option later ?
+    var trackSampleRate = engine.getValue(group, "track_samplerate");
+    var playposition = engine.getValue(group, "playposition");
+    var duration = engine.getValue(group, "duration");
+    var bpm = engine.getValue(group, "file_bpm");
+    // Get infos for each hotcues
+    for (var i = 1; i <= 16; i++) {
+        var hotcuePos = engine.getValue(group, `hotcue_${  i  }_position`);
+        // Check if hotcue is defined
+        if (hotcuePos >= 0 && hotcuePos !== undefined) {
+            // Get the current hotcue position in the track in seconds
+            var realHotCuePos = (hotcuePos / trackSampleRate / 2);
+            // Get track positionn in secondes
+            // playposition is a percentage of the duration between 0 and 1
+            var trackPositionInSeconds = (playposition * duration);
+            // Calculate beats per seconds
+            var secondsPerBeat = 60 / bpm;
+            // Number of beats before making the LEDs blink
+            var numberOfBeats = 8;
+            // We check if the hotcue is before the playhead, and just before the playhead by 4 beats
+            if (realHotCuePos >= trackPositionInSeconds && realHotCuePos <= (trackPositionInSeconds + (secondsPerBeat * numberOfBeats))) {
+                midi.sendShortMsg(0xBB, 0x04 + channel, PioneerDDJSX2.HotCueLEDStatus[i] ? 0 : 4);
+                PioneerDDJSX2.isThereHotCue[i] = true;
+                PioneerDDJSX2.HotCueLEDStatus[i] = PioneerDDJSX2.HotCueLEDStatus[i] ? 0 : 1;
+            } else {
+                PioneerDDJSX2.isThereHotCue[i] = false;
+            }
+        }
+    }
+
+    // We chech if ANY hotcue is closeby, if yes we store it so the red center light doesn't get overwritten by the bar-by-bar lights
+    var isThereDefinitelyHotCue = false;
+    for (var j = 1; j <= PioneerDDJSX2.isThereHotCue.length; j++) {
+        if (PioneerDDJSX2.isThereHotCue[j] === true) {
+            isThereDefinitelyHotCue = true;
+            break;
+        }
+    }
 
     var rawSetting = engine.getSetting("CenterRedLightsBehavior");
     var barByBarMode = (rawSetting === null) ? true : Boolean(Number(rawSetting));
 
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-
     // Increment beat counter
     PioneerDDJSX2.currentBeat[channel]++;
+    if (!isThereDefinitelyHotCue) {
+        if (barByBarMode) {
+            // ===== MODE 1: BAR-BY-BAR (Checkbox ON) =====
+            // 32 beat cycle (8 bars): 4 bars ON + 4 bars OFF
 
-    if (barByBarMode) {
-        // ===== MODE 1: BAR-BY-BAR (Checkbox ON) =====
-        // 32 beat cycle (8 bars): 4 bars ON + 4 bars OFF
+            if (PioneerDDJSX2.currentBeat[channel] > 32) {
+                PioneerDDJSX2.currentBeat[channel] = 1;
+            }
 
-        if (PioneerDDJSX2.currentBeat[channel] > 32) {
-            PioneerDDJSX2.currentBeat[channel] = 1;
+            var barNumber = Math.ceil(PioneerDDJSX2.currentBeat[channel] / 4);
+            midi.sendShortMsg(0xBB, 0x04 + channel, barNumber);
+
+        } else {
+            // ===== MODE 0: BEAT-BY-BEAT (Checkbox OFF, default) =====
+            // 8 beat cycle: 4 beats ON + 4 beats OFF
+
+            if (PioneerDDJSX2.currentBeat[channel] > 8) {
+                PioneerDDJSX2.currentBeat[channel] = 1;
+            }
+
+            midi.sendShortMsg(0xBB, 0x04 + channel, PioneerDDJSX2.currentBeat[channel]);
         }
-
-        var barNumber = Math.ceil(PioneerDDJSX2.currentBeat[channel] / 4);
-        midi.sendShortMsg(0xbb, 0x04 + channel, barNumber);
-
-    } else {
-        // ===== MODE 0: BEAT-BY-BEAT (Checkbox OFF) =====
-        // 8 beat cycle: 4 beats ON + 4 beats OFF
-
-        if (PioneerDDJSX2.currentBeat[channel] > 8) {
-            PioneerDDJSX2.currentBeat[channel] = 1;
-        }
-
-        midi.sendShortMsg(0xbb, 0x04 + channel, PioneerDDJSX2.currentBeat[channel]);
     }
 };
 
-// 3. Reset beat counter when track loads OR playposition changes
+// Reset beat counter when track loads OR playposition changes
 PioneerDDJSX2.LoadActions = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-    if (value) {
-        // Reset beat counter to 0 so first beat = LED 1
-        PioneerDDJSX2.currentBeat[channel] = 0;
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+    // Reset beat counter to 0 so first beat = LED 1
+    PioneerDDJSX2.currentBeat[channel] = 0;
 
-        // Turn off center red LEDs
-        midi.sendShortMsg(0xbb, 0x04 + channel, 0);
+    // Turn off center red LEDs
+    midi.sendShortMsg(0xBB, 0x04 + channel, 0);
 
-        // Light up load button
-        midi.sendShortMsg(0x9B, channel, 0x7F);
-    }
+    // Light up load button
+    midi.sendShortMsg(0x9B, channel, 0x7F);
 };
 
 // Update Lights for the Parameters buttons
-// This is because we can set quantize in the CUE and CUE LOOP mode
-// So that the leds are always in sync
-// Plus, this allows changing the setting in mixxx and being reflected on the controller
 // After some tests, it seems we CANNOT set the lights on Parameter 1 when we send the Serato Keepalive command
 // The lights will just blink when we press the buttons
 // Except for the CUE mode where we can set the lights as static.
-PioneerDDJSX2.ParamLights = function() {
-    // For each channel (deck)
-    for (var i = 0; i < 4; i++) {
-        var channel = `[Channel${  i+1  }]`;
-
-        // For the Quantize of each channels
-        // Rec Flip Button
-        var isQuantize = engine.getValue(channel, "quantize");
-        midi.sendShortMsg(0x90 + i, 0x4A, isQuantize ? 0x7F : 0x00);
-
-        // For the loop anchor of each channels
-        // Start Flip Button
-        var isAnchor = engine.getValue(channel, "loop_anchor");
-        midi.sendShortMsg(0x90 + i, 0x4B, isAnchor ? 0x7F : 0x00);
-
-        // For the repeat setting of each channels
-        // SHIFT + Rec Flip Button
-        var isAnchor = engine.getValue(channel, "repeat");
-        midi.sendShortMsg(0x90 + i, 0x5A, isAnchor ? 0x7F : 0x00);
-    }
+PioneerDDJSX2.ParamLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+    // For the repeat setting of each channels
+    // SHIFT + Rec Flip Button
+    var isRepeat = engine.getValue(group, "repeat");
+    midi.sendShortMsg(0x90 + channel, 0x5A, isRepeat ? 0x7F : 0x00);
 };
 
-// 4. Track last playposition to detect manual jumps
+// Function to set PAD MODE Leds when needed
+PioneerDDJSX2.QuantizeLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+
+    var isQuantize = engine.getValue(group, "quantize");
+    midi.sendShortMsg(0x90 + channel, 0x79, isQuantize ? 0x7F : 0x00);
+};
+
+// Track last playposition to detect manual jumps
 PioneerDDJSX2.lastPlayPosition = [0, 0, 0, 0];
 
 PioneerDDJSX2.ResetBeatCounter = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
     var lastPos = PioneerDDJSX2.lastPlayPosition[channel];
 
     // Only reset if this is a JUMP (difference > 0.001 = ~0.1% of track)
@@ -664,7 +818,7 @@ PioneerDDJSX2.ResetBeatCounter = function(value, group, control) {
     if (positionDiff > 0.001) {
         // This is a manual jump (needle drop, hotcue, waveform click)
         PioneerDDJSX2.currentBeat[channel] = 0;
-        midi.sendShortMsg(0xbb, 0x04 + channel, 0);
+        midi.sendShortMsg(0xBB, 0x04 + channel, 0);
     }
 
     // Store current position for next comparison
@@ -676,7 +830,7 @@ PioneerDDJSX2.ResetBeatCounter = function(value, group, control) {
 PioneerDDJSX2.slicerTick = [0, 0, 0, 0];
 
 PioneerDDJSX2.SlicerLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
 
     // Exit immediately if not in Slicer mode
     if (PioneerDDJSX2.padMode[channel] !== 2 && PioneerDDJSX2.padMode[channel] !== 6) {
@@ -687,24 +841,23 @@ PioneerDDJSX2.SlicerLights = function(value, group, control) {
 
     var slicePosition = PioneerDDJSX2.slicerTick[channel];
 
-    // Couleurs
+    // Colors
     var isLoop = (PioneerDDJSX2.padMode[channel] === 6);
     var offset = isLoop ? 0x60 : 0x20;
     var onColor = isLoop ? 0x28 : 0x01;
     var offColor = isLoop ? 0x01 : 0x28;
 
-    // Mise à jour des 8 pads
+    // Update all 8 pads
     for (var i = 0; i < 8; i++) {
         var isActive = (slicePosition === i);
         midi.sendShortMsg(0x97 + channel, offset + i, isActive ? onColor : offColor);
     }
 };
 
-
 // Updates the Performance Pads for Hotcues and Hotcues Loops
 PioneerDDJSX2.HotCuePerformancePadLed = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-    var i = PioneerDDJSX2.enums.hotcueIndex[control];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+    var i = PioneerDDJSX2.groups.hotcueIndex[control];
 
     if (i === undefined || value === 2) {
         return;
@@ -713,7 +866,7 @@ PioneerDDJSX2.HotCuePerformancePadLed = function(value, group, control) {
     var color = 0;
     if (value === 1) {
         // Map Mixxx Hotcue color to Pioneer MIDI Color
-        color = PioneerDDJSX2.padColors.getValueForNearestColor(engine.getValue(group, 'hotcue_' + (i) + '_color'));
+        color = PioneerDDJSX2.padColors.getValueForNearestColor(engine.getValue(group, `hotcue_${  i  }_color`));
     }
 
     if (i <= 8) {
@@ -727,7 +880,7 @@ PioneerDDJSX2.HotCuePerformancePadLed = function(value, group, control) {
 
 // Updates Play/Pause Button LED
 PioneerDDJSX2.PlayLeds = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x0B, value ? 0x7F : 0x00);
     midi.sendShortMsg(0x90 + channel, 0x47, value ? 0x7F : 0x00);
     if (PioneerDDJSX2.settings.DoNotTrickController) {
@@ -737,75 +890,85 @@ PioneerDDJSX2.PlayLeds = function(value, group, control) {
 
 // Updates VU Meter LEDs
 PioneerDDJSX2.VuMeter = function(value, group, control) {
-    var level = value * 127;
-    var channel = 0xB0 + PioneerDDJSX2.enums.channelGroups[group];
+    var level = value * 0x7F;
+    var channel = 0xB0 + PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(channel, 0x02, level);
 };
 
 // Updates Sync Button LED
 PioneerDDJSX2.SyncLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-    midi.sendShortMsg(0x90 + channel, 0x58, value ? 0x7f : 0x00);
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x58, value ? 0x7F : 0x00);
 };
 
 // Clears all LEDs on a specific deck (used on Eject)
 PioneerDDJSX2.UnloadLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
 
     // Clear all pads LEDs
     for (var k = 0; k < 0x30; k++) {
         midi.sendShortMsg(0x97 + channel, k, 0x00);
     }
-    for (var k = 0x40; k < 0x70; k++) {
+    for (let k = 0x40; k < 0x70; k++) {
         midi.sendShortMsg(0x97 + channel, k, 0x00);
     }
 
-    midi.sendShortMsg(0xbb, channel, 0);
-    midi.sendShortMsg(0xbb, 4 + channel, 0);
+    midi.sendShortMsg(0xBB, channel, 0);
+    midi.sendShortMsg(0xBB, 4 + channel, 0);
 };
 
 // Updates Headphone Cue (PFL) LED
 PioneerDDJSX2.HeadphoneCueLed = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x54, value ? 0x7F : 0x00);
 };
 
 // Updates Main Cue Button LED
 PioneerDDJSX2.CueLeds = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-    midi.sendShortMsg(0x90 + channel, 0x48, value ? 0x7f : 0x00);
-    midi.sendShortMsg(0x90 + channel, 0x0C, value ? 0x7f : 0x00);
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x48, value ? 0x7F : 0x00);
+    midi.sendShortMsg(0x90 + channel, 0x0C, value ? 0x7F : 0x00);
 };
 
 // Updates Key Lock / Master Tempo LED
 PioneerDDJSX2.KeyLockLeds = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x1A, value ? 0x7F : 0x00);
 };
 
 // Updates Loop 2X LED
 PioneerDDJSX2.LoopDouble = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x13, value ? 0x7F : 0x00);
 };
 
 // Updates Loop 1/2 LED
 PioneerDDJSX2.LoopHalve = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x12, value ? 0x7F : 0x00);
 };
 
-// Updates Loop In/Out/Exit LEDs
-PioneerDDJSX2.ReloopExit = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+// Updates Loop In/Out/Loop Active LEDs
+PioneerDDJSX2.LoopLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+    // Auto Loop Light
     midi.sendShortMsg(0x90 + channel, 0x14, engine.getValue(group, "loop_enabled") ? 0x7F : 0x00);
+
+    // Loop In
     midi.sendShortMsg(0x90 + channel, 0x10, (engine.getValue(group, "loop_start_position") > -1) ? 0x7F : 0x00);
+
+    // Loop Out
     midi.sendShortMsg(0x90 + channel, 0x11, (engine.getValue(group, "loop_end_position") > -1) ? 0x7F : 0x00);
+
+    // For the loop anchor of each channels
+    // Reloop Exit Button
+    var isAnchor = engine.getValue(group, "loop_anchor");
+    midi.sendShortMsg(0x90 + channel, 0x4D, isAnchor ? 0x7F : 0x00);
 };
 
 // Updates Key Shift (Pitch Adjust) LEDs
 PioneerDDJSX2.PitchAdjust = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
     if (value !== 0) {
         if (value > 0) {
             midi.sendShortMsg(0x90 + channel, 0x4a, 0x00);
@@ -821,29 +984,29 @@ PioneerDDJSX2.PitchAdjust = function(value, group, control) {
 };
 
 // FX Status LEDs
-function setFXLed(note) {
-    return function(value) {
+PioneerDDJSX2.SetFXLed = function(note) {
+    return function(value, group, control) {
         midi.sendShortMsg(0x96, note, value ? 0x7F : 0x00);
     };
-}
-PioneerDDJSX2.FX1CH1 = setFXLed(0x4C);
-PioneerDDJSX2.FX2CH1 = setFXLed(0x50);
-PioneerDDJSX2.FX1CH2 = setFXLed(0x4D);
-PioneerDDJSX2.FX2CH2 = setFXLed(0x51);
-PioneerDDJSX2.FX1CH3 = setFXLed(0x4E);
-PioneerDDJSX2.FX2CH3 = setFXLed(0x52);
-PioneerDDJSX2.FX1CH4 = setFXLed(0x4F);
-PioneerDDJSX2.FX2CH4 = setFXLed(0x53);
+};
+PioneerDDJSX2.FX1CH1 = PioneerDDJSX2.SetFXLed(0x4C);
+PioneerDDJSX2.FX2CH1 = PioneerDDJSX2.SetFXLed(0x50);
+PioneerDDJSX2.FX1CH2 = PioneerDDJSX2.SetFXLed(0x4D);
+PioneerDDJSX2.FX2CH2 = PioneerDDJSX2.SetFXLed(0x51);
+PioneerDDJSX2.FX1CH3 = PioneerDDJSX2.SetFXLed(0x4E);
+PioneerDDJSX2.FX2CH3 = PioneerDDJSX2.SetFXLed(0x52);
+PioneerDDJSX2.FX1CH4 = PioneerDDJSX2.SetFXLed(0x4F);
+PioneerDDJSX2.FX2CH4 = PioneerDDJSX2.SetFXLed(0x53);
 
 // Updates Rate/Tempo Slider direction LEDs (Up/Down arrows)
 PioneerDDJSX2.RateLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-    if (engine.getValue(group, 'rate') === 0) {
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+    if (engine.getValue(group, "rate") === 0) {
         midi.sendShortMsg(0x90 + channel, 0x37, 0x00);
         midi.sendShortMsg(0x90 + channel, 0x34, 0x00);
         return;
     }
-    if (engine.getValue(group, 'rate') < 0) {
+    if (engine.getValue(group, "rate") < 0) {
         midi.sendShortMsg(0x90 + channel, 0x34, 0x7F);
         midi.sendShortMsg(0x90 + channel, 0x37, 0x00);
     } else {
@@ -856,9 +1019,24 @@ PioneerDDJSX2.RateLights = function(value, group, control) {
 PioneerDDJSX2.FXLeds = function() {
     for (var i = 0; i < 2; i++) {
         for (var j = 0; j < 3; j++) {
-            midi.sendShortMsg(0x94 + i, 0x47 + j, engine.getValue("[EffectRack1_EffectUnit" + (i + 1) + "_Effect" + (j + 1) + "]", "enabled") ? 0x7F : 0x00);
+            midi.sendShortMsg(0x94 + i, 0x47 + j, engine.getValue(`[EffectRack1_EffectUnit${  i + 1  }_Effect${  j + 1  }]`, "enabled") ? 0x7F : 0x00);
         }
-        midi.sendShortMsg(0x94 + i, 0x4a, engine.getValue("[EffectRack1_EffectUnit" + (i + 1) + "]", "mix_mode") ? 0x7F : 0x00);
+        midi.sendShortMsg(0x94 + i, 0x4a, engine.getValue(`[EffectRack1_EffectUnit${  i + 1  }]`, "mix_mode") ? 0x7F : 0x00);
+    }
+};
+
+// Feedback for Roll Pads (Unused)
+PioneerDDJSX2.RollPerformancePadLed = function(value, group, control) {
+    var channel = PioneerDDJSX2.groups.channelGroups[group];
+    var padIndex = 0;
+    for (var i = 0; i < 8; i++) {
+        if (control === `beatloop_${  PioneerDDJSX2.settings.loopIntervals[i + 2]  }_enabled`) {
+            break;
+        }
+        padIndex++;
+    }
+    if (engine.getValue("[Channel1]", "play")) {
+        midi.sendShortMsg(0x97 + channel, 0x10 + padIndex, value ? 0x7F : 0x00);
     }
 };
 
@@ -869,7 +1047,7 @@ PioneerDDJSX2.FXLeds = function() {
 // Calculates the delta movement of the jogwheel
 PioneerDDJSX2.getJogWheelDelta = function(value) {
     return value - 0x40;
-}
+};
 
 // Enables/Disables scratching engine for a specific deck
 PioneerDDJSX2.toggleScratch = function(channel, isEnabled) {
@@ -888,7 +1066,7 @@ PioneerDDJSX2.pitchBend = function(channel, movement) {
     movement = movement / 5;
     movement = movement > 3 ? 3 : movement;
     movement = movement < -3 ? -3 : movement;
-    engine.setValue('[Channel' + deck + ']', 'jog', movement);
+    engine.setValue(`[Channel${  deck  }]`, "jog", movement);
 };
 
 // Safety timer: Disables scratch if touch is lost
@@ -926,17 +1104,17 @@ PioneerDDJSX2.jogScratchTurn = function(channel, control, value) {
         engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
     } else {
         if (PioneerDDJSX2.gridSlide[channel]) {
-            engine.setValue("[Channel" + deck + "]", (value < 64) ? "beats_translate_earlier" : "beats_translate_later", 1);
+            engine.setValue(`[Channel${  deck  }]`, (value < 64) ? "beats_translate_earlier" : "beats_translate_later", 1);
         }
         if (PioneerDDJSX2.gridAdjust[channel]) {
-            engine.setValue("[Channel" + deck + "]", (value < 64) ? "beats_adjust_faster" : "beats_adjust_slower", 1);
+            engine.setValue(`[Channel${  deck  }]`, (value < 64) ? "beats_adjust_faster" : "beats_adjust_slower", 1);
         }
     }
 };
 
 // Outer Jog Ring Touch (Seeking)
 PioneerDDJSX2.jogSeekTouch = function(channel, control, value) {
-    if (!engine.getValue('[Channel' + (channel + 1) + ']', 'play')) {
+    if (!engine.getValue(`[Channel${  channel + 1  }]`, "play")) {
         PioneerDDJSX2.toggleScratch(channel, value === 0x7F);
     }
 };
@@ -953,7 +1131,7 @@ PioneerDDJSX2.jogSeekTurn = function(channel, control, value) {
 
 // Seek through track (Shift + Jog Turn)
 PioneerDDJSX2.jogSeek = function(channel, control, value) {
-    engine.setValue("[Channel" + (channel + 1) + "]", "beatjump", PioneerDDJSX2.getJogWheelDelta(value) / 16);
+    engine.setValue(`[Channel${  channel + 1  }]`, "beatjump", PioneerDDJSX2.getJogWheelDelta(value) / 16);
 };
 
 PioneerDDJSX2.jogPitchBend = function(channel, control, value) {
@@ -962,16 +1140,16 @@ PioneerDDJSX2.jogPitchBend = function(channel, control, value) {
         engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
         PioneerDDJSX2.postponeDisableScratch(channel);
     } else {
-        if (engine.getValue('[Channel' + deck + ']', 'play')) {
+        if (engine.getValue(`[Channel${  deck  }]`, "play")) {
             PioneerDDJSX2.pitchBend(channel, PioneerDDJSX2.getJogWheelDelta(value));
         }
     }
 };
 
 // Toggle Vinyl Mode (Shift + Slip)
-PioneerDDJSX2.ToggleVinyl = function(group, control, value) {
-    if (value === 127) {
-        PioneerDDJSX2.vinylOn[group] = !PioneerDDJSX2.vinylOn[group];
+PioneerDDJSX2.ToggleVinyl = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.vinylOn[channel] = !PioneerDDJSX2.vinylOn[channel];
     }
 };
 
@@ -983,20 +1161,20 @@ PioneerDDJSX2.ToggleVinyl = function(group, control, value) {
 // Handles Logic for SoftStart/Braking if Shift is pressed/configured
 PioneerDDJSX2.Play = function(channel, control, value, status, group) {
     var deck = script.deckFromGroup(group);
-    var isPlaying = engine.getValue(group, 'play');
-    var lastHotcue = engine.getValue(group, 'hotcue_focus');
+    var isPlaying = engine.getValue(group, "play");
+    var lastHotcue = engine.getValue(group, "hotcue_focus");
     if (lastHotcue !== 0) {
-        var isLastHotcuePlaying = (lastHotcue !== -1) ? engine.getValue(group, 'hotcue_' + lastHotcue + '_status') : 0;
+        var isLastHotcuePlaying = (lastHotcue !== -1) ? engine.getValue(group, `hotcue_${  lastHotcue  }_status`) : 0;
     };
 
-    if (value === 127) {
+    if (value === 0x7F) {
         if (((control === 71 && PioneerDDJSX2.settings.UseShiftToBreak === false) || (control !== 71 && PioneerDDJSX2.settings.UseShiftToBreak === true)) && isLastHotcuePlaying !== 2) {
             if (isPlaying && PioneerDDJSX2.isBraking === 0) {
                 PioneerDDJSX2.isBraking = 1;
                 if (PioneerDDJSX2.settings.BrakeTime >= 0) {
                     engine.brake(deck, true, PioneerDDJSX2.settings.BrakeTime);
                 } else {
-                    engine.setValue(group, 'play', 0);
+                    engine.setValue(group, "play", 0);
                 }
             } else if (isPlaying && PioneerDDJSX2.isBraking === 1) {
                 PioneerDDJSX2.isBraking = 0;
@@ -1011,12 +1189,24 @@ PioneerDDJSX2.Play = function(channel, control, value, status, group) {
                 if (PioneerDDJSX2.settings.SoftStartTime >= 0) {
                     engine.softStart(deck, true, PioneerDDJSX2.settings.SoftStartTime);
                 } else {
-                    engine.setValue(group, 'play', 1);
+                    engine.setValue(group, "play", 1);
                 }
             }
         } else {
             PioneerDDJSX2.isBraking = 0;
-            engine.setValue(group, 'play', !isPlaying);
+            engine.setValue(group, "play", !isPlaying);
+        }
+    }
+};
+
+// Deck Select Buttons (7-10 on the controller)
+// Directly assigns the active deck per physical side when pressed.
+PioneerDDJSX2.DeckToggle = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        if (channel === 0 || channel === 2) {
+            PioneerDDJSX2.activeDeck.A = channel + 1; // 0+1=ch1, 2+1=ch3
+        } else {
+            PioneerDDJSX2.activeDeck.B = channel + 1; // 1+1=ch2, 3+1=ch4
         }
     }
 };
@@ -1027,7 +1217,7 @@ PioneerDDJSX2.NeedleSearch = function(channel, control, value, status, group) {
     var isPlaying = engine.getValue(group, "play");
 
     // var actualPlayPosition = 1/value;
-    var actualPlayPosition = value / 127;
+    var actualPlayPosition = value / 0x7F;
 
     // Check if it is Shifted and apply the NeedleSearchBehaviour setting if the song is playing
     if (isShifted === 3 && isPlaying) {
@@ -1041,48 +1231,48 @@ PioneerDDJSX2.NeedleSearch = function(channel, control, value, status, group) {
 
 // Sync Button (Long press logic)
 // Quick press : Enable beatsync for the current deck
-// Long press (>1000ms) : enable old behaviour of syncing both left and right tracks
-PioneerDDJSX2.SyncEnable = function(value, group, control) {
-    if (control === 127) {
+// Long press (>1000ms) : enable sync behaviour of syncing both left and right tracks
+PioneerDDJSX2.SyncEnable = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
         PioneerDDJSX2.SyncEnableTimer = engine.beginTimer(1000, function() {
-            if (value === 0 || value === 2) {
-                engine.setValue("[Channel" + (value + 1) + "]", "sync_enabled", 1);
-                engine.setValue("[Channel" + (value + 2) + "]", "sync_enabled", 1);
+            if (channel === 0 || channel === 2) {
+                engine.setValue(`[Channel${  channel + 1  }]`, "sync_enabled", 1);
+                engine.setValue(`[Channel${  channel + 2  }]`, "sync_enabled", 1);
             } else {
-                engine.setValue("[Channel" + (value + 1) + "]", "sync_enabled", 1);
-                engine.setValue("[Channel" + (value) + "]", "sync_enabled", 1);
+                engine.setValue(`[Channel${  channel + 1  }]`, "sync_enabled", 1);
+                engine.setValue(`[Channel${  channel  }]`, "sync_enabled", 1);
             }
             PioneerDDJSX2.SyncEnableTimer = null;
         }, 1);
     } else {
         if (PioneerDDJSX2.SyncEnableTimer !== null) {
-            engine.setValue("[Channel" + (value + 1) + "]", "beatsync", 1);
+            engine.setValue(`[Channel${  channel + 1  }]`, "beatsync", 1);
             engine.stopTimer(PioneerDDJSX2.SyncEnableTimer);
         }
     }
 };
 
 // Sync Disable (Shift + Sync)
-PioneerDDJSX2.SyncDisable = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-    if (control === 127) {
-        if (value === 0 || value === 2) {
-            engine.setValue("[Channel" + (value + 1) + "]", "sync_enabled", 0);
-            engine.setValue("[Channel" + (value + 2) + "]", "sync_enabled", 0);
+PioneerDDJSX2.SyncDisable = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        if (channel === 0 || channel === 2) {
+            engine.setValue(`[Channel${  channel + 1  }]`, "sync_enabled", 0);
+            engine.setValue(`[Channel${  channel + 2  }]`, "sync_enabled", 0);
         } else {
-            engine.setValue("[Channel" + (value + 1) + "]", "sync_enabled", 0);
-            engine.setValue("[Channel" + (value) + "]", "sync_enabled", 0);
+            engine.setValue(`[Channel${  channel + 1  }]`, "sync_enabled", 0);
+            engine.setValue(`[Channel${  channel  }]`, "sync_enabled", 0);
         }
     }
 };
 
 // Slip Button
-PioneerDDJSX2.SlipEnabled = function(value, group, control) {
-    if (control === 127) {
-        if (engine.getValue("[Channel" + (value + 1) + "]", "play")) {
-            engine.setValue("[Channel" + (value + 1) + "]", "slip_enabled", !engine.getValue("[Channel" + (value + 1) + "]", "slip_enabled"));
+PioneerDDJSX2.SlipEnabled = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        if (engine.getValue(`[Channel${  channel + 1  }]`, "play")) {
+
+            engine.setValue(`[Channel${  channel + 1  }]`, "slip_enabled", !engine.getValue(`[Channel${  channel + 1  }]`, "slip_enabled"));
         } else {
-            engine.setValue("[Channel" + (value + 1) + "]", "slip_enabled", !engine.getValue("[Channel" + (value + 1) + "]", "slip_enabled"));
+            engine.setValue(`[Channel${  channel + 1  }]`, "slip_enabled", !engine.getValue(`[Channel${  channel + 1  }]`, "slip_enabled"));
         }
     }
 };
@@ -1093,70 +1283,96 @@ PioneerDDJSX2.CrossfaderCurve = function(value, group, control) {
 };
 
 // Input Select Switches (Front panel)
-PioneerDDJSX2.InputSelect = function(group, control, value, status) {
-    engine.setValue("[Channel" + (group + 1) + "]", "mute", value ? 1 : 0);
-}
+PioneerDDJSX2.InputSelect = function(channel, control, value, status, group) {
+    engine.setValue(`[Channel${  channel + 1  }]`, "mute", value ? 1 : 0);
+};
 
 // Loop In Button
-PioneerDDJSX2.LoopIn = function(group, control, value, status) {
-    engine.setValue("[Channel" + (group + 1) + "]", "loop_in", value ? 1 : 0);
-    if (value === 0x7f) {
-        PioneerDDJSX2.closestBeatToLoopIn[group] = engine.getValue("[Channel" + (group + 1) + "]", "beat_closest");
+PioneerDDJSX2.LoopIn = function(channel, control, value, status, group) {
+    engine.setValue(`[Channel${  channel + 1  }]`, "loop_in", value ? 1 : 0);
+    if (value === 0x7F) {
+        PioneerDDJSX2.closestBeatToLoopIn[channel] = engine.getValue(`[Channel${  channel + 1  }]`, "beat_closest");
     }
-}
+};
 
-// 4 Beat Loop Button
-PioneerDDJSX2.FourBeat = function(group, control, value, status) {
-    var channel = "[Channel" + (group + 1) + "]";
-    if (value === 0x7f) {
-        var loop_enable = engine.getValue(channel, 'loop_enabled')
-        engine.setValue(channel, "loop_start_position", PioneerDDJSX2.closestBeatToLoopIn[group]);
-        engine.setValue(channel, "loop_end_position", PioneerDDJSX2.closestBeatToLoopIn[group] + engine.getValue(channel, 'track_samplerate') * (480 / engine.getValue(channel, 'file_bpm')));
+// 4 Beat Loop Button (Above Loop IN)
+// I think this feature could be enhanced, it is a bit finicky I think...
+// Needs ideas
+PioneerDDJSX2.FourBeat = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        var loop_enable = engine.getValue(channel, "loop_enabled");
 
+        engine.setValue(group, "loop_start_position", PioneerDDJSX2.closestBeatToLoopIn[channel]);
+        engine.setValue(group, "loop_end_position", PioneerDDJSX2.closestBeatToLoopIn[channel] + engine.getValue(group, "track_samplerate") * (480 / engine.getValue(group, "file_bpm")));
+
+        // If loop is not enabled, we enable it
         if (!loop_enable) {
             engine.setValue(channel, "reloop_toggle", 1);
         }
     }
-}
+};
 
-// Slip Mode Logic
-PioneerDDJSX2.SlipMode = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-    if (engine.getValue(group, "play")) {
-        midi.sendShortMsg(0x90 + channel, 0x40, value ? 0x7F : 0x00);
+// Handle the Reloop/Exit Loop button
+// This toggles the Loop Anchor state
+PioneerDDJSX2.ReloopExit = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        script.toggleControl(group, "loop_anchor");
+        var isAnchor = engine.getValue(group, "loop_anchor");
     }
 };
 
-PioneerDDJSX2.Shift = function(channel, control, value, status) {
-    PioneerDDJSX2.shift[channel] = value;
+
+// Slip Mode Logic
+PioneerDDJSX2.SlipMode = function(channel, control, value, status, group) {
+    if (engine.getValue(control, "play")) {
+        midi.sendShortMsg(0x90 + channel, 0x40, channel ? 0x7F : 0x00);
+    }
+};
+
+// Shift Button
+// Records shift state and clears kill gesture memory on release.
+// Clearing on release means each new shift press starts a fresh gesture —
+// the knob position at the moment shift is pressed becomes the new anchor.
+PioneerDDJSX2.Shift = function(channel, _control, value, _status, _group) {
+    PioneerDDJSX2.shiftState[channel] = value;
+    if (value === 0) {
+        const knobTypes = ["eqHigh", "eqMid", "eqLow", "filter"];
+        for (let i = 0; i < 4; i++) {
+            for (let k = 0; k < knobTypes.length; k++) {
+                const state = PioneerDDJSX2.killState[i][knobTypes[k]];
+                state.anchor = null;
+                state.lastToggleDir = null;
+            }
+        }
+    }
 };
 
 // Reverse Button (Toggle)
-PioneerDDJSX2.Reverse = function(value, group, control) {
-    if (control === 127) {
-        PioneerDDJSX2.reverse[value] = !PioneerDDJSX2.reverse[value];
-        engine.setValue("[Channel" + (value + 1) + "]", "reverse", PioneerDDJSX2.reverse[value]);
+PioneerDDJSX2.Reverse = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.reverse[channel] = !PioneerDDJSX2.reverse[channel];
+        engine.setValue(`[Channel${  channel + 1  }]`, "reverse", PioneerDDJSX2.reverse[channel]);
     }
 };
 
 // Reverse Button (Hold - Censor)
-PioneerDDJSX2.ReverseHold = function(value, group, control) {
-    if (control === 127) {
-        PioneerDDJSX2.reverse[value] = 1;
-        engine.setValue("[Channel" + (value + 1) + "]", "reverse", PioneerDDJSX2.reverse[value]);
+PioneerDDJSX2.ReverseHold = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.reverse[channel] = 1;
+        engine.setValue(`[Channel${  channel + 1  }]`, "reverse", PioneerDDJSX2.reverse[channel]);
     } else {
-        PioneerDDJSX2.reverse[value] = 0;
-        engine.setValue("[Channel" + (value + 1) + "]", "reverse", PioneerDDJSX2.reverse[value]);
+        PioneerDDJSX2.reverse[channel] = 0;
+        engine.setValue(`[Channel${  channel + 1  }]`, "reverse", PioneerDDJSX2.reverse[channel]);
     }
 };
 
 // Auto Loop Button
-PioneerDDJSX2.AutoLoop = function(channel, control, value, status) {
-    if (value === 127) {
-        if (engine.getValue("[Channel" + (channel + 1) + "]", "loop_enabled")) {
-            engine.setValue("[Channel" + (channel + 1) + "]", "reloop_toggle", 1);
+PioneerDDJSX2.AutoLoop = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        if (engine.getValue(`[Channel${  channel + 1  }]`, "loop_enabled")) {
+            engine.setValue(`[Channel${  channel + 1  }]`, "reloop_toggle", 1);
         } else {
-            engine.setValue("[Channel" + (channel + 1) + "]", "beatloop_activate", 1);
+            engine.setValue(`[Channel${  channel + 1  }]`, "beatloop_activate", 1);
         }
     }
 };
@@ -1166,8 +1382,8 @@ PioneerDDJSX2.AutoLoop = function(channel, control, value, status) {
 // We cache the MSB and wait for the LSB to apply the full value.
 
 // Tempo/Rate Slider (14-bit)
-PioneerDDJSX2.RateSlider = function(channel, control, value, status) {
-    var deckGroup = "[Channel" + (channel + 1) + "]";
+PioneerDDJSX2.RateSlider = function(channel, control, value, status, group) {
+    var deckGroup = `[Channel${  channel + 1  }]`;
     var storage = PioneerDDJSX2.midi14bit.tempo;
     if (control === 0x00) {
         storage[channel] = value;
@@ -1201,62 +1417,99 @@ PioneerDDJSX2.RateSlider = function(channel, control, value, status) {
 };
 
 // Channel Volume Faders (14-bit)
-PioneerDDJSX2.VolumeSlider = function(channel, control, value, status) {
-    var deckGroup = '[Channel' + (channel + 1) + ']';
+PioneerDDJSX2.VolumeSlider = function(channel, control, value, status, group) {
+    var deckGroup = `[Channel${  channel + 1  }]`;
     var storage = PioneerDDJSX2.midi14bit.volume;
     if (control === 0x13) {
         storage[channel] = value;
-        engine.setParameter(deckGroup, 'volume', value / 127.0);
+        engine.setParameter(deckGroup, "volume", value / 127);
     } else if (control === 0x33) {
         var value14bit = (storage[channel] << 7) | value;
-        engine.setParameter(deckGroup, 'volume', value14bit / 16383.0);
+        engine.setParameter(deckGroup, "volume", value14bit / 16383.0);
     }
 };
 
 // EQ Knobs (14-bit)
 PioneerDDJSX2.EQHigh = function(channel, control, value) {
-    PioneerDDJSX2.handle14bitEQ(channel, control, value, PioneerDDJSX2.midi14bit.eqHigh, 0x07, 0x27, 'parameter3');
+    PioneerDDJSX2.handle14bitEQ(channel, control, value, PioneerDDJSX2.midi14bit.eqHigh, 0x07, 0x27, "parameter3");
 };
 PioneerDDJSX2.EQMid = function(channel, control, value) {
-    PioneerDDJSX2.handle14bitEQ(channel, control, value, PioneerDDJSX2.midi14bit.eqMid, 0x0B, 0x2B, 'parameter2');
+    PioneerDDJSX2.handle14bitEQ(channel, control, value, PioneerDDJSX2.midi14bit.eqMid, 0x0B, 0x2B, "parameter2");
 };
 PioneerDDJSX2.EQLow = function(channel, control, value) {
-    PioneerDDJSX2.handle14bitEQ(channel, control, value, PioneerDDJSX2.midi14bit.eqLow, 0x0F, 0x2F, 'parameter1');
+    PioneerDDJSX2.handle14bitEQ(channel, control, value, PioneerDDJSX2.midi14bit.eqLow, 0x0F, 0x2F, "parameter1");
 };
 
+// The SX2 sends two MIDI messages per knob tick: MSB first, then LSB.
+// Kill logic runs on the LSB (full 14-bit combined) message only, so each
+// physical tick is evaluated once. The MSB path caches the value and applies
+// it directly (if not currently killed) to keep the UI responsive during fast turns.
+// 7-bit MSB midpoint and range for scaling to [0,1]
+PioneerDDJSX2.EQMSBMid = 64;
+PioneerDDJSX2.EQMSBRange = 64.0;
+// 14-bit midpoint and range for scaling to [0,1]
+PioneerDDJSX2.EQ14BitMid = 8192;
+PioneerDDJSX2.EQ14BitRange = 8192.0;
+
 PioneerDDJSX2.handle14bitEQ = function(channel, control, value, storage, msbCC, lsbCC, param) {
-    var deckGroup = '[EqualizerRack1_[Channel' + (channel + 1) + ']_Effect1]';
+    const group = `[EqualizerRack1_[Channel${ channel + 1 }]_Effect1]`;
+    const knobTypeMap = {
+        "parameter3": "eqHigh",
+        "parameter2": "eqMid",
+        "parameter1": "eqLow",
+    };
+
+    var knobType = knobTypeMap[param];
+
     if (control === msbCC) {
         storage[channel] = value;
-        engine.setParameter(deckGroup, param, ((value - 64) / 63.0 + 1) / 2);
+        if (!PioneerDDJSX2.killState[channel][knobType].killed) {
+            engine.setParameter(group, param, ((value - PioneerDDJSX2.EQMSBMid) / PioneerDDJSX2.EQMSBRange + 1) / 2);
+        }
     } else if (control === lsbCC) {
-        var value14bit = (storage[channel] << 7) | value;
-        engine.setParameter(deckGroup, param, ((value14bit - 8192) / 8191.0 + 1) / 2);
+        const value14bit = (storage[channel] << 7) | value;
+        const paramValue = ((value14bit - PioneerDDJSX2.EQ14BitMid) / PioneerDDJSX2.EQ14BitRange + 1) / 2;
+        if (PioneerDDJSX2.handleEQKill(channel, knobType, param, paramValue)) {
+            return;
+        }
+        engine.setParameter(group, param, paramValue);
     }
 };
 
+// Filter knob MSB CC range (channels 1-4)
+PioneerDDJSX2.FilterMSBBaseCC = 0x17; // first filter MSB CC
+PioneerDDJSX2.FilterMSBMaxCC  = 0x1A; // last filter MSB CC
+// Filter knob LSB CC range (channels 1-4)
+PioneerDDJSX2.FilterLSBBaseCC = 0x37; // first filter LSB CC
+PioneerDDJSX2.FilterLSBMaxCC  = 0x3A; // last filter LSB CC
+
 // Filter Knobs (14-bit)
-PioneerDDJSX2.Filter = function(channel, control, value) {
-    var storage = PioneerDDJSX2.midi14bit.filter;
-    if (control >= 0x17 && control <= 0x1A) {
-        var offset = control - 0x17;
+// Same MSB/LSB split as EQ — kill logic on LSB path only.
+// MSB applies directly without kill check for UI responsiveness.
+PioneerDDJSX2.Filter = function(_channel, control, value, _status, _group) {
+    const storage = PioneerDDJSX2.midi14bit.filter;
+
+    if (control >= PioneerDDJSX2.FilterMSBBaseCC && control <= PioneerDDJSX2.FilterMSBMaxCC) {
+        const offset = control - PioneerDDJSX2.FilterMSBBaseCC;
         storage[offset] = value;
-        engine.setParameter('[QuickEffectRack1_[Channel' + (offset + 1) + ']]', 'super1', ((value - 64) / 63.0 + 1) / 2);
-    } else if (control >= 0x37 && control <= 0x3A) {
-        var offset = control - 0x37;
-        var value14bit = (storage[offset] << 7) | value;
-        engine.setParameter('[QuickEffectRack1_[Channel' + (offset + 1) + ']]', 'super1', ((value14bit - 8192) / 8191.0 + 1) / 2);
+        engine.setParameter(`[QuickEffectRack1_[Channel${ offset + 1 }]]`, "super1", ((value - PioneerDDJSX2.EQMSBMid) / PioneerDDJSX2.EQMSBRange + 1) / 2);
+    } else if (control >= PioneerDDJSX2.FilterLSBBaseCC && control <= PioneerDDJSX2.FilterLSBMaxCC) {
+        const offset = control - PioneerDDJSX2.FilterLSBBaseCC;
+        const value14bit = (storage[offset] << 7) | value;
+        const paramValue = ((value14bit - PioneerDDJSX2.EQ14BitMid) / PioneerDDJSX2.EQ14BitRange + 1) / 2;
+        PioneerDDJSX2.handleFilterKill(offset, paramValue);
+        engine.setParameter(`[QuickEffectRack1_[Channel${ offset + 1 }]]`, "super1", paramValue);
     }
 };
 
 // Trim/Pregain Knobs (14-bit)
 // Includes special curve mapping because SX2 hardware trim knobs are logarithmic/weird.
 PioneerDDJSX2.Pregain = function(channel, control, value) {
-    var deckGroup = '[Channel' + (channel + 1) + ']';
+    var group = `[Channel${  channel + 1  }]`;
     var cache = PioneerDDJSX2.midi14bit.pregain;
     var value14bit;
 
-    // 1. DUAL-UPDATE LOGIC (Linear and single-curved approaches didn't work with these knobs)
+    // 1. DUAL-UPDATE LOGIC (Linear and single-curved approaches didn"t work with these knobs)
     if (control === 0x04) {
         cache[channel] = value;
         value14bit = value << 7;
@@ -1274,12 +1527,12 @@ PioneerDDJSX2.Pregain = function(channel, control, value) {
     var gainValue;
 
     if (value14bit <= centerVal) {
-        // ZONE A: 0 to Center (12 o'clock)
+        // ZONE A: 0 to Center (12 o"clock)
         // Map MIDI (0 -> 8192) to Gain (0.0 -> 1.0)
         var norm = value14bit / centerVal;
 
         // x^3 suppresses the value in the early stages.
-        // 9 o'clock physical read significantly lower in software.
+        // 9 o"clock physical read significantly lower in software.
         gainValue = norm * norm * norm;
 
     } else {
@@ -1287,7 +1540,7 @@ PioneerDDJSX2.Pregain = function(channel, control, value) {
         // Map MIDI (8192 -> 12550) to Gain (1.0 -> 4.0)
 
         // Normalize this upper section to 0.0 - 1.0
-        var norm = (value14bit - centerVal) / (maxVal - centerVal);
+        let norm = (value14bit - centerVal) / (maxVal - centerVal);
 
         // Clamp to 1.0 in case of hardware jitter at max
         if (norm > 1.0) {
@@ -1299,40 +1552,179 @@ PioneerDDJSX2.Pregain = function(channel, control, value) {
         gainValue = 1.0 + (norm * 3.0);
     }
 
-    engine.setValue(deckGroup, 'pregain', gainValue);
+    engine.setValue(group, "pregain", gainValue);
 };
 
 // =============================================================================
-// 9. FX SECTION 
+// 8b. KNOB KILL FUNCTIONS (Shift+Knob Down)
+// =============================================================================
+// Shift + turn a knob to mute it.
+//
+// Unmute by:
+//   a) Shift + turn back to the muted spot
+//   b) Move knob to center (EQ/Filter only)
+//   c) EQ only: turn fully counter-clockwise
+//
+// Uses Mixxx's EQ kill buttons and Filter effect.
+
+PioneerDDJSX2.EQParamCenter = 0.5;
+
+// Clears gesture tracking state between shift sessions.
+PioneerDDJSX2.clearKillGesture = function(state) {
+    state.anchor = null;
+    state.lastToggleDir = null;
+};
+
+// -- Kill Toggle Gate --
+// Prevents accidental muting. After pressing Shift, you must turn the knob past
+// a small threshold before muting triggers. Once muted, you can keep turning
+// the same direction without re-triggering. Turn back past the threshold to unmute.
+// This makes "mute → keep turning → reverse to unmute" work smoothly.
+PioneerDDJSX2.killShouldToggle = function(state, newParamValue) {
+    if (state.anchor === null) {
+        state.anchor = newParamValue;
+        return false;
+    }
+
+    const delta = newParamValue - state.anchor;
+
+    if (Math.abs(delta) < PioneerDDJSX2.KillThreshold) {
+        return false;
+    }
+
+    const dir = (delta > 0) ? "up" : "down";
+
+    if (state.lastToggleDir !== null && dir === state.lastToggleDir) {
+        // Still moving the same way as the last toggle — slide anchor forward.
+        state.anchor = newParamValue;
+        return false;
+    }
+
+    // Knob has reversed direction (or this is the first toggle): fire.
+    state.lastToggleDir = dir;
+    state.anchor = newParamValue;
+    return true;
+};
+
+// EQ Kill Handler
+// Intercepts EQ parameter changes when shift is held and applies kill logic.
+// Returns true if the caller should NOT apply the normal EQ value (kill is
+// active and the value should be suppressed), false if normal apply should proceed.
+//
+// Shift held + knob moved KillThreshold in any direction >> toggles kill on/off.
+// Reversing direction by KillThreshold while shift is still held >> toggles again.
+// Knob returned to center (0.5) or minimum (0.0) without shift >> deactivates kill.
+//
+// When kill is active, the EQ kill button in the Mixxx UI is pressed, which
+// silences that frequency band. On restore, the button is released and the
+// current knob position is applied immediately.
+PioneerDDJSX2.handleEQKill = function(channel, knobType, paramName, newParamValue) {
+    const state = PioneerDDJSX2.killState[channel][knobType];
+    const isShifted = PioneerDDJSX2.anyShiftHeld();
+    const group = `[EqualizerRack1_[Channel${ channel + 1 }]_Effect1]`;
+
+    if (isShifted) {
+        if (PioneerDDJSX2.killShouldToggle(state, newParamValue)) {
+            state.killed = !state.killed;
+            engine.setValue(group, `button_${ paramName }`, state.killed ? 1 : 0);
+            if (!state.killed) {
+                engine.setParameter(group, paramName, newParamValue);
+            }
+        }
+        return state.killed;
+    }
+
+    // Shift not held: clear gesture memory and check position-based restore.
+    PioneerDDJSX2.clearKillGesture(state);
+
+    if (state.killed) {
+        const atCenter = Math.abs(newParamValue - PioneerDDJSX2.EQParamCenter) < PioneerDDJSX2.KillTolerance;
+        const atMinimum = newParamValue < PioneerDDJSX2.KillTolerance;
+        if (atCenter || atMinimum) {
+            state.killed = false;
+            engine.setValue(group, `button_${ paramName }`, 0);
+            engine.setParameter(group, paramName, newParamValue);
+            return true;
+        }
+        // Kill is still active and knob is not at a restore position:
+        // suppress the value to keep the band silenced until the user
+        // explicitly restores it via center, minimum, or shift gesture.
+        return true;
+    }
+
+    return false;
+};
+
+// Filter Kill Handler
+// Same gesture logic as handleEQKill via killShouldToggle.
+// Unlike EQ, the filter knob value always passes through to the engine
+// regardless of kill state. Mixxx silences the filter by disabling the
+// QuickEffectRack rather than by blocking the knob value.
+//
+// Shift held + knob moved KillThreshold >> toggles filter enabled/disabled.
+// Knob returned to center (0.5) without shift >> re-enables filter.
+PioneerDDJSX2.handleFilterKill = function(channel, newParamValue) {
+    const state = PioneerDDJSX2.killState[channel].filter;
+    const isShifted = PioneerDDJSX2.anyShiftHeld();
+    const group = `[QuickEffectRack1_[Channel${ channel + 1 }]]`;
+
+    if (isShifted) {
+        if (PioneerDDJSX2.killShouldToggle(state, newParamValue)) {
+            state.killed = !state.killed;
+            engine.setValue(group, "enabled", state.killed ? 0 : 1);
+        }
+        return false;
+    }
+
+    PioneerDDJSX2.clearKillGesture(state);
+
+    if (state.killed) {
+        const atCenter = Math.abs(newParamValue - PioneerDDJSX2.EQParamCenter) < PioneerDDJSX2.KillTolerance;
+        if (atCenter) {
+            state.killed = false;
+            engine.setValue(group, "enabled", 1);
+        }
+    }
+
+    return false;
+};
+
+// =============================================================================
+// 9. FX SECTION
 // =============================================================================
 
 // Handle Beats Knob (Turning) - Adjusts Wet/Dry Mix
 PioneerDDJSX2.EffectJog = function(value, group, control) {
     if (control > 63) {
-        engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix", engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix") - 0.0625 * (128 - control));
+        engine.setValue(`[EffectRack1_EffectUnit${  value - 3  }]`, "mix", engine.getValue(`[EffectRack1_EffectUnit${  value - 3  }]`, "mix") - 0.0625 * (128 - control));
     } else {
-        engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix", engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix") + 0.0625 * (control));
+        engine.setValue(`[EffectRack1_EffectUnit${  value - 3  }]`, "mix", engine.getValue(`[EffectRack1_EffectUnit${  value - 3  }]`, "mix") + 0.0625 * (control));
     }
 };
 
 // Beats Button Press (Cycles selected effect focus)
-PioneerDDJSX2.BeatsPressFX = function(value, group, control) {
-    if (control === 127) {
-        PioneerDDJSX2.currentEffect[value - 4]++;
-        if (PioneerDDJSX2.currentEffect[value - 4] > 3) {
-            PioneerDDJSX2.currentEffect[value - 4] = 0;
+PioneerDDJSX2.BeatsPressFX = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.currentEffect[channel - 4]++;
+        if (PioneerDDJSX2.currentEffect[channel - 4] > 3) {
+            PioneerDDJSX2.currentEffect[channel - 4] = 0;
         }
         PioneerDDJSX2.FXLeds();
     }
 };
 
 // Shift + Beats Button Press (Cycles parameters)
-PioneerDDJSX2.ShiftBeatsPressFX = function(value, group, control) {
-    if (control === 127) {
-        var idx = ((value === 5) ? (4) : (0)) + PioneerDDJSX2.currentEffect[value - 4];
-        PioneerDDJSX2.currentEffectparamset[idx]++;
-        if (PioneerDDJSX2.currentEffectparamset[idx] >= (engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + (PioneerDDJSX2.currentEffect[value - 4] + 1) + "]", "num_parameters") / 3)) {
-            PioneerDDJSX2.currentEffectparamset[idx] = 0;
+PioneerDDJSX2.ShiftBeatsPressFX = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        // ID Effect is the ID of the currently focus effect control
+        //  (3 = main effects knobs)
+        //  (0 = first effect settings)
+        //  (1 = second effect settings)
+        //  (2 = third effect settings)
+        var id_effect = ((channel === 5) ? (4) : (0)) + PioneerDDJSX2.currentEffect[channel - 4];
+        PioneerDDJSX2.currentEffectparamset[id_effect]++;
+        if (PioneerDDJSX2.currentEffectparamset[id_effect] >= (engine.getValue(`[EffectRack1_EffectUnit${  channel - 3  }_Effect${  PioneerDDJSX2.currentEffect[channel - 4] + 1  }]`, "num_parameters") / 3)) {
+            PioneerDDJSX2.currentEffectparamset[id_effect] = 0;
         }
         PioneerDDJSX2.FXLeds();
     }
@@ -1340,66 +1732,66 @@ PioneerDDJSX2.ShiftBeatsPressFX = function(value, group, control) {
 
 // Select specific effect in slot
 PioneerDDJSX2.EffectSelect = function(value, group, control) {
-    engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + (group - 98) + "]", "effect_selector", (control === 127) ? 1 : 0);
+    engine.setValue(`[EffectRack1_EffectUnit${  value - 3  }_Effect${  group - 98  }]`, "effect_selector", (control === 0x7F) ? 1 : 0);
 };
 
 // Control FX Parameters via knobs
 PioneerDDJSX2.EffectKnob = function(value, group, control) {
     if (PioneerDDJSX2.currentEffect[value - 4] === 3) {
         switch (group) {
-            case 2:
-                engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect1]", "meta", control / 127);
-                break;
-            case 4:
-                engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect2]", "meta", control / 127);
-                break;
-            case 6:
-                engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect3]", "meta", control / 127);
-                break;
+        case 2:
+            engine.setValue(`[EffectRack1_EffectUnit${  value - 3  }_Effect1]`, "meta", control / 0x7F);
+            break;
+        case 4:
+            engine.setValue(`[EffectRack1_EffectUnit${  value - 3  }_Effect2]`, "meta", control / 0x7F);
+            break;
+        case 6:
+            engine.setValue(`[EffectRack1_EffectUnit${  value - 3  }_Effect3]`, "meta", control / 0x7F);
+            break;
         }
     } else {
         var effectNumer = PioneerDDJSX2.currentEffect[value-4] + 1;
         var offsetNumer = (PioneerDDJSX2.currentEffectparamset[((value-4)*4)+PioneerDDJSX2.currentEffect[value-4]]*3);
         switch (group) {
-            case 2:
-                engine.setParameter("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + effectNumer + "]", "parameter" + (1 + offsetNumer), control/127);
-                break;
-            case 4:
-                engine.setParameter("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + effectNumer + "]", "parameter" + (2 + offsetNumer), control/127);
-                break;
-            case 6:
-                engine.setParameter("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + effectNumer + "]", "parameter" + (3 + offsetNumer), control/127);
-                break;
+        case 2:
+            engine.setParameter(`[EffectRack1_EffectUnit${  value - 3  }_Effect${  effectNumer  }]`, `parameter${  1 + offsetNumer}`, control/0x7F);
+            break;
+        case 4:
+            engine.setParameter(`[EffectRack1_EffectUnit${  value - 3  }_Effect${  effectNumer  }]`, `parameter${  2 + offsetNumer}`, control/0x7F);
+            break;
+        case 6:
+            engine.setParameter(`[EffectRack1_EffectUnit${  value - 3  }_Effect${  effectNumer  }]`, `parameter${  3 + offsetNumer}`, control/0x7F);
+            break;
         }
-        
+
     }
 };
 
 // Enable/Disable specific effect
-PioneerDDJSX2.EffectButton = function(value, group, control) {
-    if (control === 127) {
-        if (PioneerDDJSX2.currentEffect[value - 4] === 3) {
-            engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + (group - 70) + "]", "enabled", !engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + (group - 70) + "]", "enabled"));
+PioneerDDJSX2.EffectButton = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        if (PioneerDDJSX2.currentEffect[channel - 4] === 3) {
+            engine.setValue(`[EffectRack1_EffectUnit${  channel - 3  }_Effect${  control - 70  }]`, "enabled", !engine.getValue(`[EffectRack1_EffectUnit${  channel - 3  }_Effect${  control - 70  }]`, "enabled"));
         }
     }
 };
 
 // Tap Button (Mix Mode Toggle)
-PioneerDDJSX2.EffectTap = function(value, group, control) {
-    if (control === 127 && PioneerDDJSX2.currentEffect[value - 4] === 3) {
-        engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix_mode", !engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix_mode"));
+PioneerDDJSX2.EffectTap = function(channel, control, value, status, group) {
+    if (value === 0x7F && PioneerDDJSX2.currentEffect[channel - 4] === 3) {
+        engine.setValue(`[EffectRack1_EffectUnit${  channel - 3  }]`, "mix_mode", !engine.getValue(`[EffectRack1_EffectUnit${  channel - 3  }]`, "mix_mode"));
         PioneerDDJSX2.FXLeds();
     }
 };
 
 // =============================================================================
-// 10. VIEW, GRID, & PANELS 
+// 10. VIEW, GRID, & PANELS
 // =============================================================================
 
 // Cycle through Mixxx Panel layouts (FX Rack, Samplers)
-PioneerDDJSX2.PanelSelect = function(value, group, control) {
-    if (control === 127) {
-        PioneerDDJSX2.curPanel += ((1 - (group - 120)) * 2) - 1;
+PioneerDDJSX2.PanelSelect = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.curPanel += ((1 - (control - 120)) * 2) - 1;
         if (PioneerDDJSX2.curPanel < 0) {
             PioneerDDJSX2.curPanel = 3;
         }
@@ -1412,8 +1804,8 @@ PioneerDDJSX2.PanelSelect = function(value, group, control) {
 };
 
 // Cycle through views (2 deck / 4 deck / maximized library)
-PioneerDDJSX2.ViewButton = function(value, group, control) {
-    if (control === 127) {
+PioneerDDJSX2.ViewButton = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
         PioneerDDJSX2.curView++;
         if (PioneerDDJSX2.curView > 7) {
             PioneerDDJSX2.curPanel = 0;
@@ -1424,31 +1816,31 @@ PioneerDDJSX2.ViewButton = function(value, group, control) {
 };
 
 // Enable Grid Slide Mode (used with Jog Wheel)
-PioneerDDJSX2.SetGridSlide = function(value, group, control) {
-    PioneerDDJSX2.gridSlide[value] = control ? 1 : 0;
-    midi.sendShortMsg(0x90 + value, 0x0a, control ? 0x7F : 0x00);
+PioneerDDJSX2.SetGridSlide = function(channel, control, value, status, group) {
+    PioneerDDJSX2.gridSlide[channel] = value ? 1 : 0;
+    midi.sendShortMsg(0x90 + channel, 0x0a, value ? 0x7F : 0x00);
 };
 
 // Enable Grid Adjust Mode (used with Jog Wheel)
-PioneerDDJSX2.SetGridAdjust = function(value, group, control) {
-    PioneerDDJSX2.gridAdjust[value] = control ? 1 : 0;
-    midi.sendShortMsg(0x90 + value, 0x79, control ? 0x7F : 0x00);
+PioneerDDJSX2.SetGridAdjust = function(channel, control, value, status, group) {
+    PioneerDDJSX2.gridAdjust[channel] = value ? 1 : 0;
+    midi.sendShortMsg(0x90 + channel, 0x79, value ? 0x7F : 0x00);
 };
 
 // Clear Grid Adjustment
-PioneerDDJSX2.ClearGrid = function(value, group, control) {
-    engine.setValue("[Channel" + (value + 1) + "]", "beats_undo_adjustment", 1);
-    midi.sendShortMsg(0x90 + value, 0x79, control ? 0x7F : 0x00);
+PioneerDDJSX2.ClearGrid = function(channel, control, value, status, group) {
+    engine.setValue(`[Channel${  channel + 1  }]`, "beats_undo_adjustment", 1);
+    midi.sendShortMsg(0x90 + channel, 0x79, value ? 0x7F : 0x00);
 };
 
 // =============================================================================
-// 11. SAMPLER & PAD PARAMETERS 
+// 11. SAMPLER & PAD PARAMETERS
 // =============================================================================
 
 // Plays sampler or Loads selected track if empty
-PioneerDDJSX2.SamplerPlay = function(group, control, value, status) {
-    var sampler = "[Sampler" + (1 + (control & 7) + (PioneerDDJSX2.samplerBank[group - 7] * 8)) + "]";
-    if (value === 127) {
+PioneerDDJSX2.SamplerPlay = function(channel, control, value, status, group) {
+    var sampler = `[Sampler${  1 + (control & 7) + (PioneerDDJSX2.samplerBank[channel - 7] * 8)  }]`;
+    if (value === 0x7F) {
         if (engine.getValue(sampler, "track_loaded")) {
             engine.setParameter(sampler, "start_play", value & 1);
         } else {
@@ -1458,12 +1850,12 @@ PioneerDDJSX2.SamplerPlay = function(group, control, value, status) {
 };
 
 // Stops sampler (Short press) or Ejects (Long press)
-PioneerDDJSX2.SamplerStop = function(group, control, value, status) {
-    var sampler = "[Sampler" + (1 + (control & 7) + (PioneerDDJSX2.samplerBank[group - 7] * 8)) + "]";
+PioneerDDJSX2.SamplerStop = function(channel, control, value, status, group) {
+    var sampler = `[Sampler${  1 + (control & 7) + (PioneerDDJSX2.samplerBank[channel - 7] * 8)  }]`;
     var isPlaying = engine.getValue(sampler, "play");
     var trackLoaded = engine.getValue(sampler, "track_loaded");
 
-    if (value === 127) {
+    if (value === 0x7F) {
         if (trackLoaded && !isPlaying) {
             engine.setParameter(sampler, "eject", 1);
         } else {
@@ -1474,7 +1866,7 @@ PioneerDDJSX2.SamplerStop = function(group, control, value, status) {
 
 // Updates Sampler LEDs based on state (Loaded/Playing)
 PioneerDDJSX2.SamplerLight = function(value, group, control) {
-    var sampler = PioneerDDJSX2.enums.samplerGroups[group];
+    var sampler = PioneerDDJSX2.groups.samplerGroups[group];
     if (sampler === undefined) {
         return;
     }
@@ -1493,7 +1885,7 @@ PioneerDDJSX2.SamplerLight = function(value, group, control) {
                 // White when playing
                 color = 0x40;
             } else {
-                color = 0x7f;
+                color = 0x7F;
             }
 
             if (PioneerDDJSX2.padMode[i] === 3) {
@@ -1510,24 +1902,24 @@ PioneerDDJSX2.SamplerLight = function(value, group, control) {
 // Set Sampler Gain (Velocity sensitive)
 PioneerDDJSX2.SetSampleGain = function(group, control, value) {
     var where = (control & 7) + (PioneerDDJSX2.samplerBank[group - 7] * 8);
-    PioneerDDJSX2.sampleVolume[where] = value / 127;
-    engine.setParameter("[Sampler" + (1 + where) + "]", "pregain", PioneerDDJSX2.samplerVolume * PioneerDDJSX2.sampleVolume[where]);
+    PioneerDDJSX2.sampleVolume[where] = value / 0x7F;
+    engine.setParameter(`[Sampler${  1 + where  }]`, "pregain", PioneerDDJSX2.samplerVolume * PioneerDDJSX2.sampleVolume[where]);
 };
 
 // Master Sampler Volume Knob
 PioneerDDJSX2.SetSamplerVol = function(value, group, control) {
-    PioneerDDJSX2.samplerVolume = control / 127;
-    var num = engine.getValue('[App]', 'num_samplers');
+    PioneerDDJSX2.samplerVolume = control / 0x7F;
+    var num = engine.getValue("[App]", "num_samplers");
     for (var i = 0; i < num; i++) {
-        engine.setParameter("[Sampler" + (i + 1) + "]", "pregain", PioneerDDJSX2.samplerVolume * PioneerDDJSX2.sampleVolume[i]);
+        engine.setParameter(`[Sampler${  i + 1  }]`, "pregain", PioneerDDJSX2.samplerVolume * PioneerDDJSX2.sampleVolume[i]);
     }
 };
 
 // Refreshes all sampler LEDs (used when switching banks)
-PioneerDDJSX2.RepaintSampler = function(group) {
+PioneerDDJSX2.RepaintSampler = function(channel) {
     for (var i = 0; i < 8; i++) {
-        var ai = i + PioneerDDJSX2.samplerBank[group] * 8;
-        var prefix = "[Sampler" + (ai + 1) + "]";
+        var ai = i + PioneerDDJSX2.samplerBank[channel] * 8;
+        var prefix = `[Sampler${  ai + 1  }]`;
         var loaded = engine.getValue(prefix, "track_loaded");
         var playing = engine.getValue(prefix, "play");
 
@@ -1536,128 +1928,113 @@ PioneerDDJSX2.RepaintSampler = function(group) {
             color = playing ? 0x40 : 0x7F;
         }
 
-        if (PioneerDDJSX2.padMode[group] === 3) {
-            midi.sendShortMsg(0x97 + group, 0x30 + i, color);
-            midi.sendShortMsg(0x97 + group, 0x38 + i, color);
-        } else if (PioneerDDJSX2.padMode[group] === 7) {
-            midi.sendShortMsg(0x97 + group, 0x70 + i, color);
-            midi.sendShortMsg(0x97 + group, 0x78 + i, color);
+        if (PioneerDDJSX2.padMode[channel] === 3) {
+            midi.sendShortMsg(0x97 + channel, 0x30 + i, color);
+            midi.sendShortMsg(0x97 + channel, 0x38 + i, color);
+        } else if (PioneerDDJSX2.padMode[channel] === 7) {
+            midi.sendShortMsg(0x97 + channel, 0x70 + i, color);
+            midi.sendShortMsg(0x97 + channel, 0x78 + i, color);
         }
     }
 };
 // Cycle Tempo Ranges
-PioneerDDJSX2.SetTempoRange = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.tempoRange[group]++;
-        if (PioneerDDJSX2.tempoRange[group] > 3) {
-            PioneerDDJSX2.tempoRange[group] = 0;
+PioneerDDJSX2.SetTempoRange = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.tempoRange[channel]++;
+        if (PioneerDDJSX2.tempoRange[channel] > 3) {
+            PioneerDDJSX2.tempoRange[channel] = 0;
         }
-        engine.setValue(`[Channel${  group + 1  }]`, "rateRange", PioneerDDJSX2.settings.tempoRanges[PioneerDDJSX2.tempoRange[group]]);
+        engine.setValue(`[Channel${  channel + 1  }]`, "rateRange", PioneerDDJSX2.settings.tempoRanges[PioneerDDJSX2.tempoRange[channel]]);
     }
 };
 
 // Previous Sampler Bank
-PioneerDDJSX2.SamplerParam1L = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.samplerBank[group]--;
-        if (PioneerDDJSX2.samplerBank[group] < 0) {
-            PioneerDDJSX2.samplerBank[group] = 0;
+PioneerDDJSX2.SamplerParam1L = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.samplerBank[channel]--;
+        if (PioneerDDJSX2.samplerBank[channel] < 0) {
+            PioneerDDJSX2.samplerBank[channel] = 0;
         } else {
-            PioneerDDJSX2.RepaintSampler(group);
+            PioneerDDJSX2.RepaintSampler(channel);
         }
     }
 };
 
 // Next Sampler Bank
-PioneerDDJSX2.SamplerParam1R = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.samplerBank[group]++;
-        if (PioneerDDJSX2.samplerBank[group] > 7) {
-            PioneerDDJSX2.samplerBank[group] = 7;
+PioneerDDJSX2.SamplerParam1R = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.samplerBank[channel]++;
+        if (PioneerDDJSX2.samplerBank[channel] > 7) {
+            PioneerDDJSX2.samplerBank[channel] = 7;
         } else {
-            PioneerDDJSX2.RepaintSampler(group);
+            PioneerDDJSX2.RepaintSampler(channel);
         }
     }
-    midi.sendShortMsg(0x90 + group, 0x2F, 0x7F);
+    midi.sendShortMsg(0x90 + channel, 0x2F, 0x7F);
 };
 
 // Decrease Roll Size with Parameter 1
-PioneerDDJSX2.RollParam1L = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.rollPrec[group]--;
-        if (PioneerDDJSX2.rollPrec[group] < 0) {
-            PioneerDDJSX2.rollPrec[group] = 0;
+PioneerDDJSX2.RollParam1L = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.rollPrec[channel]--;
+        if (PioneerDDJSX2.rollPrec[channel] < 0) {
+            PioneerDDJSX2.rollPrec[channel] = 0;
         }
-        midi.sendShortMsg(0x90 + group, 0x1e, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[group]]);
+        midi.sendShortMsg(0x90 + channel, 0x1E, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[channel]]);
     }
 };
 
 // Increase Roll Size with Parameter 1
-PioneerDDJSX2.RollParam1R = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.rollPrec[group]++;
-        if (PioneerDDJSX2.rollPrec[group] > 4) {
-            PioneerDDJSX2.rollPrec[group] = 4;
+PioneerDDJSX2.RollParam1R = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.rollPrec[channel]++;
+        if (PioneerDDJSX2.rollPrec[channel] > 4) {
+            PioneerDDJSX2.rollPrec[channel] = 4;
         }
-        midi.sendShortMsg(0x90 + group, 0x1e, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[group]]);
+        midi.sendShortMsg(0x90 + channel, 0x1E, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[channel]]);
     }
 };
 
 // Decrease Slicer Precision with Parameter 1
-PioneerDDJSX2.SlicerParam1L = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.beatjumpPrec[group]--;
-        if (PioneerDDJSX2.beatjumpPrec[group] < 0) {
-            PioneerDDJSX2.beatjumpPrec[group] = 0;
+PioneerDDJSX2.SlicerParam1L = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.beatjumpPrec[channel]--;
+        if (PioneerDDJSX2.beatjumpPrec[channel] < 0) {
+            PioneerDDJSX2.beatjumpPrec[channel] = 0;
         }
-        midi.sendShortMsg(0x90 + group, 0x20, PioneerDDJSX2.settings.beatjumpColors[PioneerDDJSX2.beatjumpPrec[group]]);
+        midi.sendShortMsg(0x90 + channel, 0x20, PioneerDDJSX2.settings.beatjumpColors[PioneerDDJSX2.beatjumpPrec[channel]]);
     }
 };
 
 // Increase Slicer Precision with Parameter 1
-PioneerDDJSX2.SlicerParam1R = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.beatjumpPrec[group]++;
-        if (PioneerDDJSX2.beatjumpPrec[group] > 8) {
-            PioneerDDJSX2.beatjumpPrec[group] = 8;
+PioneerDDJSX2.SlicerParam1R = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.beatjumpPrec[channel]++;
+        if (PioneerDDJSX2.beatjumpPrec[channel] > 8) {
+            PioneerDDJSX2.beatjumpPrec[channel] = 8;
         }
-        midi.sendShortMsg(0x90 + group, 0x20, PioneerDDJSX2.settings.beatjumpColors[PioneerDDJSX2.beatjumpPrec[group]]);
+        midi.sendShortMsg(0x90 + channel, 0x20, PioneerDDJSX2.settings.beatjumpColors[PioneerDDJSX2.beatjumpPrec[channel]]);
     }
 };
 
 // Parameter 1 for HOT CUE (Right)
 // Not Used
-PioneerDDJSX2.CueParam1R = function(group, control, value, status, channel) {
+PioneerDDJSX2.CueParam1R = function(channel, control, value, status, group) {
 };
 
 // Parameter 1 for HOT CUE (Left)
 // Not Used
-PioneerDDJSX2.CueParam1L = function(group, control, value, status, channel) {
+PioneerDDJSX2.CueParam1L = function(channel, control, value, status, group) {
 };
 
 // Parameter 1 for HOT CUE LOOPS (Left)
 // Not Used
-PioneerDDJSX2.CueLoopParam1R = function(group, control, value, status, channel) {
+PioneerDDJSX2.CueLoopParam1R = function(channel, control, value, status, group) {
 };
 
 // Parameter 1 for HOT CUE LOOPS (Left)
 // Not Used
-PioneerDDJSX2.CueLoopParam1L = function(group, control, value, status, channel) {
-};
-
-// Feedback for Roll Pads
-PioneerDDJSX2.RollPerformancePadLed = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-    var padIndex = 0;
-    for (var i = 0; i < 8; i++) {
-        if (control === 'beatloop_' + PioneerDDJSX2.settings.loopIntervals[i + 2] + '_enabled') {
-            break;
-        }
-        padIndex++;
-    }
-    if (engine.getValue('[Channel1]', 'play')) {
-        midi.sendShortMsg(0x97 + channel, 0x10 + padIndex, value ? 0x7F : 0x00);
-    }
+PioneerDDJSX2.CueLoopParam1L = function(channel, control, value, status, group) {
 };
 
 // =============================================================================
@@ -1665,77 +2042,77 @@ PioneerDDJSX2.RollPerformancePadLed = function(value, group, control) {
 // =============================================================================
 
 // Enable HotCue Mode
-PioneerDDJSX2.SetHotCueMode = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.padMode[group] = 0;
-        midi.sendShortMsg(0x90 + group, 0x1b, 0x7f);
+PioneerDDJSX2.SetHotCueMode = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.padMode[channel] = 0;
+        midi.sendShortMsg(0x90 + channel, 0x1B, 0x7F);
     }
 };
 
 // Enable Roll Mode
-PioneerDDJSX2.SetRollMode = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.padMode[group] = 1;
-        midi.sendShortMsg(0x90 + group, 0x1e, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[group]]);
+PioneerDDJSX2.SetRollMode = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.padMode[channel] = 1;
+        midi.sendShortMsg(0x90 + channel, 0x1E, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[channel]]);
     }
 };
 
 // Enable Slicer Mode
-PioneerDDJSX2.SetSlicerMode = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.padMode[group] = 2;
-        midi.sendShortMsg(0x90 + group, 0x20, 0x7f);
+PioneerDDJSX2.SetSlicerMode = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.padMode[channel] = 2;
+        midi.sendShortMsg(0x90 + channel, 0x20, 0x7F);
     }
 };
 
 // Enable Sampler Mode
-PioneerDDJSX2.SetSamplerMode = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.padMode[group] = 3;
-        PioneerDDJSX2.RepaintSampler(group);
-        midi.sendShortMsg(0x90 + group, 0x22, 0x7f);
+PioneerDDJSX2.SetSamplerMode = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.padMode[channel] = 3;
+        PioneerDDJSX2.RepaintSampler(channel);
+        midi.sendShortMsg(0x90 + channel, 0x22, 0x7F);
     }
 };
 
 // Enable Cue Loop Mode
-PioneerDDJSX2.SetCueLoopMode = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.padMode[group] = 4;
-        midi.sendShortMsg(0x90 + group, 0x69, PioneerDDJSX2.settings.cueLoopColors[3]);
+PioneerDDJSX2.SetCueLoopMode = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.padMode[channel] = 4;
+        midi.sendShortMsg(0x90 + channel, 0x69, 0x7F);
     }
 };
 
 // Enable Saved Loop Mode
-PioneerDDJSX2.SetSavedLoopMode = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.padMode[group] = 5;
-        midi.sendShortMsg(0x90 + group, 0x6b, 0x7f);
+PioneerDDJSX2.SetSavedLoopMode = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.padMode[channel] = 5;
+        midi.sendShortMsg(0x90 + channel, 0x6b, 0x7F);
     }
 };
 
 // Enable Slicer Loop Mode
-PioneerDDJSX2.SetSlicerLoopMode = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.padMode[group] = 6;
-        midi.sendShortMsg(0x90 + group, 0x6d, 0x7f);
+PioneerDDJSX2.SetSlicerLoopMode = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.padMode[channel] = 6;
+        midi.sendShortMsg(0x90 + channel, 0x6d, 0x7F);
     }
 };
 
 // Enable Velocity Sampler Mode
-PioneerDDJSX2.SetVelocitySamplerMode = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.padMode[group] = 7;
-        PioneerDDJSX2.RepaintSampler(group);
-        midi.sendShortMsg(0x90 + group, 0x6f, 0x7f);
+PioneerDDJSX2.SetVelocitySamplerMode = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.padMode[channel] = 7;
+        PioneerDDJSX2.RepaintSampler(channel);
+        midi.sendShortMsg(0x90 + channel, 0x6f, 0x7F);
     }
 };
 
 // Logic for Saved Loop Pads
-PioneerDDJSX2.SavedLoop = function(performanceChannel, control, value, status) {
-    var deck = performanceChannel - 6;
-    var group = '[Channel' + deck + ']';
+PioneerDDJSX2.SavedLoop = function(channel, control, value, status, group) {
+    var deck = channel - 6;
+
     var interval = PioneerDDJSX2.settings.loopIntervals[control - 0x50 + 4];
-    var isAutoLoopEnabled = engine.getValue(group, 'beatloop_' + interval + '_enabled');
+    var isAutoLoopEnabled = engine.getValue(group, `beatloop_${  interval  }_enabled`);
 
     if (value === 0x7F) {
         for (var i = 0; i < 8; i++) {
@@ -1743,180 +2120,273 @@ PioneerDDJSX2.SavedLoop = function(performanceChannel, control, value, status) {
         }
 
         if (isAutoLoopEnabled !== 1) {
-            engine.setValue(group, 'beatloop_' + interval + '_activate', 1);
-            midi.sendShortMsg(0x97 + deck - 1, control, 0x7f);
+            engine.setValue(group, `beatloop_${  interval  }_activate`, 1);
+            midi.sendShortMsg(0x97 + deck - 1, control, 0x7F);
         } else {
-            engine.setValue(group, 'beatloop_' + interval + '_toggle', 1);
+            engine.setValue(group, `beatloop_${  interval  }_toggle`, 1);
             midi.sendShortMsg(0x97 + deck - 1, control, 0x00);
         }
     }
 };
 
 // Logic for Beat Jump Pads
-// TODO(XXX) : BeatJump is mapped to Slicer, create a real Slicer or wait for Mixxx to implement one. 
-PioneerDDJSX2.BeatJump = function(performanceChannel, control, value, status) {
-    var deck = performanceChannel - 7;
-    var group = '[Channel' + (deck + 1) + ']';
+// TODO(XXX) : BeatJump is mapped to Slicer, create a real Slicer or wait for Mixxx to implement one.
+PioneerDDJSX2.BeatJump = function(channel, control, value, status, group) {
+    var deck = channel - 7;
+
     const which = (control & 3) + PioneerDDJSX2.beatjumpPrec[deck];
 
     if (value === 0x7F) {
         var interval = PioneerDDJSX2.settings.loopIntervals[which];
         if (control & 4) {
-            engine.setValue(group, 'beatjump_' + interval + '_backward', 1);
+            engine.setValue(group, `beatjump_${  interval  }_backward`, 1);
         } else {
-            engine.setValue(group, 'beatjump_' + interval + '_forward', 1);
+            engine.setValue(group, `beatjump_${  interval  }_forward`, 1);
         }
     }
-    midi.sendShortMsg(0x97 + deck, control, (value === 0x7f) ? (PioneerDDJSX2.settings.beatjumpColors[which]) : (0x00));
+    midi.sendShortMsg(0x97 + deck, control, (value === 0x7F) ? (PioneerDDJSX2.settings.beatjumpColors[which]) : (0x00));
 };
 
 // Logic for Roll Pads
-PioneerDDJSX2.RollPerformancePad = function(performanceChannel, control, value, status) {
-    var deck = performanceChannel - 6;
-    var group = '[Channel' + deck + ']';
-    var interval = PioneerDDJSX2.settings.loopIntervals[control - 0x10 + PioneerDDJSX2.rollPrec[performanceChannel - 7]];
+PioneerDDJSX2.RollPerformancePad = function(channel, control, value, status, group) {
+    var deck = channel - 6;
+
+    var interval = PioneerDDJSX2.settings.loopIntervals[control - 0x10 + PioneerDDJSX2.rollPrec[channel - 7]];
 
     if (value === 0x7F) {
-        engine.setValue(group, 'beatlooproll_' + interval + '_activate', 1);
+        engine.setValue(group, `beatlooproll_${  interval  }_activate`, 1);
     } else {
-        engine.setValue(group, 'beatlooproll_' + interval + '_activate', 0);
+        engine.setValue(group, `beatlooproll_${  interval  }_activate`, 0);
     }
 
-    midi.sendShortMsg(0x97 + deck - 1, control, (value === 0x7f) ? (PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[performanceChannel - 7]]) : (0x00));
+    midi.sendShortMsg(0x97 + deck - 1, control, (value === 0x7F) ? (PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[channel - 7]]) : (0x00));
 };
 
 // =============================================================================
 // 13. LIBRARY & BROWSER
 // =============================================================================
 
-// Rotary Selector Navigation (Tracklist / Library)
-PioneerDDJSX2.RotarySelector = function(channel, control, value, status) {
-    var delta = 0x40 - Math.abs(0x40 - value);
+// Center point of the relative rotary encoder (value > this means clockwise)
+//0x40;
+
+// Sort button CC numbers and their corresponding Mixxx library column indices
+PioneerDDJSX2.SortButtons = {
+    88: {column: 15,}, // Artist
+    89: {column: 2,}, // Title
+    96: {column: 9,}, // BPM
+    97: {column: 1,}, // Tracknumber
+};
+
+// Rotary Selector Navigation - Works across ALL library widgets.
+// Uses [Library],MoveVertical which handles sidebar, tracks, searchbox, and dialogs.
+// If any channel's LOAD is held, cycle that channel's QuickEffect preset
+// instead of scrolling the library. Works on all 4 channels independently.
+PioneerDDJSX2.RotarySelector = function(_channel, _control, value, _status, _group) {
+    let delta = 0x40 - Math.abs(0x40 - value);
     if (value > 0x40) {
         delta *= -1;
     }
 
-    if (PioneerDDJSX2.status.rotarySelector.target === 1) {
-        engine.setValue('[Playlist]', 'SelectTrackKnob', delta);
-    } else if (delta > 0) {
-        engine.setValue('[Playlist]', 'SelectNextPlaylist', 1);
-    } else if (delta < 0) {
-        engine.setValue('[Playlist]', 'SelectPrevPlaylist', 1);
+    // Check if any channel's LOAD button is currently held
+    let loadChannel = -1;
+    for (let i = 0; i < 4; i++) {
+        if (PioneerDDJSX2.loadHeld[i]) {
+            loadChannel = i;
+            break;
+        }
     }
+
+    if (loadChannel !== -1) {
+        // LOAD is held — mark rotary as used (suppresses track load on release)
+        // and cycle the QuickEffect preset for that channel
+        PioneerDDJSX2.loadRotaryUsed[loadChannel] = true;
+
+        const filterGroup = `[QuickEffectRack1_[Channel${ loadChannel + 1 }]]`;
+        if (delta > 0) {
+            engine.setValue(filterGroup, "next_chain_preset", 1);
+        } else if (delta < 0) {
+            engine.setValue(filterGroup, "prev_chain_preset", 1);
+        }
+        // Suppress library scroll — do NOT fall through to MoveVertical
+        return;
+    }
+
+    // Normal library scroll
+    engine.setValue("[Library]", "MoveVertical", delta);
 };
 
 // Sort Library via Shift + Load Buttons
-PioneerDDJSX2.SortLibrary = function(performanceChannel, control, value, status) {
-    if (value === 127) {
-        if (control === 88) {
-            engine.setValue("[Library]", 'sort_column_toggle', 15);
+PioneerDDJSX2.SortLibrary = function(_channel, control, value, _status, _group) {
+    if (value === 0x7F) {
+        const sortButton = PioneerDDJSX2.SortButtons[control];
+        if (sortButton) {
+            engine.setValue("[Library]", "sort_column_toggle", sortButton.column);
         }
-        if (control === 89) {
-            engine.setValue("[Library]", 'sort_column_toggle', 2);
-        }
-        if (control === 96) {
-            engine.setValue("[Library]", 'sort_column_toggle', 9);
-        }
-        if (control === 97) {
-            engine.setValue("[Library]", 'sort_column_toggle', 1);
+    }
+};
+
+// Function when loading tracks, with a setting to enable PFL for the current track and disable all the other.
+// Tracks LOAD hold state for LOAD+Rotary QuickEffect cycling.
+// If the rotary was turned while LOAD was held, the track load is suppressed on release.
+
+// Base MIDI control number for the Load buttons (decks 1-4)
+PioneerDDJSX2.LoadSelectedTrack = function(_channel, control, value, _status, group) {
+    const channel = script.deckFromGroup(group) - 1;
+    if (value === 0x7F) {
+        // Press — arm hold state only, do NOT load yet
+        PioneerDDJSX2.loadHeld[channel] = true;
+        PioneerDDJSX2.loadRotaryUsed[channel] = false;
+    } else {
+        // Release — clear hold state
+        PioneerDDJSX2.loadHeld[channel] = false;
+        // Only load if the rotary was not used during the hold
+        if (!PioneerDDJSX2.loadRotaryUsed[channel]) {
+            engine.setValue(group, "LoadSelectedTrack", 1);
+            if (PioneerDDJSX2.settings.LoadBehaviour && !engine.getValue(group, "play")) {
+                for (let i = 1; i <= 4; i++) {
+                    engine.setValue(`[Channel${ i }]`, "pfl", 0);
+                }
+                engine.setValue(group, "pfl", 1);
+                engine.setValue(group, "cue_goto", 1);
+            }
         }
     }
 };
 
 // Back Button - returns focus to Library sidebar
+// Uses MoveFocus to move back through: tracks -> searchbox -> sidebar
 PioneerDDJSX2.BackButton = function(channel, control, value, status) {
     if (value === 0x7F) {
-        PioneerDDJSX2.status.rotarySelector.target = PioneerDDJSX2.enums.rotarySelector.targets.libraries;
+        engine.setValue("[Library]", "MoveFocus", -1);
     }
 };
 
-// Rotary Click - Toggles folder expansion or enters playlist
+// Rotary Click - Context-aware action based on focused widget
+// - In sidebar (focused_widget=0): Uses ToggleSelectedSidebarItem to expand/collapse or jump to tracks
+// - In tracks/searchbox/dialogs: Uses GoToItem to load track or confirm action
 PioneerDDJSX2.RotarySelectorClick = function(channel, control, value, status) {
     if (value === 0x7F) {
-        var target = PioneerDDJSX2.enums.rotarySelector.targets.tracklist;
+        var focusedWidget = engine.getValue("[Library]", "focused_widget");
 
-        var tracklist = PioneerDDJSX2.enums.rotarySelector.targets.tracklist;
-        var libraries = PioneerDDJSX2.enums.rotarySelector.targets.libraries;
-
-        // Expand/Collapse the current item
-        engine.setValue("[Playlist]", "ToggleSelectedSidebarItem", 1);
-
-        switch (PioneerDDJSX2.status.rotarySelector.target) {
-            case tracklist:
-                target = libraries;
-                break;
-            case libraries:
-                target = tracklist;
-                break;
+        if (focusedWidget === 0) {
+            // In sidebar - toggle expansion or jump to tracks
+            engine.setValue("[Playlist]", "ToggleSelectedSidebarItem", 1);
+        } else {
+            // In tracks table, searchbox, or dialogs - perform action
+            engine.setValue("[Library]", "GoToItem", 1);
         }
-
-        PioneerDDJSX2.status.rotarySelector.target = target;
     }
 };
 
-// Shift + Rotary Click - Loads selected track
+// Shift + Rotary Click - Loads selected track to preview deck
+// Always uses GoToItem regardless of focused widget
 PioneerDDJSX2.rotarySelectorShiftedClick = function(channel, control, value) {
-    if (value) {
-        script.toggleControl("[Library]", "GoToItem");
+    if (value === 0x7F) {
+        engine.setValue("[Library]", "GoToItem", 1);
     }
 };
 
 // =============================================================================
-// 14. FLIP SECTION
+// 13. FLIP SECTION
 // =============================================================================
-// This is the Flip section of each deck, Mixxx doesn't have Flip feature,
+// This is the Flip section of each deck, Mixxx doesn"t have Flip feature,
 // so we can map them to something else
 
-// Flip Start Button, toggle Loop Anchor
-PioneerDDJSX2.FlipStart = function(group, control, value, status, channel) {
-    if (value === 127) {
-        script.toggleControl(channel, "loop_anchor");
-        var isAnchor = engine.getValue(channel, "loop_anchor");
-        midi.sendShortMsg(0x90 + group, 0x4B, isAnchor ? 0x7F : 0x00);
-    }
-};
+// Flip Slot Button, Sync key with the playing track on the adjacent channel
+// Reads the key of the master (playing) channel and
+// uses sync_key to match it.
+// ALTERNATIVE SYNC: Opposed physical deck partner key sync.
+// Mixxx's sync_key always syncs to the first numerically ordered deck that is playing with a detected beatgrid,
+// which can be the wrong target when more than 2 decks are active simultaneously.
+// Instead, this finds whichever channel is currently playing on the opposite physical side (A: ch1/3, B: ch2/4)
+// and manually matches the key offset to that specific deck, replicating and bypassing sync_key entirely.
+PioneerDDJSX2.FlipSlot = function(channel, control, value, status, group) {
+    if (value === 0x7F && engine.getValue(group, "track_loaded")) {
+        if (PioneerDDJSX2.settings.KeySyncBehaviour === true) {
+            const deckNum = script.deckFromGroup(group);
 
-// Flip Rec Button, toggle Hot Cue Quantize
-PioneerDDJSX2.FlipRec = function(group, control, value, status, channel) {
-    if (value === 127) {
-        script.toggleControl(channel, "quantize");
-        var isQuantize = engine.getValue(channel, "quantize");
-        midi.sendShortMsg(0x90 + group, 0x4A, isQuantize ? 0x7F : 0x00);
-    }
-};
+            // Use the currently active deck on the opposite physical side
+            const partnerDeck = (deckNum === 1 || deckNum === 3) ? PioneerDDJSX2.activeDeck.B : PioneerDDJSX2.activeDeck.A;
 
-// Flip Slot Button, Reset current track key to default (pitch)
-PioneerDDJSX2.FlipSlot = function(group, control, value, status, channel) {
-    if (engine.getValue(channel, "track_loaded")) {
-        if (value === 127) {
-            engine.setValue(channel, "pitch_adjust_set_zero", 1);
+            const partnerGroup = `[Channel${  partnerDeck  }]`;
+
+            if (!engine.getValue(partnerGroup, "track_loaded") ||
+                engine.getValue(partnerGroup, "key") === 0) {
+                return;
+            }
+
+            const myFileKey   = engine.getValue(group, "file_key");
+            const partnerKey  = engine.getValue(partnerGroup, "key");
+            const partnerDist = engine.getValue(partnerGroup, "visual_key_distance");
+
+            const myMajor      = myFileKey >= 1 && myFileKey <= 12;
+            const partnerMajor = partnerKey >= 1 && partnerKey <= 12;
+
+            let targetKey = partnerKey;
+            if (myMajor !== partnerMajor) {
+                targetKey = (partnerKey > 12) ? partnerKey - 12 : partnerKey + 12;
+            }
+
+            const myTonic     = (myFileKey - 1) % 12;
+            const targetTonic = (targetKey - 1) % 12;
+            let steps         = targetTonic - myTonic;
+
+            if (steps > 6) {
+                steps -= 12;
+            } else if (steps < -6) {
+                steps += 12;
+            }
+
+            if (steps < -2) {
+                steps = 5 + steps;
+            } else if (steps > 2) {
+                steps = -5 + steps;
+            }
+
+            const pitchToTakeOctaves = (steps + partnerDist) / 12.0;
+            engine.setValue(group, "pitch", pitchToTakeOctaves * 12);
+
+        } else {
+            engine.setValue(group, "sync_key", 1);
         }
     }
 };
 
-// Flip Save (SHIFT + Slot) Button, Set the pitch of the track down
-PioneerDDJSX2.FlipSave = function(group, control, value, status, channel) {
-    if (engine.getValue(channel, "track_loaded")) {
-        if (value === 127) {
-            engine.setValue(channel, "pitch_down", 1);
+// Flip Save (SHIFT + Slot) Button, Reset key to original
+PioneerDDJSX2.FlipSave = function(channel, control, value, status, group) {
+    if (engine.getValue(group, "track_loaded")) {
+        if (value === 0x7F) {
+            engine.setValue(group, "pitch_adjust_set_zero", 1);
+        }
+    }
+};
+
+// Flip Rec Button, Set the pitch of the track down
+PioneerDDJSX2.FlipRec = function(channel, control, value, status, group) {
+    if (engine.getValue(group, "track_loaded")) {
+        if (value === 0x7F) {
+            engine.setValue(group, "pitch_down", 1);
         }
     }
 };
 
 // Flip Save (SHIFT + Rec) Button, repeat setting for the current track
-PioneerDDJSX2.FlipLoop = function(group, control, value, status, channel) {
-    if (value === 127) {
-        script.toggleControl(channel, "repeat");
-        var isAnchor = engine.getValue(channel, "repeat");
-        midi.sendShortMsg(0x90 + group, 0x5A, isAnchor ? 0x7F : 0x00);
+PioneerDDJSX2.FlipLoop = function(channel, control, value, status, group) {
+    if (value === 0x7F) {
+        script.toggleControl(group, "repeat");
+        var isRepeat = engine.getValue(group, "repeat");
     }
 };
 
-// Flip Save (SHIFT + Start) Button, Set the pitch of the track up
-PioneerDDJSX2.FlipOnOff = function(group, control, value, status, channel) {
-    if (engine.getValue(channel, "track_loaded")) {
-        if (value === 127) {
-            engine.setValue(channel, "pitch_up", 1);
+// Flip Start Button, Set the pitch of the track up
+PioneerDDJSX2.FlipStart = function(channel, control, value, status, group) {
+    if (engine.getValue(group, "track_loaded")) {
+        if (value === 0x7F) {
+            engine.setValue(group, "pitch_up", 1);
         }
     }
+};
+
+// Flip On/Off Button
+PioneerDDJSX2.FlipOnOff = function(channel, control, value, status, group) {
 };

--- a/res/controllers/PIONEER-DDJ-SX2.scripts.js
+++ b/res/controllers/PIONEER-DDJ-SX2.scripts.js
@@ -1,7 +1,3 @@
-/* eslint-disable no-undef */
-/* eslint-disable no-var */
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 // Pioneer DDJ-SX2 mapping for Mixxx
 // Based on tildearrow's mapping for the DDJ-SX2
 // Modifications by Krafting, eXWoLL(+Assistant)

--- a/res/controllers/PIONEER-DDJ-SX2.scripts.js
+++ b/res/controllers/PIONEER-DDJ-SX2.scripts.js
@@ -374,7 +374,7 @@ PioneerDDJSX2.activeDeck = {A: 1, B: 2};
 // =============================================================================
 
 // Called when the controller is detected or the script is reloaded.
-PioneerDDJSX2.init = function(id) {
+PioneerDDJSX2.init = function(_id) {
     // Send Serato Recall Sysex (Forces controller into correct mode)
     midi.sendSysexMsg(PioneerDDJSX2.recallState, PioneerDDJSX2.recallState.length);
 
@@ -636,8 +636,8 @@ PioneerDDJSX2.UnbindControlConnections = function() {
 // rapidly to the jog rings. This function limits updates to ~30ms.
 
 // Handles WHITE outer ring ONLY
-PioneerDDJSX2.DeckLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.DeckLights = function(_value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
 
     // THROTTLE: Limit update rate to ~30ms to prevent controller freeze
     var now = Date.now();
@@ -690,8 +690,8 @@ PioneerDDJSX2.DeckLights = function(value, group, control) {
 // Handles BOTH beat modes for RED center LEDs
 // MODE 0 (Checkbox OFF): Beat-by-beat - 1 LED per beat, 4 beat cycle
 // MODE 1 (Checkbox ON):  Bar-by-bar - 1 LED per bar (4 beats), 4 bar cycle (16 beats)
-PioneerDDJSX2.UpdateCenterBeatLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.UpdateCenterBeatLights = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
 
     if (value === 0) {
         return;
@@ -768,8 +768,8 @@ PioneerDDJSX2.UpdateCenterBeatLights = function(value, group, control) {
 };
 
 // Reset beat counter when track loads OR playposition changes
-PioneerDDJSX2.LoadActions = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.LoadActions = function(_value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     // Reset beat counter to 0 so first beat = LED 1
     PioneerDDJSX2.currentBeat[channel] = 0;
 
@@ -784,8 +784,8 @@ PioneerDDJSX2.LoadActions = function(value, group, control) {
 // After some tests, it seems we CANNOT set the lights on Parameter 1 when we send the Serato Keepalive command
 // The lights will just blink when we press the buttons
 // Except for the CUE mode where we can set the lights as static.
-PioneerDDJSX2.ParamLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.ParamLights = function(_value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     // For the repeat setting of each channels
     // SHIFT + Rec Flip Button
     var isRepeat = engine.getValue(group, "repeat");
@@ -793,8 +793,8 @@ PioneerDDJSX2.ParamLights = function(value, group, control) {
 };
 
 // Function to set PAD MODE Leds when needed
-PioneerDDJSX2.QuantizeLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.QuantizeLights = function(_value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
 
     var isQuantize = engine.getValue(group, "quantize");
     midi.sendShortMsg(0x90 + channel, 0x79, isQuantize ? 0x7F : 0x00);
@@ -803,8 +803,8 @@ PioneerDDJSX2.QuantizeLights = function(value, group, control) {
 // Track last playposition to detect manual jumps
 PioneerDDJSX2.lastPlayPosition = [0, 0, 0, 0];
 
-PioneerDDJSX2.ResetBeatCounter = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.ResetBeatCounter = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     var lastPos = PioneerDDJSX2.lastPlayPosition[channel];
 
     // Only reset if this is a JUMP (difference > 0.001 = ~0.1% of track)
@@ -825,8 +825,8 @@ PioneerDDJSX2.ResetBeatCounter = function(value, group, control) {
 // Handles the chasing lights on the pads when Slicer mode is active.
 PioneerDDJSX2.slicerTick = [0, 0, 0, 0];
 
-PioneerDDJSX2.SlicerLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.SlicerLights = function(_value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
 
     // Exit immediately if not in Slicer mode
     if (PioneerDDJSX2.padMode[channel] !== 2 && PioneerDDJSX2.padMode[channel] !== 6) {
@@ -875,8 +875,8 @@ PioneerDDJSX2.HotCuePerformancePadLed = function(value, group, control) {
 };
 
 // Updates Play/Pause Button LED
-PioneerDDJSX2.PlayLeds = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.PlayLeds = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x0B, value ? 0x7F : 0x00);
     midi.sendShortMsg(0x90 + channel, 0x47, value ? 0x7F : 0x00);
     if (PioneerDDJSX2.settings.DoNotTrickController) {
@@ -885,21 +885,21 @@ PioneerDDJSX2.PlayLeds = function(value, group, control) {
 };
 
 // Updates VU Meter LEDs
-PioneerDDJSX2.VuMeter = function(value, group, control) {
-    var level = value * 0x7F;
+PioneerDDJSX2.VuMeter = function(value, group, _control) {
+    const level = value * 0x7F;
     var channel = 0xB0 + PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(channel, 0x02, level);
 };
 
 // Updates Sync Button LED
-PioneerDDJSX2.SyncLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.SyncLights = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x58, value ? 0x7F : 0x00);
 };
 
 // Clears all LEDs on a specific deck (used on Eject)
-PioneerDDJSX2.UnloadLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.UnloadLights = function(_value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
 
     // Clear all pads LEDs
     for (var k = 0; k < 0x30; k++) {
@@ -914,39 +914,39 @@ PioneerDDJSX2.UnloadLights = function(value, group, control) {
 };
 
 // Updates Headphone Cue (PFL) LED
-PioneerDDJSX2.HeadphoneCueLed = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.HeadphoneCueLed = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x54, value ? 0x7F : 0x00);
 };
 
 // Updates Main Cue Button LED
-PioneerDDJSX2.CueLeds = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.CueLeds = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x48, value ? 0x7F : 0x00);
     midi.sendShortMsg(0x90 + channel, 0x0C, value ? 0x7F : 0x00);
 };
 
 // Updates Key Lock / Master Tempo LED
-PioneerDDJSX2.KeyLockLeds = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.KeyLockLeds = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x1A, value ? 0x7F : 0x00);
 };
 
 // Updates Loop 2X LED
-PioneerDDJSX2.LoopDouble = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.LoopDouble = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x13, value ? 0x7F : 0x00);
 };
 
 // Updates Loop 1/2 LED
-PioneerDDJSX2.LoopHalve = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.LoopHalve = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x12, value ? 0x7F : 0x00);
 };
 
 // Updates Loop In/Out/Loop Active LEDs
-PioneerDDJSX2.LoopLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.LoopLights = function(_value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     // Auto Loop Light
     midi.sendShortMsg(0x90 + channel, 0x14, engine.getValue(group, "loop_enabled") ? 0x7F : 0x00);
 
@@ -963,8 +963,8 @@ PioneerDDJSX2.LoopLights = function(value, group, control) {
 };
 
 // Updates Key Shift (Pitch Adjust) LEDs
-PioneerDDJSX2.PitchAdjust = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.PitchAdjust = function(value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     if (value !== 0) {
         if (value > 0) {
             midi.sendShortMsg(0x90 + channel, 0x4a, 0x00);
@@ -981,7 +981,7 @@ PioneerDDJSX2.PitchAdjust = function(value, group, control) {
 
 // FX Status LEDs
 PioneerDDJSX2.SetFXLed = function(note) {
-    return function(value, group, control) {
+    return function(value, _group, _control) {
         midi.sendShortMsg(0x96, note, value ? 0x7F : 0x00);
     };
 };
@@ -995,8 +995,8 @@ PioneerDDJSX2.FX1CH4 = PioneerDDJSX2.SetFXLed(0x4F);
 PioneerDDJSX2.FX2CH4 = PioneerDDJSX2.SetFXLed(0x53);
 
 // Updates Rate/Tempo Slider direction LEDs (Up/Down arrows)
-PioneerDDJSX2.RateLights = function(value, group, control) {
-    var channel = PioneerDDJSX2.groups.channelGroups[group];
+PioneerDDJSX2.RateLights = function(_value, group, _control) {
+    const channel = PioneerDDJSX2.groups.channelGroups[group];
     if (engine.getValue(group, "rate") === 0) {
         midi.sendShortMsg(0x90 + channel, 0x37, 0x00);
         midi.sendShortMsg(0x90 + channel, 0x34, 0x00);
@@ -1084,7 +1084,7 @@ PioneerDDJSX2.postponeDisableScratch = function(channel) {
 };
 
 // Touched the Jog Platter (top surface)
-PioneerDDJSX2.jogScratchTouch = function(channel, control, value) {
+PioneerDDJSX2.jogScratchTouch = function(channel, _control, value) {
     if (value === 0x7F && PioneerDDJSX2.vinylOn[channel]) {
         PioneerDDJSX2.unscheduleDisableScratch(channel);
         PioneerDDJSX2.toggleScratch(channel, true);
@@ -1094,8 +1094,8 @@ PioneerDDJSX2.jogScratchTouch = function(channel, control, value) {
 };
 
 // Turned the Jog Platter (top surface) - Scratching or Grid Adjust
-PioneerDDJSX2.jogScratchTurn = function(channel, control, value) {
-    var deck = channel + 1;
+PioneerDDJSX2.jogScratchTurn = function(channel, _control, value) {
+    const deck = channel + 1;
     if (engine.isScratching(deck) && !PioneerDDJSX2.gridSlide[channel] && !PioneerDDJSX2.gridAdjust[channel]) {
         engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
     } else {
@@ -1109,15 +1109,15 @@ PioneerDDJSX2.jogScratchTurn = function(channel, control, value) {
 };
 
 // Outer Jog Ring Touch (Seeking)
-PioneerDDJSX2.jogSeekTouch = function(channel, control, value) {
+PioneerDDJSX2.jogSeekTouch = function(channel, _control, value) {
     if (!engine.getValue(`[Channel${  channel + 1  }]`, "play")) {
         PioneerDDJSX2.toggleScratch(channel, value === 0x7F);
     }
 };
 
 // Outer Jog Ring Turn (Seeking or Nudging)
-PioneerDDJSX2.jogSeekTurn = function(channel, control, value) {
-    var deck = channel + 1;
+PioneerDDJSX2.jogSeekTurn = function(channel, _control, value) {
+    const deck = channel + 1;
     if (engine.isScratching(deck)) {
         engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
     } else {
@@ -1126,12 +1126,12 @@ PioneerDDJSX2.jogSeekTurn = function(channel, control, value) {
 };
 
 // Seek through track (Shift + Jog Turn)
-PioneerDDJSX2.jogSeek = function(channel, control, value) {
+PioneerDDJSX2.jogSeek = function(channel, _control, value) {
     engine.setValue(`[Channel${  channel + 1  }]`, "beatjump", PioneerDDJSX2.getJogWheelDelta(value) / 16);
 };
 
-PioneerDDJSX2.jogPitchBend = function(channel, control, value) {
-    var deck = channel + 1;
+PioneerDDJSX2.jogPitchBend = function(channel, _control, value) {
+    const deck = channel + 1;
     if (engine.isScratching(deck)) {
         engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
         PioneerDDJSX2.postponeDisableScratch(channel);
@@ -1143,7 +1143,7 @@ PioneerDDJSX2.jogPitchBend = function(channel, control, value) {
 };
 
 // Toggle Vinyl Mode (Shift + Slip)
-PioneerDDJSX2.ToggleVinyl = function(channel, control, value, status, group) {
+PioneerDDJSX2.ToggleVinyl = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.vinylOn[channel] = !PioneerDDJSX2.vinylOn[channel];
     }
@@ -1155,8 +1155,8 @@ PioneerDDJSX2.ToggleVinyl = function(channel, control, value, status, group) {
 
 // Play/Pause Button
 // Handles Logic for SoftStart/Braking if Shift is pressed/configured
-PioneerDDJSX2.Play = function(channel, control, value, status, group) {
-    var deck = script.deckFromGroup(group);
+PioneerDDJSX2.Play = function(_channel, control, value, _status, group) {
+    const deck = script.deckFromGroup(group);
     var isPlaying = engine.getValue(group, "play");
     var lastHotcue = engine.getValue(group, "hotcue_focus");
     if (lastHotcue !== 0) {
@@ -1197,7 +1197,7 @@ PioneerDDJSX2.Play = function(channel, control, value, status, group) {
 
 // Deck Select Buttons (7-10 on the controller)
 // Directly assigns the active deck per physical side when pressed.
-PioneerDDJSX2.DeckToggle = function(channel, control, value, status, group) {
+PioneerDDJSX2.DeckToggle = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         if (channel === 0 || channel === 2) {
             PioneerDDJSX2.activeDeck.A = channel + 1; // 0+1=ch1, 2+1=ch3
@@ -1207,7 +1207,7 @@ PioneerDDJSX2.DeckToggle = function(channel, control, value, status, group) {
     }
 };
 
-PioneerDDJSX2.NeedleSearch = function(channel, control, value, status, group) {
+PioneerDDJSX2.NeedleSearch = function(_channel, control, value, _status, group) {
     // For isShifted, 3 = Not Shifting ; 28 = Shifting
     var isShifted = control;
     var isPlaying = engine.getValue(group, "play");
@@ -1228,7 +1228,7 @@ PioneerDDJSX2.NeedleSearch = function(channel, control, value, status, group) {
 // Sync Button (Long press logic)
 // Quick press : Enable beatsync for the current deck
 // Long press (>1000ms) : enable sync behaviour of syncing both left and right tracks
-PioneerDDJSX2.SyncEnable = function(channel, control, value, status, group) {
+PioneerDDJSX2.SyncEnable = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.SyncEnableTimer = engine.beginTimer(1000, function() {
             if (channel === 0 || channel === 2) {
@@ -1249,7 +1249,7 @@ PioneerDDJSX2.SyncEnable = function(channel, control, value, status, group) {
 };
 
 // Sync Disable (Shift + Sync)
-PioneerDDJSX2.SyncDisable = function(channel, control, value, status, group) {
+PioneerDDJSX2.SyncDisable = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         if (channel === 0 || channel === 2) {
             engine.setValue(`[Channel${  channel + 1  }]`, "sync_enabled", 0);
@@ -1262,7 +1262,7 @@ PioneerDDJSX2.SyncDisable = function(channel, control, value, status, group) {
 };
 
 // Slip Button
-PioneerDDJSX2.SlipEnabled = function(channel, control, value, status, group) {
+PioneerDDJSX2.SlipEnabled = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         if (engine.getValue(`[Channel${  channel + 1  }]`, "play")) {
 
@@ -1274,17 +1274,17 @@ PioneerDDJSX2.SlipEnabled = function(channel, control, value, status, group) {
 };
 
 // Crossfader Curve Adjust (Front panel knob)
-PioneerDDJSX2.CrossfaderCurve = function(value, group, control) {
+PioneerDDJSX2.CrossfaderCurve = function(_value, _group, control) {
     engine.setValue("[Mixer Profile]", "xFaderCurve", control / 16);
 };
 
 // Input Select Switches (Front panel)
-PioneerDDJSX2.InputSelect = function(channel, control, value, status, group) {
+PioneerDDJSX2.InputSelect = function(channel, _control, value, _status, _group) {
     engine.setValue(`[Channel${  channel + 1  }]`, "mute", value ? 1 : 0);
 };
 
 // Loop In Button
-PioneerDDJSX2.LoopIn = function(channel, control, value, status, group) {
+PioneerDDJSX2.LoopIn = function(channel, _control, value, _status, _group) {
     engine.setValue(`[Channel${  channel + 1  }]`, "loop_in", value ? 1 : 0);
     if (value === 0x7F) {
         PioneerDDJSX2.closestBeatToLoopIn[channel] = engine.getValue(`[Channel${  channel + 1  }]`, "beat_closest");
@@ -1294,7 +1294,7 @@ PioneerDDJSX2.LoopIn = function(channel, control, value, status, group) {
 // 4 Beat Loop Button (Above Loop IN)
 // I think this feature could be enhanced, it is a bit finicky I think...
 // Needs ideas
-PioneerDDJSX2.FourBeat = function(channel, control, value, status, group) {
+PioneerDDJSX2.FourBeat = function(channel, _control, value, _status, group) {
     if (value === 0x7F) {
         var loop_enable = engine.getValue(channel, "loop_enabled");
 
@@ -1310,7 +1310,7 @@ PioneerDDJSX2.FourBeat = function(channel, control, value, status, group) {
 
 // Handle the Reloop/Exit Loop button
 // This toggles the Loop Anchor state
-PioneerDDJSX2.ReloopExit = function(channel, control, value, status, group) {
+PioneerDDJSX2.ReloopExit = function(_channel, _control, value, _status, group) {
     if (value === 0x7F) {
         script.toggleControl(group, "loop_anchor");
         var isAnchor = engine.getValue(group, "loop_anchor");
@@ -1319,7 +1319,7 @@ PioneerDDJSX2.ReloopExit = function(channel, control, value, status, group) {
 
 
 // Slip Mode Logic
-PioneerDDJSX2.SlipMode = function(channel, control, value, status, group) {
+PioneerDDJSX2.SlipMode = function(channel, control, _value, _status, _group) {
     if (engine.getValue(control, "play")) {
         midi.sendShortMsg(0x90 + channel, 0x40, channel ? 0x7F : 0x00);
     }
@@ -1344,7 +1344,7 @@ PioneerDDJSX2.Shift = function(channel, _control, value, _status, _group) {
 };
 
 // Reverse Button (Toggle)
-PioneerDDJSX2.Reverse = function(channel, control, value, status, group) {
+PioneerDDJSX2.Reverse = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.reverse[channel] = !PioneerDDJSX2.reverse[channel];
         engine.setValue(`[Channel${  channel + 1  }]`, "reverse", PioneerDDJSX2.reverse[channel]);
@@ -1352,7 +1352,7 @@ PioneerDDJSX2.Reverse = function(channel, control, value, status, group) {
 };
 
 // Reverse Button (Hold - Censor)
-PioneerDDJSX2.ReverseHold = function(channel, control, value, status, group) {
+PioneerDDJSX2.ReverseHold = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.reverse[channel] = 1;
         engine.setValue(`[Channel${  channel + 1  }]`, "reverse", PioneerDDJSX2.reverse[channel]);
@@ -1363,7 +1363,7 @@ PioneerDDJSX2.ReverseHold = function(channel, control, value, status, group) {
 };
 
 // Auto Loop Button
-PioneerDDJSX2.AutoLoop = function(channel, control, value, status, group) {
+PioneerDDJSX2.AutoLoop = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         if (engine.getValue(`[Channel${  channel + 1  }]`, "loop_enabled")) {
             engine.setValue(`[Channel${  channel + 1  }]`, "reloop_toggle", 1);
@@ -1378,8 +1378,8 @@ PioneerDDJSX2.AutoLoop = function(channel, control, value, status, group) {
 // We cache the MSB and wait for the LSB to apply the full value.
 
 // Tempo/Rate Slider (14-bit)
-PioneerDDJSX2.RateSlider = function(channel, control, value, status, group) {
-    var deckGroup = `[Channel${  channel + 1  }]`;
+PioneerDDJSX2.RateSlider = function(channel, control, value, _status, _group) {
+    const deckGroup = `[Channel${  channel + 1  }]`;
     var storage = PioneerDDJSX2.midi14bit.tempo;
     if (control === 0x00) {
         storage[channel] = value;
@@ -1413,8 +1413,8 @@ PioneerDDJSX2.RateSlider = function(channel, control, value, status, group) {
 };
 
 // Channel Volume Faders (14-bit)
-PioneerDDJSX2.VolumeSlider = function(channel, control, value, status, group) {
-    var deckGroup = `[Channel${  channel + 1  }]`;
+PioneerDDJSX2.VolumeSlider = function(channel, control, value, _status, _group) {
+    const deckGroup = `[Channel${  channel + 1  }]`;
     var storage = PioneerDDJSX2.midi14bit.volume;
     if (control === 0x13) {
         storage[channel] = value;
@@ -1690,7 +1690,7 @@ PioneerDDJSX2.handleFilterKill = function(channel, newParamValue) {
 // =============================================================================
 
 // Handle Beats Knob (Turning) - Adjusts Wet/Dry Mix
-PioneerDDJSX2.EffectJog = function(value, group, control) {
+PioneerDDJSX2.EffectJog = function(value, _group, control) {
     if (control > 63) {
         engine.setValue(`[EffectRack1_EffectUnit${  value - 3  }]`, "mix", engine.getValue(`[EffectRack1_EffectUnit${  value - 3  }]`, "mix") - 0.0625 * (128 - control));
     } else {
@@ -1699,7 +1699,7 @@ PioneerDDJSX2.EffectJog = function(value, group, control) {
 };
 
 // Beats Button Press (Cycles selected effect focus)
-PioneerDDJSX2.BeatsPressFX = function(channel, control, value, status, group) {
+PioneerDDJSX2.BeatsPressFX = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.currentEffect[channel - 4]++;
         if (PioneerDDJSX2.currentEffect[channel - 4] > 3) {
@@ -1710,7 +1710,7 @@ PioneerDDJSX2.BeatsPressFX = function(channel, control, value, status, group) {
 };
 
 // Shift + Beats Button Press (Cycles parameters)
-PioneerDDJSX2.ShiftBeatsPressFX = function(channel, control, value, status, group) {
+PioneerDDJSX2.ShiftBeatsPressFX = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         // ID Effect is the ID of the currently focus effect control
         //  (3 = main effects knobs)
@@ -1764,7 +1764,7 @@ PioneerDDJSX2.EffectKnob = function(value, group, control) {
 };
 
 // Enable/Disable specific effect
-PioneerDDJSX2.EffectButton = function(channel, control, value, status, group) {
+PioneerDDJSX2.EffectButton = function(channel, control, value, _status, _group) {
     if (value === 0x7F) {
         if (PioneerDDJSX2.currentEffect[channel - 4] === 3) {
             engine.setValue(`[EffectRack1_EffectUnit${  channel - 3  }_Effect${  control - 70  }]`, "enabled", !engine.getValue(`[EffectRack1_EffectUnit${  channel - 3  }_Effect${  control - 70  }]`, "enabled"));
@@ -1773,7 +1773,7 @@ PioneerDDJSX2.EffectButton = function(channel, control, value, status, group) {
 };
 
 // Tap Button (Mix Mode Toggle)
-PioneerDDJSX2.EffectTap = function(channel, control, value, status, group) {
+PioneerDDJSX2.EffectTap = function(channel, _control, value, _status, _group) {
     if (value === 0x7F && PioneerDDJSX2.currentEffect[channel - 4] === 3) {
         engine.setValue(`[EffectRack1_EffectUnit${  channel - 3  }]`, "mix_mode", !engine.getValue(`[EffectRack1_EffectUnit${  channel - 3  }]`, "mix_mode"));
         PioneerDDJSX2.FXLeds();
@@ -1785,7 +1785,7 @@ PioneerDDJSX2.EffectTap = function(channel, control, value, status, group) {
 // =============================================================================
 
 // Cycle through Mixxx Panel layouts (FX Rack, Samplers)
-PioneerDDJSX2.PanelSelect = function(channel, control, value, status, group) {
+PioneerDDJSX2.PanelSelect = function(_channel, control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.curPanel += ((1 - (control - 120)) * 2) - 1;
         if (PioneerDDJSX2.curPanel < 0) {
@@ -1800,7 +1800,7 @@ PioneerDDJSX2.PanelSelect = function(channel, control, value, status, group) {
 };
 
 // Cycle through views (2 deck / 4 deck / maximized library)
-PioneerDDJSX2.ViewButton = function(channel, control, value, status, group) {
+PioneerDDJSX2.ViewButton = function(_channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.curView++;
         if (PioneerDDJSX2.curView > 7) {
@@ -1812,19 +1812,19 @@ PioneerDDJSX2.ViewButton = function(channel, control, value, status, group) {
 };
 
 // Enable Grid Slide Mode (used with Jog Wheel)
-PioneerDDJSX2.SetGridSlide = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetGridSlide = function(channel, _control, value, _status, _group) {
     PioneerDDJSX2.gridSlide[channel] = value ? 1 : 0;
     midi.sendShortMsg(0x90 + channel, 0x0a, value ? 0x7F : 0x00);
 };
 
 // Enable Grid Adjust Mode (used with Jog Wheel)
-PioneerDDJSX2.SetGridAdjust = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetGridAdjust = function(channel, _control, value, _status, _group) {
     PioneerDDJSX2.gridAdjust[channel] = value ? 1 : 0;
     midi.sendShortMsg(0x90 + channel, 0x79, value ? 0x7F : 0x00);
 };
 
 // Clear Grid Adjustment
-PioneerDDJSX2.ClearGrid = function(channel, control, value, status, group) {
+PioneerDDJSX2.ClearGrid = function(channel, _control, value, _status, _group) {
     engine.setValue(`[Channel${  channel + 1  }]`, "beats_undo_adjustment", 1);
     midi.sendShortMsg(0x90 + channel, 0x79, value ? 0x7F : 0x00);
 };
@@ -1834,8 +1834,8 @@ PioneerDDJSX2.ClearGrid = function(channel, control, value, status, group) {
 // =============================================================================
 
 // Plays sampler or Loads selected track if empty
-PioneerDDJSX2.SamplerPlay = function(channel, control, value, status, group) {
-    var sampler = `[Sampler${  1 + (control & 7) + (PioneerDDJSX2.samplerBank[channel - 7] * 8)  }]`;
+PioneerDDJSX2.SamplerPlay = function(channel, control, value, _status, _group) {
+    const sampler = `[Sampler${  1 + (control & 7) + (PioneerDDJSX2.samplerBank[channel - 7] * 8)  }]`;
     if (value === 0x7F) {
         if (engine.getValue(sampler, "track_loaded")) {
             engine.setParameter(sampler, "start_play", value & 1);
@@ -1846,8 +1846,8 @@ PioneerDDJSX2.SamplerPlay = function(channel, control, value, status, group) {
 };
 
 // Stops sampler (Short press) or Ejects (Long press)
-PioneerDDJSX2.SamplerStop = function(channel, control, value, status, group) {
-    var sampler = `[Sampler${  1 + (control & 7) + (PioneerDDJSX2.samplerBank[channel - 7] * 8)  }]`;
+PioneerDDJSX2.SamplerStop = function(channel, control, value, _status, _group) {
+    const sampler = `[Sampler${  1 + (control & 7) + (PioneerDDJSX2.samplerBank[channel - 7] * 8)  }]`;
     var isPlaying = engine.getValue(sampler, "play");
     var trackLoaded = engine.getValue(sampler, "track_loaded");
 
@@ -1861,8 +1861,8 @@ PioneerDDJSX2.SamplerStop = function(channel, control, value, status, group) {
 };
 
 // Updates Sampler LEDs based on state (Loaded/Playing)
-PioneerDDJSX2.SamplerLight = function(value, group, control) {
-    var sampler = PioneerDDJSX2.groups.samplerGroups[group];
+PioneerDDJSX2.SamplerLight = function(value, group, _control) {
+    const sampler = PioneerDDJSX2.groups.samplerGroups[group];
     if (sampler === undefined) {
         return;
     }
@@ -1903,7 +1903,7 @@ PioneerDDJSX2.SetSampleGain = function(group, control, value) {
 };
 
 // Master Sampler Volume Knob
-PioneerDDJSX2.SetSamplerVol = function(value, group, control) {
+PioneerDDJSX2.SetSamplerVol = function(_value, _group, control) {
     PioneerDDJSX2.samplerVolume = control / 0x7F;
     var num = engine.getValue("[App]", "num_samplers");
     for (var i = 0; i < num; i++) {
@@ -1934,7 +1934,7 @@ PioneerDDJSX2.RepaintSampler = function(channel) {
     }
 };
 // Cycle Tempo Ranges
-PioneerDDJSX2.SetTempoRange = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetTempoRange = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.tempoRange[channel]++;
         if (PioneerDDJSX2.tempoRange[channel] > 3) {
@@ -1945,7 +1945,7 @@ PioneerDDJSX2.SetTempoRange = function(channel, control, value, status, group) {
 };
 
 // Previous Sampler Bank
-PioneerDDJSX2.SamplerParam1L = function(channel, control, value, status, group) {
+PioneerDDJSX2.SamplerParam1L = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.samplerBank[channel]--;
         if (PioneerDDJSX2.samplerBank[channel] < 0) {
@@ -1957,7 +1957,7 @@ PioneerDDJSX2.SamplerParam1L = function(channel, control, value, status, group) 
 };
 
 // Next Sampler Bank
-PioneerDDJSX2.SamplerParam1R = function(channel, control, value, status, group) {
+PioneerDDJSX2.SamplerParam1R = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.samplerBank[channel]++;
         if (PioneerDDJSX2.samplerBank[channel] > 7) {
@@ -1970,7 +1970,7 @@ PioneerDDJSX2.SamplerParam1R = function(channel, control, value, status, group) 
 };
 
 // Decrease Roll Size with Parameter 1
-PioneerDDJSX2.RollParam1L = function(channel, control, value, status, group) {
+PioneerDDJSX2.RollParam1L = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.rollPrec[channel]--;
         if (PioneerDDJSX2.rollPrec[channel] < 0) {
@@ -1981,7 +1981,7 @@ PioneerDDJSX2.RollParam1L = function(channel, control, value, status, group) {
 };
 
 // Increase Roll Size with Parameter 1
-PioneerDDJSX2.RollParam1R = function(channel, control, value, status, group) {
+PioneerDDJSX2.RollParam1R = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.rollPrec[channel]++;
         if (PioneerDDJSX2.rollPrec[channel] > 4) {
@@ -1992,7 +1992,7 @@ PioneerDDJSX2.RollParam1R = function(channel, control, value, status, group) {
 };
 
 // Decrease Slicer Precision with Parameter 1
-PioneerDDJSX2.SlicerParam1L = function(channel, control, value, status, group) {
+PioneerDDJSX2.SlicerParam1L = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.beatjumpPrec[channel]--;
         if (PioneerDDJSX2.beatjumpPrec[channel] < 0) {
@@ -2003,7 +2003,7 @@ PioneerDDJSX2.SlicerParam1L = function(channel, control, value, status, group) {
 };
 
 // Increase Slicer Precision with Parameter 1
-PioneerDDJSX2.SlicerParam1R = function(channel, control, value, status, group) {
+PioneerDDJSX2.SlicerParam1R = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.beatjumpPrec[channel]++;
         if (PioneerDDJSX2.beatjumpPrec[channel] > 8) {
@@ -2015,22 +2015,22 @@ PioneerDDJSX2.SlicerParam1R = function(channel, control, value, status, group) {
 
 // Parameter 1 for HOT CUE (Right)
 // Not Used
-PioneerDDJSX2.CueParam1R = function(channel, control, value, status, group) {
+PioneerDDJSX2.CueParam1R = function(_channel, _control, _value, _status, _group) {
 };
 
 // Parameter 1 for HOT CUE (Left)
 // Not Used
-PioneerDDJSX2.CueParam1L = function(channel, control, value, status, group) {
+PioneerDDJSX2.CueParam1L = function(_channel, _control, _value, _status, _group) {
 };
 
 // Parameter 1 for HOT CUE LOOPS (Left)
 // Not Used
-PioneerDDJSX2.CueLoopParam1R = function(channel, control, value, status, group) {
+PioneerDDJSX2.CueLoopParam1R = function(_channel, _control, _value, _status, _group) {
 };
 
 // Parameter 1 for HOT CUE LOOPS (Left)
 // Not Used
-PioneerDDJSX2.CueLoopParam1L = function(channel, control, value, status, group) {
+PioneerDDJSX2.CueLoopParam1L = function(_channel, _control, _value, _status, _group) {
 };
 
 // =============================================================================
@@ -2038,7 +2038,7 @@ PioneerDDJSX2.CueLoopParam1L = function(channel, control, value, status, group) 
 // =============================================================================
 
 // Enable HotCue Mode
-PioneerDDJSX2.SetHotCueMode = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetHotCueMode = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.padMode[channel] = 0;
         midi.sendShortMsg(0x90 + channel, 0x1B, 0x7F);
@@ -2046,7 +2046,7 @@ PioneerDDJSX2.SetHotCueMode = function(channel, control, value, status, group) {
 };
 
 // Enable Roll Mode
-PioneerDDJSX2.SetRollMode = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetRollMode = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.padMode[channel] = 1;
         midi.sendShortMsg(0x90 + channel, 0x1E, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[channel]]);
@@ -2054,7 +2054,7 @@ PioneerDDJSX2.SetRollMode = function(channel, control, value, status, group) {
 };
 
 // Enable Slicer Mode
-PioneerDDJSX2.SetSlicerMode = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetSlicerMode = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.padMode[channel] = 2;
         midi.sendShortMsg(0x90 + channel, 0x20, 0x7F);
@@ -2062,7 +2062,7 @@ PioneerDDJSX2.SetSlicerMode = function(channel, control, value, status, group) {
 };
 
 // Enable Sampler Mode
-PioneerDDJSX2.SetSamplerMode = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetSamplerMode = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.padMode[channel] = 3;
         PioneerDDJSX2.RepaintSampler(channel);
@@ -2071,7 +2071,7 @@ PioneerDDJSX2.SetSamplerMode = function(channel, control, value, status, group) 
 };
 
 // Enable Cue Loop Mode
-PioneerDDJSX2.SetCueLoopMode = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetCueLoopMode = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.padMode[channel] = 4;
         midi.sendShortMsg(0x90 + channel, 0x69, 0x7F);
@@ -2079,7 +2079,7 @@ PioneerDDJSX2.SetCueLoopMode = function(channel, control, value, status, group) 
 };
 
 // Enable Saved Loop Mode
-PioneerDDJSX2.SetSavedLoopMode = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetSavedLoopMode = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.padMode[channel] = 5;
         midi.sendShortMsg(0x90 + channel, 0x6b, 0x7F);
@@ -2087,7 +2087,7 @@ PioneerDDJSX2.SetSavedLoopMode = function(channel, control, value, status, group
 };
 
 // Enable Slicer Loop Mode
-PioneerDDJSX2.SetSlicerLoopMode = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetSlicerLoopMode = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.padMode[channel] = 6;
         midi.sendShortMsg(0x90 + channel, 0x6d, 0x7F);
@@ -2095,7 +2095,7 @@ PioneerDDJSX2.SetSlicerLoopMode = function(channel, control, value, status, grou
 };
 
 // Enable Velocity Sampler Mode
-PioneerDDJSX2.SetVelocitySamplerMode = function(channel, control, value, status, group) {
+PioneerDDJSX2.SetVelocitySamplerMode = function(channel, _control, value, _status, _group) {
     if (value === 0x7F) {
         PioneerDDJSX2.padMode[channel] = 7;
         PioneerDDJSX2.RepaintSampler(channel);
@@ -2104,8 +2104,8 @@ PioneerDDJSX2.SetVelocitySamplerMode = function(channel, control, value, status,
 };
 
 // Logic for Saved Loop Pads
-PioneerDDJSX2.SavedLoop = function(channel, control, value, status, group) {
-    var deck = channel - 6;
+PioneerDDJSX2.SavedLoop = function(channel, control, value, _status, group) {
+    const deck = channel - 6;
 
     var interval = PioneerDDJSX2.settings.loopIntervals[control - 0x50 + 4];
     var isAutoLoopEnabled = engine.getValue(group, `beatloop_${  interval  }_enabled`);
@@ -2127,8 +2127,8 @@ PioneerDDJSX2.SavedLoop = function(channel, control, value, status, group) {
 
 // Logic for Beat Jump Pads
 // TODO(XXX) : BeatJump is mapped to Slicer, create a real Slicer or wait for Mixxx to implement one.
-PioneerDDJSX2.BeatJump = function(channel, control, value, status, group) {
-    var deck = channel - 7;
+PioneerDDJSX2.BeatJump = function(channel, control, value, _status, group) {
+    const deck = channel - 7;
 
     const which = (control & 3) + PioneerDDJSX2.beatjumpPrec[deck];
 
@@ -2144,8 +2144,8 @@ PioneerDDJSX2.BeatJump = function(channel, control, value, status, group) {
 };
 
 // Logic for Roll Pads
-PioneerDDJSX2.RollPerformancePad = function(channel, control, value, status, group) {
-    var deck = channel - 6;
+PioneerDDJSX2.RollPerformancePad = function(channel, control, value, _status, group) {
+    const deck = channel - 6;
 
     var interval = PioneerDDJSX2.settings.loopIntervals[control - 0x10 + PioneerDDJSX2.rollPrec[channel - 7]];
 
@@ -2226,7 +2226,7 @@ PioneerDDJSX2.SortLibrary = function(_channel, control, value, _status, _group) 
 // If the rotary was turned while LOAD was held, the track load is suppressed on release.
 
 // Base MIDI control number for the Load buttons (decks 1-4)
-PioneerDDJSX2.LoadSelectedTrack = function(_channel, control, value, _status, group) {
+PioneerDDJSX2.LoadSelectedTrack = function(_channel, _control, value, _status, group) {
     const channel = script.deckFromGroup(group) - 1;
     if (value === 0x7F) {
         // Press — arm hold state only, do NOT load yet
@@ -2251,7 +2251,7 @@ PioneerDDJSX2.LoadSelectedTrack = function(_channel, control, value, _status, gr
 
 // Back Button - returns focus to Library sidebar
 // Uses MoveFocus to move back through: tracks -> searchbox -> sidebar
-PioneerDDJSX2.BackButton = function(channel, control, value, status) {
+PioneerDDJSX2.BackButton = function(_channel, _control, value, _status) {
     if (value === 0x7F) {
         engine.setValue("[Library]", "MoveFocus", -1);
     }
@@ -2260,7 +2260,7 @@ PioneerDDJSX2.BackButton = function(channel, control, value, status) {
 // Rotary Click - Context-aware action based on focused widget
 // - In sidebar (focused_widget=0): Uses ToggleSelectedSidebarItem to expand/collapse or jump to tracks
 // - In tracks/searchbox/dialogs: Uses GoToItem to load track or confirm action
-PioneerDDJSX2.RotarySelectorClick = function(channel, control, value, status) {
+PioneerDDJSX2.RotarySelectorClick = function(_channel, _control, value, _status) {
     if (value === 0x7F) {
         var focusedWidget = engine.getValue("[Library]", "focused_widget");
 
@@ -2276,7 +2276,7 @@ PioneerDDJSX2.RotarySelectorClick = function(channel, control, value, status) {
 
 // Shift + Rotary Click - Loads selected track to preview deck
 // Always uses GoToItem regardless of focused widget
-PioneerDDJSX2.rotarySelectorShiftedClick = function(channel, control, value) {
+PioneerDDJSX2.rotarySelectorShiftedClick = function(_channel, _control, value) {
     if (value === 0x7F) {
         engine.setValue("[Library]", "GoToItem", 1);
     }
@@ -2296,7 +2296,7 @@ PioneerDDJSX2.rotarySelectorShiftedClick = function(channel, control, value) {
 // which can be the wrong target when more than 2 decks are active simultaneously.
 // Instead, this finds whichever channel is currently playing on the opposite physical side (A: ch1/3, B: ch2/4)
 // and manually matches the key offset to that specific deck, replicating and bypassing sync_key entirely.
-PioneerDDJSX2.FlipSlot = function(channel, control, value, status, group) {
+PioneerDDJSX2.FlipSlot = function(_channel, _control, value, _status, group) {
     if (value === 0x7F && engine.getValue(group, "track_loaded")) {
         if (PioneerDDJSX2.settings.KeySyncBehaviour === true) {
             const deckNum = script.deckFromGroup(group);
@@ -2349,7 +2349,7 @@ PioneerDDJSX2.FlipSlot = function(channel, control, value, status, group) {
 };
 
 // Flip Save (SHIFT + Slot) Button, Reset key to original
-PioneerDDJSX2.FlipSave = function(channel, control, value, status, group) {
+PioneerDDJSX2.FlipSave = function(_channel, _control, value, _status, group) {
     if (engine.getValue(group, "track_loaded")) {
         if (value === 0x7F) {
             engine.setValue(group, "pitch_adjust_set_zero", 1);
@@ -2358,7 +2358,7 @@ PioneerDDJSX2.FlipSave = function(channel, control, value, status, group) {
 };
 
 // Flip Rec Button, Set the pitch of the track down
-PioneerDDJSX2.FlipRec = function(channel, control, value, status, group) {
+PioneerDDJSX2.FlipRec = function(_channel, _control, value, _status, group) {
     if (engine.getValue(group, "track_loaded")) {
         if (value === 0x7F) {
             engine.setValue(group, "pitch_down", 1);
@@ -2367,7 +2367,7 @@ PioneerDDJSX2.FlipRec = function(channel, control, value, status, group) {
 };
 
 // Flip Save (SHIFT + Rec) Button, repeat setting for the current track
-PioneerDDJSX2.FlipLoop = function(channel, control, value, status, group) {
+PioneerDDJSX2.FlipLoop = function(_channel, _control, value, _status, group) {
     if (value === 0x7F) {
         script.toggleControl(group, "repeat");
         var isRepeat = engine.getValue(group, "repeat");
@@ -2375,7 +2375,7 @@ PioneerDDJSX2.FlipLoop = function(channel, control, value, status, group) {
 };
 
 // Flip Start Button, Set the pitch of the track up
-PioneerDDJSX2.FlipStart = function(channel, control, value, status, group) {
+PioneerDDJSX2.FlipStart = function(_channel, _control, value, _status, group) {
     if (engine.getValue(group, "track_loaded")) {
         if (value === 0x7F) {
             engine.setValue(group, "pitch_up", 1);
@@ -2384,5 +2384,5 @@ PioneerDDJSX2.FlipStart = function(channel, control, value, status, group) {
 };
 
 // Flip On/Off Button
-PioneerDDJSX2.FlipOnOff = function(channel, control, value, status, group) {
+PioneerDDJSX2.FlipOnOff = function(_channel, _control, _value, _status, _group) {
 };

--- a/res/controllers/PIONEER-DDJ-SX2.scripts.js
+++ b/res/controllers/PIONEER-DDJ-SX2.scripts.js
@@ -1,0 +1,1805 @@
+// Pioneer DDJ-SX2 mapping for Mixxx - WIP
+// Based on hrudham's mapping for the DDJ-SR
+// Modifications by tildearrow, Krafting, eXWoLL
+
+// Thanks to:
+// 		hrudham for making the DDJ-SR mapping
+// 		pioneer for making such an awesome controller
+//
+// =============================================================================
+// SCRIPT INDEX
+// =============================================================================
+// 1.  CONSTANTS, DEBUGGING & HELPERS ............ 
+// 2.  STATE VARIABLES & SETTINGS ................ 
+// 3.  INITIALIZATION & SHUTDOWN ................. 
+// 4.  TIMER & BLINKING .......................... 
+// 5.  CONNECTIONS (Signals) ..................... 
+// 6.  LIGHTING & FEEDBACK ........... 
+// 7.  JOGWHEEL & SCRATCHING ..................... 
+// 8.  MIXER & TRANSPORT (14-bit Support) ........ 
+// 9.  FX SECTION ................................ 
+// 10. VIEW, GRID, & PANELS ...................... 
+// 11. SAMPLER & PAD PARAMETERS .................. 
+// 12. PAD MODES ................................. 
+// 13. LIBRARY & BROWSER ......................... 
+// =============================================================================
+//
+// License: (MIT)
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+var PioneerDDJSX2 = {};
+
+// =============================================================================
+// 1. CONSTANTS, DEBUGGING & HELPERS
+// =============================================================================
+
+// SysEx constants for Controller Initialization & Keep Alive.
+// The SX2 requires a "Keep Alive" signal periodically to prevent it from 
+// falling back to a standby/demo state or locking the jog wheels.
+PioneerDDJSX2.keepAlive = [0xF0, 0x00, 0x20, 0x7f, 0x50, 0x01, 0xF7];
+PioneerDDJSX2.recallState = [0xF0, 0x00, 0x20, 0x7f, 0x03, 0x01, 0xF7];
+
+// Performance pad colors (Hex to MIDI value mapping)
+// Maps standard HTML-style Hex codes to the specific MIDI velocity values 
+// required by the Pioneer RGB pads.
+// 0: Off, 1-127: Various colors and brightness levels.
+
+// Performance pad colors
+// 0: off
+// 1: blue
+// 12: cyan
+// 22: green
+// 31: yellow
+// 41: red
+// 48: magenta
+// 62: blue
+// 63: black
+// 64: white (actually light blue)
+// 65-126: invalid
+// 127: current mode default
+
+PioneerDDJSX2.padColors = new ColorMapper({
+    0x0000FF: 1,
+    0x0010FF: 2,
+    0x0028FF: 3,
+    0x0040FF: 4,
+    0x0060FF: 5,
+    0x0080FF: 6,
+    0x00A0FF: 7,
+    0x00B0FF: 8,
+    0x00D0FF: 9,
+    0x00E0FF: 10,
+    0x00F0FF: 11,
+
+    0x00FFFF: 12,
+    0x00FFF0: 13,
+    0x00FFE0: 14,
+    0x00FFD0: 15,
+    0x00FFB0: 16,
+    0x00FF90: 17,
+    0x00FF70: 18,
+    0x00FF50: 19,
+    0x00FF30: 20,
+    0x00FF10: 21,
+
+    0x00FF00: 22,
+    0x10FF00: 23,
+    0x30FF00: 24,
+    0x40FF00: 25,
+    0x60FF00: 26,
+    0x80FF00: 27,
+    0xA0FF00: 28,
+    0xC0FF00: 29,
+    0xE0FF00: 30,
+
+    0xFFFF00: 31,
+    0xFFE000: 32,
+    0xFFC000: 33,
+    0xFFB000: 34,
+    0xFFA000: 35,
+    0xFF9000: 36,
+    0xFF7000: 37,
+    0xFF5000: 38,
+    0xFF3000: 39,
+    0xFF1000: 40,
+
+    0xFF0000: 41,
+    0xFF0020: 42,
+    0xFF0030: 43,
+    0xFF0060: 44,
+    0xFF0090: 45,
+    0xFF00A0: 46,
+    0xFF00E0: 47,
+
+    0xFF00FF: 48,
+    0xF000FF: 49,
+    0xE000FF: 50,
+    0xD000FF: 51,
+    0xC000FF: 52,
+    0xB000FF: 53,
+    0xA000FF: 54,
+    0x9000FF: 55,
+    0x8000FF: 56,
+    0x6000FF: 57,
+    0x5000FF: 58,
+    0x4000FF: 59,
+    0x3000FF: 60,
+    0x2000FF: 61,
+    0x1000FF: 62,
+
+    0x000000: 63,
+    0xF0FFFF: 64,
+});
+
+
+// =============================================================================
+// 2. STATE VARIABLES & SETTINGS
+// =============================================================================
+
+// Timers and System State
+PioneerDDJSX2.lightsTimer = 0; // Reference to the Keep-Alive/Blink timer
+PioneerDDJSX2.SyncEnableTimer = null; // Timer for Sync vs BeatSync logic
+PioneerDDJSX2.conns = []; // Stores signal connections to unbind on shutdown
+PioneerDDJSX2.channels = {
+    0x00: {},
+    0x01: {},
+    0x02: {},
+    0x03: {}
+};
+
+// Deck & Pad State
+PioneerDDJSX2.shift = [0, 0, 0, 0]; // Shift button state per deck
+PioneerDDJSX2.reverse = [0, 0, 0, 0]; // Reverse playback state
+PioneerDDJSX2.vinylOn = [1, 1, 1, 1]; // Vinyl Mode enabled
+PioneerDDJSX2.padMode = [0, 0, 0, 0]; // Current Pad Mode (Hotcue, Roll, Slicer, etc.)
+// 0: 8% of max, 1: 16%, 2: 32%, 3: 64%
+PioneerDDJSX2.tempoRange = [0, 0, 0, 0];
+PioneerDDJSX2.closestBeatToLoopIn = [0, 0, 0, 0];
+PioneerDDJSX2.isBraking = 0; // Tracks if deck is currently in braking animation
+
+// Jogwheel & Grid State
+PioneerDDJSX2.gridSlide = [0, 0, 0, 0]; // Modifier state for Slide Grid
+PioneerDDJSX2.gridAdjust = [0, 0, 0, 0]; // Modifier state for Adjust Grid
+PioneerDDJSX2.TurnTablePos = [0, 0, 0, 0]; // Current virtual rotation position
+PioneerDDJSX2.FinalTurnPos = [-1, -1, -1, -1]; // Last sent LED position (deduplication)
+
+// LED Optimization State
+// Critical for SX2: Throttles MIDI messages to prevent bus saturation
+PioneerDDJSX2.lastLightUpdate = [0, 0, 0, 0];
+PioneerDDJSX2.currentBeat = [0, 0, 0, 0];
+PioneerDDJSX2.blinkState = 0; // Toggles every timer tick for blinking LEDs
+
+// View & Layout
+PioneerDDJSX2.curPanel = 0; // Tracks visible GUI panels
+PioneerDDJSX2.curView = 0; // Tracks visible waveform views
+
+// Pad Parameters
+PioneerDDJSX2.rollPrec = [2, 2, 2, 2]; // Precision for Roll loop sizes
+PioneerDDJSX2.beat = [0, 0, 0, 0]; // Current beat calculation for Slicer/LEDs
+PioneerDDJSX2.beatjumpPrec = [2, 2, 2, 2]; // Precision for Beatjump/Slicer
+
+// Sampler State
+PioneerDDJSX2.samplerVolume = 1.0;
+PioneerDDJSX2.sampleVolume = new Array(64).fill(0.9);
+PioneerDDJSX2.samplerBank = [0, 0, 0, 0]; // Offset for sampler banks (0=1-8, 1=9-16, etc)
+
+// Effects State
+PioneerDDJSX2.currentEffect = [3, 3]; // Selected FX unit
+PioneerDDJSX2.currentEffectparamset = [0, 0, 0, 0, 0, 0, 0, 0];
+PioneerDDJSX2.linkTypeTimer = 0;
+PioneerDDJSX2.linkType = [
+    [],
+    []
+];
+
+// 14-bit MIDI Cache
+// Stores the MSB (Most Significant Byte) to combine with LSB for high-res control
+PioneerDDJSX2.midi14bit = {
+    tempo: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0
+    },
+    volume: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0
+    },
+    eqHigh: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0
+    },
+    eqMid: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0
+    },
+    eqLow: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0
+    },
+    filter: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0
+    },
+    pregain: {
+        0: 0,
+        1: 0,
+        2: 0,
+        3: 0
+    }
+};
+
+// Settings (Pulled from Preferences or Defaults)
+PioneerDDJSX2.settings = {
+    alpha: 1.0 / 8,
+    beta: (1.0 / 8) / 32,
+    jogResolution: 2054, // Resolution per rotation for scratching
+    vinylSpeed: 33 + 1 / 3,
+    loopIntervals: ['0.03125', '0.0625', '0.125', '0.25', '0.5', '1', '2', '4', '8', '16', '32', '64'],
+    tempoRanges: [0.08, 0.16, 0.32, 0.64],
+    rollColors: [0x19, 0x20, 0x13, 0x0e, 0x05],
+    beatjumpColors: [0x3c, 0x3a, 0x38, 0x36, 0x34, 0x32, 0x30, 0x2e, 0x2c, 0x2a, 0x28],
+    cueLoopColors: [0x30, 0x35, 0x3a, 0x01, 0x05, 0x0a, 0x10, 0x15, 0x1a, 0x24, 0x27, 0x2a],
+    safeScratchTimeout: engine.getSetting('safeScratchTimeout'),
+    CenterRedLightsBehavior: engine.getSetting('CenterRedLightsBehavior'),
+    CenterWhiteLightsBehavior: engine.getSetting('CenterWhiteLightsBehavior'), // 0 for rotations, 1 for duration
+    DoNotTrickController: engine.getSetting('DoNotTrickController'),
+    SoftStartTime: engine.getSetting('SoftStartTime'),
+    BrakeTime: engine.getSetting('BrakeTime'),
+    UseShiftToBreak: engine.getSetting('UseShiftToBreak')
+};
+
+// Enums for efficient lookup
+PioneerDDJSX2.enums = {
+    rotarySelector: {
+        targets: {
+            libraries: 0,
+            tracklist: 1
+        }
+    },
+    channelGroups: {
+        '[Channel1]': 0x00,
+        '[Channel2]': 0x01,
+        '[Channel3]': 0x02,
+        '[Channel4]': 0x03
+    },
+    samplerGroups: {},
+    hotcueIndex: {}
+};
+
+// Populate Enums dynamically
+for (var i = 0; i < 64; i++) {
+    PioneerDDJSX2.enums.samplerGroups['[Sampler' + (i + 1) + ']'] = i;
+}
+for (var i = 1; i <= 24; i++) {
+    PioneerDDJSX2.enums.hotcueIndex['hotcue_' + i + '_status'] = i;
+}
+
+PioneerDDJSX2.status = {rotarySelector: {target: PioneerDDJSX2.enums.rotarySelector.targets.tracklist}};
+
+// =============================================================================
+// 3. INITIALIZATION & SHUTDOWN
+// =============================================================================
+
+// Called when the controller is detected or the script is reloaded.
+PioneerDDJSX2.init = function(id) {
+    PioneerDDJSX2.channels = {
+        0x00: {},
+        0x01: {},
+        0x02: {},
+        0x03: {}
+    };
+
+    // Startup Animation (Sends lights to the Master Level Meter)
+    midi.sendShortMsg(0x90, 0x0b, 0x10);
+    midi.sendShortMsg(0x91, 0x0b, 0x10);
+    midi.sendShortMsg(0x92, 0x0b, 0x10);
+    midi.sendShortMsg(0x93, 0x0b, 0x10);
+    midi.sendShortMsg(0x90, 0x1b, 0x7f);
+    midi.sendShortMsg(0x91, 0x1b, 0x7f);
+    midi.sendShortMsg(0x92, 0x1b, 0x7f);
+    midi.sendShortMsg(0x93, 0x1b, 0x7f);
+
+    // Bind Mixxx Controls to JS functions using engine.makeConnection
+    PioneerDDJSX2.BindControlConnections();
+
+    // Reset Hardware state (Quick Effects default to Filter)
+    engine.setValue("[QuickEffectRack1_[Channel1]_Effect1]", "parameter2", 4);
+    engine.setValue("[QuickEffectRack1_[Channel2]_Effect1]", "parameter2", 4);
+    engine.setValue("[QuickEffectRack1_[Channel3]_Effect1]", "parameter2", 4);
+    engine.setValue("[QuickEffectRack1_[Channel4]_Effect1]", "parameter2", 4);
+
+    // Turn off Deck Lights initially to ensure clean state
+    for (var i = 0; i < 8; i++) {
+        midi.sendShortMsg(0xbb, i, 0);
+    }
+
+    // Initialize Deck defaults (Vinyl mode on, Tempo range reset)
+    for (var i = 0; i < 4; i++) {
+        midi.sendShortMsg(0x90 + i, 0x0d, 0x7f);
+        engine.setValue("[Channel" + (i + 1) + "]", "rateRange", PioneerDDJSX2.settings.tempoRanges[PioneerDDJSX2.tempoRange[i]]);
+        PioneerDDJSX2.RepaintSampler(i);
+    }
+
+    PioneerDDJSX2.FXLeds();
+
+    // Restore Hotcues LED state from engine
+    for (var i = 1; i <= 4; i++) {
+        for (var j = 1; j <= 16; j++) {
+            PioneerDDJSX2.HotCuePerformancePadLed(engine.getValue("[Channel" + i + "]", "hotcue_" + j + "_status"), "[Channel" + i + "]", "hotcue_" + j + "_status");
+        }
+    }
+
+    // Enable Effects Units for all channels by default
+    engine.setValue("[EffectRack1_EffectUnit1]", "group_[Channel1]_enable", 1);
+    engine.setValue("[EffectRack1_EffectUnit1]", "group_[Channel3]_enable", 1);
+    engine.setValue("[EffectRack1_EffectUnit2]", "group_[Channel2]_enable", 1);
+    engine.setValue("[EffectRack1_EffectUnit2]", "group_[Channel4]_enable", 1);
+
+    // Start Blink/Keep-Alive Timer (250ms interval)
+    PioneerDDJSX2.lightsTimer = engine.beginTimer(250, PioneerDDJSX2.doTimer, 0);
+
+    // Send Serato Recall Sysex (Forces controller into correct mode)
+    midi.sendSysexMsg(PioneerDDJSX2.recallState, PioneerDDJSX2.recallState.length);
+
+    // Initialize 14-bit cache structures if undefined
+    if (typeof PioneerDDJSX2.midi14bit === 'undefined') {
+        PioneerDDJSX2.midi14bit = {};
+    }
+    if (typeof PioneerDDJSX2.midi14bit.pregain === 'undefined') {
+        PioneerDDJSX2.midi14bit.pregain = [0, 0, 0, 0]; // For 4 channels
+    }
+
+}
+
+// Called when the controller is disconnected or script is stopped.
+PioneerDDJSX2.shutdown = function() {
+    PioneerDDJSX2.UnbindControlConnections();
+    // Turn off lights
+    for (var i = 0; i < 8; i++) {
+        midi.sendShortMsg(0xbb, i, 0);
+    };
+    // Stop main timer
+    if (PioneerDDJSX2.lightsTimer) {
+        engine.stopTimer(PioneerDDJSX2.lightsTimer)
+    };
+};
+
+// =============================================================================
+// 4. TIMER & BLINKING
+// =============================================================================
+
+// Global timer function. Handles "Keep Alive" messages and LED blinking.
+PioneerDDJSX2.doTimer = function() {
+    // Send Keep Alive Sysex to prevent controller sleep/demo mode
+    if (!PioneerDDJSX2.settings.DoNotTrickController) {
+        midi.sendSysexMsg(PioneerDDJSX2.keepAlive, PioneerDDJSX2.keepAlive.length);
+    }
+
+    // Handle blinking LEDs (Slip Mode and Reverse)
+    for (var i = 0; i < 4; i++) {
+        // Slip Blink
+        if (engine.getValue("[Channel" + (i + 1) + "]", "slip_enabled")) {
+            midi.sendShortMsg(0x90 + i, 0x40, PioneerDDJSX2.blinkState ? 0x7F : 0x00);
+        } else {
+            midi.sendShortMsg(0x90 + i, 0x40, 0x00);
+        }
+
+        // Reverse Blink
+        if (PioneerDDJSX2.reverse[i]) {
+            midi.sendShortMsg(0x90 + i, 0x38, PioneerDDJSX2.blinkState ? 0x7f : 0x00);
+        } else {
+            midi.sendShortMsg(0x90 + i, 0x38, 0x00);
+        }
+    }
+    // Toggle blink state for next tick
+    PioneerDDJSX2.blinkState = !PioneerDDJSX2.blinkState;
+}
+
+// =============================================================================
+// 5. CONNECTIONS (Signals)
+// =============================================================================
+
+// Binds Mixxx Engine signals (e.g., 'play', 'vu_meter') to script functions.
+// This allows the controller LEDs to react to changes in the software UI.
+PioneerDDJSX2.BindControlConnections = function() {
+    for (var i = 1; i <= 4; i++) {
+        var group = '[Channel' + i + ']';
+
+        // CRITICAL: JOGWHEEL & SLICER FEEDBACK
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'playposition', PioneerDDJSX2.deckLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'beat_next', PioneerDDJSX2.SlicerLights));
+        // PioneerDDJSX2.conns.push(engine.makeConnection(group, 'beat_distance', PioneerDDJSX2.SlicerLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'beat_active', PioneerDDJSX2.UpdateCenterBeatLights));
+
+        // NEW: Reset beat counter when playposition changes (needle drop, hotcue jumps)
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'playposition', PioneerDDJSX2.ResetBeatCounter));
+
+        // STANDARD INDICATORS
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'vu_meter', PioneerDDJSX2.VuMeter));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'play_indicator', PioneerDDJSX2.PlayLeds));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'sync_enabled', PioneerDDJSX2.SyncLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'cue_indicator', PioneerDDJSX2.CueLeds));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'pfl', PioneerDDJSX2.HeadphoneCueLed));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'keylock', PioneerDDJSX2.KeyLockLeds));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_double', PioneerDDJSX2.LoopDouble));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_halve', PioneerDDJSX2.LoopHalve));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'rate', PioneerDDJSX2.RateLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'eject', PioneerDDJSX2.UnloadLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_enabled', PioneerDDJSX2.ReloopExit));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_in', PioneerDDJSX2.ReloopExit));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_out', PioneerDDJSX2.ReloopExit));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'track_samples', PioneerDDJSX2.LoadActions));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'pitch_adjust', PioneerDDJSX2.PitchAdjust));
+
+        // HOTCUES (Status and Color)
+        for (var j = 1; j <= 16; j++) {
+            PioneerDDJSX2.conns.push(engine.makeConnection(group, 'hotcue_' + j + '_status', PioneerDDJSX2.HotCuePerformancePadLed));
+            PioneerDDJSX2.conns.push(engine.makeConnection(group, 'hotcue_' + j + '_color', PioneerDDJSX2.HotCuePerformancePadLed));
+        }
+    }
+
+    // FX Connections (Enable/Disable LEDs)
+    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel1]_enable', PioneerDDJSX2.FX1CH1));
+    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel1]_enable', PioneerDDJSX2.FX2CH1));
+    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel2]_enable', PioneerDDJSX2.FX1CH2));
+    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel2]_enable', PioneerDDJSX2.FX2CH2));
+    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel3]_enable', PioneerDDJSX2.FX1CH3));
+    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel3]_enable', PioneerDDJSX2.FX2CH3));
+    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel4]_enable', PioneerDDJSX2.FX1CH4));
+    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel4]_enable', PioneerDDJSX2.FX2CH4));
+
+    // Effect Leds
+    for (var i = 1; i <= 3; i++) {
+        PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1_Effect' + i + ']', 'enabled', PioneerDDJSX2.FXLeds));
+        PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2_Effect' + i + ']', 'enabled', PioneerDDJSX2.FXLeds));
+    }
+
+    // Sampler Connections (Play/Load state)
+    var numSamplers = engine.getValue('[App]', 'num_samplers');
+    for (var i = 1; i <= numSamplers; i++) {
+        PioneerDDJSX2.conns.push(engine.makeConnection('[Sampler' + i + ']', 'play', PioneerDDJSX2.SamplerLight));
+        PioneerDDJSX2.conns.push(engine.makeConnection('[Sampler' + i + ']', 'track_loaded', PioneerDDJSX2.SamplerLight));
+    }
+};
+
+// Unbinds all connections. Used during Shutdown.
+PioneerDDJSX2.UnbindControlConnections = function() {
+    for (var i = 0; i < PioneerDDJSX2.conns.length; i++) {
+        if (PioneerDDJSX2.conns[i]) {
+            PioneerDDJSX2.conns[i].disconnect();
+        }
+    }
+    PioneerDDJSX2.conns = [];
+};
+
+// =============================================================================
+// 6. LIGHTING & FEEDBACK
+// =============================================================================
+// This calculates the rotating LED ring on the jog wheel.
+// INCLUDES THROTTLING: The SX2 can freeze if too many MIDI messages are sent
+// rapidly to the jog rings. This function limits updates to ~30ms.
+
+// 1. Handles WHITE outer ring ONLY
+PioneerDDJSX2.deckLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+
+    // THROTTLE: Limit update rate to ~30ms to prevent controller freeze
+    var now = Date.now();
+    if (now - PioneerDDJSX2.lastLightUpdate[channel] < 30) {
+        return;
+    }
+    PioneerDDJSX2.lastLightUpdate[channel] = now;
+
+    var trackSamples = engine.getValue(group, "track_samples");
+    var trackRate = engine.getValue(group, "track_samplerate");
+
+    if (!trackSamples || !trackRate) {
+        return;
+    }
+
+    // Calculate rotation position for WHITE outer ring
+    PioneerDDJSX2.TurnTablePos[channel] = (engine.getValue(group, "playposition") * (trackSamples / trackRate) / 2);
+    var finalPos = Math.floor(1 + (PioneerDDJSX2.TurnTablePos[channel] * 39.96) % 0x48);
+
+
+    // This calculate the track progress to show it to the user.
+    var trackProgression = Math.floor(1 + engine.getValue(group, "playposition") * 72);
+
+    // This is the function to determine how the white LEDs should be used. 
+    function whiteLeds(finalPos, trackProgression) {
+        if (PioneerDDJSX2.settings.CenterWhiteLightsBehavior === 1) {
+            midi.sendShortMsg(0xbb, channel, PioneerDDJSX2.blinkState ? trackProgression : 0x00);
+        } else {
+            midi.sendShortMsg(0xbb, channel, PioneerDDJSX2.blinkState ? finalPos : 0x00);
+        }
+    }
+
+
+    // Only send MIDI if position changed to reduce traffic
+    if (finalPos !== PioneerDDJSX2.FinalTurnPos[channel]) {
+        PioneerDDJSX2.FinalTurnPos[channel] = finalPos;
+
+        // Check if the song is soon at the end
+        var isEndOfTrack = engine.getValue(group, "end_of_track");
+
+        // END-OF-TRACK WARNING BLINK (WHITE outer ring)
+        if (isEndOfTrack === 1 && !engine.isScratching(channel + 1)) {
+            if (PioneerDDJSX2.settings.CenterWhiteLightsBehavior === 1) {
+                midi.sendShortMsg(0xbb, channel, PioneerDDJSX2.blinkState ? trackProgression : 0x00);
+            } else {
+                midi.sendShortMsg(0xbb, channel, PioneerDDJSX2.blinkState ? finalPos : 0x00);
+            }
+        } else {
+            // Normal playback - steady white ring rotation
+            if (PioneerDDJSX2.settings.CenterWhiteLightsBehavior === 1) {
+                midi.sendShortMsg(0xbb, channel, trackProgression);
+            } else {
+                midi.sendShortMsg(0xbb, channel, finalPos);
+            }
+        }
+    }
+
+};
+
+
+// CENTER RED JOGWHEEL LIGHTS (4 LEDs - 2 MODES ONLY)
+// =============================================================================
+// 2. Handles BOTH beat modes for RED center LEDs
+// MODE 0 (Checkbox OFF): Beat-by-beat - 1 LED per beat, 4 beat cycle
+// MODE 1 (Checkbox ON):  Bar-by-bar - 1 LED per bar (4 beats), 4 bar cycle (16 beats)
+PioneerDDJSX2.UpdateCenterBeatLights = function(value, group, control) {
+    if (value === 0) {
+        return
+    };
+
+    var rawSetting = engine.getSetting("CenterRedLightsBehavior");
+    var barByBarMode = (rawSetting === null) ? true : Boolean(Number(rawSetting));
+
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+
+    // Increment beat counter
+    PioneerDDJSX2.currentBeat[channel]++;
+
+    if (barByBarMode) {
+        // ===== MODE 1: BAR-BY-BAR (Checkbox ON) =====
+        // 32 beat cycle (8 bars): 4 bars ON + 4 bars OFF
+
+        if (PioneerDDJSX2.currentBeat[channel] > 32) {
+            PioneerDDJSX2.currentBeat[channel] = 1;
+        }
+
+        var barNumber = Math.ceil(PioneerDDJSX2.currentBeat[channel] / 4);
+        midi.sendShortMsg(0xbb, 0x04 + channel, barNumber);
+
+    } else {
+        // ===== MODE 0: BEAT-BY-BEAT (Checkbox OFF) =====
+        // 8 beat cycle: 4 beats ON + 4 beats OFF
+
+        if (PioneerDDJSX2.currentBeat[channel] > 8) {
+            PioneerDDJSX2.currentBeat[channel] = 1;
+        }
+
+        midi.sendShortMsg(0xbb, 0x04 + channel, PioneerDDJSX2.currentBeat[channel]);
+    }
+};
+
+// 3. Reset beat counter when track loads OR playposition changes
+PioneerDDJSX2.LoadActions = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    if (value) {
+        // Reset beat counter to 0 so first beat = LED 1
+        PioneerDDJSX2.currentBeat[channel] = 0;
+
+        // Turn off center red LEDs
+        midi.sendShortMsg(0xbb, 0x04 + channel, 0);
+
+        // Light up load button
+        midi.sendShortMsg(0x9b, channel, 0x7F);
+    }
+};
+
+// 4. Track last playposition to detect manual jumps
+PioneerDDJSX2.lastPlayPosition = [0, 0, 0, 0];
+
+PioneerDDJSX2.ResetBeatCounter = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var lastPos = PioneerDDJSX2.lastPlayPosition[channel];
+
+    // Only reset if this is a JUMP (difference > 0.001 = ~0.1% of track)
+    // Normal playback moves very smoothly, jumps are much larger
+    var positionDiff = Math.abs(value - lastPos);
+
+    if (positionDiff > 0.001) {
+        // This is a manual jump (needle drop, hotcue, waveform click)
+        PioneerDDJSX2.currentBeat[channel] = 0;
+        midi.sendShortMsg(0xbb, 0x04 + channel, 0);
+    }
+
+    // Store current position for next comparison
+    PioneerDDJSX2.lastPlayPosition[channel] = value;
+};
+
+// Slicer Lights
+// Handles the chasing lights on the pads when Slicer mode is active.
+PioneerDDJSX2.slicerTick = [0, 0, 0, 0];
+
+PioneerDDJSX2.SlicerLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+
+    // Exit immediately if not in Slicer mode
+    if (PioneerDDJSX2.padMode[channel] !== 2 && PioneerDDJSX2.padMode[channel] !== 6) {
+        return;
+    }
+
+    PioneerDDJSX2.slicerTick[channel] = (PioneerDDJSX2.slicerTick[channel] + 1) % 8;
+
+    var slicePosition = PioneerDDJSX2.slicerTick[channel];
+
+    // Couleurs
+    var isLoop = (PioneerDDJSX2.padMode[channel] === 6);
+    var offset = isLoop ? 0x60 : 0x20;
+    var onColor = isLoop ? 0x28 : 0x01;
+    var offColor = isLoop ? 0x01 : 0x28;
+
+    // Mise à jour des 8 pads
+    for (var i = 0; i < 8; i++) {
+        var isActive = (slicePosition === i);
+        midi.sendShortMsg(0x97 + channel, offset + i, isActive ? onColor : offColor);
+    }
+};
+
+
+// Updates the Performance Pads for Hotcues and Hotcues Loops
+PioneerDDJSX2.HotCuePerformancePadLed = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var i = PioneerDDJSX2.enums.hotcueIndex[control];
+
+    if (i === undefined || value === 2) {
+        return;
+    }
+
+    var color = 0;
+    if (value === 1) {
+        // Map Mixxx Hotcue color to Pioneer MIDI Color
+        color = PioneerDDJSX2.padColors.getValueForNearestColor(engine.getValue(group, 'hotcue_' + (i) + '_color'));
+    }
+
+    if (i <= 8) {
+        midi.sendShortMsg(0x97 + channel, 0x00 + i-1, color);
+        midi.sendShortMsg(0x97 + channel, 0x08 + i-1, color);
+    } else if (i > 8 && i <= 16) {
+        midi.sendShortMsg(0x97 + channel, 0x40 + (i-1) % 8, color);
+        midi.sendShortMsg(0x97 + channel, 0x48 + (i-1) % 8, color);
+    }
+};
+
+// Updates Play/Pause Button LED
+PioneerDDJSX2.PlayLeds = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x0B, value ? 0x7F : 0x00);
+    midi.sendShortMsg(0x90 + channel, 0x47, value ? 0x7F : 0x00);
+    if (PioneerDDJSX2.settings.DoNotTrickController) {
+        midi.sendShortMsg(0x9B, 0x0c + channel, value ? 0x7F : 0x00);
+    }
+};
+
+// Updates VU Meter LEDs
+PioneerDDJSX2.VuMeter = function(value, group, control) {
+    var level = value * 127;
+    var channel = 0xB0 + PioneerDDJSX2.enums.channelGroups[group];
+    midi.sendShortMsg(channel, 0x02, level);
+};
+
+// Updates Sync Button LED
+PioneerDDJSX2.SyncLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x58, value ? 0x7f : 0x00);
+};
+
+// Clears all LEDs on a specific deck (used on Eject)
+PioneerDDJSX2.UnloadLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    for (var k = 0; k < 0x30; k++) {
+        midi.sendShortMsg(0x97 + channel, k, 0x00);
+    }
+    for (var k = 0x40; k < 0x70; k++) {
+        midi.sendShortMsg(0x97 + channel, k, 0x00);
+    }
+    midi.sendShortMsg(0xbb, channel, 0);
+    midi.sendShortMsg(0xbb, 4 + channel, 0);
+};
+
+// Updates Headphone Cue (PFL) LED
+PioneerDDJSX2.HeadphoneCueLed = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x54, value ? 0x7F : 0x00);
+};
+
+// Updates Main Cue Button LED
+PioneerDDJSX2.CueLeds = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x48, value ? 0x7f : 0x00);
+    midi.sendShortMsg(0x90 + channel, 0x0C, value ? 0x7f : 0x00);
+};
+
+// Updates Key Lock / Master Tempo LED
+PioneerDDJSX2.KeyLockLeds = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x1A, value ? 0x7F : 0x00);
+};
+
+// Updates Loop 2X LED
+PioneerDDJSX2.LoopDouble = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x13, value ? 0x7F : 0x00);
+};
+
+// Updates Loop 1/2 LED
+PioneerDDJSX2.LoopHalve = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x12, value ? 0x7F : 0x00);
+};
+
+// Provides feedback when loading a track (Button blink)
+PioneerDDJSX2.LoadActions = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    if (value) {
+        midi.sendShortMsg(0x9b, channel, 0x7F);
+    }
+};
+
+// Updates Loop In/Out/Exit LEDs
+PioneerDDJSX2.ReloopExit = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    midi.sendShortMsg(0x90 + channel, 0x14, engine.getValue(group, "loop_enabled") ? 0x7F : 0x00);
+    midi.sendShortMsg(0x90 + channel, 0x10, (engine.getValue(group, "loop_start_position") > -1) ? 0x7F : 0x00);
+    midi.sendShortMsg(0x90 + channel, 0x11, (engine.getValue(group, "loop_end_position") > -1) ? 0x7F : 0x00);
+};
+
+// Updates Key Shift (Pitch Adjust) LEDs
+PioneerDDJSX2.PitchAdjust = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    if (value !== 0) {
+        if (value > 0) {
+            midi.sendShortMsg(0x90 + channel, 0x4a, 0x00);
+            midi.sendShortMsg(0x90 + channel, 0x4b, 0x7F);
+        } else {
+            midi.sendShortMsg(0x90 + channel, 0x4a, 0x7F);
+            midi.sendShortMsg(0x90 + channel, 0x4b, 0x00);
+        }
+    } else {
+        midi.sendShortMsg(0x90 + channel, 0x4a, 0x00);
+        midi.sendShortMsg(0x90 + channel, 0x4b, 0x00);
+    }
+};
+
+// FX Status LEDs
+function setFXLed(note) {
+    return function(value) {
+        midi.sendShortMsg(0x96, note, value ? 0x7F : 0x00);
+    };
+}
+PioneerDDJSX2.FX1CH1 = setFXLed(0x4C);
+PioneerDDJSX2.FX2CH1 = setFXLed(0x50);
+PioneerDDJSX2.FX1CH2 = setFXLed(0x4D);
+PioneerDDJSX2.FX2CH2 = setFXLed(0x51);
+PioneerDDJSX2.FX1CH3 = setFXLed(0x4E);
+PioneerDDJSX2.FX2CH3 = setFXLed(0x52);
+PioneerDDJSX2.FX1CH4 = setFXLed(0x4F);
+PioneerDDJSX2.FX2CH4 = setFXLed(0x53);
+
+// Updates Rate/Tempo Slider direction LEDs (Up/Down arrows)
+PioneerDDJSX2.RateLights = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    if (engine.getValue(group, 'rate') === 0) {
+        midi.sendShortMsg(0x90 + channel, 0x37, 0x00);
+        midi.sendShortMsg(0x90 + channel, 0x34, 0x00);
+        return;
+    }
+    if (engine.getValue(group, 'rate') < 0) {
+        midi.sendShortMsg(0x90 + channel, 0x34, 0x7F);
+        midi.sendShortMsg(0x90 + channel, 0x37, 0x00);
+    } else {
+        midi.sendShortMsg(0x90 + channel, 0x37, 0x7F);
+        midi.sendShortMsg(0x90 + channel, 0x34, 0x00);
+    }
+};
+
+// Updates FX Unit On/Off LEDs
+PioneerDDJSX2.FXLeds = function() {
+    for (var i = 0; i < 2; i++) {
+        for (var j = 0; j < 3; j++) {
+            midi.sendShortMsg(0x94 + i, 0x47 + j, engine.getValue("[EffectRack1_EffectUnit" + (i + 1) + "_Effect" + (j + 1) + "]", "enabled") ? 0x7F : 0x00);
+        }
+        midi.sendShortMsg(0x94 + i, 0x4a, engine.getValue("[EffectRack1_EffectUnit" + (i + 1) + "]", "mix_mode") ? 0x7F : 0x00);
+    }
+};
+
+// =============================================================================
+// 7. JOGWHEEL & SCRATCHING
+// =============================================================================
+
+// Calculates the delta movement of the jogwheel
+PioneerDDJSX2.getJogWheelDelta = function(value) {
+    return value - 0x40;
+}
+
+// Enables/Disables scratching engine for a specific deck
+PioneerDDJSX2.toggleScratch = function(channel, isEnabled) {
+    var deck = channel + 1;
+    PioneerDDJSX2.channels[channel].disableScratchTimer = 0;
+    if (isEnabled) {
+        engine.scratchEnable(deck, PioneerDDJSX2.settings.jogResolution, PioneerDDJSX2.settings.vinylSpeed, PioneerDDJSX2.settings.alpha, PioneerDDJSX2.settings.beta);
+    } else {
+        engine.scratchDisable(deck);
+    }
+};
+
+// Handles pitch bending (nudging) via the outer jog ring
+PioneerDDJSX2.pitchBend = function(channel, movement) {
+    var deck = channel + 1;
+    movement = movement / 5;
+    movement = movement > 3 ? 3 : movement;
+    movement = movement < -3 ? -3 : movement;
+    engine.setValue('[Channel' + deck + ']', 'jog', movement);
+};
+
+// Safety timer: Disables scratch if touch is lost
+PioneerDDJSX2.scheduleDisableScratch = function(channel) {
+    PioneerDDJSX2.channels[channel].disableScratchTimer = engine.beginTimer(PioneerDDJSX2.settings.safeScratchTimeout, function() {
+        PioneerDDJSX2.toggleScratch(channel, false);
+    }, true);
+};
+
+PioneerDDJSX2.unscheduleDisableScratch = function(channel) {
+    if (PioneerDDJSX2.channels[channel].disableScratchTimer) {
+        engine.stopTimer(PioneerDDJSX2.channels[channel].disableScratchTimer);
+    }
+};
+
+PioneerDDJSX2.postponeDisableScratch = function(channel) {
+    PioneerDDJSX2.unscheduleDisableScratch(channel);
+    PioneerDDJSX2.scheduleDisableScratch(channel);
+};
+
+// Touched the Jog Platter (top surface)
+PioneerDDJSX2.jogScratchTouch = function(channel, control, value, status) {
+    if (value === 0x7F && PioneerDDJSX2.vinylOn[channel]) {
+        PioneerDDJSX2.unscheduleDisableScratch(channel);
+        PioneerDDJSX2.toggleScratch(channel, true);
+    } else {
+        PioneerDDJSX2.scheduleDisableScratch(channel);
+    }
+};
+
+// Turned the Jog Platter (top surface) - Scratching or Grid Adjust
+PioneerDDJSX2.jogScratchTurn = function(channel, control, value, status) {
+    var deck = channel + 1;
+    if (engine.isScratching(deck) && !PioneerDDJSX2.gridSlide[channel] && !PioneerDDJSX2.gridAdjust[channel]) {
+        engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
+    } else {
+        if (PioneerDDJSX2.gridSlide[channel]) {
+            engine.setValue("[Channel" + deck + "]", (value < 64) ? "beats_translate_earlier" : "beats_translate_later", 1);
+        }
+        if (PioneerDDJSX2.gridAdjust[channel]) {
+            engine.setValue("[Channel" + deck + "]", (value < 64) ? "beats_adjust_faster" : "beats_adjust_slower", 1);
+        }
+    }
+};
+
+// Outer Jog Ring Touch (Seeking)
+PioneerDDJSX2.jogSeekTouch = function(channel, control, value, status) {
+    if (!engine.getValue('[Channel' + (channel + 1) + ']', 'play')) {
+        PioneerDDJSX2.toggleScratch(channel, value === 0x7F);
+    }
+};
+
+// Outer Jog Ring Turn (Seeking or Nudging)
+PioneerDDJSX2.jogSeekTurn = function(channel, control, value, status) {
+    var deck = channel + 1;
+    if (engine.isScratching(deck)) {
+        engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
+    } else {
+        PioneerDDJSX2.pitchBend(channel, PioneerDDJSX2.getJogWheelDelta(value));
+    }
+};
+
+// Seek through track (Shift + Jog Turn)
+PioneerDDJSX2.jogSeek = function(channel, control, value, status) {
+    engine.setValue("[Channel" + (channel + 1) + "]", "beatjump", PioneerDDJSX2.getJogWheelDelta(value) / 16);
+};
+
+PioneerDDJSX2.jogPitchBend = function(channel, control, value, status) {
+    var deck = channel + 1;
+    if (engine.isScratching(deck)) {
+        engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
+        PioneerDDJSX2.postponeDisableScratch(channel);
+    } else {
+        if (engine.getValue('[Channel' + deck + ']', 'play')) {
+            PioneerDDJSX2.pitchBend(channel, PioneerDDJSX2.getJogWheelDelta(value));
+        }
+    }
+};
+
+// =============================================================================
+// 8. MIXER & TRANSPORT (14-bit Support)
+// =============================================================================
+
+// Play/Pause Button
+// Handles Logic for SoftStart/Braking if Shift is pressed/configured
+PioneerDDJSX2.Play = function(channel, control, value, status, group) {
+    var deck = script.deckFromGroup(group);
+    var isPlaying = engine.getValue(group, 'play');
+    var lastHotcue = engine.getValue(group, 'hotcue_focus');
+    if (lastHotcue !== 0) {
+        var isLastHotcuePlaying = (lastHotcue !== -1) ? engine.getValue(group, 'hotcue_' + lastHotcue + '_status') : 0;
+    };
+
+    if (value === 127) {
+        if (((control === 71 && PioneerDDJSX2.settings.UseShiftToBreak === false) || (control !== 71 && PioneerDDJSX2.settings.UseShiftToBreak === true)) && isLastHotcuePlaying !== 2) {
+            if (isPlaying && PioneerDDJSX2.isBraking === 0) {
+                PioneerDDJSX2.isBraking = 1;
+                if (PioneerDDJSX2.settings.BrakeTime >= 0) {
+                    engine.brake(deck, true, PioneerDDJSX2.settings.BrakeTime);
+                } else {
+                    engine.setValue(group, 'play', 0);
+                }
+            } else if (isPlaying && PioneerDDJSX2.isBraking === 1) {
+                PioneerDDJSX2.isBraking = 0;
+                if (PioneerDDJSX2.settings.SoftStartTime >= 0) {
+                    engine.softStart(deck, true, PioneerDDJSX2.settings.SoftStartTime);
+                } else {
+                    engine.brake(deck, false);
+                    engine.softStart(deck, false);
+                }
+            } else {
+                PioneerDDJSX2.isBraking = 0;
+                if (PioneerDDJSX2.settings.SoftStartTime >= 0) {
+                    engine.softStart(deck, true, PioneerDDJSX2.settings.SoftStartTime);
+                } else {
+                    engine.setValue(group, 'play', 1);
+                }
+            }
+        } else {
+            PioneerDDJSX2.isBraking = 0;
+            engine.setValue(group, 'play', !isPlaying);
+        }
+    }
+};
+
+// Sync Button (Long press logic)
+// Quick press : Enable beatsync for the current deck
+// Long press (>1000ms) : enable old behaviour of syncing both left and right tracks
+PioneerDDJSX2.SyncEnable = function(value, group, control) {
+    if (control === 127) {
+        PioneerDDJSX2.SyncEnableTimer = engine.beginTimer(1000, function() {
+            if (value === 0 || value === 2) {
+                engine.setValue("[Channel" + (value + 1) + "]", "sync_enabled", 1);
+                engine.setValue("[Channel" + (value + 2) + "]", "sync_enabled", 1);
+            } else {
+                engine.setValue("[Channel" + (value + 1) + "]", "sync_enabled", 1);
+                engine.setValue("[Channel" + (value) + "]", "sync_enabled", 1);
+            }
+            PioneerDDJSX2.SyncEnableTimer = null;
+        }, 1);
+    } else {
+        if (PioneerDDJSX2.SyncEnableTimer !== null) {
+            engine.setValue("[Channel" + (value + 1) + "]", "beatsync", 1);
+            engine.stopTimer(PioneerDDJSX2.SyncEnableTimer);
+        }
+    }
+};
+
+// Sync Disable (Shift + Sync)
+PioneerDDJSX2.SyncDisable = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    if (control === 127) {
+        if (value === 0 || value === 2) {
+            engine.setValue("[Channel" + (value + 1) + "]", "sync_enabled", 0);
+            engine.setValue("[Channel" + (value + 2) + "]", "sync_enabled", 0);
+        } else {
+            engine.setValue("[Channel" + (value + 1) + "]", "sync_enabled", 0);
+            engine.setValue("[Channel" + (value) + "]", "sync_enabled", 0);
+        }
+    }
+};
+
+// Slip Button
+PioneerDDJSX2.SlipEnabled = function(value, group, control) {
+    if (control === 127) {
+        if (engine.getValue("[Channel" + (value + 1) + "]", "play")) {
+            engine.setValue("[Channel" + (value + 1) + "]", "slip_enabled", !engine.getValue("[Channel" + (value + 1) + "]", "slip_enabled"));
+            midi.sendShortMsg(0x90 + value, 0x3e, engine.getValue("[Channel" + (value + 1) + "]", "slip_enabled") ? 0x7F : 0x00);
+        } else {
+            engine.setValue("[Channel" + (value + 1) + "]", "slip_enabled", !engine.getValue("[Channel" + (value + 1) + "]", "slip_enabled"));
+        }
+    }
+};
+
+// Crossfader Curve Adjust (Front panel knob)
+PioneerDDJSX2.CrossfaderCurve = function(value, group, control) {
+    engine.setValue("[Mixer Profile]", "xFaderCurve", control / 16);
+};
+
+// Input Select Switches (Front panel)
+PioneerDDJSX2.InputSelect = function(group, control, value, status) {
+    engine.setValue("[Channel" + (group + 1) + "]", "mute", value ? 1 : 0);
+}
+
+// Loop In Button
+PioneerDDJSX2.LoopIn = function(group, control, value, status) {
+    engine.setValue("[Channel" + (group + 1) + "]", "loop_in", value ? 1 : 0);
+    if (value === 0x7f) {
+        PioneerDDJSX2.closestBeatToLoopIn[group] = engine.getValue("[Channel" + (group + 1) + "]", "beat_closest");
+    }
+}
+
+// 4 Beat Loop Button
+PioneerDDJSX2.FourBeat = function(group, control, value, status) {
+    var channel = "[Channel" + (group + 1) + "]";
+    if (value === 0x7f) {
+        var loop_enable = engine.getValue(channel, 'loop_enabled')
+        engine.setValue(channel, "loop_start_position", PioneerDDJSX2.closestBeatToLoopIn[group]);
+        engine.setValue(channel, "loop_end_position", PioneerDDJSX2.closestBeatToLoopIn[group] + engine.getValue(channel, 'track_samplerate') * (480 / engine.getValue(channel, 'file_bpm')));
+
+        if (!loop_enable) {
+            engine.setValue(channel, "reloop_toggle", 1);
+        }
+    }
+}
+
+// Slip Mode Logic
+PioneerDDJSX2.SlipMode = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    if (engine.getValue(group, "play")) {
+        midi.sendShortMsg(0x90 + channel, 0x40, value ? 0x7F : 0x00);
+    }
+};
+
+PioneerDDJSX2.Shift = function(channel, control, value, status) {
+    PioneerDDJSX2.shift[channel] = value;
+};
+
+// Reverse Button (Toggle)
+PioneerDDJSX2.Reverse = function(value, group, control) {
+    if (control === 127) {
+        PioneerDDJSX2.reverse[value] = !PioneerDDJSX2.reverse[value];
+        engine.setValue("[Channel" + (value + 1) + "]", "reverse", PioneerDDJSX2.reverse[value]);
+    }
+};
+
+// Reverse Button (Hold - Censor)
+PioneerDDJSX2.ReverseHold = function(value, group, control) {
+    if (control === 127) {
+        PioneerDDJSX2.reverse[value] = 1;
+        engine.setValue("[Channel" + (value + 1) + "]", "reverse", PioneerDDJSX2.reverse[value]);
+    } else {
+        PioneerDDJSX2.reverse[value] = 0;
+        engine.setValue("[Channel" + (value + 1) + "]", "reverse", PioneerDDJSX2.reverse[value]);
+    }
+};
+
+// Auto Loop Button
+PioneerDDJSX2.AutoLoop = function(channel, control, value, status) {
+    if (value === 127) {
+        if (engine.getValue("[Channel" + (channel + 1) + "]", "loop_enabled")) {
+            engine.setValue("[Channel" + (channel + 1) + "]", "reloop_toggle", 1);
+        } else {
+            engine.setValue("[Channel" + (channel + 1) + "]", "beatloop_activate", 1);
+        }
+    }
+};
+
+// --- 14-BIT MIDI IMPLEMENTATION ---
+// The SX2 sends high-resolution MIDI using two messages (MSB and LSB).
+// We cache the MSB and wait for the LSB to apply the full value.
+
+// Tempo/Rate Slider (14-bit)
+PioneerDDJSX2.RateSlider = function(channel, control, value, status) {
+    var deckGroup = "[Channel" + (channel + 1) + "]";
+    var storage = PioneerDDJSX2.midi14bit.tempo;
+    if (control === 0x00) {
+        storage[channel] = value;
+        return;
+    }
+    if (control === 0x20) {
+        var msb = storage[channel];
+        var value14bit = (msb << 7) | value;
+        var rate;
+        // Calculate centered rate (-1 to 1)
+        if (value14bit < 8192) {
+            rate = (value14bit - 8192) / 8192;
+        } else {
+            rate = (value14bit - 8192) / 8191;
+        }
+
+        rate = -rate;
+        var fileBPM = engine.getValue(deckGroup, "file_bpm");
+        var tempoRange = engine.getValue(deckGroup, "rateRange");
+
+        // BPM Quantization logic for smoother sliders
+        if (fileBPM > 0 && tempoRange > 0) {
+            var bpmChange = rate * tempoRange * fileBPM;
+            var quantizedBpmChange = Math.round(bpmChange * 10) / 10;
+            var quantizedRate = quantizedBpmChange / (tempoRange * fileBPM);
+            engine.setValue(deckGroup, "rate", quantizedRate);
+        } else {
+            engine.setValue(deckGroup, "rate", rate);
+        }
+    }
+};
+
+// Channel Volume Faders (14-bit)
+PioneerDDJSX2.VolumeSlider = function(channel, control, value, status) {
+    var deckGroup = '[Channel' + (channel + 1) + ']';
+    var storage = PioneerDDJSX2.midi14bit.volume;
+    if (control === 0x13) {
+        storage[channel] = value;
+        engine.setParameter(deckGroup, 'volume', value / 127.0);
+    } else if (control === 0x33) {
+        var value14bit = (storage[channel] << 7) | value;
+        engine.setParameter(deckGroup, 'volume', value14bit / 16383.0);
+    }
+};
+
+// EQ Knobs (14-bit)
+PioneerDDJSX2.EQHigh = function(channel, control, value) {
+    PioneerDDJSX2.handle14bitEQ(channel, control, value, PioneerDDJSX2.midi14bit.eqHigh, 0x07, 0x27, 'parameter3');
+};
+PioneerDDJSX2.EQMid = function(channel, control, value) {
+    PioneerDDJSX2.handle14bitEQ(channel, control, value, PioneerDDJSX2.midi14bit.eqMid, 0x0B, 0x2B, 'parameter2');
+};
+PioneerDDJSX2.EQLow = function(channel, control, value) {
+    PioneerDDJSX2.handle14bitEQ(channel, control, value, PioneerDDJSX2.midi14bit.eqLow, 0x0F, 0x2F, 'parameter1');
+};
+
+PioneerDDJSX2.handle14bitEQ = function(channel, control, value, storage, msbCC, lsbCC, param) {
+    var deckGroup = '[EqualizerRack1_[Channel' + (channel + 1) + ']_Effect1]';
+    if (control === msbCC) {
+        storage[channel] = value;
+        engine.setParameter(deckGroup, param, ((value - 64) / 63.0 + 1) / 2);
+    } else if (control === lsbCC) {
+        var value14bit = (storage[channel] << 7) | value;
+        engine.setParameter(deckGroup, param, ((value14bit - 8192) / 8191.0 + 1) / 2);
+    }
+};
+
+// Filter Knobs (14-bit)
+PioneerDDJSX2.Filter = function(channel, control, value) {
+    var storage = PioneerDDJSX2.midi14bit.filter;
+    if (control >= 0x17 && control <= 0x1A) {
+        var offset = control - 0x17;
+        storage[offset] = value;
+        engine.setParameter('[QuickEffectRack1_[Channel' + (offset + 1) + ']]', 'super1', ((value - 64) / 63.0 + 1) / 2);
+    } else if (control >= 0x37 && control <= 0x3A) {
+        var offset = control - 0x37;
+        var value14bit = (storage[offset] << 7) | value;
+        engine.setParameter('[QuickEffectRack1_[Channel' + (offset + 1) + ']]', 'super1', ((value14bit - 8192) / 8191.0 + 1) / 2);
+    }
+};
+
+// Trim/Pregain Knobs (14-bit)
+// Includes special curve mapping because SX2 hardware trim knobs are logarithmic/weird.
+PioneerDDJSX2.Pregain = function(channel, control, value) {
+    var deckGroup = '[Channel' + (channel + 1) + ']';
+    var cache = PioneerDDJSX2.midi14bit.pregain;
+    var value14bit;
+
+    // 1. DUAL-UPDATE LOGIC (Linear and single-curved approaches didn't work with these knobs)
+    if (control === 0x04) {
+        cache[channel] = value;
+        value14bit = value << 7;
+    } else if (control === 0x24) {
+        value14bit = (cache[channel] << 7) | value;
+    } else {
+        return;
+    }
+
+    // 2. ASYMMETRIC MAPPING
+    // Center: 8192 (Standard MIDI center)
+    // Max: 12550 (Calibrated to hardware log)
+    var centerVal = 8192.0;
+    var maxVal = 12550.0;
+    var gainValue;
+
+    if (value14bit <= centerVal) {
+        // ZONE A: 0 to Center (12 o'clock)
+        // Map MIDI (0 -> 8192) to Gain (0.0 -> 1.0)
+        var norm = value14bit / centerVal;
+
+        // x^3 suppresses the value in the early stages.
+        // 9 o'clock physical read significantly lower in software.
+        gainValue = norm * norm * norm;
+
+    } else {
+        // ZONE B: Center to Max
+        // Map MIDI (8192 -> 12550) to Gain (1.0 -> 4.0)
+
+        // Normalize this upper section to 0.0 - 1.0
+        var norm = (value14bit - centerVal) / (maxVal - centerVal);
+
+        // Clamp to 1.0 in case of hardware jitter at max
+        if (norm > 1.0) {
+            norm = 1.0;
+        }
+
+        // Scale linearly to the top range (Unity to +12dB)
+        // 1.0 (Start) + (norm * 3.0 range)
+        gainValue = 1.0 + (norm * 3.0);
+    }
+
+    engine.setValue(deckGroup, 'pregain', gainValue);
+};
+
+// =============================================================================
+// 9. FX SECTION 
+// =============================================================================
+
+// Handle Beats Knob (Turning) - Adjusts Wet/Dry Mix
+PioneerDDJSX2.EffectJog = function(value, group, control) {
+    if (control > 63) {
+        engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix", engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix") - 0.0625 * (128 - control));
+    } else {
+        engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix", engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix") + 0.0625 * (control));
+    }
+};
+
+// Beats Button Press (Cycles selected effect focus)
+PioneerDDJSX2.BeatsPressFX = function(value, group, control) {
+    if (control === 127) {
+        PioneerDDJSX2.currentEffect[value - 4]++;
+        if (PioneerDDJSX2.currentEffect[value - 4] > 3) {
+            PioneerDDJSX2.currentEffect[value - 4] = 0;
+        }
+        PioneerDDJSX2.FXLeds();
+    }
+};
+
+// Shift + Beats Button Press (Cycles parameters)
+PioneerDDJSX2.ShiftBeatsPressFX = function(value, group, control) {
+    if (control === 127) {
+        var idx = ((value === 5) ? (4) : (0)) + PioneerDDJSX2.currentEffect[value - 4];
+        PioneerDDJSX2.currentEffectparamset[idx]++;
+        if (PioneerDDJSX2.currentEffectparamset[idx] >= (engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + (PioneerDDJSX2.currentEffect[value - 4] + 1) + "]", "num_parameters") / 3)) {
+            PioneerDDJSX2.currentEffectparamset[idx] = 0;
+        }
+        PioneerDDJSX2.FXLeds();
+    }
+};
+
+// Select specific effect in slot
+PioneerDDJSX2.EffectSelect = function(value, group, control) {
+    engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + (group - 98) + "]", "effect_selector", (control === 127) ? 1 : 0);
+};
+
+// Control FX Parameters via knobs
+PioneerDDJSX2.EffectKnob = function(value, group, control) {
+    if (PioneerDDJSX2.currentEffect[value - 4] === 3) {
+        switch (group) {
+            case 2:
+                engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect1]", "meta", control / 127);
+                break;
+            case 4:
+                engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect2]", "meta", control / 127);
+                break;
+            case 6:
+                engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect3]", "meta", control / 127);
+                break;
+        }
+    } else {
+        var effectNumer = PioneerDDJSX2.currentEffect[value-4] + 1;
+        var offsetNumer = (PioneerDDJSX2.currentEffectparamset[((value-4)*4)+PioneerDDJSX2.currentEffect[value-4]]*3);
+        switch (group) {
+            case 2:
+                engine.setParameter("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + effectNumer + "]", "parameter" + (1 + offsetNumer), control/127);
+                break;
+            case 4:
+                engine.setParameter("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + effectNumer + "]", "parameter" + (2 + offsetNumer), control/127);
+                break;
+            case 6:
+                engine.setParameter("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + effectNumer + "]", "parameter" + (3 + offsetNumer), control/127);
+                break;
+        }
+        
+    }
+};
+
+// Enable/Disable specific effect
+PioneerDDJSX2.EffectButton = function(value, group, control) {
+    if (control === 127) {
+        if (PioneerDDJSX2.currentEffect[value - 4] === 3) {
+            engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + (group - 70) + "]", "enabled", !engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "_Effect" + (group - 70) + "]", "enabled"));
+        }
+    }
+};
+
+// Tap Button (Mix Mode Toggle)
+PioneerDDJSX2.EffectTap = function(value, group, control) {
+    if (control === 127 && PioneerDDJSX2.currentEffect[value - 4] === 3) {
+        engine.setValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix_mode", !engine.getValue("[EffectRack1_EffectUnit" + (value - 3) + "]", "mix_mode"));
+        PioneerDDJSX2.FXLeds();
+    }
+};
+
+// =============================================================================
+// 10. VIEW, GRID, & PANELS 
+// =============================================================================
+
+// Cycle through Mixxx Panel layouts (FX Rack, Samplers)
+PioneerDDJSX2.PanelSelect = function(value, group, control) {
+    if (control === 127) {
+        PioneerDDJSX2.curPanel += ((1 - (group - 120)) * 2) - 1;
+        if (PioneerDDJSX2.curPanel < 0) {
+            PioneerDDJSX2.curPanel = 3;
+        }
+        if (PioneerDDJSX2.curPanel > 3) {
+            PioneerDDJSX2.curPanel = 0;
+        }
+        engine.setValue("[Skin]", "show_samplers", (PioneerDDJSX2.curPanel & 1));
+        engine.setValue("[Skin]", "show_effectrack", (PioneerDDJSX2.curPanel & 2) >> 1);
+    }
+};
+
+// Cycle through views (2 deck / 4 deck / maximized library)
+PioneerDDJSX2.ViewButton = function(value, group, control) {
+    if (control === 127) {
+        PioneerDDJSX2.curView++;
+        if (PioneerDDJSX2.curView > 7) {
+            PioneerDDJSX2.curPanel = 0;
+        }
+
+        engine.setValue("[Skin]", "show_4decks", PioneerDDJSX2.curView & 1);
+    }
+};
+
+// Enable Grid Slide Mode (used with Jog Wheel)
+PioneerDDJSX2.SetGridSlide = function(value, group, control) {
+    PioneerDDJSX2.gridSlide[value] = control ? 1 : 0;
+    midi.sendShortMsg(0x90 + value, 0x0a, control ? 0x7F : 0x00);
+};
+
+// Enable Grid Adjust Mode (used with Jog Wheel)
+PioneerDDJSX2.SetGridAdjust = function(value, group, control) {
+    PioneerDDJSX2.gridAdjust[value] = control ? 1 : 0;
+    midi.sendShortMsg(0x90 + value, 0x79, control ? 0x7F : 0x00);
+};
+
+// Clear Grid Adjustment
+PioneerDDJSX2.ClearGrid = function(value, group, control) {
+    engine.setValue("[Channel" + (value + 1) + "]", "beats_undo_adjustment", 1);
+    midi.sendShortMsg(0x90 + value, 0x79, control ? 0x7F : 0x00);
+};
+
+// =============================================================================
+// 11. SAMPLER & PAD PARAMETERS 
+// =============================================================================
+
+// Plays sampler or Loads selected track if empty
+PioneerDDJSX2.SamplerPlay = function(group, control, value, status) {
+    var sampler = "[Sampler" + (1 + (control & 7) + (PioneerDDJSX2.samplerBank[group - 7] * 8)) + "]";
+    if (value === 127) {
+        if (engine.getValue(sampler, "track_loaded")) {
+            engine.setParameter(sampler, "start_play", value & 1);
+        } else {
+            engine.setParameter(sampler, "LoadSelectedTrack", value & 1);
+        }
+    }
+};
+
+// Stops sampler (Short press) or Ejects (Long press)
+PioneerDDJSX2.SamplerStop = function(group, control, value, status) {
+    var sampler = "[Sampler" + (1 + (control & 7) + (PioneerDDJSX2.samplerBank[group - 7] * 8)) + "]";
+    var isPlaying = engine.getValue(sampler, "play");
+    var trackLoaded = engine.getValue(sampler, "track_loaded");
+
+    if (value === 127) {
+        if (trackLoaded && !isPlaying) {
+            engine.setParameter(sampler, "eject", 1);
+        } else {
+            engine.setParameter(sampler, "stop", 1);
+        }
+    }
+};
+
+// Updates Sampler LEDs based on state (Loaded/Playing)
+PioneerDDJSX2.SamplerLight = function(value, group, control) {
+    var sampler = PioneerDDJSX2.enums.samplerGroups[group];
+    if (sampler === undefined) {
+        return;
+    }
+
+    var loaded = engine.getValue(group, "track_loaded");
+    var isPlaying = engine.getValue(group, "play");
+
+    for (var i = 0; i < 4; i++) {
+        if ((PioneerDDJSX2.samplerBank[i] << 3) === (sampler & (~7))) {
+            var offset = (sampler & 7);
+            var color = 0;
+
+            if (!loaded) {
+                color = 0;
+            } else if (value && isPlaying) {
+                // White when playing
+                color = 0x40;
+            } else {
+                color = 0x7f;
+            }
+
+            if (PioneerDDJSX2.padMode[i] === 3) {
+                midi.sendShortMsg(0x97 + i, 0x30 + offset, color);
+                midi.sendShortMsg(0x97 + i, 0x38 + offset, color);
+            } else if (PioneerDDJSX2.padMode[i] === 7) {
+                midi.sendShortMsg(0x97 + i, 0x70 + offset, color);
+                midi.sendShortMsg(0x97 + i, 0x78 + offset, color);
+            }
+        }
+    }
+};
+
+// Set Sampler Gain (Velocity sensitive)
+PioneerDDJSX2.SetSampleGain = function(group, control, value) {
+    var where = (control & 7) + (PioneerDDJSX2.samplerBank[group - 7] * 8);
+    PioneerDDJSX2.sampleVolume[where] = value / 127;
+    engine.setParameter("[Sampler" + (1 + where) + "]", "pregain", PioneerDDJSX2.samplerVolume * PioneerDDJSX2.sampleVolume[where]);
+};
+
+// Master Sampler Volume Knob
+PioneerDDJSX2.SetSamplerVol = function(value, group, control) {
+    PioneerDDJSX2.samplerVolume = control / 127;
+    var num = engine.getValue('[App]', 'num_samplers');
+    for (var i = 0; i < num; i++) {
+        engine.setParameter("[Sampler" + (i + 1) + "]", "pregain", PioneerDDJSX2.samplerVolume * PioneerDDJSX2.sampleVolume[i]);
+    }
+};
+
+// Refreshes all sampler LEDs (used when switching banks)
+PioneerDDJSX2.RepaintSampler = function(group) {
+    for (var i = 0; i < 8; i++) {
+        var ai = i + PioneerDDJSX2.samplerBank[group] * 8;
+        var prefix = "[Sampler" + (ai + 1) + "]";
+        var loaded = engine.getValue(prefix, "track_loaded");
+        var playing = engine.getValue(prefix, "play");
+
+        var color = 0;
+        if (loaded) {
+            color = playing ? 0x40 : 0x7F;
+        }
+
+        if (PioneerDDJSX2.padMode[group] === 3) {
+            midi.sendShortMsg(0x97 + group, 0x30 + i, color);
+            midi.sendShortMsg(0x97 + group, 0x38 + i, color);
+        } else if (PioneerDDJSX2.padMode[group] === 7) {
+            midi.sendShortMsg(0x97 + group, 0x70 + i, color);
+            midi.sendShortMsg(0x97 + group, 0x78 + i, color);
+        }
+    }
+};
+
+// Previous Sampler Bank
+PioneerDDJSX2.SamplerParam1L = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.samplerBank[group]--;
+        if (PioneerDDJSX2.samplerBank[group] < 0) {
+            PioneerDDJSX2.samplerBank[group] = 0;
+        } else {
+            PioneerDDJSX2.RepaintSampler(group);
+        }
+    }
+};
+
+// Next Sampler Bank
+PioneerDDJSX2.SamplerParam1R = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.samplerBank[group]++;
+        if (PioneerDDJSX2.samplerBank[group] > 7) {
+            PioneerDDJSX2.samplerBank[group] = 7;
+        } else {
+            PioneerDDJSX2.RepaintSampler(group);
+        }
+    }
+};
+
+// Cycle Tempo Ranges
+PioneerDDJSX2.SetTempoRange = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.tempoRange[group]++;
+        if (PioneerDDJSX2.tempoRange[group] > 3) {
+            PioneerDDJSX2.tempoRange[group] = 0;
+        }
+        engine.setValue("[Channel" + (group + 1) + "]", "rateRange", PioneerDDJSX2.settings.tempoRanges[PioneerDDJSX2.tempoRange[group]]);
+    }
+};
+
+// Toggle Vinyl Mode (Shift + Slip)
+PioneerDDJSX2.ToggleVinyl = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.vinylOn[group] = !PioneerDDJSX2.vinylOn[group];
+    }
+};
+
+// Decrease Roll Size
+PioneerDDJSX2.RollParam1L = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.rollPrec[group]--;
+        if (PioneerDDJSX2.rollPrec[group] < 0) {
+            PioneerDDJSX2.rollPrec[group] = 0;
+        }
+        midi.sendShortMsg(0x90 + group, 0x1e, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[group]]);
+    }
+};
+
+// Increase Roll Size
+PioneerDDJSX2.RollParam1R = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.rollPrec[group]++;
+        if (PioneerDDJSX2.rollPrec[group] > 4) {
+            PioneerDDJSX2.rollPrec[group] = 4;
+        }
+        midi.sendShortMsg(0x90 + group, 0x1e, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[group]]);
+    }
+};
+
+// Decrease Slicer Precision
+PioneerDDJSX2.SlicerParam1L = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.beatjumpPrec[group]--;
+        if (PioneerDDJSX2.beatjumpPrec[group] < 0) {
+            PioneerDDJSX2.beatjumpPrec[group] = 0;
+        }
+        midi.sendShortMsg(0x90 + group, 0x20, PioneerDDJSX2.settings.beatjumpColors[PioneerDDJSX2.beatjumpPrec[group]]);
+    }
+};
+
+// Increase Slicer Precision
+PioneerDDJSX2.SlicerParam1R = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.beatjumpPrec[group]++;
+        if (PioneerDDJSX2.beatjumpPrec[group] > 8) {
+            PioneerDDJSX2.beatjumpPrec[group] = 8;
+        }
+        midi.sendShortMsg(0x90 + group, 0x20, PioneerDDJSX2.settings.beatjumpColors[PioneerDDJSX2.beatjumpPrec[group]]);
+    }
+};
+
+// Feedback for Roll Pads
+PioneerDDJSX2.RollPerformancePadLed = function(value, group, control) {
+    var channel = PioneerDDJSX2.enums.channelGroups[group];
+    var padIndex = 0;
+    for (var i = 0; i < 8; i++) {
+        if (control === 'beatloop_' + PioneerDDJSX2.settings.loopIntervals[i + 2] + '_enabled') {
+            break;
+        }
+        padIndex++;
+    }
+    if (engine.getValue('[Channel1]', 'play')) {
+        midi.sendShortMsg(0x97 + channel, 0x10 + padIndex, value ? 0x7F : 0x00);
+    }
+};
+
+// =============================================================================
+// 12. PAD MODES
+// =============================================================================
+
+// Enable HotCue Mode
+PioneerDDJSX2.SetHotCueMode = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.padMode[group] = 0;
+        midi.sendShortMsg(0x90 + group, 0x1b, 0x7f);
+    }
+};
+
+// Enable Roll Mode
+PioneerDDJSX2.SetRollMode = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.padMode[group] = 1;
+        midi.sendShortMsg(0x90 + group, 0x1e, PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[group]]);
+    }
+};
+
+// Enable Slicer Mode
+PioneerDDJSX2.SetSlicerMode = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.padMode[group] = 2;
+        midi.sendShortMsg(0x90 + group, 0x20, 0x7f);
+    }
+};
+
+// Enable Sampler Mode
+PioneerDDJSX2.SetSamplerMode = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.padMode[group] = 3;
+        PioneerDDJSX2.RepaintSampler(group);
+        midi.sendShortMsg(0x90 + group, 0x22, 0x7f);
+    }
+};
+
+// Enable Cue Loop Mode
+PioneerDDJSX2.SetCueLoopMode = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.padMode[group] = 4;
+        midi.sendShortMsg(0x90 + group, 0x69, PioneerDDJSX2.settings.cueLoopColors[3]);
+    }
+};
+
+// Enable Saved Loop Mode
+PioneerDDJSX2.SetSavedLoopMode = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.padMode[group] = 5;
+        midi.sendShortMsg(0x90 + group, 0x6b, 0x7f);
+    }
+};
+
+// Enable Slicer Loop Mode
+PioneerDDJSX2.SetSlicerLoopMode = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.padMode[group] = 6;
+        midi.sendShortMsg(0x90 + group, 0x6d, 0x7f);
+    }
+};
+
+// Enable Velocity Sampler Mode
+PioneerDDJSX2.SetVelocitySamplerMode = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.padMode[group] = 7;
+        PioneerDDJSX2.RepaintSampler(group);
+        midi.sendShortMsg(0x90 + group, 0x6f, 0x7f);
+    }
+};
+
+// Logic for Saved Loop Pads
+PioneerDDJSX2.SavedLoop = function(performanceChannel, control, value, status) {
+    var deck = performanceChannel - 6;
+    var group = '[Channel' + deck + ']';
+    var interval = PioneerDDJSX2.settings.loopIntervals[control - 0x50 + 4];
+    var isAutoLoopEnabled = engine.getValue(group, 'beatloop_' + interval + '_enabled');
+
+    if (value === 0x7F) {
+        for (var i = 0; i < 8; i++) {
+            midi.sendShortMsg(0x97 + deck - 1, 80 + i, 0x00);
+        }
+
+        if (isAutoLoopEnabled !== 1) {
+            engine.setValue(group, 'beatloop_' + interval + '_activate', 1);
+            midi.sendShortMsg(0x97 + deck - 1, control, 0x7f);
+        } else {
+            engine.setValue(group, 'beatloop_' + interval + '_toggle', 1);
+            midi.sendShortMsg(0x97 + deck - 1, control, 0x00);
+        }
+    }
+};
+
+// Logic for Beat Jump Pads
+// TODO(XXX) : BeatJump is mapped to Slicer, create a real Slicer or wait for Mixxx to implement one. 
+PioneerDDJSX2.BeatJump = function(performanceChannel, control, value, status) {
+    var deck = performanceChannel - 7;
+    var group = '[Channel' + (deck + 1) + ']';
+    const which = (control & 3) + PioneerDDJSX2.beatjumpPrec[deck];
+
+    if (value === 0x7F) {
+        var interval = PioneerDDJSX2.settings.loopIntervals[which];
+        if (control & 4) {
+            engine.setValue(group, 'beatjump_' + interval + '_backward', 1);
+        } else {
+            engine.setValue(group, 'beatjump_' + interval + '_forward', 1);
+        }
+    }
+    midi.sendShortMsg(0x97 + deck, control, (value === 0x7f) ? (PioneerDDJSX2.settings.beatjumpColors[which]) : (0x00));
+};
+
+// Logic for Roll Pads
+PioneerDDJSX2.RollPerformancePad = function(performanceChannel, control, value, status) {
+    var deck = performanceChannel - 6;
+    var group = '[Channel' + deck + ']';
+    var interval = PioneerDDJSX2.settings.loopIntervals[control - 0x10 + PioneerDDJSX2.rollPrec[performanceChannel - 7]];
+
+    if (value === 0x7F) {
+        engine.setValue(group, 'beatlooproll_' + interval + '_activate', 1);
+    } else {
+        engine.setValue(group, 'beatlooproll_' + interval + '_activate', 0);
+    }
+
+    midi.sendShortMsg(0x97 + deck - 1, control, (value === 0x7f) ? (PioneerDDJSX2.settings.rollColors[PioneerDDJSX2.rollPrec[performanceChannel - 7]]) : (0x00));
+};
+
+// =============================================================================
+// 13. LIBRARY & BROWSER
+// =============================================================================
+
+// Rotary Selector Navigation (Tracklist / Library)
+PioneerDDJSX2.RotarySelector = function(channel, control, value, status) {
+    var delta = 0x40 - Math.abs(0x40 - value);
+    if (value > 0x40) {
+        delta *= -1;
+    }
+
+    if (PioneerDDJSX2.status.rotarySelector.target === 1) {
+        engine.setValue('[Playlist]', 'SelectTrackKnob', delta);
+    } else if (delta > 0) {
+        engine.setValue('[Playlist]', 'SelectNextPlaylist', 1);
+    } else if (delta < 0) {
+        engine.setValue('[Playlist]', 'SelectPrevPlaylist', 1);
+    }
+};
+
+// Sort Library via Shift + Load Buttons
+PioneerDDJSX2.SortLibrary = function(performanceChannel, control, value, status) {
+    if (value === 127) {
+        if (control === 88) {
+            engine.setValue("[Library]", 'sort_column_toggle', 15);
+        }
+        if (control === 89) {
+            engine.setValue("[Library]", 'sort_column_toggle', 2);
+        }
+        if (control === 96) {
+            engine.setValue("[Library]", 'sort_column_toggle', 9);
+        }
+        if (control === 97) {
+            engine.setValue("[Library]", 'sort_column_toggle', 1);
+        }
+    }
+};
+
+// Back Button - returns focus to Library sidebar
+PioneerDDJSX2.BackButton = function(channel, control, value, status) {
+    if (value === 0x7F) {
+        PioneerDDJSX2.status.rotarySelector.target = PioneerDDJSX2.enums.rotarySelector.targets.libraries;
+    }
+};
+
+// Rotary Click - Toggles folder expansion or enters playlist
+PioneerDDJSX2.RotarySelectorClick = function(channel, control, value, status) {
+    if (value === 0x7F) {
+        var target = PioneerDDJSX2.enums.rotarySelector.targets.tracklist;
+
+        var tracklist = PioneerDDJSX2.enums.rotarySelector.targets.tracklist;
+        var libraries = PioneerDDJSX2.enums.rotarySelector.targets.libraries;
+
+        // Expand/Collapse the current item
+        engine.setValue("[Playlist]", "ToggleSelectedSidebarItem", 1);
+
+        switch (PioneerDDJSX2.status.rotarySelector.target) {
+            case tracklist:
+                target = libraries;
+                break;
+            case libraries:
+                target = tracklist;
+                break;
+        }
+
+        PioneerDDJSX2.status.rotarySelector.target = target;
+    }
+};
+
+// Shift + Rotary Click - Loads selected track
+PioneerDDJSX2.rotarySelectorShiftedClick = function(channel, control, value) {
+    if (value) {
+        script.toggleControl("[Library]", "GoToItem");
+    }
+};

--- a/res/controllers/PIONEER-DDJ-SX2.scripts.js
+++ b/res/controllers/PIONEER-DDJ-SX2.scripts.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-var */
+/* eslint-disable no-undef */
 // Pioneer DDJ-SX2 mapping for Mixxx - WIP
 // Based on hrudham's mapping for the DDJ-SR
 // Modifications by tildearrow, Krafting, eXWoLL
@@ -9,19 +11,20 @@
 // =============================================================================
 // SCRIPT INDEX
 // =============================================================================
-// 1.  CONSTANTS, DEBUGGING & HELPERS ............ 
-// 2.  STATE VARIABLES & SETTINGS ................ 
-// 3.  INITIALIZATION & SHUTDOWN ................. 
-// 4.  TIMER & BLINKING .......................... 
-// 5.  CONNECTIONS (Signals) ..................... 
-// 6.  LIGHTING & FEEDBACK ........... 
-// 7.  JOGWHEEL & SCRATCHING ..................... 
-// 8.  MIXER & TRANSPORT (14-bit Support) ........ 
-// 9.  FX SECTION ................................ 
-// 10. VIEW, GRID, & PANELS ...................... 
-// 11. SAMPLER & PAD PARAMETERS .................. 
-// 12. PAD MODES ................................. 
-// 13. LIBRARY & BROWSER ......................... 
+// 1.  CONSTANTS, DEBUGGING & HELPERS ............
+// 2.  STATE VARIABLES & SETTINGS ................
+// 3.  INITIALIZATION & SHUTDOWN .................
+// 4.  TIMER & BLINKING ..........................
+// 5.  CONNECTIONS (Signals) .....................
+// 6.  LIGHTING & FEEDBACK .......................
+// 7.  JOGWHEEL & SCRATCHING .....................
+// 8.  MIXER & TRANSPORT (14-bit Support) ........
+// 9.  FX SECTION ................................
+// 10. VIEW, GRID, & PANELS ......................
+// 11. SAMPLER & PAD PARAMETERS ..................
+// 12. PAD MODES .................................
+// 13. LIBRARY & BROWSER .........................
+// 14. FLIP SECTION ..............................
 // =============================================================================
 //
 // License: (MIT)
@@ -269,6 +272,7 @@ PioneerDDJSX2.settings = {
     safeScratchTimeout: engine.getSetting('safeScratchTimeout'),
     CenterRedLightsBehavior: engine.getSetting('CenterRedLightsBehavior'),
     CenterWhiteLightsBehavior: engine.getSetting('CenterWhiteLightsBehavior'), // 0 for rotations, 1 for duration
+    NeedleSearchBehaviour: engine.getSetting("NeedleSearchBehaviour"),
     DoNotTrickController: engine.getSetting('DoNotTrickController'),
     SoftStartTime: engine.getSetting('SoftStartTime'),
     BrakeTime: engine.getSetting('BrakeTime'),
@@ -309,6 +313,9 @@ PioneerDDJSX2.status = {rotarySelector: {target: PioneerDDJSX2.enums.rotarySelec
 
 // Called when the controller is detected or the script is reloaded.
 PioneerDDJSX2.init = function(id) {
+    // Send Serato Recall Sysex (Forces controller into correct mode)
+    midi.sendSysexMsg(PioneerDDJSX2.recallState, PioneerDDJSX2.recallState.length);
+
     PioneerDDJSX2.channels = {
         0x00: {},
         0x01: {},
@@ -365,9 +372,6 @@ PioneerDDJSX2.init = function(id) {
     // Start Blink/Keep-Alive Timer (250ms interval)
     PioneerDDJSX2.lightsTimer = engine.beginTimer(250, PioneerDDJSX2.doTimer, 0);
 
-    // Send Serato Recall Sysex (Forces controller into correct mode)
-    midi.sendSysexMsg(PioneerDDJSX2.recallState, PioneerDDJSX2.recallState.length);
-
     // Initialize 14-bit cache structures if undefined
     if (typeof PioneerDDJSX2.midi14bit === 'undefined') {
         PioneerDDJSX2.midi14bit = {};
@@ -387,7 +391,7 @@ PioneerDDJSX2.shutdown = function() {
     };
     // Stop main timer
     if (PioneerDDJSX2.lightsTimer) {
-        engine.stopTimer(PioneerDDJSX2.lightsTimer)
+        engine.stopTimer(PioneerDDJSX2.lightsTimer);
     };
 };
 
@@ -402,20 +406,22 @@ PioneerDDJSX2.doTimer = function() {
         midi.sendSysexMsg(PioneerDDJSX2.keepAlive, PioneerDDJSX2.keepAlive.length);
     }
 
-    // Handle blinking LEDs (Slip Mode and Reverse)
+    // Handle blinking LEDs (Slip Mode and Reverse) for each Deck
     for (var i = 0; i < 4; i++) {
         // Slip Blink
         if (engine.getValue("[Channel" + (i + 1) + "]", "slip_enabled")) {
-            midi.sendShortMsg(0x90 + i, 0x40, PioneerDDJSX2.blinkState ? 0x7F : 0x00);
+            midi.sendShortMsg(0x90 + i, 0x40, PioneerDDJSX2.blinkState ? 0x7F : 0x00); // Slip Button normal
         } else {
-            midi.sendShortMsg(0x90 + i, 0x40, 0x00);
+            midi.sendShortMsg(0x90 + i, 0x40, 0x00); // Slip Button normal
         }
 
         // Reverse Blink
         if (PioneerDDJSX2.reverse[i]) {
-            midi.sendShortMsg(0x90 + i, 0x38, PioneerDDJSX2.blinkState ? 0x7f : 0x00);
+            midi.sendShortMsg(0x90 + i, 0x38, PioneerDDJSX2.blinkState ? 0x7f : 0x00); // Reverse Button when shifting
+            midi.sendShortMsg(0x90 + i, 0x15, PioneerDDJSX2.blinkState ? 0x7f : 0x00); // Reverse Button normal
         } else {
-            midi.sendShortMsg(0x90 + i, 0x38, 0x00);
+            midi.sendShortMsg(0x90 + i, 0x38, 0x00); // Reverse Button when shifting
+            midi.sendShortMsg(0x90 + i, 0x15, 0x00); // Reverse Button normal
         }
     }
     // Toggle blink state for next tick
@@ -435,7 +441,6 @@ PioneerDDJSX2.BindControlConnections = function() {
         // CRITICAL: JOGWHEEL & SLICER FEEDBACK
         PioneerDDJSX2.conns.push(engine.makeConnection(group, 'playposition', PioneerDDJSX2.deckLights));
         PioneerDDJSX2.conns.push(engine.makeConnection(group, 'beat_next', PioneerDDJSX2.SlicerLights));
-        // PioneerDDJSX2.conns.push(engine.makeConnection(group, 'beat_distance', PioneerDDJSX2.SlicerLights));
         PioneerDDJSX2.conns.push(engine.makeConnection(group, 'beat_active', PioneerDDJSX2.UpdateCenterBeatLights));
 
         // NEW: Reset beat counter when playposition changes (needle drop, hotcue jumps)
@@ -454,9 +459,12 @@ PioneerDDJSX2.BindControlConnections = function() {
         PioneerDDJSX2.conns.push(engine.makeConnection(group, 'eject', PioneerDDJSX2.UnloadLights));
         PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_enabled', PioneerDDJSX2.ReloopExit));
         PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_in', PioneerDDJSX2.ReloopExit));
-        PioneerDDJSX2.conns.push(engine.makeConnection(group, 'loop_out', PioneerDDJSX2.ReloopExit));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_out", PioneerDDJSX2.ReloopExit));
         PioneerDDJSX2.conns.push(engine.makeConnection(group, 'track_samples', PioneerDDJSX2.LoadActions));
         PioneerDDJSX2.conns.push(engine.makeConnection(group, 'pitch_adjust', PioneerDDJSX2.PitchAdjust));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "quantize", PioneerDDJSX2.ParamLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "loop_anchor", PioneerDDJSX2.ParamLights));
+        PioneerDDJSX2.conns.push(engine.makeConnection(group, "repeat", PioneerDDJSX2.ParamLights));
 
         // HOTCUES (Status and Color)
         for (var j = 1; j <= 16; j++) {
@@ -468,7 +476,7 @@ PioneerDDJSX2.BindControlConnections = function() {
     // FX Connections (Enable/Disable LEDs)
     PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel1]_enable', PioneerDDJSX2.FX1CH1));
     PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel1]_enable', PioneerDDJSX2.FX2CH1));
-    PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel2]_enable', PioneerDDJSX2.FX1CH2));
+    PioneerDDJSX2.conns.push(engine.makeConnection("[EffectRack1_EffectUnit1]", "group_[Channel2]_enable", PioneerDDJSX2.FX1CH2));
     PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel2]_enable', PioneerDDJSX2.FX2CH2));
     PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit1]', 'group_[Channel3]_enable', PioneerDDJSX2.FX1CH3));
     PioneerDDJSX2.conns.push(engine.makeConnection('[EffectRack1_EffectUnit2]', 'group_[Channel3]_enable', PioneerDDJSX2.FX2CH3));
@@ -528,19 +536,8 @@ PioneerDDJSX2.deckLights = function(value, group, control) {
     PioneerDDJSX2.TurnTablePos[channel] = (engine.getValue(group, "playposition") * (trackSamples / trackRate) / 2);
     var finalPos = Math.floor(1 + (PioneerDDJSX2.TurnTablePos[channel] * 39.96) % 0x48);
 
-
     // This calculate the track progress to show it to the user.
     var trackProgression = Math.floor(1 + engine.getValue(group, "playposition") * 72);
-
-    // This is the function to determine how the white LEDs should be used. 
-    function whiteLeds(finalPos, trackProgression) {
-        if (PioneerDDJSX2.settings.CenterWhiteLightsBehavior === 1) {
-            midi.sendShortMsg(0xbb, channel, PioneerDDJSX2.blinkState ? trackProgression : 0x00);
-        } else {
-            midi.sendShortMsg(0xbb, channel, PioneerDDJSX2.blinkState ? finalPos : 0x00);
-        }
-    }
-
 
     // Only send MIDI if position changed to reduce traffic
     if (finalPos !== PioneerDDJSX2.FinalTurnPos[channel]) {
@@ -565,7 +562,6 @@ PioneerDDJSX2.deckLights = function(value, group, control) {
             }
         }
     }
-
 };
 
 
@@ -621,7 +617,36 @@ PioneerDDJSX2.LoadActions = function(value, group, control) {
         midi.sendShortMsg(0xbb, 0x04 + channel, 0);
 
         // Light up load button
-        midi.sendShortMsg(0x9b, channel, 0x7F);
+        midi.sendShortMsg(0x9B, channel, 0x7F);
+    }
+};
+
+// Update Lights for the Parameters buttons
+// This is because we can set quantize in the CUE and CUE LOOP mode
+// So that the leds are always in sync
+// Plus, this allows changing the setting in mixxx and being reflected on the controller
+// After some tests, it seems we CANNOT set the lights on Parameter 1 when we send the Serato Keepalive command
+// The lights will just blink when we press the buttons
+// Except for the CUE mode where we can set the lights as static.
+PioneerDDJSX2.ParamLights = function() {
+    // For each channel (deck)
+    for (var i = 0; i < 4; i++) {
+        var channel = `[Channel${  i+1  }]`;
+
+        // For the Quantize of each channels
+        // Rec Flip Button
+        var isQuantize = engine.getValue(channel, "quantize");
+        midi.sendShortMsg(0x90 + i, 0x4A, isQuantize ? 0x7F : 0x00);
+
+        // For the loop anchor of each channels
+        // Start Flip Button
+        var isAnchor = engine.getValue(channel, "loop_anchor");
+        midi.sendShortMsg(0x90 + i, 0x4B, isAnchor ? 0x7F : 0x00);
+
+        // For the repeat setting of each channels
+        // SHIFT + Rec Flip Button
+        var isAnchor = engine.getValue(channel, "repeat");
+        midi.sendShortMsg(0x90 + i, 0x5A, isAnchor ? 0x7F : 0x00);
     }
 };
 
@@ -726,12 +751,15 @@ PioneerDDJSX2.SyncLights = function(value, group, control) {
 // Clears all LEDs on a specific deck (used on Eject)
 PioneerDDJSX2.UnloadLights = function(value, group, control) {
     var channel = PioneerDDJSX2.enums.channelGroups[group];
+
+    // Clear all pads LEDs
     for (var k = 0; k < 0x30; k++) {
         midi.sendShortMsg(0x97 + channel, k, 0x00);
     }
     for (var k = 0x40; k < 0x70; k++) {
         midi.sendShortMsg(0x97 + channel, k, 0x00);
     }
+
     midi.sendShortMsg(0xbb, channel, 0);
     midi.sendShortMsg(0xbb, 4 + channel, 0);
 };
@@ -765,14 +793,6 @@ PioneerDDJSX2.LoopDouble = function(value, group, control) {
 PioneerDDJSX2.LoopHalve = function(value, group, control) {
     var channel = PioneerDDJSX2.enums.channelGroups[group];
     midi.sendShortMsg(0x90 + channel, 0x12, value ? 0x7F : 0x00);
-};
-
-// Provides feedback when loading a track (Button blink)
-PioneerDDJSX2.LoadActions = function(value, group, control) {
-    var channel = PioneerDDJSX2.enums.channelGroups[group];
-    if (value) {
-        midi.sendShortMsg(0x9b, channel, 0x7F);
-    }
 };
 
 // Updates Loop In/Out/Exit LEDs
@@ -890,7 +910,7 @@ PioneerDDJSX2.postponeDisableScratch = function(channel) {
 };
 
 // Touched the Jog Platter (top surface)
-PioneerDDJSX2.jogScratchTouch = function(channel, control, value, status) {
+PioneerDDJSX2.jogScratchTouch = function(channel, control, value) {
     if (value === 0x7F && PioneerDDJSX2.vinylOn[channel]) {
         PioneerDDJSX2.unscheduleDisableScratch(channel);
         PioneerDDJSX2.toggleScratch(channel, true);
@@ -900,7 +920,7 @@ PioneerDDJSX2.jogScratchTouch = function(channel, control, value, status) {
 };
 
 // Turned the Jog Platter (top surface) - Scratching or Grid Adjust
-PioneerDDJSX2.jogScratchTurn = function(channel, control, value, status) {
+PioneerDDJSX2.jogScratchTurn = function(channel, control, value) {
     var deck = channel + 1;
     if (engine.isScratching(deck) && !PioneerDDJSX2.gridSlide[channel] && !PioneerDDJSX2.gridAdjust[channel]) {
         engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
@@ -915,14 +935,14 @@ PioneerDDJSX2.jogScratchTurn = function(channel, control, value, status) {
 };
 
 // Outer Jog Ring Touch (Seeking)
-PioneerDDJSX2.jogSeekTouch = function(channel, control, value, status) {
+PioneerDDJSX2.jogSeekTouch = function(channel, control, value) {
     if (!engine.getValue('[Channel' + (channel + 1) + ']', 'play')) {
         PioneerDDJSX2.toggleScratch(channel, value === 0x7F);
     }
 };
 
 // Outer Jog Ring Turn (Seeking or Nudging)
-PioneerDDJSX2.jogSeekTurn = function(channel, control, value, status) {
+PioneerDDJSX2.jogSeekTurn = function(channel, control, value) {
     var deck = channel + 1;
     if (engine.isScratching(deck)) {
         engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
@@ -932,11 +952,11 @@ PioneerDDJSX2.jogSeekTurn = function(channel, control, value, status) {
 };
 
 // Seek through track (Shift + Jog Turn)
-PioneerDDJSX2.jogSeek = function(channel, control, value, status) {
+PioneerDDJSX2.jogSeek = function(channel, control, value) {
     engine.setValue("[Channel" + (channel + 1) + "]", "beatjump", PioneerDDJSX2.getJogWheelDelta(value) / 16);
 };
 
-PioneerDDJSX2.jogPitchBend = function(channel, control, value, status) {
+PioneerDDJSX2.jogPitchBend = function(channel, control, value) {
     var deck = channel + 1;
     if (engine.isScratching(deck)) {
         engine.scratchTick(deck, PioneerDDJSX2.getJogWheelDelta(value));
@@ -945,6 +965,13 @@ PioneerDDJSX2.jogPitchBend = function(channel, control, value, status) {
         if (engine.getValue('[Channel' + deck + ']', 'play')) {
             PioneerDDJSX2.pitchBend(channel, PioneerDDJSX2.getJogWheelDelta(value));
         }
+    }
+};
+
+// Toggle Vinyl Mode (Shift + Slip)
+PioneerDDJSX2.ToggleVinyl = function(group, control, value) {
+    if (value === 127) {
+        PioneerDDJSX2.vinylOn[group] = !PioneerDDJSX2.vinylOn[group];
     }
 };
 
@@ -994,6 +1021,24 @@ PioneerDDJSX2.Play = function(channel, control, value, status, group) {
     }
 };
 
+PioneerDDJSX2.NeedleSearch = function(channel, control, value, status, group) {
+    // For isShifted, 3 = Not Shifting ; 28 = Shifting
+    var isShifted = control;
+    var isPlaying = engine.getValue(group, "play");
+
+    // var actualPlayPosition = 1/value;
+    var actualPlayPosition = value / 127;
+
+    // Check if it is Shifted and apply the NeedleSearchBehaviour setting if the song is playing
+    if (isShifted === 3 && isPlaying) {
+        if (PioneerDDJSX2.settings.NeedleSearchBehaviour === true) {
+            engine.setValue(group, "playposition", actualPlayPosition);
+        }
+    } else {
+        engine.setValue(group, "playposition", actualPlayPosition);
+    }
+};
+
 // Sync Button (Long press logic)
 // Quick press : Enable beatsync for the current deck
 // Long press (>1000ms) : enable old behaviour of syncing both left and right tracks
@@ -1036,7 +1081,6 @@ PioneerDDJSX2.SlipEnabled = function(value, group, control) {
     if (control === 127) {
         if (engine.getValue("[Channel" + (value + 1) + "]", "play")) {
             engine.setValue("[Channel" + (value + 1) + "]", "slip_enabled", !engine.getValue("[Channel" + (value + 1) + "]", "slip_enabled"));
-            midi.sendShortMsg(0x90 + value, 0x3e, engine.getValue("[Channel" + (value + 1) + "]", "slip_enabled") ? 0x7F : 0x00);
         } else {
             engine.setValue("[Channel" + (value + 1) + "]", "slip_enabled", !engine.getValue("[Channel" + (value + 1) + "]", "slip_enabled"));
         }
@@ -1501,6 +1545,16 @@ PioneerDDJSX2.RepaintSampler = function(group) {
         }
     }
 };
+// Cycle Tempo Ranges
+PioneerDDJSX2.SetTempoRange = function(group, control, value, status) {
+    if (value === 127) {
+        PioneerDDJSX2.tempoRange[group]++;
+        if (PioneerDDJSX2.tempoRange[group] > 3) {
+            PioneerDDJSX2.tempoRange[group] = 0;
+        }
+        engine.setValue(`[Channel${  group + 1  }]`, "rateRange", PioneerDDJSX2.settings.tempoRanges[PioneerDDJSX2.tempoRange[group]]);
+    }
+};
 
 // Previous Sampler Bank
 PioneerDDJSX2.SamplerParam1L = function(group, control, value, status) {
@@ -1524,27 +1578,10 @@ PioneerDDJSX2.SamplerParam1R = function(group, control, value, status) {
             PioneerDDJSX2.RepaintSampler(group);
         }
     }
+    midi.sendShortMsg(0x90 + group, 0x2F, 0x7F);
 };
 
-// Cycle Tempo Ranges
-PioneerDDJSX2.SetTempoRange = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.tempoRange[group]++;
-        if (PioneerDDJSX2.tempoRange[group] > 3) {
-            PioneerDDJSX2.tempoRange[group] = 0;
-        }
-        engine.setValue("[Channel" + (group + 1) + "]", "rateRange", PioneerDDJSX2.settings.tempoRanges[PioneerDDJSX2.tempoRange[group]]);
-    }
-};
-
-// Toggle Vinyl Mode (Shift + Slip)
-PioneerDDJSX2.ToggleVinyl = function(group, control, value, status) {
-    if (value === 127) {
-        PioneerDDJSX2.vinylOn[group] = !PioneerDDJSX2.vinylOn[group];
-    }
-};
-
-// Decrease Roll Size
+// Decrease Roll Size with Parameter 1
 PioneerDDJSX2.RollParam1L = function(group, control, value, status) {
     if (value === 127) {
         PioneerDDJSX2.rollPrec[group]--;
@@ -1555,7 +1592,7 @@ PioneerDDJSX2.RollParam1L = function(group, control, value, status) {
     }
 };
 
-// Increase Roll Size
+// Increase Roll Size with Parameter 1
 PioneerDDJSX2.RollParam1R = function(group, control, value, status) {
     if (value === 127) {
         PioneerDDJSX2.rollPrec[group]++;
@@ -1566,7 +1603,7 @@ PioneerDDJSX2.RollParam1R = function(group, control, value, status) {
     }
 };
 
-// Decrease Slicer Precision
+// Decrease Slicer Precision with Parameter 1
 PioneerDDJSX2.SlicerParam1L = function(group, control, value, status) {
     if (value === 127) {
         PioneerDDJSX2.beatjumpPrec[group]--;
@@ -1577,7 +1614,7 @@ PioneerDDJSX2.SlicerParam1L = function(group, control, value, status) {
     }
 };
 
-// Increase Slicer Precision
+// Increase Slicer Precision with Parameter 1
 PioneerDDJSX2.SlicerParam1R = function(group, control, value, status) {
     if (value === 127) {
         PioneerDDJSX2.beatjumpPrec[group]++;
@@ -1586,6 +1623,26 @@ PioneerDDJSX2.SlicerParam1R = function(group, control, value, status) {
         }
         midi.sendShortMsg(0x90 + group, 0x20, PioneerDDJSX2.settings.beatjumpColors[PioneerDDJSX2.beatjumpPrec[group]]);
     }
+};
+
+// Parameter 1 for HOT CUE (Right)
+// Not Used
+PioneerDDJSX2.CueParam1R = function(group, control, value, status, channel) {
+};
+
+// Parameter 1 for HOT CUE (Left)
+// Not Used
+PioneerDDJSX2.CueParam1L = function(group, control, value, status, channel) {
+};
+
+// Parameter 1 for HOT CUE LOOPS (Left)
+// Not Used
+PioneerDDJSX2.CueLoopParam1R = function(group, control, value, status, channel) {
+};
+
+// Parameter 1 for HOT CUE LOOPS (Left)
+// Not Used
+PioneerDDJSX2.CueLoopParam1L = function(group, control, value, status, channel) {
 };
 
 // Feedback for Roll Pads
@@ -1801,5 +1858,65 @@ PioneerDDJSX2.RotarySelectorClick = function(channel, control, value, status) {
 PioneerDDJSX2.rotarySelectorShiftedClick = function(channel, control, value) {
     if (value) {
         script.toggleControl("[Library]", "GoToItem");
+    }
+};
+
+// =============================================================================
+// 14. FLIP SECTION
+// =============================================================================
+// This is the Flip section of each deck, Mixxx doesn't have Flip feature,
+// so we can map them to something else
+
+// Flip Start Button, toggle Loop Anchor
+PioneerDDJSX2.FlipStart = function(group, control, value, status, channel) {
+    if (value === 127) {
+        script.toggleControl(channel, "loop_anchor");
+        var isAnchor = engine.getValue(channel, "loop_anchor");
+        midi.sendShortMsg(0x90 + group, 0x4B, isAnchor ? 0x7F : 0x00);
+    }
+};
+
+// Flip Rec Button, toggle Hot Cue Quantize
+PioneerDDJSX2.FlipRec = function(group, control, value, status, channel) {
+    if (value === 127) {
+        script.toggleControl(channel, "quantize");
+        var isQuantize = engine.getValue(channel, "quantize");
+        midi.sendShortMsg(0x90 + group, 0x4A, isQuantize ? 0x7F : 0x00);
+    }
+};
+
+// Flip Slot Button, Reset current track key to default (pitch)
+PioneerDDJSX2.FlipSlot = function(group, control, value, status, channel) {
+    if (engine.getValue(channel, "track_loaded")) {
+        if (value === 127) {
+            engine.setValue(channel, "pitch_adjust_set_zero", 1);
+        }
+    }
+};
+
+// Flip Save (SHIFT + Slot) Button, Set the pitch of the track down
+PioneerDDJSX2.FlipSave = function(group, control, value, status, channel) {
+    if (engine.getValue(channel, "track_loaded")) {
+        if (value === 127) {
+            engine.setValue(channel, "pitch_down", 1);
+        }
+    }
+};
+
+// Flip Save (SHIFT + Rec) Button, repeat setting for the current track
+PioneerDDJSX2.FlipLoop = function(group, control, value, status, channel) {
+    if (value === 127) {
+        script.toggleControl(channel, "repeat");
+        var isAnchor = engine.getValue(channel, "repeat");
+        midi.sendShortMsg(0x90 + group, 0x5A, isAnchor ? 0x7F : 0x00);
+    }
+};
+
+// Flip Save (SHIFT + Start) Button, Set the pitch of the track up
+PioneerDDJSX2.FlipOnOff = function(group, control, value, status, channel) {
+    if (engine.getValue(channel, "track_loaded")) {
+        if (value === 127) {
+            engine.setValue(channel, "pitch_up", 1);
+        }
     }
 };


### PR DESCRIPTION
Initial implementation of the Pioneer DDJ-SX2 controller. Supports most features mentioned in the manual.  (Some are not possible, for example the Flip controls)

Related documentation is at https://github.com/mixxxdj/manual/pull/877

There is an area of the mapping I would love to get help with though, nothing blocking this PR, but if anyone would like to help, it's about the Slicer mode is just some beatjump rightnow, but it would be great to have a real Slicer

There is also the Slicer Loop mode that does the exact same as the current slicer mode (beatjump), I might use it for STEMs support later on when 2.6 comes around, or if anyone have any better ideas ! :)

By the way, the code lives here too : https://gitlab.com/Krafting/mixxx-pioneer-ddj-sx2 

p.s. This is my first mapping contribution, please tell me if I'm doing anything wrong!

This is based on tildearrow's mapping ( https://github.com/tildearrow/Mixxx-Pioneer-DDJ-SX2 ), heavily modified by myself and eXWoLL1 