### PR TITLE
Numark NS4FX Beat Jump

### DIFF
--- a/res/controllers/Numark NS4FX.midi.xml
+++ b/res/controllers/Numark NS4FX.midi.xml
@@ -28,6 +28,13 @@
             <option type="boolean" variable="useFadercutsAsStems" label="Control stems with Fader Cuts pads" default="false" description="When enabled, the 'Fader Cuts' pad mode is replaced with a mode to control Stems (mute, volume, and quick effects)."/>
             <option type="boolean" variable="useAdditionalHotcues" label="Add hotcues 5-8 to the second row of pads" default="false" description="When enabled, the bottom row of transport pads (CUE, START, BACK, FWD) will function as hotcues 5-8 when the pad mode is set to 'Hot Cue'."/>
         </group>
+        <group label="Performance Pads - Auto Loop Beat Jump">
+            <option type="boolean" variable="useAutoLoopBeatJump" label="Control beat jump with Auto Loop second row pads" default="false" description="When enabled, the bottom row of transport pads (CUE, START, BACK, FWD) will control beat jump (back, dec, inc, fwd) when the pad mode is set to 'Auto Loop'."/>
+            <option type="integer" variable="shiftPad5JumpBeats" min="-512" max="512" default="-4" description="Shift Auto Loop Jump size key 5"/>
+            <option type="integer" variable="shiftPad6JumpBeats" min="-512" max="512" default="-1" description="Shift Auto Loop Jump size key 6"/>
+            <option type="integer" variable="shiftPad7JumpBeats" min="-512" max="512" default="1" description="Shift Auto Loop Jump size key 7"/>
+            <option type="integer" variable="shiftPad8JumpBeats" min="-512" max="512" default="4" description="Shift Auto Loop Jump size key 8"/>
+        </group>
     </settings>
     <controller id="NS4FX">
         <scriptfiles>

--- a/res/controllers/Numark-NS4FX-scripts.js
+++ b/res/controllers/Numark-NS4FX-scripts.js
@@ -9,6 +9,14 @@ const defaultPadMode = engine.getSetting("defaultPadMode");
 const useFadercutsAsStems = engine.getSetting("useFadercutsAsStems");
 const useAdditionalHotcues = engine.getSetting("useAdditionalHotcues");
 const exitSlipmodeAfterScratching = engine.getSetting("exitSlipmodeAfterScratching");
+const useAutoLoopBeatJump = engine.getSetting("useAutoLoopBeatJump");
+const shiftAutoloopJump = [
+    null,
+    parseInt(engine.getSetting("shiftPad5JumpBeats")),
+    parseInt(engine.getSetting("shiftPad6JumpBeats")),
+    parseInt(engine.getSetting("shiftPad7JumpBeats")),
+    parseInt(engine.getSetting("shiftPad8JumpBeats"))
+]
 
 /**
  * Creates a configuration object for a performance pad to be used for stem control.
@@ -127,6 +135,7 @@ const createTransportPad = function(deck, padNumber, defaultKey, momentary) {
         input: function(channel, control, value, status, group) {
             NS4FX.dbg(`Transport pad ${padNumber} on deck ${deck.number} pressed with value ${value}`);
             const isHotcueModeForTransport = useAdditionalHotcues && deck.padmode_str === "hotcue";
+            const isBeatJumpModeForTransport = useAutoLoopBeatJump && deck.padmode_str === "autoloop";
 
             if (isHotcueModeForTransport) {
                 if (NS4FX.shift) {
@@ -137,7 +146,11 @@ const createTransportPad = function(deck, padNumber, defaultKey, momentary) {
                     return;
                 }
                 hotcueButton.input(channel, control, value, status, group);
-            } else {
+            } else if (isBeatJumpModeForTransport) {
+                deck.autoloop_buttons[padNumber + 4].input(channel, control, value, status, group)
+            }
+            else
+            {
                 if (defaultKey) {
                     if (momentary) {
                         const isPress = (value === 0x7F);
@@ -1061,6 +1074,47 @@ NS4FX.Deck = function(number, midi_chan) {
                 midi.sendShortMsg(this.midi[0], this.midi[1], value ? 0x7F : 0x01); // LED on/off
             },
             number: i // Stores the button number (1-4)
+        });
+
+        this.autoloop_buttons[9 - i] = new components.Button({
+            input: function(channel, control, value, status) {
+                const deckGroup = `[Channel${deck.number}]`; // Deck group based on deck number
+                if (useAutoLoopBeatJump) {
+                    if (value > 0) { // only trigger on press
+                        if (NS4FX.shift) {
+                            NS4FX.dbg(`SHIFT on transport pad ${this.transportPadNumber} on deck ${deck.number}. Jump by ${shiftAutoloopJump[this.transportPadNumber]} beats`);
+                            engine.setValue(deckGroup, "beatjump", shiftAutoloopJump[this.transportPadNumber]);
+                        }
+                        else
+                        {
+                            switch (this.transportPadNumber) {
+                                case 1:   // Jump backward
+                                    engine.setValue(deckGroup, "beatjump_backward", 1);
+                                    break;
+
+                                case 2: { // Decrease beatjump size
+                                    let size = engine.getValue(deckGroup, "beatjump_size");
+                                    size = Math.max(1 / 32, size / 2);
+                                    engine.setValue(deckGroup, "beatjump_size", size);
+                                    break;
+                                }
+
+                                case 3: { // Increase beatjump size
+                                    let size = engine.getValue(deckGroup, "beatjump_size");
+                                    size = Math.min(512, size * 2);
+                                    engine.setValue(deckGroup, "beatjump_size", size);
+                                    break;
+                                }
+
+                                case 4:   // Jump forward
+                                    engine.setValue(deckGroup, "beatjump_forward", 1);
+                                    break;
+                            }
+                        }
+                    }
+                }
+            },
+            transportPadNumber: 5 - i // Stores the transport button number (1-4)
         });
 
         if (!useFadercutsAsStems) {

--- a/res/controllers/Numark-NS4FX-scripts.js
+++ b/res/controllers/Numark-NS4FX-scripts.js
@@ -148,9 +148,7 @@ const createTransportPad = function(deck, padNumber, defaultKey, momentary) {
                 hotcueButton.input(channel, control, value, status, group);
             } else if (isBeatJumpModeForTransport) {
                 deck.autoloop_buttons[padNumber + 4].input(channel, control, value, status, group)
-            }
-            else
-            {
+            } else {
                 if (defaultKey) {
                     if (momentary) {
                         const isPress = (value === 0x7F);


### PR DESCRIPTION
 * Add an option to use the second row of transport pads to control beat jump in Auto Loop mode.

 * Pad 5 jumps backwards, 6 decreases beat jump, 7 increases beat jump and 8 jumps forwards.

 * Shift & second row pad jumps by number of beats configured in controller preferences.