### PR TITLE
(fix) Track: emit bpmLockChanged when updating TrackRecord so `bpmlock` control is also updated

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -1192,6 +1192,7 @@ void BpmControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
 }
 
 void BpmControl::trackBpmLockChanged(bool locked) {
+    // This is called by EngineBuffer after receiving Track::bpmLockChanged() signal
     m_pBpmLock->setAndConfirm(locked);
     if (locked) {
         m_pBeatsUndoPossible->forceSet(0);
@@ -1255,7 +1256,8 @@ void BpmControl::slotToggleBpmLock(double v) {
     }
     bool locked = pTrack->isBpmLocked();
     pTrack->setBpmLocked(!locked);
-    // The pushbutton is updated in trackBpmLockChanged() via bpmLockChanged() signal.
+    // Track emits bpmLockChanged() signal, and EngineBuffer updates the pushbutton
+    // by calling trackBpmLockChanged()
 }
 
 mixxx::Bpm BpmControl::updateLocalBpm() {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -303,6 +303,7 @@ bool Track::replaceRecord(
     const auto newReplayGain = newRecord.getMetadata().getTrackInfo().getReplayGain();
     const auto newColor = newRecord.getColor();
     const auto newRating = newRecord.getRating();
+    const bool newBpmLocked = newRecord.getBpmLocked();
 
     auto locked = lockMutex(&m_qMutex);
     const bool recordUnchanged = m_record == newRecord;
@@ -313,6 +314,7 @@ bool Track::replaceRecord(
     const auto oldReplayGain = m_record.getMetadata().getTrackInfo().getReplayGain();
     const auto oldColor = m_record.getColor();
     const auto oldRating = m_record.getRating();
+    const bool oldBpmLocked = m_record.getBpmLocked();
 
     bool bpmUpdatedFlag;
     if (pOptionalBeats) {
@@ -338,6 +340,9 @@ bool Track::replaceRecord(
 
     if (bpmUpdatedFlag) {
         emit beatsUpdated();
+    }
+    if (oldBpmLocked != newBpmLocked) {
+        emit bpmLockChanged(newBpmLocked);
     }
     if (oldReplayGain != newReplayGain) {
         emit replayGainUpdated(newReplayGain);


### PR DESCRIPTION
Follow-up for #16025 
Fixes #16407