### PR TITLE
Library: Make Parser::playlistEntryToFileInfo public

### DIFF
--- a/src/library/parser.h
+++ b/src/library/parser.h
@@ -31,11 +31,12 @@ class Parser {
     static QList<QString> parseAllLocations(const QString& playlistFile);
     static QList<QString> parse(const QString& playlistFile);
 
-  protected:
-    // check for Utf8 encoding
-    static bool isUtf8(const char* string);
     // Resolve an absolute or relative file path
     static mixxx::FileInfo playlistEntryToFileInfo(
             const QString& playlistEntry,
             const QString& basePath = QString());
+
+  protected:
+    // check for Utf8 encoding
+    static bool isUtf8(const char* string);
 };


### PR DESCRIPTION
# Library: Make Parser::playlistEntryToFileInfo public

This PR makes the `Parser::playlistEntryToFileInfo` method public. This is a prerequisite for reusing the playlist entry resolution logic in other parts of the library (like `BasePlaylistFeature`) without duplicating code.

## Changes
- Changed access modifier for `playlistEntryToFileInfo` from `protected` to `public` in `src/library/parser.h`.
- Kept `isUtf8` protected as it is an internal utility.
