### PR TITLE
(fix) Library -> Hidden: add/fix track load connection

### DIFF
--- a/src/library/missing_hidden/dlghidden.cpp
+++ b/src/library/missing_hidden/dlghidden.cpp
@@ -64,6 +64,20 @@ DlgHidden::DlgHidden(
             &WTrackTableView::trackSelected,
             this,
             &DlgHidden::trackSelected);
+    connect(m_pTrackTableView,
+            &WTrackTableView::loadTrack,
+            this,
+            &DlgHidden::loadTrack);
+    connect(m_pTrackTableView,
+            &WTrackTableView::loadTrackToPlayer,
+            this,
+            [=, this](TrackPointer track, const QString& group) {
+                emit loadTrackToPlayer(track, group,
+#ifdef __STEM__
+                        mixxx::StemChannelSelection(),
+#endif
+                        false);
+            });
 
     connect(pLibrary,
             &Library::setTrackTableFont,

--- a/src/library/missing_hidden/dlghidden.h
+++ b/src/library/missing_hidden/dlghidden.h
@@ -3,6 +3,9 @@
 #include "library/libraryview.h"
 #include "library/ui_dlghidden.h"
 #include "preferences/usersettings.h"
+#ifdef __STEM__
+#include "engine/engine.h"
+#endif
 
 class WLibrary;
 class WTrackTableView;
@@ -33,6 +36,15 @@ class DlgHidden : public QWidget, public Ui::DlgHidden, public LibraryView {
 
   signals:
     void trackSelected(TrackPointer pTrack);
+    void loadTrack(TrackPointer tio);
+#ifdef __STEM__
+    void loadTrackToPlayer(TrackPointer tio,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask,
+            bool);
+#else
+    void loadTrackToPlayer(TrackPointer tio, const QString& group, bool);
+#endif
 
   private:
     void activateButtons(bool enable);

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -141,6 +141,20 @@ void MixxxLibraryFeature::bindLibraryWidget(WLibrary* pLibraryWidget,
             &DlgHidden::trackSelected,
             this,
             &MixxxLibraryFeature::trackSelected);
+    connect(m_pHiddenView,
+            &DlgHidden::loadTrack,
+            this,
+            &MixxxLibraryFeature::loadTrack);
+    connect(m_pHiddenView,
+            &DlgHidden::loadTrackToPlayer,
+            this,
+            [=, this](TrackPointer track, const QString& group) {
+                emit loadTrackToPlayer(track, group,
+#ifdef __STEM__
+                        mixxx::StemChannelSelection(),
+#endif
+                        false);
+            });
 
     m_pMissingView = new DlgMissing(pLibraryWidget, m_pConfig, m_pLibrary,
                                     pKeyboard);


### PR DESCRIPTION
Previously it was not possible to load a track from Hidden, only drag'n'drop worked.
Now possible by double-click, keyboard, controller and via track menu, like in the other track views (except Missing)