### PR TITLE
fix(Android): add audio friendly card name

### DIFF
--- a/res/qml/Settings/AudioRouter.qml
+++ b/res/qml/Settings/AudioRouter.qml
@@ -161,6 +161,7 @@ Rectangle {
         // case "PulseAudio":
         // case "sndio":
 
+        case "Android Oboe":
         case "ALSA":
             {
                 const hwAlsa = / (\(hw:\d+,\d+\))/;


### PR DESCRIPTION
Replace the current default output on Android (`Output #1`, `Output #2`) with a more user friendly one, as reported by the Android system.