### PR TITLE
LateNight samplers display sample key (configurable)

### DIFF
--- a/res/skins/LateNight/helpers/skin_settings_samplers.xml
+++ b/res/skins/LateNight/helpers/skin_settings_samplers.xml
@@ -86,7 +86,10 @@ Description:
                   <SetVariable name="Text">Fx controls</SetVariable>
                   <SetVariable name="Setting">[Skin],show_sampler_fx</SetVariable>
                 </Template>
-
+                <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
+                  <SetVariable name="Text">Show Sampler key</SetVariable>
+                  <SetVariable name="Setting">[LateNight],show_sampler_key</SetVariable>
+                </Template>
                 <WidgetGroup>
                   <ObjectName>SamplerLoadSaveBox</ObjectName>
                   <Layout>horizontal</Layout>

--- a/res/skins/LateNight/helpers/skin_settings_samplers.xml
+++ b/res/skins/LateNight/helpers/skin_settings_samplers.xml
@@ -86,10 +86,6 @@ Description:
                   <SetVariable name="Text">Fx controls</SetVariable>
                   <SetVariable name="Setting">[Skin],show_sampler_fx</SetVariable>
                 </Template>
-                <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
-                  <SetVariable name="Text">Show Sampler key</SetVariable>
-                  <SetVariable name="Setting">[LateNight],show_sampler_key</SetVariable>
-                </Template>
                 <WidgetGroup>
                   <ObjectName>SamplerLoadSaveBox</ObjectName>
                   <Layout>horizontal</Layout>

--- a/res/skins/LateNight/samplers/sampler.xml
+++ b/res/skins/LateNight/samplers/sampler.xml
@@ -37,10 +37,10 @@
                 <Connection>
                   <ConfigKey><Variable name="Group"/>,visual_key</ConfigKey>
                 </Connection>
-                <Connection>
+                <!--<Connection>
                   <ConfigKey persist="true">[LateNight],show_sampler_key</ConfigKey>
                   <BindProperty>visible</BindProperty>
-                </Connection>
+                </Connection>-->
               </Key>
               <WidgetGroup>
                 <ObjectName>SamplerTitleBpmSeparator</ObjectName>

--- a/res/skins/LateNight/samplers/sampler.xml
+++ b/res/skins/LateNight/samplers/sampler.xml
@@ -37,10 +37,6 @@
                 <Connection>
                   <ConfigKey><Variable name="Group"/>,visual_key</ConfigKey>
                 </Connection>
-                <!--<Connection>
-                  <ConfigKey persist="true">[LateNight],show_sampler_key</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>-->
               </Key>
               <WidgetGroup>
                 <ObjectName>SamplerTitleBpmSeparator</ObjectName>

--- a/res/skins/LateNight/samplers/sampler.xml
+++ b/res/skins/LateNight/samplers/sampler.xml
@@ -26,7 +26,22 @@
                 <Property>titleInfo</Property>
                 <Elide>right</Elide>
               </TrackProperty>
-
+              <Key>
+                <ObjectName>KeyText</ObjectName>
+                <TooltipId>track_key</TooltipId>
+                <Group><Variable name="Group"/></Group>
+                <MinimumSize>40,20</MinimumSize>
+                <MaximumSize>60,20</MaximumSize>
+                <SizePolicy>me,f</SizePolicy>
+                <Elide>right</Elide>
+                <Connection>
+                  <ConfigKey><Variable name="Group"/>,visual_key</ConfigKey>
+                </Connection>
+                <Connection>
+                  <ConfigKey persist="true">[LateNight],show_sampler_key</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </Key>
               <WidgetGroup>
                 <ObjectName>SamplerTitleBpmSeparator</ObjectName>
                 <Layout>horizontal</Layout>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -89,7 +89,6 @@
       <attribute persist="true" config_key="[LateNight],expand_samplers_1-4">0</attribute>
       <attribute persist="true" config_key="[LateNight],expand_samplers_1-8">0</attribute>
       <attribute persist="true" config_key="[LateNight],expand_samplers_9-16">0</attribute>
-      <attribute persist="true" config_key="[LateNight],show_sampler_key">0</attribute>
     <!-- Mic / Aux -->
       <attribute persist="true" config_key="[Skin],show_microphones">0</attribute>
     <!-- Library -->

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -89,6 +89,7 @@
       <attribute persist="true" config_key="[LateNight],expand_samplers_1-4">0</attribute>
       <attribute persist="true" config_key="[LateNight],expand_samplers_1-8">0</attribute>
       <attribute persist="true" config_key="[LateNight],expand_samplers_9-16">0</attribute>
+      <attribute persist="true" config_key="[LateNight],show_sampler_key">0</attribute>
     <!-- Mic / Aux -->
       <attribute persist="true" config_key="[Skin],show_microphones">0</attribute>
     <!-- Library -->

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -125,7 +125,7 @@ WSearchLineEdit,
   border-top-right-radius: 1px;
   background-color: #151515;
   }
-  #KeyText {
+  #Deck #KeyText {
     border-top: 1px solid #0c0c0c;
     border-bottom: 1px solid #0c0c0c;
   }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -147,6 +147,12 @@ QAbstractScrollArea::corner {
     margin-top: 1px;
   }
 
+
+#KeyText {
+  border: 0px;
+  color: #766b65;
+}
+
 /* recessed regions */
 #WaveformBox1,
 #WaveformBox2,
@@ -155,7 +161,7 @@ QAbstractScrollArea::corner {
 #WaveformsFrame,
 #OverviewBox,
 #OverviewBoxMini,
-#KeyText,
+#Deck #KeyText,
 WCueMenuPopup #CueLabelEdit {
   border-top: 1px solid #0d0d0d;
   border-left: 1px solid #121212;


### PR DESCRIPTION
Added a toggle in skin settings to show sample key next to sample name : **Show Sampler key**

This is only visible in expanded sampler views : mini samplers do not display the key (this is consistent with the behavior of the existing parameter **Fx controls**)

Setting OFF (default behavior)
<img width="2008" height="205" alt="setting OFF" src="https://github.com/user-attachments/assets/7c245b8d-6291-46b1-bbe9-b53c0b7fdff3" />

Setting ON (they keys are displayed)
<img width="2011" height="253" alt="setting ON" src="https://github.com/user-attachments/assets/9933a8df-a8b9-4831-8a66-36e257661867" />
