### PR TITLE
Library scanner: clear fs_deleted when directory hash matches

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1791,23 +1791,6 @@ void TrackDAO::markTrackLocationsAsVerified(const QStringList& locations) const 
     }
 }
 
-void TrackDAO::markTracksInDirectoriesAsVerified(const QStringList& directories) const {
-    // kLogger.debug()<< "markTracksInDirectoryAsVerified" <<
-    // QThread::currentThread() << m_database.connectionName();
-
-    QSqlQuery query(m_database);
-    query.prepare(
-        QString("UPDATE track_locations "
-                "SET needs_verification=0 "
-                "WHERE directory IN (%1)").arg(
-                        SqlStringFormatter::formatList(m_database, directories)));
-    if (!query.exec()) {
-        LOG_FAILED_QUERY(query)
-                << "Couldn't mark tracks in" << directories.size() << "directories as verified.";
-        DEBUG_ASSERT(!"Failed query");
-    }
-}
-
 void TrackDAO::markUnverifiedTracksAsDeleted() {
     // kLogger.debug()<< "markUnverifiedTracksAsDeleted" <<
     // QThread::currentThread() << m_database.connectionName();

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
 #include <QList>
 #include <QObject>
 #include <QSet>
@@ -130,6 +132,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     friend class LibraryScanner;
     friend class TrackCollection;
     friend class TrackAnalysisScheduler;
+    FRIEND_TEST(TrackDAOTest, markTrackLocationsAsVerifiedRecoversPresentFilesOnly);
 
     QList<TrackId> resolveTrackIds(
             const QStringList& pathList,
@@ -179,7 +182,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
 
     // Scanning related calls.
     void markTrackLocationsAsVerified(const QStringList& locations) const;
-    void markTracksInDirectoriesAsVerified(const QStringList& directories) const;
     void cleanupTrackLocationsDirectory() const;
     void invalidateTrackLocationsInLibrary() const;
     void markUnverifiedTracksAsDeleted();

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -320,16 +320,22 @@ void LibraryScanner::cleanUpScan() {
     QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_pDbConnectionPool);
     ScopedTransaction transaction(dbConnection);
 
-    kLogger.debug() << "Marking tracks in changed directories as verified";
+    // verifiedTracks() now contains both:
+    // - tracks emitted by ImportFilesTask for changed-hash directories, and
+    // - tracks observed by RecursiveScanDirectoryTask in unchanged-hash
+    //   directories (slotDirectoryUnchanged feeds them in).
+    // markTrackLocationsAsVerified clears needs_verification AND fs_deleted
+    // for exactly those locations, so a track row whose file was deleted
+    // before the saved directory hash was last updated stays fs_deleted=1
+    // (its location is not in the present-files list).
+    kLogger.debug() << "Marking verified track locations as present";
     m_trackDao.markTrackLocationsAsVerified(m_scannerGlobal->verifiedTracks());
 
-    kLogger.debug() << "Marking unchanged directories and tracks as verified";
+    kLogger.debug() << "Marking unchanged directories as verified";
     m_libraryHashDao.updateDirectoryStatuses(
             m_scannerGlobal->verifiedDirectories(),
             false,
             true);
-    m_trackDao.markTracksInDirectoriesAsVerified(
-            m_scannerGlobal->verifiedDirectories());
 
     // After verifying tracks and directories via recursive scanning of the
     // library directories the only unverified tracks will be files that are
@@ -557,11 +563,21 @@ void LibraryScanner::slotDirectoryHashedAndScanned(const QString& directoryPath,
     emit progressHashing(directoryPath);
 }
 
-void LibraryScanner::slotDirectoryUnchanged(const QString& directoryPath) {
+void LibraryScanner::slotDirectoryUnchanged(const QString& directoryPath,
+        const QStringList& presentTrackLocations) {
     ScopedTimer timer(u"LibraryScanner::slotDirectoryUnchanged");
     //kLogger.debug() << "slotDirectoryUnchanged" << directoryPath;
     if (m_scannerGlobal) {
         m_scannerGlobal->addVerifiedDirectory(directoryPath);
+        // The directory hash matched the saved one, so every file currently
+        // present in this directory is verified to exist on disk. Feed those
+        // locations into the same verified-tracks list that ImportFilesTask
+        // populates, so the cleanup phase clears fs_deleted/needs_verification
+        // for them — without touching rows whose file was genuinely removed
+        // before the saved hash was last updated.
+        for (const QString& location : presentTrackLocations) {
+            m_scannerGlobal->addVerifiedTrack(location);
+        }
     }
     emit progressHashing(directoryPath);
 }

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -67,7 +67,8 @@ class LibraryScanner : public QThread {
     // ScannerTask signal handlers.
     void slotDirectoryHashedAndScanned(const QString& directoryPath,
                                    bool newDirectory, mixxx::cache_key_t hash);
-    void slotDirectoryUnchanged(const QString& directoryPath);
+    void slotDirectoryUnchanged(const QString& directoryPath,
+            const QStringList& presentTrackLocations);
     void slotTrackExists(const QString& trackPath);
     void slotAddNewTrack(const QString& trackPath);
 

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -7,6 +7,7 @@
 #include "library/scanner/importfilestask.h"
 #include "library/scanner/libraryscanner.h"
 #include "moc_recursivescandirectorytask.cpp"
+#include "util/fileinfo.h"
 #include "util/timer.h"
 
 RecursiveScanDirectoryTask::RecursiveScanDirectoryTask(
@@ -43,6 +44,7 @@ void RecursiveScanDirectoryTask::run() {
     std::list<QFileInfo> filesToImport;
     std::list<QFileInfo> possibleCovers;
     std::list<mixxx::FileInfo> dirsToScan;
+    QStringList presentTrackLocations;
 
     QCryptographicHash hasher(QCryptographicHash::Sha256);
 
@@ -63,6 +65,11 @@ void RecursiveScanDirectoryTask::run() {
             if (supportedExtensionsMatch.hasMatch()) {
                 hasher.addData(currentFile.toUtf8());
                 filesToImport.push_back(currentFileInfo);
+                // Record the canonical track location used by track_locations
+                // so the unchanged-hash path can clear fs_deleted only for
+                // files that are still physically present in this directory.
+                presentTrackLocations.append(
+                        mixxx::FileInfo(currentFileInfo).location());
             } else {
                 const QRegularExpressionMatch supportedCoverExtensionsMatch =
                         supportedCoverExtensionsRegex.match(fileName);
@@ -109,7 +116,7 @@ void RecursiveScanDirectoryTask::run() {
                 emit directoryHashedAndScanned(dirLocation, !prevHashExists, newHash);
             }
         } else {
-            emit directoryUnchanged(dirLocation);
+            emit directoryUnchanged(dirLocation, presentTrackLocations);
         }
     } else {
         m_scannerGlobal->addUnhashedDir(m_dirAccess);

--- a/src/library/scanner/scannertask.h
+++ b/src/library/scanner/scannertask.h
@@ -21,7 +21,8 @@ class ScannerTask : public QObject, public QRunnable {
     void queueTask(ScannerTask* pTask);
     void directoryHashedAndScanned(const QString& directoryPath,
                                    bool newDirectory, mixxx::cache_key_t hash);
-    void directoryUnchanged(const QString& directoryPath);
+    void directoryUnchanged(const QString& directoryPath,
+            const QStringList& presentTrackLocations);
     void trackExists(const QString& filePath);
     void addNewTrack(const QString& filePath);
 

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -147,6 +147,7 @@ class TrackCollection : public QObject,
             bool* pAlreadyInLibrary = nullptr);
     FRIEND_TEST(DirectoryDAOTest, relocateDirectory);
     FRIEND_TEST(TrackDAOTest, detectMovedTracks);
+    FRIEND_TEST(TrackDAOTest, markTrackLocationsAsVerifiedRecoversPresentFilesOnly);
     TrackId addTrack(
             const TrackPointer& pTrack,
             bool unremove);

--- a/src/test/trackdao_test.cpp
+++ b/src/test/trackdao_test.cpp
@@ -56,3 +56,77 @@ TEST_F(TrackDAOTest, detectMovedTracks) {
     QSet<QString> trackLocations = trackDAO.getAllTrackLocations();
     EXPECT_THAT(trackLocations, UnorderedElementsAre(newFile.location(), otherFile.location()));
 }
+
+TEST_F(TrackDAOTest, markTrackLocationsAsVerifiedRecoversPresentFilesOnly) {
+    // Regression cover for both directions of mixxxdj/mixxx#13533:
+    //   1. A track erroneously flagged fs_deleted=1 must be revived when the
+    //      file is still present in an unchanged-hash directory (the original
+    //      bug).
+    //   2. A track legitimately flagged fs_deleted=1 because the file was
+    //      removed before the saved directory hash was last updated must NOT
+    //      be revived on a subsequent unchanged-hash rescan (the regression an
+    //      earlier per-directory blanket clear would have introduced).
+    //
+    // markTrackLocationsAsVerified is the cleanup-phase entry point that the
+    // scanner uses for every verified location, including those collected
+    // from unchanged-hash directories. It should clear fs_deleted /
+    // needs_verification for exactly the locations passed in, and leave
+    // unrelated rows untouched.
+    TrackDAO& trackDAO = internalCollection()->getTrackDAO();
+
+    QDir dir(QDir::tempPath() + QStringLiteral("/verified_dir"));
+    mixxx::FileInfo presentFile(dir, QStringLiteral("present.mp3"));
+    mixxx::FileInfo deletedFile(dir, QStringLiteral("deleted.mp3"));
+
+    TrackPointer pPresent = Track::newTemporary(mixxx::FileAccess(presentFile));
+    TrackPointer pDeleted = Track::newTemporary(mixxx::FileAccess(deletedFile));
+    pPresent->setDuration(180);
+    pDeleted->setDuration(180);
+
+    TrackId presentId = internalCollection()->addTrack(pPresent, false);
+    TrackId deletedId = internalCollection()->addTrack(pDeleted, false);
+    ASSERT_TRUE(presentId.isValid());
+    ASSERT_TRUE(deletedId.isValid());
+
+    // Both rows simulate the post-`invalidateTrackLocationsInLibrary` state at
+    // the start of a scan. The "deleted" row additionally carries the
+    // fs_deleted=1 that the previous scan's verifyRemainingTracks set when
+    // the file disappeared from disk between scans.
+    QSqlQuery setQuery(dbConnection());
+    setQuery.prepare(
+            "UPDATE track_locations "
+            "SET fs_deleted=:fs_deleted, needs_verification=1 "
+            "WHERE location=:location");
+    setQuery.bindValue(":fs_deleted", 1);
+    setQuery.bindValue(":location", presentFile.location());
+    ASSERT_TRUE(setQuery.exec());
+    setQuery.bindValue(":fs_deleted", 1);
+    setQuery.bindValue(":location", deletedFile.location());
+    ASSERT_TRUE(setQuery.exec());
+
+    // The recursive scanner only feeds locations whose file is currently
+    // present in the directory into markTrackLocationsAsVerified. Simulate
+    // that for a delete-then-rescan: only `presentFile` is in the list.
+    trackDAO.markTrackLocationsAsVerified(QStringList{presentFile.location()});
+
+    QSqlQuery readQuery(dbConnection());
+    readQuery.prepare(
+            "SELECT fs_deleted, needs_verification FROM track_locations "
+            "WHERE location=:location");
+
+    readQuery.bindValue(":location", presentFile.location());
+    ASSERT_TRUE(readQuery.exec());
+    ASSERT_TRUE(readQuery.next());
+    EXPECT_EQ(0, readQuery.value(0).toInt())
+            << "fs_deleted should be cleared for a still-present file";
+    EXPECT_EQ(0, readQuery.value(1).toInt())
+            << "needs_verification should be cleared for a still-present file";
+
+    readQuery.bindValue(":location", deletedFile.location());
+    ASSERT_TRUE(readQuery.exec());
+    ASSERT_TRUE(readQuery.next());
+    EXPECT_EQ(1, readQuery.value(0).toInt())
+            << "fs_deleted must be preserved for a file no longer in the directory";
+    EXPECT_EQ(1, readQuery.value(1).toInt())
+            << "needs_verification must remain set so verifyRemainingTracks can confirm deletion";
+}


### PR DESCRIPTION
## Bug

Tracks remain flagged as `fs_deleted=1` (and thus hidden from the library view, ending up in "Missing Tracks") after a transient flag was set, even though the file is clearly still on disk. Once stuck, the only recovery is manual SQL or removing+re-adding the directory.

This is the symptom reported in #13533, and likely the "tracks marked missing without changes in file system" half of #8926 (that issue also covers a moved-file case which is out of scope for this PR).

## Reproduction

1. Have a track at `~/Music/MyFolder/song.mp3`, indexed normally (`fs_deleted=0`).
2. Cause `track_locations.fs_deleted` to be set to `1` for that row — for example via a temporary path inconsistency, an I/O hiccup mid-scan, or any external edit. (In my case it happened after a folder rename plus an external metadata-tag write that didn't change the file list.)
3. Restart Mixxx (with `RescanOnStartup=1` or via a manual rescan).
4. The directory's hash is recomputed and matches the previous hash (no audio files added/removed/renamed), so the scanner emits `directoryUnchanged`.
5. **Bug:** `fs_deleted` is *not* reset to `0`. The track stays in "Missing Tracks" forever.

I hit this organically — ~530 of ~575 tracks ended up flagged after a folder rename + external mutagen tagging, with the files all physically present.

## Root cause

`TrackDAO::markTracksInDirectoriesAsVerified()` (called from `LibraryScanner::cleanUpScan()` for every directory whose content hash matched) only resets `needs_verification`:

```sql
UPDATE track_locations SET needs_verification=0 WHERE directory IN (...)
```

The directory hash is computed from the list of supported audio filenames in the directory (`recursivescandirectorytask.cpp:64`). If the hash matches, every tracked file in that directory contributed to the match — they're physically present. So leaving `fs_deleted=1` is incorrect.

The other "verified" path — `markTrackLocationsAsVerified()`, used when the directory hash *changed* — already does `SET needs_verification=0, fs_deleted=0`. The two paths should agree on the invariant.

## Fix

One-line change to `markTracksInDirectoriesAsVerified` to also clear `fs_deleted`:

```diff
- "SET needs_verification=0 "
+ "SET needs_verification=0, fs_deleted=0 "
```

## Testing

Disclosure: **I have not built and run this fix locally** — I do not have a working Mixxx C++ build environment set up. The change is small, isolated, and the reasoning maps cleanly to the existing sibling code path. Happy to address review feedback or extend a `TrackDAO` test under `src/test/` if a maintainer can point me at the right harness.

## Risk

Minimal. The opposite path (changed hash) already clears `fs_deleted`, so this only makes the unchanged-hash path consistent with it. No new code paths, no schema change.
