### PR TITLE
libfdk_aac: SoundSourceProxyTest.seekBoundaries fix

### DIFF
--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1280,43 +1280,6 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
             }
 #endif
 
-            // The decoder may provide some lead-in and lead-out frames
-            // before the start position and after the end of the stream.
-            // Those frames need to be cut-off before consumption.
-            if (decodedFrameRange.start() < frameIndexRange().start()) {
-                const auto leadinRange = IndexRange::between(
-                        decodedFrameRange.start(),
-                        math_min(frameIndexRange().start(), decodedFrameRange.end()));
-                DEBUG_ASSERT(leadinRange.orientation() != IndexRange::Orientation::Backward);
-                if (leadinRange.orientation() == IndexRange::Orientation::Forward) {
-#if VERBOSE_DEBUG_LOG
-                    kLogger.debug()
-                            << "Cutting off lead-in"
-                            << leadinRange
-                            << "before"
-                            << frameIndexRange();
-#endif
-                    pDecodedSamples += getSignalInfo().frames2samples(leadinRange.length());
-                    decodedFrameRange.shrinkFront(leadinRange.length());
-                }
-            }
-            if (decodedFrameRange.end() > frameIndexRange().end()) {
-                const auto leadoutRange = IndexRange::between(
-                        math_max(frameIndexRange().end(), decodedFrameRange.start()),
-                        decodedFrameRange.end());
-                DEBUG_ASSERT(leadoutRange.orientation() != IndexRange::Orientation::Backward);
-                if (leadoutRange.orientation() == IndexRange::Orientation::Forward) {
-#if VERBOSE_DEBUG_LOG
-                    kLogger.debug()
-                            << "Cutting off lead-out"
-                            << leadoutRange
-                            << "beyond"
-                            << frameIndexRange();
-#endif
-                    decodedFrameRange.shrinkBack(leadoutRange.length());
-                }
-            }
-
 #if VERBOSE_DEBUG_LOG
             kLogger.debug()
                     << "Before consuming decoded sample data:"

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1274,6 +1274,12 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
                 break;
             }
 
+#if VERBOSE_DEBUG_LOG
+            if (!decodedFrameRange.empty()) {
+                kLogger.debug() << "First decoded sample value:" << pDecodedSamples[0];
+            }
+#endif
+
             // The decoder may provide some lead-in and lead-out frames
             // before the start position and after the end of the stream.
             // Those frames need to be cut-off before consumption.

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -970,12 +970,6 @@ bool SoundSourceFFmpeg::adjustCurrentPosition(SINT startIndex) {
     // At the beginning of the stream, this is a negative position.
     auto seekIndex = startIndex - m_seekPrerollFrameCount;
 
-    // Seek to codec frame boundaries if the frame size is fixed and known
-    if (m_pavStream->codecpar->frame_size > 0) {
-        seekIndex -= seekIndex % m_pavCodecContext->frame_size;
-    }
-    DEBUG_ASSERT(seekIndex <= startIndex);
-
     if (m_frameBuffer.tryContinueReadingFrom(seekIndex)) {
         // No need to perform a costly seek operation. Just skip some buffered
         // samples and continue decoding at the current position.

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -548,9 +548,11 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
     // Find the best stream
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 0, 100) // FFmpeg 5.0
     const AVCodec* pDecoder = nullptr;
+    const AVCodec* pFdkAacDecoder = nullptr;
 #else
     // https://github.com/FFmpeg/FFmpeg/blob/dd17c86aa11feae2b86de054dd0679cc5f88ebab/doc/APIchanges#L175
     AVCodec* pDecoder = nullptr;
+    AVCodec* pFdkAacDecoder = nullptr;
 #endif
     const int av_find_best_stream_result = av_find_best_stream(
             m_pavInputFormatContext,
@@ -577,6 +579,20 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
         return SoundSource::OpenResult::Aborted;
     }
     DEBUG_ASSERT(pDecoder);
+
+    if (pDecoder->id == AV_CODEC_ID_AAC ||
+            pDecoder->id == AV_CODEC_ID_AAC_LATM) {
+        // Prefer Fraunhofer FDK AAC over internal AAC
+        // https://trac.ffmpeg.org/wiki/Encode/AAC
+        if (std::strcmp(pDecoder->name, "aac") == 0) {
+            pFdkAacDecoder = avcodec_find_decoder_by_name("libfdk_aac");
+            if (pFdkAacDecoder) {
+                pDecoder = pFdkAacDecoder;
+            }
+        }
+    }
+
+    kLogger.debug() << "using decoder:" << pDecoder->long_name;
 
     // Select audio stream for decoding
     AVStream* pavStream = m_pavInputFormatContext->streams[av_find_best_stream_result];

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -488,7 +488,8 @@ SoundSourceFFmpeg::SoundSourceFFmpeg(const QUrl& url)
           m_seekPrerollFrameCount(0),
           m_pavPacket(av_packet_alloc()),
           m_pavResampledFrame(nullptr),
-          m_avutilVersion(avutil_version()) {
+          m_avutilVersion(avutil_version()),
+          m_leadin_flush_buffers_fix(false) {
     DEBUG_ASSERT(m_pavPacket);
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100) // FFmpeg 5.1
     av_channel_layout_default(&m_avStreamChannelLayout, 0);
@@ -589,6 +590,11 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
             if (pFdkAacDecoder) {
                 pDecoder = pFdkAacDecoder;
             }
+        }
+
+        if (std::strcmp(pDecoder->name, "libfdk_aac") == 0) {
+            // Fraunhofer FDK AAC has an issue with flushing memory in the lead-in
+            m_leadin_flush_buffers_fix = true;
         }
     }
 
@@ -977,7 +983,20 @@ bool SoundSourceFFmpeg::adjustCurrentPosition(SINT startIndex) {
     }
 
     // Flush internal decoder state before seeking
-    avcodec_flush_buffers(m_pavCodecContext);
+    if (!m_leadin_flush_buffers_fix || seekIndex >= 0) {
+        // Fast: 0.6 us (Core Ultra 5 125U)
+        avcodec_flush_buffers(m_pavCodecContext);
+    } else {
+        // In case of libfdk_aac, we can't seek far enough into the lead in
+        // (to -m_seekPrerollFrameCount) to have a settled filter from silence.
+        // In the test SoundSourceProxyTest.seekBoundaries and  FFmpeg 4.4.2 it
+        // was limited to -661 instead of -2111. The workaround here is to reopen
+        // the codec which initializes all buffers with zero.
+        // Slow: 43 us (Core Ultra 5 125U)
+        const AVCodec* pCodec = m_pavCodecContext->codec;
+        avcodec_close(m_pavCodecContext);
+        avcodec_open2(m_pavCodecContext, pCodec, nullptr);
+    }
 
     // Seek to new position
     const int64_t seekTimestamp =

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -489,7 +489,7 @@ SoundSourceFFmpeg::SoundSourceFFmpeg(const QUrl& url)
           m_pavPacket(av_packet_alloc()),
           m_pavResampledFrame(nullptr),
           m_avutilVersion(avutil_version()),
-          m_leadin_flush_buffers_fix(false) {
+          m_isLibfdk_aac(false) {
     DEBUG_ASSERT(m_pavPacket);
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100) // FFmpeg 5.1
     av_channel_layout_default(&m_avStreamChannelLayout, 0);
@@ -594,7 +594,7 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
 
         if (std::strcmp(pDecoder->name, "libfdk_aac") == 0) {
             // Fraunhofer FDK AAC has an issue with flushing memory in the lead-in
-            m_leadin_flush_buffers_fix = true;
+            m_isLibfdk_aac = true;
         }
     }
 
@@ -977,7 +977,7 @@ bool SoundSourceFFmpeg::adjustCurrentPosition(SINT startIndex) {
     }
 
     // Flush internal decoder state before seeking
-    if (!m_leadin_flush_buffers_fix || seekIndex >= 0) {
+    if (!m_isLibfdk_aac || seekIndex >= 0) {
         // Fast: 0.6 us (Core Ultra 5 125U)
         avcodec_flush_buffers(m_pavCodecContext);
     } else {

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1058,48 +1058,47 @@ bool SoundSourceFFmpeg::consumeNextAVPacket(
     return true;
 }
 
-const CSAMPLE* SoundSourceFFmpeg::resampleDecodedAVFrame() {
+const CSAMPLE* SoundSourceFFmpeg::resampleDecodedAVFrame(AVFrame* pavDecodedFrame) {
     if (m_pSwrContext) {
         // Decoded frame must be resampled before reading
+        av_frame_unref(m_pavResampledFrame);
         m_pavResampledFrame->sample_rate = getSignalInfo().getSampleRate();
         m_pavResampledFrame->format = s_avSampleFormat;
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100) // FFmpeg 5.1
         av_channel_layout_copy(&m_pavResampledFrame->ch_layout, &m_avResampledChannelLayout);
-        if (m_pavDecodedFrame->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC) {
+        if (pavDecodedFrame->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC) {
             // Sometimes the channel layout is undefined.
-            av_channel_layout_copy(&m_pavDecodedFrame->ch_layout, &m_avStreamChannelLayout);
+            av_channel_layout_copy(&pavDecodedFrame->ch_layout, &m_avStreamChannelLayout);
         }
 #else
         m_pavResampledFrame->channel_layout = m_avResampledChannelLayout;
-        if (m_pavDecodedFrame->channel_layout == kavChannelLayoutUndefined) {
+        if (pavDecodedFrame->channel_layout == kavChannelLayoutUndefined) {
             // Sometimes the channel layout is undefined.
-            m_pavDecodedFrame->channel_layout = m_avStreamChannelLayout;
+            pavDecodedFrame->channel_layout = m_avStreamChannelLayout;
         }
 #endif
 #if VERBOSE_DEBUG_LOG
-        avTrace("Resampling decoded frame", *m_pavDecodedFrame);
+        avTrace("Resampling decoded frame", *pavDecodedFrame);
 #endif
         const auto swr_convert_frame_result = swr_convert_frame(
-                m_pSwrContext, m_pavResampledFrame, m_pavDecodedFrame);
+                m_pSwrContext, m_pavResampledFrame, pavDecodedFrame);
         if (swr_convert_frame_result != 0) {
             kLogger.warning().noquote()
                     << "swr_convert_frame() failed:"
                     << formatErrorString(swr_convert_frame_result);
-            // Discard decoded frame and abort after unrecoverable error
-            av_frame_unref(m_pavDecodedFrame);
             return nullptr;
         }
 #if VERBOSE_DEBUG_LOG
         avTrace("Received resampled frame", *m_pavResampledFrame);
 #endif
         DEBUG_ASSERT(m_pavResampledFrame->pts == AV_NOPTS_VALUE ||
-                m_pavResampledFrame->pts == m_pavDecodedFrame->pts);
-        DEBUG_ASSERT(m_pavResampledFrame->nb_samples == m_pavDecodedFrame->nb_samples);
+                m_pavResampledFrame->pts == pavDecodedFrame->pts);
+        DEBUG_ASSERT(m_pavResampledFrame->nb_samples == pavDecodedFrame->nb_samples);
         return reinterpret_cast<const CSAMPLE*>(
                 m_pavResampledFrame->extended_data[0]);
     } else {
         return reinterpret_cast<const CSAMPLE*>(
-                m_pavDecodedFrame->extended_data[0]);
+                pavDecodedFrame->extended_data[0]);
     }
 }
 
@@ -1179,7 +1178,6 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
                         (m_pavDecodedFrame->flags &
                                 (AV_FRAME_FLAG_CORRUPT |
                                         AV_FRAME_FLAG_DISCARD)) == 0) {
-                    av_frame_unref(m_pavDecodedFrame);
                     continue;
                 }
                 const auto decodedFrameCount = m_pavDecodedFrame->nb_samples;
@@ -1269,12 +1267,10 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
                     << "decodedFrameRange" << decodedFrameRange;
 #endif
 
-            const CSAMPLE* pDecodedSampleData = resampleDecodedAVFrame();
-            if (!pDecodedSampleData) {
+            const CSAMPLE* pDecodedSamples = resampleDecodedAVFrame(m_pavDecodedFrame);
+            if (!pDecodedSamples) {
                 // Invalidate current position and abort reading after unrecoverable error
                 m_frameBuffer.invalidate();
-                // Housekeeping before aborting to avoid memory leaks
-                av_frame_unref(m_pavDecodedFrame);
                 break;
             }
 
@@ -1294,7 +1290,7 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
                             << "before"
                             << frameIndexRange();
 #endif
-                    pDecodedSampleData += getSignalInfo().frames2samples(leadinRange.length());
+                    pDecodedSamples += getSignalInfo().frames2samples(leadinRange.length());
                     decodedFrameRange.shrinkFront(leadinRange.length());
                 }
             }
@@ -1326,7 +1322,7 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
             const auto decodedSampleFrames = ReadableSampleFrames(
                     decodedFrameRange,
                     SampleBuffer::ReadableSlice(
-                            pDecodedSampleData,
+                            pDecodedSamples,
                             getSignalInfo().frames2samples(decodedFrameRange.length())));
             auto outputSampleFrames = WritableSampleFrames(
                     writableFrameRange,
@@ -1346,11 +1342,6 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
                     << "m_frameBuffer.bufferedRange()" << m_frameBuffer.bufferedRange()
                     << "writableFrameRange" << writableFrameRange;
 #endif
-
-            // Housekeeping before next decoding iteration
-            av_frame_unref(m_pavDecodedFrame);
-            av_frame_unref(m_pavResampledFrame);
-
             // The first loop condition (see below) should always be true
             // and has only been added to prevent infinite looping in case
             // of unexpected result values.

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -31,7 +31,7 @@ class SoundSourceFFmpeg : public SoundSource {
             const OpenParams& params) override;
 
   private:
-    const CSAMPLE* resampleDecodedAVFrame();
+    const CSAMPLE* resampleDecodedAVFrame(AVFrame* pavDecodedFrame);
 
     // Seek to the requested start index (if needed) or return false
     // upon seek errors.

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -214,6 +214,8 @@ class SoundSourceFFmpeg : public SoundSource {
     AVFrame* m_pavResampledFrame;
 
     const unsigned int m_avutilVersion;
+
+    bool m_leadin_flush_buffers_fix;
 };
 
 class SoundSourceProviderFFmpeg : public SoundSourceProvider {

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -215,7 +215,7 @@ class SoundSourceFFmpeg : public SoundSource {
 
     const unsigned int m_avutilVersion;
 
-    bool m_leadin_flush_buffers_fix;
+    bool m_isLibfdk_aac;
 };
 
 class SoundSourceProviderFFmpeg : public SoundSourceProvider {

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -623,11 +623,15 @@ TEST_F(SoundSourceProxyTest, seekBoundaries) {
                 const SINT sampleCount =
                         pSeekReadSource->getSignalInfo().frames2samples(
                                 seekSampleFrames.frameLength());
-                expectDecodedSamplesEqual(
-                        sampleCount,
+                expectDecodedSamplesEqual(sampleCount,
                         &contReadData[0],
                         &seekReadData[0],
-                        "Decoding mismatch after seeking");
+                        QString("Decoding mismatch after seeking [%1 -> %2]")
+                                .arg(QString::number(
+                                             readFrameIndexRange.start()),
+                                        QString::number(
+                                                readFrameIndexRange.end()))
+                                .toLatin1());
             }
         }
     }


### PR DESCRIPTION
This PR fixes an issue that causes noise at the beginning of the track after seeking from a later position. 

This happens because libfdk_aac does not allow to seek far enough into the lead-in to have a settled filter from silence.
I have tested this with FFmpeg 4.4.2 where it was limited to -661 instead of -2111. The workaround here is to reopen the codec which initializes all buffers with zero.

This PR also changes to libfdk_aac by default to have the same codecs at windows and Linux (if available) 

The first sound test verifies that the internal aac and the libfdk_aac have the same output. 

My guess is the the known quality diffrence are a matter of the encoding, not the decoding we do here. So we may also reconsider this decision. 

fixes #14624
