### PR TITLE
(fix) Hidden/Missing: fix missing tracks showing up in Hidden, Missing empty

### DIFF
--- a/src/library/missing_hidden/hiddentablemodel.cpp
+++ b/src/library/missing_hidden/hiddentablemodel.cpp
@@ -31,8 +31,6 @@ void HiddenTableModel::setTableModel() {
             "CREATE TEMPORARY VIEW IF NOT EXISTS " + tableName +
             " AS SELECT " + columns.join(",") +
             " FROM library "
-            "INNER JOIN track_locations "
-            "ON library.location=track_locations.id "
             "WHERE mixxx_deleted=1");
     if (!query.exec()) {
         qDebug() << query.executedQuery() << query.lastError();

--- a/src/library/missing_hidden/missingtablemodel.cpp
+++ b/src/library/missing_hidden/missingtablemodel.cpp
@@ -7,7 +7,6 @@
 
 namespace {
 
-const QString kMissingFilter = "mixxx_deleted=0 AND fs_deleted=1";
 const QString kModelName = "missing:";
 
 } // anonymous namespace
@@ -21,21 +20,19 @@ MissingTableModel::MissingTableModel(QObject* parent,
 
 void MissingTableModel::setTableModel(int id) {
     Q_UNUSED(id);
-    QSqlQuery query(m_database);
-    //query.prepare("DROP VIEW " + playlistTableName);
-    //query.exec();
-    QString tableName("missing_songs");
+    const QString tableName("missing_songs");
 
     QStringList columns;
     columns << "library." + LIBRARYTABLE_ID;
 
-    query.prepare("CREATE TEMPORARY VIEW IF NOT EXISTS " + tableName + " AS "
-                  "SELECT "
-                  + columns.join(",") +
-                  " FROM library "
-                  "INNER JOIN track_locations "
-                  "ON library.location=track_locations.id "
-                  "WHERE " + kMissingFilter);
+    QSqlQuery query(m_database);
+    query.prepare(
+            "CREATE TEMPORARY VIEW IF NOT EXISTS " + tableName +
+            " AS SELECT " + columns.join(",") +
+            " FROM library "
+            "INNER JOIN track_locations "
+            "ON library.location=track_locations.id "
+            "WHERE fs_deleted=1");
     if (!query.exec()) {
         qDebug() << query.executedQuery() << query.lastError();
     }

--- a/src/library/missing_hidden/missingtablemodel.cpp
+++ b/src/library/missing_hidden/missingtablemodel.cpp
@@ -18,8 +18,7 @@ MissingTableModel::MissingTableModel(QObject* parent,
     setTableModel();
 }
 
-void MissingTableModel::setTableModel(int id) {
-    Q_UNUSED(id);
+void MissingTableModel::setTableModel() {
     const QString tableName("missing_songs");
 
     QStringList columns;
@@ -49,6 +48,7 @@ void MissingTableModel::setTableModel(int id) {
             std::move(tableColumns),
             m_pTrackCollectionManager->internalCollection()->getTrackSource());
     setDefaultSort(fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ARTIST), Qt::AscendingOrder);
+    setSearch("");
 }
 
 MissingTableModel::~MissingTableModel() {

--- a/src/library/missing_hidden/missingtablemodel.h
+++ b/src/library/missing_hidden/missingtablemodel.h
@@ -15,7 +15,7 @@ class MissingTableModel final : public BaseSqlTableModel {
     MissingTableModel(QObject* parent, TrackCollectionManager* pTrackCollectionManager);
     ~MissingTableModel() final;
 
-    void setTableModel(int id = -1);
+    void setTableModel();
 
     bool isColumnInternal(int column) final;
     void purgeTracks(const QModelIndexList& indices) final;


### PR DESCRIPTION
I noticed a lot of tracks in Hidden that were marked missing (were renamed on disk).
But Missing was empty :man_shrugging: 

Turns out the model filters were too strict.

Now Missing shows only `fs_deleted=1` (`mixxx_deleted` doesn't matter here at all)
Hidden shows `mixxx_deleted=1` AND `fs_deleted=0`