### PR TITLE
DlgTrackInfoMulti: add Find/Replace GUI for all string properties

### DIFF
--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -114,6 +114,38 @@ void setCommonValueOrVariousStringAndFormatFont(QLabel* pLabel,
     }
 }
 
+/// This allows to map track properties to their respective get and set functions
+/// which allows concise Find/Replace logic in saveTracks().
+/// Works for both TrackInfo and AlbumInfo members.
+struct PropAccessor {
+    std::function<QString(const mixxx::TrackMetadata&)> getter;
+    std::function<void(mixxx::TrackMetadata&, const QString&)> setter;
+};
+static const QMap<DlgTrackInfoMulti::TrackProperty, PropAccessor> kPropAccessorMap = {
+        {DlgTrackInfoMulti::TrackProperty::Title, {
+                [](const auto& m) { return m.getTrackInfo().getTitle(); },
+                [](auto& m, const auto& str) { m.refTrackInfo().setTitle(str); }}},
+        {DlgTrackInfoMulti::TrackProperty::Artist, {
+                [](const auto& m) { return m.getTrackInfo().getArtist(); },
+                [](auto& m, const auto& str) { m.refTrackInfo().setArtist(str); }}},
+        {DlgTrackInfoMulti::TrackProperty::Genre, {
+                [](const auto& m) { return m.getTrackInfo().getGenre(); },
+                [](auto& m, const auto& str) { m.refTrackInfo().setGenre(str); }}},
+        {DlgTrackInfoMulti::TrackProperty::Grouping, {
+                [](const auto& m) { return m.getTrackInfo().getGrouping(); },
+                [](auto& m, const auto& str) { m.refTrackInfo().setGrouping(str); }}},
+        {DlgTrackInfoMulti::TrackProperty::Composer, {
+                [](const auto& m) { return m.getTrackInfo().getComposer(); },
+                [](auto& m, const auto& str) { m.refTrackInfo().setComposer(str); }}},
+        {DlgTrackInfoMulti::TrackProperty::Comment, {
+                [](const auto& m) { return m.getTrackInfo().getComment(); },
+                [](auto& m, const auto& str) { m.refTrackInfo().setComment(str); }}},
+        {DlgTrackInfoMulti::TrackProperty::Album, {
+                [](const auto& m) { return m.getAlbumInfo().getTitle(); },
+                [](auto& m, const auto& str) { m.refAlbumInfo().setTitle(str); }}},
+        {DlgTrackInfoMulti::TrackProperty::AlbumArtist, {
+                [](const auto& m) { return m.getAlbumInfo().getArtist(); },
+                [](auto& m, const auto& str) { m.refAlbumInfo().setArtist(str); }}} };
 } // namespace
 
 DlgTrackInfoMulti::DlgTrackInfoMulti(UserSettingsPointer pUserSettings)
@@ -187,6 +219,28 @@ void DlgTrackInfoMulti::init() {
             &QPushButton::clicked,
             this,
             &DlgTrackInfoMulti::slotOpenInFileBrowser);
+
+    // Add find/replace-capable property items in the order they are in the GUI
+    comboFindReplace->addItem(lblTitle->text(), QVariant::fromValue(TrackProperty::Title));
+    comboFindReplace->addItem(lblArtist->text(), QVariant::fromValue(TrackProperty::Artist));
+    comboFindReplace->addItem(lblAlbum->text(), QVariant::fromValue(TrackProperty::Album));
+    comboFindReplace->addItem(lblAlbumArtist->text(),
+            QVariant::fromValue(TrackProperty::AlbumArtist));
+    comboFindReplace->addItem(lblComposer->text(), QVariant::fromValue(TrackProperty::Composer));
+    comboFindReplace->addItem(lblGenre->text(), QVariant::fromValue(TrackProperty::Genre));
+    comboFindReplace->addItem(lblGrouping->text(), QVariant::fromValue(TrackProperty::Grouping));
+    comboFindReplace->addItem(lblTrackComment->text(), QVariant::fromValue(TrackProperty::Comment));
+    checkboxReplace->setChecked(false);
+    connect(comboFindReplace,
+            &QComboBox::currentIndexChanged,
+            this,
+            &DlgTrackInfoMulti::slotUpdateFindReplaceGUI);
+    connect(checkboxReplace,
+            &QCheckBox::toggled,
+            this,
+            &DlgTrackInfoMulti::slotUpdateFindReplaceGUI);
+    // Update Find/Replace widgets
+    slotUpdateFindReplaceGUI();
 
     QList<QComboBox*> valueComboBoxes;
     valueComboBoxes.append(txtArtist);
@@ -694,26 +748,34 @@ void DlgTrackInfoMulti::saveTracks() {
     const QString num = validEditText(txtTrackNumber);
     const QString comment = validCommentText(txtCommentBox, txtComment);
 
+    // Check and prepare Find/Replace
+    TrackProperty findReplacePropId = getSelectedFindReplacePropMaybeInvalid();
+    // This returns true for exactly one property when the Replace checkbox is ticked
+    auto doFindReplaceProperty = [&](TrackProperty propId) {
+        return findReplacePropId == propId;
+    };
+    // We apply the regularly edited properties one by one, then maybe run
+    // the Find/Replace routine for the selected property
     for (auto& rec : m_trackRecords) {
-        if (!title.isNull()) {
+        if (!title.isNull() && !doFindReplaceProperty(TrackProperty::Title)) {
             rec.refMetadata().refTrackInfo().setTitle(title);
         }
-        if (!artist.isNull()) {
+        if (!artist.isNull() && !doFindReplaceProperty(TrackProperty::Artist)) {
             rec.refMetadata().refTrackInfo().setArtist(artist);
         }
-        if (!album.isNull()) {
+        if (!album.isNull() && !doFindReplaceProperty(TrackProperty::Album)) {
             rec.refMetadata().refAlbumInfo().setTitle(album);
         }
-        if (!albumArtist.isNull()) {
+        if (!albumArtist.isNull() && !doFindReplaceProperty(TrackProperty::AlbumArtist)) {
             rec.refMetadata().refAlbumInfo().setArtist(albumArtist);
         }
-        if (!genre.isNull()) {
+        if (!genre.isNull() && !doFindReplaceProperty(TrackProperty::Genre)) {
             rec.refMetadata().refTrackInfo().setGenre(genre);
         }
-        if (!composer.isNull()) {
+        if (!composer.isNull() && !doFindReplaceProperty(TrackProperty::Composer)) {
             rec.refMetadata().refTrackInfo().setComposer(composer);
         }
-        if (!grouping.isNull()) {
+        if (!grouping.isNull() && !doFindReplaceProperty(TrackProperty::Grouping)) {
             rec.refMetadata().refTrackInfo().setGrouping(grouping);
         }
         if (!year.isNull()) {
@@ -727,7 +789,7 @@ void DlgTrackInfoMulti::saveTracks() {
         if (!num.isNull()) {
             rec.refMetadata().refTrackInfo().setTrackNumber(num);
         }
-        if (!comment.isNull()) {
+        if (!comment.isNull() && !doFindReplaceProperty(TrackProperty::Comment)) {
             rec.refMetadata().refTrackInfo().setComment(comment);
         }
         if (m_colorChanged) {
@@ -735,6 +797,47 @@ void DlgTrackInfoMulti::saveTracks() {
         }
         if (m_starRatingModified) {
             rec.setRating(m_newRating);
+        }
+    }
+
+    // Even though we may have skipped the property selected for Find/Replace,
+    // we can find/replace only if we have a Find string.
+    QString findStr = txtFind->text();
+    if (findReplacePropId != TrackProperty::Invalid && !findStr.isEmpty()) {
+        // Since we allow editing the multi-line Comments property, we also care
+        // about linebreaks. We accept \n for find and replace, but we need to
+        // handle those explicitly.
+        // Find: QRegularExpression takes \n as linebreak natively, BUT source
+        // data may also contain CRLF \r\n or just \r. Let's make the find string
+        // agnostic by replacing \n with \R which matches all sorts of commonly
+        // used linebreaks as well as esoteric variants like \u2028.
+        // The later QString::replace() will then consume or replace all
+        // linebreak occurrences.
+        // We must also escape special regex characters (like parentheses) so
+        // they are treated as literal text (while preserving the \n -> \R).
+        QStringList findParts = findStr.split(QStringLiteral("\\n"));
+        for (QString& part : findParts) {
+            part = QRegularExpression::escape(part);
+        }
+        findStr = findParts.join(QStringLiteral("\\R"));
+        QRegularExpression findRegEx(findStr, QRegularExpression::CaseInsensitiveOption);
+
+        // Replace: \n is seen as two separate chars (\ + n), replace all
+        // occurrences with linefeed char \n.
+        QString replaceStr = txtReplace->text();
+        replaceStr.replace("\\n", "\n");
+
+        DEBUG_ASSERT(kPropAccessorMap.contains(findReplacePropId));
+        const auto& propAccessor = kPropAccessorMap[findReplacePropId];
+
+        for (auto& rec : m_trackRecords) {
+            auto& metadata = rec.refMetadata();
+            QString propertyStr = propAccessor.getter(metadata);
+            QRegularExpressionMatch regexMatch = findRegEx.match(propertyStr);
+            if (regexMatch.hasMatch()) {
+                propertyStr.replace(findRegEx, replaceStr);
+                propAccessor.setter(metadata, propertyStr);
+            }
         }
     }
 
@@ -1125,4 +1228,36 @@ void DlgTrackInfoMulti::slotReloadCoverArt() {
         rec.setCoverInfo(cover);
     }
     updateCoverArtFromTracks();
+}
+
+/// Enable/disable Find/Replace widgets and the respective property QLineEdit
+/// when find/replace mode is toggled and when a property is selected
+void DlgTrackInfoMulti::slotUpdateFindReplaceGUI() {
+    bool checked = checkboxReplace->isChecked();
+    auto findReplacePropId = getSelectedFindReplacePropMaybeInvalid();
+
+    txtTitle->setEnabled(!checked || findReplacePropId != TrackProperty::Title);
+    txtArtist->setEnabled(!checked || findReplacePropId != TrackProperty::Artist);
+    txtAlbum->setEnabled(!checked || findReplacePropId != TrackProperty::Album);
+    txtAlbumArtist->setEnabled(!checked || findReplacePropId != TrackProperty::AlbumArtist);
+    txtComposer->setEnabled(!checked || findReplacePropId != TrackProperty::Composer);
+    txtGenre->setEnabled(!checked || findReplacePropId != TrackProperty::Genre);
+    txtGrouping->setEnabled(!checked || findReplacePropId != TrackProperty::Grouping);
+    txtComment->setEnabled(!checked || findReplacePropId != TrackProperty::Comment);
+    txtCommentBox->setEnabled(!checked || findReplacePropId != TrackProperty::Comment);
+
+    comboFindReplace->setEnabled(checked);
+    lblFind->setEnabled(checked);
+    txtFind->setEnabled(checked);
+    lblReplace->setEnabled(checked);
+    txtReplace->setEnabled(checked);
+}
+
+DlgTrackInfoMulti::TrackProperty DlgTrackInfoMulti::getSelectedFindReplacePropMaybeInvalid() const {
+    if (!checkboxReplace->isChecked()) {
+        return TrackProperty::Invalid;
+    }
+    auto doFindReplaceProperty = comboFindReplace->currentData();
+    // This returns enum item 0 (TrackProperty::Invalid) in case it can't convert
+    return doFindReplaceProperty.value<TrackProperty>();
 }

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -1,9 +1,11 @@
 #include "library/dlgtrackinfomulti.h"
 
+#include <QCheckBox>
 #include <QLineEdit>
 #include <QListView>
 #include <QStyleFactory>
 #include <QtDebug>
+#include <memory>
 
 #include "defs_urls.h"
 #include "library/coverartcache.h"
@@ -12,6 +14,7 @@
 #include "moc_dlgtrackinfomulti.cpp"
 #include "preferences/colorpalettesettings.h"
 #include "sources/soundsourceproxy.h"
+#include "track/beats.h"
 #include "track/beatutils.h"
 #include "track/track.h"
 #include "util/color/color.h"
@@ -20,6 +23,7 @@
 #include "util/duration.h"
 #include "util/string.h"
 #include "util/stringformat.h"
+#include "util/tapfilter.h"
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
 #include "widget/wstarrating.h"

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -70,6 +70,18 @@ QString validEditText(QComboBox* pBox) {
     return mixxx::removeTrailingWhitespaces(currText);
 }
 
+/// Same for Comments, just with the extra QPlainTextEdit
+QString validCommentText(QComboBox* pBox, QPlainTextEdit* pTextEdit) {
+    const QString origText = pTextEdit->property(kOrigValProp).toString();
+    const QString currText = pTextEdit->toPlainText();
+    if ((pBox->count() > 0 && !pTextEdit->placeholderText().isNull()) ||
+            (pBox->count() == 0 && currText == origText)) {
+        return {};
+    }
+    // Remove trailing whitespaces.
+    return mixxx::removeTrailingWhitespaces(currText);
+}
+
 /// Sets the text of a QLabel, either the only/common value or the 'various' string.
 /// In case of `various`, the text is also set italic.
 /// This is used for bitrate, sample rate and file directories.
@@ -668,7 +680,8 @@ void DlgTrackInfoMulti::saveTracks() {
         commentTextChanged();
     }
 
-    // Check the values so we don't have to do it for every track record
+    // Check the values so we don't have to do it for every track record.
+    // QString::isNull() indicates that the property is unchanged.
     const QString title = validEditText(txtTitle);
     const QString artist = validEditText(txtArtist);
     const QString album = validEditText(txtAlbum);
@@ -679,16 +692,7 @@ void DlgTrackInfoMulti::saveTracks() {
     const QString year = validEditText(txtYear);
     const QString key = validEditText(txtKey);
     const QString num = validEditText(txtTrackNumber);
-    // Check if the Comment has been changed.
-    // (same as in validEditText(), just for the QPlainTextEdit)
-    QString comment;
-    const QString origText = txtComment->property(kOrigValProp).toString();
-    const QString currText = txtComment->toPlainText();
-    if ((txtCommentBox->count() > 0 && txtComment->placeholderText().isNull()) ||
-            (txtCommentBox->count() == 0 && currText != origText)) {
-        // Remove trailing whitespaces.
-        comment = mixxx::removeTrailingWhitespaces(currText);
-    }
+    const QString comment = validCommentText(txtCommentBox, txtComment);
 
     for (auto& rec : m_trackRecords) {
         if (!title.isNull()) {

--- a/src/library/dlgtrackinfomulti.h
+++ b/src/library/dlgtrackinfomulti.h
@@ -3,15 +3,12 @@
 #include <QDialog>
 #include <QHash>
 #include <QModelIndex>
-#include <memory>
 
 #include "library/ui_dlgtrackinfomulti.h"
 #include "preferences/usersettings.h"
-#include "track/beats.h"
 #include "track/track_decl.h"
 #include "track/trackrecord.h"
 #include "util/parented_ptr.h"
-#include "util/tapfilter.h"
 #include "widget/wcolorpickeraction.h"
 
 class WColorPickerAction;

--- a/src/library/dlgtrackinfomulti.h
+++ b/src/library/dlgtrackinfomulti.h
@@ -25,6 +25,19 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
     explicit DlgTrackInfoMulti(UserSettingsPointer pUserSettings);
     ~DlgTrackInfoMulti() override = default;
 
+    /// enum for editable QString track properties
+    enum class TrackProperty {
+        Invalid = 0,
+        Artist,
+        Title,
+        Album,
+        AlbumArtist,
+        Genre,
+        Grouping,
+        Composer,
+        Comment
+    };
+
     void loadTracks(const QList<TrackPointer>& pTracks);
     void focusField(const QString& property);
 
@@ -64,6 +77,8 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
     void slotCoverInfoSelected(const CoverInfoRelative& coverInfo);
     void slotReloadCoverArt();
 
+    void slotUpdateFindReplaceGUI();
+
     void slotOpenInFileBrowser();
 
   private:
@@ -100,6 +115,8 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
         return trackIt.value();
     }
 
+    TrackProperty getSelectedFindReplacePropMaybeInvalid() const;
+
     const UserSettingsPointer m_pUserSettings;
 
     QHash<TrackId, TrackPointer> m_pLoadedTracks;
@@ -116,3 +133,5 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
     mixxx::RgbColor::optional_t m_newColor;
     parented_ptr<WColorPickerAction> m_pColorPicker;
 };
+
+Q_DECLARE_METATYPE(DlgTrackInfoMulti::TrackProperty)

--- a/src/library/dlgtrackinfomulti.ui
+++ b/src/library/dlgtrackinfomulti.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>575</width>
-    <height>642</height>
+    <height>350</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -421,7 +421,7 @@
       <item row="9" column="1" colspan="3">
        <widget class="QPushButton" name="btnColorPicker">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -429,8 +429,102 @@
        </widget>
       </item>
 
-      <item row="10" column="0">
-       <spacer name="spacerColorPicker">
+      <item row="10" column="0" colspan="4">
+       <widget class="Line" name="separatorFindReplace">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+
+      <item row="11" column="0">
+       <widget class="QCheckBox" name="checkboxReplace">
+        <property name="text">
+         <string>Find/Replace</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1" colspan="3">
+       <widget class="QComboBox" name="comboFindReplace">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+
+      <item row="12" column="0">
+       <widget class="QLabel" name="lblFind">
+        <property name="text">
+         <string>Find:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1" colspan="3">
+       <widget class="QLineEdit" name="txtFind">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+
+      <item row="13" column="0">
+       <widget class="QLabel" name="lblReplace">
+        <property name="text">
+         <string>Replace:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignRight|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="1" colspan="3">
+       <widget class="QLineEdit" name="txtReplace">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+
+      <item row="14" column="0" colspan="4">
+       <widget class="Line" name="separatorMetadataImport">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+
+      <item row="15" column="0">
+       <spacer name="spacerImportMetadata">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
@@ -443,7 +537,7 @@
        </spacer>
       </item>
 
-      <item row="11" column="0" colspan="4">
+      <item row="15" column="0" colspan="4">
        <widget class="QPushButton" name="btnImportMetadataFromFile">
         <property name="text">
          <string>Re-Import Metadata from files</string>
@@ -745,6 +839,10 @@
   <tabstop>txtGrouping</tabstop>
   <tabstop>txtCommentBox</tabstop>
   <tabstop>txtComment</tabstop>
+  <tabstop>checkboxReplace</tabstop>
+  <tabstop>comboFindReplace</tabstop>
+  <tabstop>txtFind</tabstop>
+  <tabstop>txtReplace</tabstop>
   <tabstop>txtYear</tabstop>
   <tabstop>txtKey</tabstop>
   <tabstop>txtTrackNumber</tabstop>


### PR DESCRIPTION
While I've been using #14667 in my branch, I noticed I'd love to have Find/Replace for all properties, for example to remove  this annyoing `(Original Mix)` from all my Beatport tracks, or change `feat.` to `ft.` etc.

So here we go, the GUI/UX is straight-foward IMO:
* check Find/Replace
-> the edit boxes are enabled and the lineedit/combobox for the selected property (Title by default) is disabled
* enter find and replace strings, Apply

It also supports inserting/replacing linebreaks with `\n`, regardless if they appear as `\n`, `\r\n` or just `\r` in the source data.

This is how it looks:
<img width="588" height="716" alt="trackinfo-find-replace" src="https://github.com/user-attachments/assets/ddfc68c2-44cc-42a2-be50-020ac4c147dd" />

Note that the original dialog is already to tall for screens smaller than 1080p, but this is fixed in #15073 and that should merge cleanly.