### PR TITLE
FFmpeg: fix of gap bug fix 

### DIFF
--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -154,12 +154,14 @@ void SoundSourceFFmpeg::initChannelLayoutFromStream(
         // layout, e.g. for a mono WAV files with a single channel!
         av_channel_layout_default(pUninitializedChannelLayout,
                 avStream.codecpar->ch_layout.nb_channels);
-        kLogger.info()
-                << "Unknown channel layout -> using default layout"
-                << pUninitializedChannelLayout->order
-                << "for"
-                << avStream.codecpar->ch_layout.nb_channels
-                << "channel(s)";
+        if (avStream.codecpar->ch_layout.nb_channels > 1) {
+            kLogger.warning()
+                    << "Unknown channel layout -> using default layout"
+                    << pUninitializedChannelLayout->order
+                    << "for"
+                    << avStream.codecpar->ch_layout.nb_channels
+                    << "channels";
+        }
     } else {
         av_channel_layout_default(pUninitializedChannelLayout, 0);
         av_channel_layout_copy(pUninitializedChannelLayout, &avStream.codecpar->ch_layout);
@@ -173,12 +175,14 @@ int64_t SoundSourceFFmpeg::getStreamChannelLayout(const AVStream& avStream) {
         // Workaround: FFmpeg sometimes fails to determine the channel
         // layout, e.g. for a mono WAV files with a single channel!
         channel_layout = av_get_default_channel_layout(avStream.codecpar->channels);
-        kLogger.info()
-                << "Unknown channel layout -> using default layout"
-                << channel_layout
-                << "for"
-                << avStream.codecpar->channels
-                << "channel(s)";
+        if (avStream.codecpar->channels > 1) {
+            kLogger.warning()
+                    << "Unknown channel layout -> using default layout"
+                    << channel_layout
+                    << "for"
+                    << avStream.codecpar->channels
+                    << "channels";
+        }
     }
     return channel_layout;
 }
@@ -459,7 +463,7 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileTypes() const {
     }
 
     if (!disabledInputFormats.isEmpty()) {
-        kLogger.info().noquote()
+        kLogger.debug().noquote()
                 << "Disabling untested input formats:"
                 << disabledInputFormats.join(QStringLiteral(", "));
     }

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1183,21 +1183,15 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
                         convertStreamTimeToFrameIndex(
                                 *m_pavStream, m_pavDecodedFrame->pts);
 
-                if (m_avutilVersion >= AV_VERSION_INT(56, 52, 100)) {
-                    // From ffmpeg 4.4 only audible samples are counted, i.e. any inaudible aka
-                    // "priming" samples are not included in nb_samples!
-                    // https://github.com/mixxxdj/mixxx/issues/10464
-                    if (streamFrameIndex < 0) {
 #if VERBOSE_DEBUG_LOG
-                        const auto inaudibleFrameCountUntilStartOfStream = -streamFrameIndex;
-                        kLogger.debug()
-                                << "Skipping"
-                                << inaudibleFrameCountUntilStartOfStream
-                                << "inaudible sample frames before the start of the stream";
-#endif
-                        streamFrameIndex = 0;
-                    }
+                if (streamFrameIndex < 0) {
+                    const SINT inaudibleFrameCountUntilStartOfStream = -streamFrameIndex;
+                    kLogger.info()
+                            << "Stream has"
+                            << inaudibleFrameCountUntilStartOfStream
+                            << "inaudible sample frames before the start";
                 }
+#endif
 
                 decodedFrameRange = IndexRange::forward(
                         streamFrameIndex,

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -56,7 +56,7 @@ constexpr SINT kMaxSamplesPerMP3Frame = 1152;
 const Logger kLogger("SoundSourceFFmpeg");
 
 int64_t getStreamStartTime(const AVStream& avStream) {
-    auto start_time = avStream.start_time;
+    int64_t start_time = avStream.start_time;
     if (start_time == AV_NOPTS_VALUE) {
         // This case is not unlikely, e.g. happens when decoding WAV files.
         switch (avStream.codecpar->codec_id) {
@@ -529,7 +529,11 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
     kLogger.debug()
             << "AVFormatContext"
             << "{ nb_streams" << m_pavInputFormatContext->nb_streams
-            << "| start_time" << m_pavInputFormatContext->start_time
+            << "| start_time"
+            << (m_pavInputFormatContext->start_time == AV_NOPTS_VALUE
+                               ? "AV_NOPTS_VALUE"
+                               : QString::number(
+                                         m_pavInputFormatContext->start_time))
             << "| duration" << m_pavInputFormatContext->duration
             << "| bit_rate" << m_pavInputFormatContext->bit_rate
             << "| packet_size" << m_pavInputFormatContext->packet_size

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -608,6 +608,9 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
         return SoundSource::OpenResult::Aborted;
     }
 
+    // Copy time base for random seeks:
+    pavCodecContext->pkt_timebase = pavStream->time_base;
+
     // Request output format
     pavCodecContext->request_sample_fmt = s_avSampleFormat;
     if (params.getSignalInfo().getChannelCount().isValid()) {

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -26,7 +26,7 @@ class SoundSourceFFmpeg : public SoundSource {
     ReadableSampleFrames readSampleFramesClamped(
             const WritableSampleFrames& sampleFrames) override;
 
-    virtual OpenResult tryOpen(
+    OpenResult tryOpen(
             OpenMode mode,
             const OpenParams& params) override;
 


### PR DESCRIPTION
This fixes the first issue of the libfdk_aac encoding in Mixxx, discovered by SoundSourceProxyTest.seekBoundaries.

We need to copy time base to decoder context for random seeks. This also avoids warnings like "Could not update timestamps for skipped samples."

This is highly recommended here:
https://github.com/FFmpeg/FFmpeg/blob/c8a4770599792375a05b173fa589c6970fe41868/doc/examples/transcode.c#L102

This fully fixes the root cause of: https://github.com/mixxxdj/mixxx/issues/10464

This PR removes the original workaround for this issue in: 
https://github.com/mixxxdj/mixxx/pull/4245 

