### PR TITLE
Skins cleanup to prevent warnings during load

### DIFF
--- a/res/skins/Deere/special_cue_button.xml
+++ b/res/skins/Deere/special_cue_button.xml
@@ -19,15 +19,11 @@ Variables:
       <Number>0</Number>
       <Text><Variable name="label"/></Text>
       <Alignment><Variable name="Align"/></Alignment>
-      <Pressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_<Variable name="state_0_pressed"/></Pressed>
-      <Unpressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_<Variable name="state_0_unpressed"/></Unpressed>
     </State>
     <State>
       <Number>1</Number>
       <Text><Variable name="label"/></Text>
       <Alignment><Variable name="Align"/></Alignment>
-      <Pressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_<Variable name="state_1_pressed"/></Pressed>
-      <Unpressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_<Variable name="state_1_unpressed"/></Unpressed>
     </State>
     <Connection>
       <ConfigKey><Variable name="group"/>,<Variable name="cue_type"/>_activate</ConfigKey>


### PR DESCRIPTION
While working on skins in development mode, I noticed some warnings and used the opportunity to clean them up.

 - Deere
   - errors : `debug [Main] WPushButton "SpecialCueButton" Error loading pixmap "skin:/buttons/btn_" for state 0`
   - fix : removed the reference in the only file that used these files (res/skins/Deere/special_cue_button.xml). This files exists in other skins, but it is an empty dummy svg, so I thought it would be cleaner to just ignore it
 - LateNight Classic
   - errors ; `qt.svg:warning [Main] Cannot open file 'res/skins/LateNight/classic/buttons/btn__loop_active.svg', [...]`
   - fix : copied the file frome LateNight Palemoon

Note that the issue does not occur in lateNigh64 because the stylesheets are different between the normal and 64 version, hence this picture is never referenced in LateNight64
