### PR TITLE
Traktor Kontrol S3: map library column sort to on unused star track button

### DIFF
--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -910,6 +910,7 @@ TraktorS3.Deck = class {
         // There is no control object to mark / unmark a track as played.
         // this.defineButton(messageShort, "!SetPlayed", 0x01, 0x10, 0x04, 0x20,
         // deckFn.SetPlayedHandler);
+        this.defineButton(messageShort, "!StarTrack", 0x01, 0x10, 0x04, 0x20, deckFn.StarTrackHandler);
         this.defineButton(messageShort, "!LibraryFocus", 0x01, 0x20, 0x04, 0x40, deckFn.LibraryFocusHandler);
         this.defineButton(messageShort, "!MaximizeLibrary", 0x01, 0x40, 0x04, 0x80, deckFn.MaximizeLibraryHandler);
 
@@ -1141,6 +1142,15 @@ TraktorS3.Deck = class {
             this.previewPressed = false;
             engine.setValue("[PreviewDeck1]", "play", 0);
         }
+    }
+
+    StarTrackHandler(field) {
+        this.colorOutput(field.value, "!StarTrack");
+        if (field.value === 0) {
+            return;
+        }
+
+        engine.setValue("[Library]", "sort_focused_column", 1);
     }
 
     LibraryFocusHandler(field) {
@@ -1430,6 +1440,7 @@ TraktorS3.Deck = class {
         this.defineOutput(outputA, "slip_enabled", 0x02, 0x1B);
         this.defineOutput(outputA, "reverse", 0x03, 0x1C);
         this.defineOutput(outputA, "!PreviewTrack", 0x04, 0x1D);
+        this.defineOutput(outputA, "!StarTrack", 0x05, 0x1E);
         this.defineOutput(outputA, "!LibraryFocus", 0x06, 0x1F);
         this.defineOutput(outputA, "!MaximizeLibrary", 0x07, 0x20);
         this.defineOutput(outputA, "quantize", 0x08, 0x21);


### PR DESCRIPTION
Mapped the previously unused "Star" button on the Traktor Kontrol S3 to the sort_focused_column function.

Motivation and Context
This allows to quickly toggle the sort order (ascending/descending) of the currently focused library column directly from the hardware, improving navigation without needing to touch the mouse or keyboard.

Tested manually on my Traktor Kontrol S3 : 

- The button triggers the library sort as expected.
- The LED feedback works correctly (button lights up when pressed and turns off when released).