### PR TITLE
Real NowPlaying in Titlebar (and file)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1492,6 +1492,7 @@ add_library(
   src/mixer/basetrackplayer.cpp
   src/mixer/deck.cpp
   src/mixer/microphone.cpp
+  src/mixer/nowplaying.cpp
   src/mixer/playerinfo.cpp
   src/mixer/playermanager.cpp
   src/mixer/previewdeck.cpp

--- a/src/mixer/nowplaying.cpp
+++ b/src/mixer/nowplaying.cpp
@@ -1,0 +1,582 @@
+#include "mixer/nowplaying.h"
+
+#include <QDateTime>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QTextStream>
+#include <algorithm>
+
+#include "control/controlobject.h"
+#include "control/controlproxy.h"
+#include "mixer/playerinfo.h"
+#include "moc_nowplaying.cpp"
+#include "util/versionstore.h"
+
+namespace {
+const ConfigKey kConfigKeyNowPlayingEnabled = ConfigKey("[NowPlaying]", "Enabled");
+const ConfigKey kConfigKeyNowPlayingPollInterval = ConfigKey("[NowPlaying]", "PollInterval");
+const ConfigKey kConfigKeyNowPlayingAppendMode = ConfigKey("[NowPlaying]", "AppendMode");
+const ConfigKey kConfigKeyNowPlayingAddTimestamp = ConfigKey("[NowPlaying]", "AddTimestamp");
+const ConfigKey kConfigKeyNowPlayingArchive = ConfigKey("[NowPlaying]", "Archive");
+
+constexpr bool kDefaultNowPlayingEnabled = true;
+constexpr int kDefaultPollInterval = 1000;
+constexpr bool kDefaultAppendMode = false;
+constexpr bool kDefaultAddTimestamp = true;
+constexpr bool kDefaultArchive = true;
+
+constexpr int MAX_DECKS = 4;
+constexpr double VOLUME_THRESHOLD = 0.001;
+constexpr bool debugNowPlaing = true;
+} // namespace
+
+// NowPlaying Main
+NowPlaying::NowPlaying(UserSettingsPointer pConfig, QObject* parent)
+        : QObject(parent),
+          m_pConfig(std::move(pConfig)),
+          m_pWorker(nullptr) {
+}
+
+NowPlaying::~NowPlaying() {
+    shutdown();
+}
+
+void NowPlaying::initialize() {
+    m_pWorker = new NowPlayingWorker(m_pConfig, nullptr);
+    m_pWorker->moveToThread(&m_workerThread);
+
+    connect(&m_workerThread, &QThread::finished, m_pWorker, &QObject::deleteLater);
+    connect(m_pWorker,
+            &NowPlayingWorker::updateWindowTitle,
+            this,
+            &NowPlaying::slotUpdateWindowTitle,
+            Qt::QueuedConnection);
+
+    m_workerThread.start();
+    QMetaObject::invokeMethod(m_pWorker, &NowPlayingWorker::initialize, Qt::QueuedConnection);
+}
+
+void NowPlaying::shutdown() {
+    if (m_pWorker) {
+        QMetaObject::invokeMethod(m_pWorker, &NowPlayingWorker::shutdown, Qt::QueuedConnection);
+    }
+    m_workerThread.quit();
+    m_workerThread.wait();
+}
+
+void NowPlaying::slotUpdateWindowTitle(const QString& title, const QString& filePath) {
+    QWidget* pParentWidget = qobject_cast<QWidget*>(parent());
+    if (!pParentWidget) {
+        return;
+    }
+
+    pParentWidget->setWindowTitle(title);
+    pParentWidget->setWindowFilePath(filePath);
+}
+
+// NowPlay Worker
+NowPlayingWorker::NowPlayingWorker(UserSettingsPointer pConfig, QObject* parent)
+        : QObject(parent),
+          m_pConfig(std::move(pConfig)),
+          m_pMasterCrossfaderProxy(nullptr),
+          m_pollTimer(nullptr),
+          m_sessionArchived(false),
+          m_nowPlayingEnabled(true),
+          m_pollIntervalMs(1000),
+          m_appendMode(false),
+          m_addTimestamp(true),
+          m_archive(true) {
+    VERIFY_OR_DEBUG_ASSERT(m_pConfig) {
+        qDebug() << "[NowPlaying]: UserSettingsPointer is null!";
+        return;
+    }
+
+    const QString settingsPath = m_pConfig->getSettingsPath();
+    m_nowPlayingFilePath = settingsPath + "/NowPlaying.txt";
+    m_archiveFolderPath = settingsPath + "/NowPlaying";
+
+    for (int i = 0; i < MAX_DECKS; ++i) {
+        DeckState state;
+        state.group = QString("[Channel%1]").arg(i + 1);
+        m_deckStates.append(state);
+    }
+}
+
+NowPlayingWorker::~NowPlayingWorker() {
+    shutdown();
+}
+
+void NowPlayingWorker::initialize() {
+    // Read initial settings
+    m_nowPlayingEnabled = m_pConfig->getValue(
+            kConfigKeyNowPlayingEnabled, kDefaultNowPlayingEnabled);
+    m_pollIntervalMs = m_pConfig->getValue(kConfigKeyNowPlayingPollInterval, kDefaultPollInterval);
+    m_appendMode = m_pConfig->getValue(kConfigKeyNowPlayingAppendMode, kDefaultAppendMode);
+    m_addTimestamp = m_pConfig->getValue(kConfigKeyNowPlayingAddTimestamp, kDefaultAddTimestamp);
+    m_archive = m_pConfig->getValue(kConfigKeyNowPlayingArchive, kDefaultArchive);
+
+    if (debugNowPlaing) {
+        qDebug() << "[NowPlayingWorker] Initialized with enabled:" << m_nowPlayingEnabled
+                 << "appendMode:" << m_appendMode << "pollInterval:" << m_pollIntervalMs;
+    }
+
+    // Check if NowPlaying.txt exists from previous session (crash or normal)
+    QFile existingFile(m_nowPlayingFilePath);
+    if (existingFile.exists() && existingFile.size() > 0) {
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlayingWorker] Found existing NowPlaying.txt with content";
+        }
+
+        const QFileInfo fileInfo(existingFile);
+        const QString timestamp = fileInfo.lastModified().toString("yyyyMMdd_HHmmss");
+        const QString expectedArchiveName = QString("NowPlaying_%1.txt").arg(timestamp);
+        const QString archivePath = m_archiveFolderPath + "/" + expectedArchiveName;
+
+        if (QFile::exists(archivePath)) {
+            qDebug() << "[NowPlayingWorker] Archive already exists:" << expectedArchiveName;
+            if (existingFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+                existingFile.resize(0);
+                existingFile.close();
+                if (debugNowPlaing) {
+                    qDebug() << "[NowPlayingWorker] Cleared existing "
+                                "NowPlaying.txt (already archived)";
+                }
+            }
+        } else {
+            if (debugNowPlaing) {
+                qDebug() << "[NowPlayingWorker] Archive not found, archiving now";
+            }
+            ensureArchiveFolderExists();
+            if (existingFile.copy(archivePath)) {
+                qDebug() << "[NowPlayingWorker] Archived previous session to:" << archivePath;
+                if (existingFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+                    existingFile.resize(0);
+                    existingFile.close();
+                    qDebug() << "[NowPlayingWorker] Cleared NowPlaying.txt after archive";
+                }
+            } else {
+                if (debugNowPlaing) {
+                    qDebug() << "[NowPlayingWorker] Failed to archive previous session";
+                }
+            }
+        }
+    }
+
+    if (m_nowPlayingEnabled) {
+        writeSessionHeader();
+        m_sessionArchived = false;
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlayingWorker] Started new session";
+        }
+    }
+
+    connect(&PlayerInfo::instance(),
+            &PlayerInfo::trackChanged,
+            this,
+            &NowPlayingWorker::slotTrackChanged,
+            Qt::DirectConnection);
+
+    for (int i = 0; i < MAX_DECKS; ++i) {
+        const QString& group = m_deckStates[i].group;
+
+        if (ControlObject::exists(ConfigKey(group, "play"))) {
+            ControlProxy* proxy = new ControlProxy(group, "play");
+            m_deckPlayProxies.append(proxy);
+        }
+        if (ControlObject::exists(ConfigKey(group, "pregain"))) {
+            ControlProxy* proxy = new ControlProxy(group, "pregain");
+            m_deckPregainProxies.append(proxy);
+        }
+        if (ControlObject::exists(ConfigKey(group, "volume"))) {
+            ControlProxy* proxy = new ControlProxy(group, "volume");
+            m_deckVolumeProxies.append(proxy);
+        }
+        if (ControlObject::exists(ConfigKey(group, "orientation"))) {
+            ControlProxy* proxy = new ControlProxy(group, "orientation");
+            m_deckCrossfaderOrientationProxies.append(proxy);
+        }
+    }
+
+    if (ControlObject::exists(ConfigKey("[Master]", "crossfader"))) {
+        m_pMasterCrossfaderProxy = new ControlProxy("[Master]", "crossfader");
+    }
+
+    m_pollTimer = new QTimer(this);
+    m_pollTimer->setInterval(m_pollIntervalMs);
+    connect(m_pollTimer, &QTimer::timeout, this, &NowPlayingWorker::slotPollNowPlaying);
+    m_pollTimer->start();
+
+    slotPollNowPlaying();
+}
+
+void NowPlayingWorker::shutdown() {
+    if (m_pollTimer) {
+        m_pollTimer->stop();
+        delete m_pollTimer;
+        m_pollTimer = nullptr;
+    }
+
+    if (m_nowPlayingEnabled && m_appendMode && m_archive && !m_sessionArchived) {
+        QFile currentFile(m_nowPlayingFilePath);
+        if (currentFile.exists() && currentFile.size() > 0) {
+            const QFileInfo fileInfo(currentFile);
+            const QString timestamp = fileInfo.lastModified().toString("yyyyMMdd_HHmmss");
+            const QString archivePath = m_archiveFolderPath + "/NowPlaying_" + timestamp + ".txt";
+
+            if (!QFile::exists(archivePath)) {
+                ensureArchiveFolderExists();
+                if (currentFile.copy(archivePath)) {
+                    if (debugNowPlaing) {
+                        qDebug() << "[NowPlayingWorker] Archived session to:" << archivePath;
+                    }
+                    m_sessionArchived = true;
+                }
+            }
+        }
+    } else if (m_nowPlayingEnabled && m_appendMode && !m_archive) {
+        QFile file(m_nowPlayingFilePath);
+        if (file.open(QIODevice::Append | QIODevice::Text)) {
+            QTextStream stream(&file);
+            stream << "# Session ended: "
+                   << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss") << "\n";
+            stream << "# " << QString(50, '-') << "\n\n";
+            file.close();
+        }
+    }
+
+    qDeleteAll(m_deckPlayProxies);
+    qDeleteAll(m_deckPregainProxies);
+    qDeleteAll(m_deckVolumeProxies);
+    qDeleteAll(m_deckCrossfaderOrientationProxies);
+    delete m_pMasterCrossfaderProxy;
+
+    m_deckPlayProxies.clear();
+    m_deckPregainProxies.clear();
+    m_deckVolumeProxies.clear();
+    m_deckCrossfaderOrientationProxies.clear();
+    m_pMasterCrossfaderProxy = nullptr;
+}
+
+void NowPlayingWorker::DeckState::calculateEffectiveVolume(double crossfaderValue) {
+    double baseVolume = volume * pregain;
+    const double EPSILON = 0.001;
+
+    if (!isPlaying || !currentTrack || baseVolume < EPSILON) {
+        effectiveVolume = 0.0;
+        return;
+    }
+
+    const double FULL_LEFT = -1.0;
+    const double FULL_RIGHT = 1.0;
+
+    if (crossfaderValue < -0.95) {
+        if (crossfaderOrientation == 0) {
+            effectiveVolume = baseVolume;
+        } else if (crossfaderOrientation == 1) {
+            effectiveVolume = baseVolume * 0.7;
+        } else {
+            effectiveVolume = 0.0;
+        }
+    } else if (crossfaderValue > 0.95) {
+        if (crossfaderOrientation == 2) {
+            effectiveVolume = baseVolume;
+        } else if (crossfaderOrientation == 1) {
+            effectiveVolume = baseVolume * 0.7;
+        } else {
+            effectiveVolume = 0.0;
+        }
+    } else {
+        double blendFactor = (crossfaderValue - FULL_LEFT) / (FULL_RIGHT - FULL_LEFT);
+        blendFactor = std::max(0.0, std::min(1.0, blendFactor));
+
+        if (crossfaderOrientation == 0) {
+            effectiveVolume = baseVolume * (1.0 - blendFactor);
+        } else if (crossfaderOrientation == 2) {
+            effectiveVolume = baseVolume * blendFactor;
+        } else {
+            effectiveVolume = baseVolume;
+        }
+    }
+}
+
+void NowPlayingWorker::ensureArchiveFolderExists() {
+    QDir dir(m_archiveFolderPath);
+    if (!dir.exists() && !dir.mkpath(".")) {
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlaying] Failed to create archive folder:" << m_archiveFolderPath;
+        }
+    } else {
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlaying] Failed to create archive folder:" << m_archiveFolderPath;
+        }
+    }
+}
+
+void NowPlayingWorker::archiveCurrentSession() {
+    if (!m_nowPlayingEnabled || !m_appendMode || !m_archive || m_sessionArchived) {
+        return;
+    }
+
+    QFile currentFile(m_nowPlayingFilePath);
+    if (!currentFile.exists()) {
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlayingWorker] No file to archive";
+        }
+        return;
+    }
+
+    if (currentFile.size() == 0) {
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlayingWorker] File is empty, nothing to archive";
+        }
+        return;
+    }
+
+    ensureArchiveFolderExists();
+
+    const QFileInfo fileInfo(currentFile);
+    const QString timestamp = fileInfo.lastModified().toString("yyyyMMdd_HHmmss");
+    const QString archivePath = m_archiveFolderPath + "/NowPlaying_" + timestamp + ".txt";
+
+    // Check if this session was already archived
+    // = checking if archived file with in names filetimpestamp of original
+    if (QFile::exists(archivePath)) {
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlayingWorker] Session already archived:" << archivePath;
+        }
+        m_sessionArchived = true;
+        return;
+    }
+
+    // Check for any file with same timestamp (in case of rename)
+    QDir archiveDir(m_archiveFolderPath);
+    QStringList existingFiles = archiveDir.entryList(QDir::Files);
+    for (const QString& existingFile : std::as_const(existingFiles)) {
+        if (existingFile.contains(timestamp)) {
+            if (debugNowPlaing) {
+                qDebug() << "[NowPlayingWorker] Session already archived as:" << existingFile;
+            }
+            m_sessionArchived = true;
+            return;
+        }
+    }
+
+    // No archive found -> create new one
+    if (currentFile.copy(archivePath)) {
+        QFile archivedFile(archivePath);
+        archivedFile.setPermissions(QFile::ReadOwner | QFile::WriteOwner |
+                QFile::ReadGroup | QFile::ReadOther);
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlayingWorker] Archived session to:" << archivePath;
+        }
+        m_sessionArchived = true;
+    } else {
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlayingWorker] Failed to archive session";
+        }
+    }
+}
+
+int NowPlayingWorker::getDeckIndexFromGroup(const QString& group) const {
+    for (int i = 0; i < MAX_DECKS; ++i) {
+        if (m_deckStates[i].group == group) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+void NowPlayingWorker::slotTrackChanged(
+        const QString& group, TrackPointer pTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
+    const int deckIndex = getDeckIndexFromGroup(group);
+    if (deckIndex >= 0) {
+        m_deckStates[deckIndex].currentTrack = std::move(pTrack);
+    }
+}
+
+void NowPlayingWorker::slotPollNowPlaying() {
+    if (debugNowPlaing) {
+        qDebug() << "[NowPlayingWorker] Polling...";
+    }
+
+    const bool newEnabled = m_pConfig->getValue(
+            kConfigKeyNowPlayingEnabled, kDefaultNowPlayingEnabled);
+    const int newPollInterval = m_pConfig->getValue(
+            kConfigKeyNowPlayingPollInterval, kDefaultPollInterval);
+    const bool newAppendMode = m_pConfig->getValue(
+            kConfigKeyNowPlayingAppendMode, kDefaultAppendMode);
+    const bool newAddTimestamp = m_pConfig->getValue(
+            kConfigKeyNowPlayingAddTimestamp, kDefaultAddTimestamp);
+    const bool newArchive = m_pConfig->getValue(kConfigKeyNowPlayingArchive, kDefaultArchive);
+
+    if (newEnabled != m_nowPlayingEnabled) {
+        m_nowPlayingEnabled = newEnabled;
+        if (m_nowPlayingEnabled) {
+            if (debugNowPlaing) {
+                qDebug() << "[NowPlaying] File writing enabled - writing session header";
+            }
+            writeSessionHeader();
+        } else {
+            if (debugNowPlaing) {
+                qDebug() << "[NowPlaying] File writing disabled - archiving and clearing";
+            }
+            if (m_appendMode && m_archive) {
+                archiveCurrentSession();
+            }
+            QFile file(m_nowPlayingFilePath);
+            if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+                file.resize(0);
+                file.close();
+                file.setPermissions(QFile::ReadOwner | QFile::WriteOwner |
+                        QFile::ReadGroup | QFile::ReadOther);
+            }
+        }
+    }
+
+    if (newAppendMode != m_appendMode) {
+        m_appendMode = newAppendMode;
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlaying] AppendMode changed to:" << m_appendMode;
+        }
+        if (m_nowPlayingEnabled) {
+            writeSessionHeader();
+        }
+    } else {
+        m_appendMode = newAppendMode;
+    }
+
+    m_archive = newArchive;
+
+    m_addTimestamp = newAddTimestamp;
+
+    if (newPollInterval != m_pollIntervalMs && newPollInterval > 0) {
+        m_pollIntervalMs = newPollInterval;
+        if (m_pollTimer) {
+            m_pollTimer->setInterval(m_pollIntervalMs);
+        }
+        qDebug() << "[NowPlaying] Poll interval changed to:" << m_pollIntervalMs;
+    }
+
+    const double crossfaderValue = m_pMasterCrossfaderProxy ? m_pMasterCrossfaderProxy->get() : 0.0;
+
+    QList<DeckState> audibleDecks;
+    for (int i = 0; i < MAX_DECKS; ++i) {
+        if (i < m_deckPlayProxies.size() && m_deckPlayProxies[i]) {
+            m_deckStates[i].isPlaying = m_deckPlayProxies[i]->get() > 0.0;
+        }
+        if (i < m_deckPregainProxies.size() && m_deckPregainProxies[i]) {
+            m_deckStates[i].pregain = m_deckPregainProxies[i]->get();
+        }
+        if (i < m_deckVolumeProxies.size() && m_deckVolumeProxies[i]) {
+            m_deckStates[i].volume = m_deckVolumeProxies[i]->get();
+        }
+        if (i < m_deckCrossfaderOrientationProxies.size() &&
+                m_deckCrossfaderOrientationProxies[i]) {
+            m_deckStates[i].crossfaderOrientation = static_cast<int>(
+                    m_deckCrossfaderOrientationProxies[i]->get());
+        }
+
+        m_deckStates[i].calculateEffectiveVolume(crossfaderValue);
+
+        if (m_deckStates[i].isPlaying &&
+                m_deckStates[i].effectiveVolume > VOLUME_THRESHOLD &&
+                m_deckStates[i].currentTrack) {
+            audibleDecks.append(m_deckStates[i]);
+        }
+    }
+
+    // Sort by volume (loudest first)
+    std::sort(audibleDecks.begin(), audibleDecks.end(), [](const DeckState& a, const DeckState& b) {
+        return a.effectiveVolume > b.effectiveVolume;
+    });
+
+    if (audibleDecks.isEmpty()) {
+        emit updateWindowTitle(VersionStore::applicationName(), QString());
+        if (m_nowPlayingEnabled) {
+            writeNowPlayingFile("");
+        }
+        return;
+    }
+
+    QStringList trackStrings;
+    trackStrings.reserve(audibleDecks.size());
+    for (const auto& deck : std::as_const(audibleDecks)) {
+        const QString trackInfo = deck.currentTrack->getInfo();
+        if (!trackInfo.isEmpty()) {
+            trackStrings.append(trackInfo);
+        }
+    }
+
+    const QString combinedTitle = trackStrings.join(" | ");
+    const QString appTitle = VersionStore::applicationName();
+    const QString windowTitle = QString("%1 | %2").arg(appTitle, combinedTitle);
+    const QString filePath = audibleDecks[0].currentTrack->getLocation();
+
+    emit updateWindowTitle(windowTitle, filePath);
+
+    if (m_nowPlayingEnabled) {
+        writeNowPlayingFile(trackStrings.join(" | "));
+    }
+}
+
+void NowPlayingWorker::writeNowPlayingFile(const QString& content) {
+    static QString lastContent;
+
+    if (!m_nowPlayingEnabled) {
+        return;
+    }
+
+    if (content == lastContent) {
+        return;
+    }
+
+    QFile file(m_nowPlayingFilePath);
+    const QIODevice::OpenMode mode =
+            (m_appendMode ? QIODevice::Append : QIODevice::WriteOnly) |
+            QIODevice::Text;
+
+    if (file.open(mode)) {
+        QTextStream stream(&file);
+
+        if (m_appendMode && m_addTimestamp) {
+            const QString timestamp = QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss");
+            if (content.isEmpty()) {
+                stream << timestamp << " | [NO TRACKS PLAYING]\n";
+            } else {
+                stream << timestamp << " | " << content << "\n";
+            }
+        } else if (m_appendMode && !m_addTimestamp) {
+            if (content.isEmpty()) {
+                stream << "[NO TRACKS PLAYING]\n";
+            } else {
+                stream << content << "\n";
+            }
+        } else if (!content.isEmpty()) {
+            stream << content << "\n";
+        }
+
+        file.close();
+        lastContent = content;
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlaying] File written:" << content;
+        }
+    }
+}
+
+void NowPlayingWorker::writeSessionHeader() {
+    QFile file(m_nowPlayingFilePath);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QTextStream stream(&file);
+        stream << "# Mixxx Session started: "
+               << QDateTime::currentDateTime().toString("yyyy-MM-dd hh:mm:ss") << "\n";
+        stream << "# " << QString(50, '-') << "\n";
+        file.close();
+        file.setPermissions(QFile::ReadOwner | QFile::WriteOwner |
+                QFile::ReadGroup | QFile::ReadOther);
+        if (debugNowPlaing) {
+            qDebug() << "[NowPlaying] Session header written";
+        }
+    }
+}

--- a/src/mixer/nowplaying.h
+++ b/src/mixer/nowplaying.h
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <QList>
+#include <QObject>
+#include <QString>
+#include <QThread>
+#include <QTimer>
+#include <memory>
+
+#include "preferences/usersettings.h"
+#include "track/track.h"
+
+class ControlProxy;
+
+class NowPlayingWorker : public QObject {
+    Q_OBJECT
+
+  public:
+    explicit NowPlayingWorker(UserSettingsPointer pConfig, QObject* parent = nullptr);
+    ~NowPlayingWorker() override;
+
+    void initialize();
+    void shutdown();
+
+  signals:
+    void updateWindowTitle(const QString& title, const QString& filePath);
+    void fileWriteRequested(const QString& content);
+
+  private slots:
+    void slotPollNowPlaying();
+    void slotTrackChanged(const QString& group, TrackPointer pTrack, TrackPointer pOldTrack);
+
+  private:
+    struct DeckState {
+        QString group;
+        TrackPointer currentTrack;
+        double volume;
+        double pregain;
+        double crossfaderOrientation;
+        bool isPlaying;
+        double effectiveVolume;
+
+        void calculateEffectiveVolume(double crossfaderValue);
+    };
+
+    UserSettingsPointer m_pConfig;
+
+    QList<ControlProxy*> m_deckPlayProxies;
+    QList<ControlProxy*> m_deckPregainProxies;
+    QList<ControlProxy*> m_deckVolumeProxies;
+    QList<ControlProxy*> m_deckCrossfaderOrientationProxies;
+    ControlProxy* m_pMasterCrossfaderProxy;
+
+    QList<DeckState> m_deckStates;
+    QTimer* m_pollTimer;
+    QString m_nowPlayingFilePath;
+    QString m_archiveFolderPath;
+    bool m_sessionArchived;
+
+    bool m_nowPlayingEnabled;
+    int m_pollIntervalMs;
+    bool m_appendMode;
+    bool m_addTimestamp;
+    bool m_archive;
+
+    void writeNowPlayingFile(const QString& content);
+    int getDeckIndexFromGroup(const QString& group) const;
+    void archiveCurrentSession();
+    void ensureArchiveFolderExists();
+    void writeSessionHeader();
+};
+
+class NowPlaying : public QObject {
+    Q_OBJECT
+
+  public:
+    explicit NowPlaying(UserSettingsPointer pConfig, QObject* parent = nullptr);
+    ~NowPlaying() override;
+
+    void initialize();
+    void shutdown();
+
+  private slots:
+    void slotUpdateWindowTitle(const QString& title, const QString& filePath);
+
+  private:
+    UserSettingsPointer m_pConfig;
+    QThread m_workerThread;
+    NowPlayingWorker* m_pWorker;
+};
+
+// #pragma once
+//
+// #include <QList>
+// #include <QObject>
+// #include <QString>
+// #include <QTimer>
+// #include <memory>
+//
+// #include "preferences/usersettings.h"
+// #include "track/track.h"
+//
+// class ControlProxy;
+//
+// class NowPlaying : public QObject {
+//     Q_OBJECT
+//
+//   public:
+//     NowPlaying(UserSettingsPointer pConfig,
+//             QObject* parent = nullptr);
+//     ~NowPlaying();
+//
+//     void initialize();
+//     void shutdown();
+//
+//   private slots:
+//     void slotPollNowPlaying();
+//     void slotTrackChanged(const QString& group, TrackPointer pTrack, TrackPointer pOldTrack);
+//
+//   private:
+//     struct DeckState {
+//         QString group;
+//         TrackPointer currentTrack;
+//         double volume;
+//         double pregain;
+//         double crossfaderOrientation;
+//         bool isPlaying;
+//         double effectiveVolume;
+//
+//         void calculateEffectiveVolume(double crossfaderValue);
+//     };
+//
+//     UserSettingsPointer m_pConfig;
+//
+//     QList<ControlProxy*> m_deckPlayProxies;
+//     QList<ControlProxy*> m_deckPregainProxies;
+//     QList<ControlProxy*> m_deckVolumeProxies;
+//     QList<ControlProxy*> m_deckCrossfaderOrientationProxies;
+//     ControlProxy* m_pMasterCrossfaderProxy;
+//
+//     QList<DeckState> m_deckStates;
+//     QTimer m_pollTimer;
+//     QString m_nowPlayingFilePath;
+//     QString m_archiveFolderPath;
+//     bool m_sessionArchived;
+//
+//     bool m_nowPlayingEnabled;
+//     int m_pollIntervalMs;
+//     bool m_appendMode;
+//     bool m_addTimestamp;
+//     bool m_archive;
+//
+//     void writeNowPlayingFile(const QString& content);
+//     void updateWindowTitle(const QList<DeckState>& audibleDecks);
+//     int getDeckIndexFromGroup(const QString& group);
+//     void archiveCurrentSession();
+//     void ensureArchiveFolderExists();
+//     void writeSessionHeader();
+// };

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -43,6 +43,7 @@
 #endif
 #include "library/library_prefs.h"
 #include "library/trackcollectionmanager.h"
+#include "mixer/nowplaying.h"
 #include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
 #include "recording/recordingmanager.h"
@@ -452,10 +453,10 @@ void MixxxMainWindow::initialize() {
             this,
             &MixxxMainWindow::slotNoVinylControlInputConfigured);
 
-    connect(&PlayerInfo::instance(),
-            &PlayerInfo::currentPlayingTrackChanged,
-            this,
-            &MixxxMainWindow::slotUpdateWindowTitle);
+    m_pNowPlaying = std::make_unique<NowPlaying>(
+            m_pCoreServices->getSettings(),
+            this);
+    m_pNowPlaying->initialize();
 
     // Start Auto DJ if the cmdline arg is passed.
     if (CmdlineArgs::Instance().getStartAutoDJ()) {
@@ -589,7 +590,6 @@ void MixxxMainWindow::initializeWindow() {
                     .toUtf8()));
 
     setWindowIcon(QIcon(MIXXX_ICON_PATH));
-    slotUpdateWindowTitle(TrackPointer());
 }
 
 #ifndef __APPLE__
@@ -790,27 +790,6 @@ QDialog::DialogCode MixxxMainWindow::noOutputDlg(bool* continueClicked) {
             return QDialog::Rejected;
         }
     }
-}
-
-void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
-    QString appTitle = VersionStore::applicationName();
-    QString filePath;
-
-    // If we have a track, use getInfo() to format a summary string and prepend
-    // it to the title.
-    // TODO(rryan): Does this violate Mac App Store policies?
-    if (pTrack) {
-        QString trackInfo = pTrack->getInfo();
-        if (!trackInfo.isEmpty()) {
-            appTitle = QString("%1 | %2").arg(trackInfo, appTitle);
-        }
-        filePath = pTrack->getLocation();
-    }
-    setWindowTitle(appTitle);
-
-    // Display a draggable proxy icon for the track in the title bar on
-    // platforms that support it, e.g. macOS
-    setWindowFilePath(filePath);
 }
 
 void MixxxMainWindow::createMenuBar() {

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <memory>
 
+#include "mixer/nowplaying.h"
 #include "preferences/constants.h"
 #include "soundio/sounddevicestatus.h"
 #include "track/track_decl.h"
@@ -73,8 +74,6 @@ class MixxxMainWindow : public QMainWindow {
     /// open the developer tools dialog.
     void slotDeveloperTools(bool enable);
     void slotDeveloperToolsClosed();
-
-    void slotUpdateWindowTitle(TrackPointer pTrack);
 
     /// warn the user when inputs are not configured.
     void slotNoMicrophoneInputConfigured();
@@ -162,4 +161,6 @@ class MixxxMainWindow : public QMainWindow {
     mixxx::preferences::ScreenSaver m_inhibitScreensaver;
 
     QSet<ControlObject*> m_skinCreatedControls;
+
+    std::unique_ptr<NowPlaying> m_pNowPlaying;
 };

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -29,6 +29,18 @@ constexpr double kDefaultPositionDisplayType =
 // to playermanager.cpp
 const QString kAppGroup = QStringLiteral("[App]");
 const QString kControlsGroup = QStringLiteral("[Controls]");
+
+const ConfigKey kConfigKeyNowPlayingEnabled = ConfigKey("[NowPlaying]", "Enabled");
+const ConfigKey kConfigKeyNowPlayingAppendMode = ConfigKey("[NowPlaying]", "AppendMode");
+const ConfigKey kConfigKeyNowPlayingAddTimestamp = ConfigKey("[NowPlaying]", "AddTimestamp");
+const ConfigKey kConfigKeyNowPlayingArchive = ConfigKey("[NowPlaying]", "Archive");
+const ConfigKey kConfigKeyNowPlayingPollInterval = ConfigKey("[NowPlaying]", "PollInterval");
+
+constexpr bool kDefaultNowPlayingEnabled = true;
+constexpr bool kDefaultNowPlayingAppendMode = false;
+constexpr bool kDefaultNowPlayingAddTimestamp = true;
+constexpr bool kDefaultNowPlayingArchive = true;
+constexpr int kDefaultNowPlayingPollInterval = 1000;
 } // namespace
 
 DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
@@ -429,6 +441,76 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
     RateControl::setPermanentRateChangeCoarseAmount(m_dRatePermCoarse);
     RateControl::setPermanentRateChangeFineAmount(m_dRatePermFine);
 
+    // NowPlaying settings
+    m_bNowPlayingEnabled = m_pConfig->getValue(
+            kConfigKeyNowPlayingEnabled, kDefaultNowPlayingEnabled);
+    m_bNowPlayingAppendMode = m_pConfig->getValue(
+            kConfigKeyNowPlayingAppendMode, kDefaultNowPlayingAppendMode);
+    m_bNowPlayingAddTimestamp = m_pConfig->getValue(
+            kConfigKeyNowPlayingAddTimestamp, kDefaultNowPlayingAddTimestamp);
+    m_bNowPlayingArchive = m_pConfig->getValue(
+            kConfigKeyNowPlayingArchive, kDefaultNowPlayingArchive);
+    m_iNowPlayingPollInterval = m_pConfig->getValue(
+            kConfigKeyNowPlayingPollInterval, kDefaultNowPlayingPollInterval);
+
+    checkBoxEnableNowPlaying->setChecked(m_bNowPlayingEnabled);
+    checkBoxNowPlayingAppend->setChecked(m_bNowPlayingAppendMode);
+    checkBoxNowPlayingAddTimestamp->setChecked(m_bNowPlayingAddTimestamp);
+    checkBoxNowPlayingArchive->setChecked(m_bNowPlayingArchive);
+
+    // nowPlaying poll interval combo box
+    int intervalIndex = 1;
+    switch (m_iNowPlayingPollInterval) {
+    case 500:
+        intervalIndex = 0;
+        break;
+    case 1000:
+        intervalIndex = 1;
+        break;
+    case 2000:
+        intervalIndex = 2;
+        break;
+    case 5000:
+        intervalIndex = 3;
+        break;
+    case 10000:
+        intervalIndex = 4;
+        break;
+    default:
+        intervalIndex = 1;
+        break;
+    }
+    comboBoxNowPlayingPollInterval->setCurrentIndex(intervalIndex);
+
+    checkBoxNowPlayingAppend->setEnabled(m_bNowPlayingEnabled);
+    checkBoxNowPlayingAddTimestamp->setEnabled(m_bNowPlayingEnabled && m_bNowPlayingAppendMode);
+    checkBoxNowPlayingArchive->setEnabled(m_bNowPlayingEnabled && m_bNowPlayingAppendMode);
+    labelNowPlayingAppend->setEnabled(m_bNowPlayingEnabled);
+    labelNowPlayingArchive->setEnabled(m_bNowPlayingEnabled && m_bNowPlayingAppendMode);
+    labelNowPlayingPollInterval->setEnabled(m_bNowPlayingEnabled);
+    comboBoxNowPlayingPollInterval->setEnabled(m_bNowPlayingEnabled);
+
+    connect(checkBoxEnableNowPlaying,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefDeck::slotEnableNowPlayingChanged);
+    connect(checkBoxNowPlayingAppend,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefDeck::slotNowPlayingAppendChanged);
+    connect(checkBoxNowPlayingAddTimestamp,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefDeck::slotNowPlayingAddTimestampChanged);
+    connect(checkBoxNowPlayingArchive,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefDeck::slotNowPlayingArchiveChanged);
+    connect(comboBoxNowPlayingPollInterval,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &DlgPrefDeck::slotNowPlayingPollIntervalChanged);
+
     slotUpdate();
 }
 
@@ -521,6 +603,45 @@ void DlgPrefDeck::slotUpdate() {
     spinBoxTemporaryRateFine->setValue(RateControl::getTemporaryRateChangeFineAmount());
     spinBoxPermanentRateCoarse->setValue(RateControl::getPermanentRateChangeCoarseAmount());
     spinBoxPermanentRateFine->setValue(RateControl::getPermanentRateChangeFineAmount());
+
+    m_bNowPlayingEnabled = m_pConfig->getValue(
+            kConfigKeyNowPlayingEnabled, kDefaultNowPlayingEnabled);
+    m_bNowPlayingAppendMode = m_pConfig->getValue(
+            kConfigKeyNowPlayingAppendMode, kDefaultNowPlayingAppendMode);
+    m_bNowPlayingAddTimestamp = m_pConfig->getValue(
+            kConfigKeyNowPlayingAddTimestamp, kDefaultNowPlayingAddTimestamp);
+    m_bNowPlayingArchive = m_pConfig->getValue(
+            kConfigKeyNowPlayingArchive, kDefaultNowPlayingArchive);
+    m_iNowPlayingPollInterval = m_pConfig->getValue(
+            kConfigKeyNowPlayingPollInterval, kDefaultNowPlayingPollInterval);
+
+    checkBoxEnableNowPlaying->setChecked(m_bNowPlayingEnabled);
+    checkBoxNowPlayingAppend->setChecked(m_bNowPlayingAppendMode);
+    checkBoxNowPlayingAddTimestamp->setChecked(m_bNowPlayingAddTimestamp);
+    checkBoxNowPlayingArchive->setChecked(m_bNowPlayingArchive);
+
+    int intervalIndex = 1;
+    switch (m_iNowPlayingPollInterval) {
+    case 500:
+        intervalIndex = 0;
+        break;
+    case 1000:
+        intervalIndex = 1;
+        break;
+    case 2000:
+        intervalIndex = 2;
+        break;
+    case 5000:
+        intervalIndex = 3;
+        break;
+    case 10000:
+        intervalIndex = 4;
+        break;
+    default:
+        intervalIndex = 1;
+        break;
+    }
+    comboBoxNowPlayingPollInterval->setCurrentIndex(intervalIndex);
 }
 
 void DlgPrefDeck::slotResetToDefaults() {
@@ -564,6 +685,12 @@ void DlgPrefDeck::slotResetToDefaults() {
 
     radioButtonOriginalKey->setChecked(true);
     radioButtonResetUnlockedKey->setChecked(true);
+
+    checkBoxEnableNowPlaying->setChecked(kDefaultNowPlayingEnabled);
+    checkBoxNowPlayingAppend->setChecked(kDefaultNowPlayingAppendMode);
+    checkBoxNowPlayingAddTimestamp->setChecked(kDefaultNowPlayingAddTimestamp);
+    checkBoxNowPlayingArchive->setChecked(kDefaultNowPlayingArchive);
+    comboBoxNowPlayingPollInterval->setCurrentIndex(1);
 }
 
 void DlgPrefDeck::slotMoveIntroStartCheckbox(bool checked) {
@@ -792,6 +919,13 @@ void DlgPrefDeck::slotApply() {
     m_pConfig->setValue(
             ConfigKey(kControlsGroup, QStringLiteral("RatePermRight")),
             m_dRatePermFine);
+
+    // nowPlaying
+    m_pConfig->setValue(kConfigKeyNowPlayingEnabled, m_bNowPlayingEnabled);
+    m_pConfig->setValue(kConfigKeyNowPlayingAppendMode, m_bNowPlayingAppendMode);
+    m_pConfig->setValue(kConfigKeyNowPlayingAddTimestamp, m_bNowPlayingAddTimestamp);
+    m_pConfig->setValue(kConfigKeyNowPlayingArchive, m_bNowPlayingArchive);
+    m_pConfig->setValue(kConfigKeyNowPlayingPollInterval, m_iNowPlayingPollInterval);
 }
 
 void DlgPrefDeck::slotNumDecksChanged(double new_count, bool initializing) {
@@ -878,4 +1012,57 @@ int DlgPrefDeck::cueDefaultIndexByData(int userData) const {
     qWarning() << "No default cue behavior found for value" << userData
                << "returning default";
     return 0;
+}
+
+void DlgPrefDeck::slotEnableNowPlayingChanged(bool checked) {
+    m_bNowPlayingEnabled = checked;
+
+    // Enable/disable dependent controls
+    checkBoxNowPlayingAppend->setEnabled(checked);
+    checkBoxNowPlayingAddTimestamp->setEnabled(checked && m_bNowPlayingAppendMode);
+    checkBoxNowPlayingArchive->setEnabled(checked && m_bNowPlayingAppendMode);
+    labelNowPlayingAppend->setEnabled(checked);
+    labelNowPlayingArchive->setEnabled(checked && m_bNowPlayingAppendMode);
+    labelNowPlayingPollInterval->setEnabled(checked);
+    comboBoxNowPlayingPollInterval->setEnabled(checked);
+}
+
+void DlgPrefDeck::slotNowPlayingAppendChanged(bool checked) {
+    m_bNowPlayingAppendMode = checked;
+
+    // Timestamp and archive only make sense in append mode
+    checkBoxNowPlayingAddTimestamp->setEnabled(m_bNowPlayingEnabled && checked);
+    checkBoxNowPlayingArchive->setEnabled(m_bNowPlayingEnabled && checked);
+    labelNowPlayingArchive->setEnabled(m_bNowPlayingEnabled && checked);
+}
+
+void DlgPrefDeck::slotNowPlayingAddTimestampChanged(bool checked) {
+    m_bNowPlayingAddTimestamp = checked;
+}
+
+void DlgPrefDeck::slotNowPlayingArchiveChanged(bool checked) {
+    m_bNowPlayingArchive = checked;
+}
+
+void DlgPrefDeck::slotNowPlayingPollIntervalChanged(int index) {
+    switch (index) {
+    case 0:
+        m_iNowPlayingPollInterval = 500;
+        break;
+    case 1:
+        m_iNowPlayingPollInterval = 1000;
+        break;
+    case 2:
+        m_iNowPlayingPollInterval = 2000;
+        break;
+    case 3:
+        m_iNowPlayingPollInterval = 5000;
+        break;
+    case 4:
+        m_iNowPlayingPollInterval = 10000;
+        break;
+    default:
+        m_iNowPlayingPollInterval = 1000;
+        break;
+    }
 }

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -63,6 +63,12 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotUpdateSpeedAutoReset(bool);
     void slotUpdatePitchAutoReset(bool);
 
+    void slotEnableNowPlayingChanged(bool checked);
+    void slotNowPlayingAppendChanged(bool checked);
+    void slotNowPlayingAddTimestampChanged(bool checked);
+    void slotNowPlayingArchiveChanged(bool checked);
+    void slotNowPlayingPollIntervalChanged(int index);
+
   private:
     // Because the CueDefault list is out of order, we have to set the combo
     // box using the user data, not the index.  Returns the index of the item
@@ -114,4 +120,10 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     double m_dRateTempFine;
     double m_dRatePermCoarse;
     double m_dRatePermFine;
+
+    bool m_bNowPlayingEnabled;
+    bool m_bNowPlayingAppendMode;
+    bool m_bNowPlayingAddTimestamp;
+    bool m_bNowPlayingArchive;
+    int m_iNowPlayingPollInterval;
 };

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -643,19 +643,109 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
+    <item row="2" column="0">
+      <widget class="QGroupBox" name="groupBoxNowPlaying">
+        <property name="title">
+          <string>NowPlaying</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayoutNowPlaying">
+          <property name="spacing">
+            <number>10</number>
+          </property>
+          <item row="0" column="0" colspan="3">
+            <widget class="QCheckBox" name="checkBoxEnableNowPlaying">
+              <property name="text">
+                <string>Enable NowPlaying file</string>
+              </property>
+            </widget>
+          </item>
+          <item row="1" column="0">
+            <widget class="QLabel" name="labelNowPlayingAppend">
+              <property name="text">
+                <string>Append to file</string>
+              </property>
+            </widget>
+          </item>
+          <item row="1" column="1">
+            <widget class="QCheckBox" name="checkBoxNowPlayingAppend">
+              <property name="text">
+                <string/>
+              </property>
+            </widget>
+          </item>
+          <item row="1" column="2">
+            <widget class="QCheckBox" name="checkBoxNowPlayingAddTimestamp">
+              <property name="text">
+                <string>Add timestamp</string>
+              </property>
+            </widget>
+          </item>
+          <item row="2" column="0">
+            <widget class="QLabel" name="labelNowPlayingArchive">
+              <property name="text">
+                <string>Archive sessions</string>
+              </property>
+            </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+            <widget class="QCheckBox" name="checkBoxNowPlayingArchive">
+              <property name="text">
+                <string/>
+              </property>
+            </widget>
+          </item>
+          <item row="3" column="0">
+            <widget class="QLabel" name="labelNowPlayingPollInterval">
+              <property name="text">
+                <string>Poll interval (ms)</string>
+              </property>
+            </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+            <widget class="QComboBox" name="comboBoxNowPlayingPollInterval">
+              <item>
+                <property name="text">
+                  <string>500 ms (fast)</string>
+                </property>
+              </item>
+              <item>
+                <property name="text">
+                  <string>1000 ms (default)</string>
+                </property>
+              </item>
+              <item>
+                <property name="text">
+                  <string>2000 ms</string>
+                </property>
+              </item>
+              <item>
+                <property name="text">
+                  <string>5000 ms</string>
+                </property>
+              </item>
+              <item>
+                <property name="text">
+                  <string>10000 ms (slow)</string>
+                </property>
+              </item>
+            </widget>
+          </item>
+        </layout>
+      </widget>
+    </item>
+    <item row="3" column="0">
+      <spacer name="verticalSpacer2">
+        <property name="orientation">
+          <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+          <size>
+            <width>20</width>
+            <height>40</height>
+          </size>
+        </property>
+      </spacer>
+    </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
@@ -685,6 +775,11 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
   <tabstop>spinBoxTemporaryRateCoarse</tabstop>
   <tabstop>spinBoxPermanentRateFine</tabstop>
   <tabstop>spinBoxPermanentRateCoarse</tabstop>
+  <tabstop>checkBoxEnableNowPlaying</tabstop>
+  <tabstop>checkBoxNowPlayingAppend</tabstop>
+  <tabstop>checkBoxNowPlayingAddTimestamp</tabstop>
+  <tabstop>checkBoxNowPlayingArchive</tabstop>
+  <tabstop>comboBoxNowPlayingPollInterval</tabstop>
  </tabstops>
  <resources/>
  <buttongroups>


### PR DESCRIPTION
Something that catches my eye time and time again and that I kept noting in my todos.
Building further on previous NowPlaying experiments.

With this PR all songs played in decks that are audible are displayed correctly in the titlebar.

The algorithm attempts to mimic the final output as closely as possible and sort the tracks by audible volume.

Based on the replaygain (all tracks play at 'same normalized level') we don't need signalstrength, 
with playstate, pregain, volume, orientation and crossfader we can detect all decks (not samplers, aux, mic, vinyl passthrough) that are audible in the 'main output', sort them on volume and display them in the titlebar, formatted as 
Mixxx | Artist 1 - Track 1 | Artist 2 - Track 2 | Artist 3 - Track 3  | Artist 4 - Track 4

eg
when all decks are playing, deck 1 & 3 assigned left of the crossfader, 2 & 4 to the right
when all pregains are centered
when decks 1 & 2 have volume fader at 60% and deck 3 & 4 at 80%
when crossfader is completely moved to the right
-> Track 4 | Track 2
when crossfader is centered
-> Track 3 | Track 4 | Track 1 | Track 2
when crossfader is completely moved to the left
-> Track 3 | Track 1

**Q&A**

**Can this info be written in a file?**
-> In Preferences -> Decks you can enable the NowPlaying function which will create a NowPlaying.txt file in the usersettings folder.

**Is this only writing the current situation, the current playing song or can I keep a complete history?**
-> In Preferences -> Decks when the NowPlaying function is enabled you can also check the "append to file"  checkbox, new lines will be appended at the bottom and you will keep the history of the current session. On top you get a session heading for free.
 "Mixxx Session started: <Date> <Time>"

**Is it possible to have the time a song was played in the NowPlaying.txt file?**
-> In Preferences -> Decks when the NowPlaying function and "append to file" are enabled, you can also check the 'Add timestamp" checkbox. This will prepend the lines with <date> <time>. Date is helpfull when passing midnight. 

**Can these files be archived?**
-> In Preferences -> Decks when the NowPlaying function and "append to file" are enabled, you can also check the "Archive sessions" checkbox, this will copy the NowPlaying.txt file to a NowPlaying_<<date_time>>.txt file in a NowPlaying subfolder of the UserSettingsFolder. <<date_time>> = the file modified timestamp of the original NowPlaying.txt.

**How many times does NowPlaying checj which songs are playing?** 
-> In Preferences -> Decks when the NowPlaying function is enabled you can also set the "Poll intervall' from 500ms to 10 sec. 
eg if your AutoDJ is set on transition duration of 5 sec and you set the Polling interval on 10 sec the transition may possibly not be written in the NowPlaying file.

**If I set the polling on 1 sec will there be 240 times the same line for a 4 minutes song?**
-> No if the line that must be written is the same as the previous ... it's skipped. So only lines reflecting a new situation are written.

**What if my PC / Mixxx crashes on shutdown?**
-> The NowPlaying.txt file is unchanged until the next session. At the startup of the next session Mixxx will check if a file like NowPlaying_<<date_time>>.txt with <<date_time<> = the file modified timestamp of the original NowPlaying.txt file. 
----> If it not exists (you deleted or moved  it or it wasn't created because of a crash) Mixxx will create that file, so with <date> <time> of the end of your previous session. If 
----> If it exists (no problams at shutsown) Mixxx will start a new session with an empty NowPlaying.txt file.

**Can I change the settings during a session?**
-> Yes but the NowPlaying cannot turn back time, so the session starts on enabling. On disabling the NowPlaying, in a session will cause loosing the current session history. 

**What will be written in the file?**
Each changed situation will be noted.
examples with Track 1 from Artist 1 in deck 1, Track 2 from Artist 2 in deck 2
eg AutoDJ is playing with a transition of 5 seconds, 
        20260425 22:00:00 | Artist 1 - Track 1
        20260425 22:03:00 | Artist 1 - Track 1 | Artist 2 - Track 2
        20260425 22:03:03 | Artist 2 - Track 2 | Artist 1 - Track 1
        20260425 22:03:05 | Artist 2 - Track 2
-> you 'll have all intermediate steps the crossfader takes.

eg you are mixing with the crossfader in the centered position, all decks have centered crossfader orientation and equal pregain
Deck 1: volume = 90%,  you are mixing in Deck 2 fader is at 65% but track is not playing
20260425 22:00:00 | Artist 1 - Track 1
--> you press play on deck 2
20260425 22:00:30 | Artist 1 - Track 1 | Artist 2 - Track 2
--> you move the volume fader from deck 2 to the same level as the volume fader of deck 1
--> no new lines written, same volume, when same volume number order of the decks.
--> you move the volume fader of deck 1 to lower the volume
20260425 22:01:00 | Artist 2 - Track 2 | Artist 1 - Track 1
--> now the loudest playing track is in deck 2

