### PR TITLE
[GSoC] LateNightQML: Enable QML skins as a preference option (Developer Mode)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3794,6 +3794,8 @@ if(QT_KNOWN_POLICY_QTP0002 AND ANDROID)
 endif()
 
 if(QML)
+  target_sources(mixxx-lib PRIVATE src/skin/qml/qmlskin.cpp)
+
   if(QT_KNOWN_POLICY_QTP0004)
     # See: https://doc.qt.io/qt-6/qt-cmake-policy-qtp0004.html
     # OLD (Qt < 6.8) requires to import qml modules with a folder e.g.:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,8 @@
 #if defined(__WINDOWS__)
 #include "nativeeventhandlerwin.h"
 #endif
+#include "skin/skin.h"
+#include "skin/skinloader.h"
 #include "sources/soundsourceproxy.h"
 #include "util/cmdlineargs.h"
 #include "util/console.h"
@@ -60,20 +62,29 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
     CmdlineArgs::Instance().parseForUserFeedback();
 
     int exitCode;
+    auto pCoreServices = std::make_shared<mixxx::CoreServices>(args, pApp);
 #ifdef MIXXX_USE_QML
-    if (args.isQml()) {
+    QString mainQmlFilePath;
+    bool loadQml = args.isQml();
+    if (!loadQml && args.getDeveloper()) {
+        mixxx::skin::SkinLoader skinLoader(pCoreServices->getSettings());
+        const mixxx::skin::SkinPointer pSkin = skinLoader.getConfiguredSkin();
+        if (pSkin && pSkin->type() == mixxx::skin::SkinType::QML) {
+            loadQml = true;
+            mainQmlFilePath = pSkin->mainQmlFilePath();
+        }
+    }
+    if (loadQml) {
         // This is a workaround to support Qt 6.4.2, currently shipped on
         // Ubuntu 24.04 See
         // https://github.com/mixxxdj/mixxx/pull/14514#issuecomment-2770811094
         // for further details
         qputenv("QT_QUICK_TABLEVIEW_COMPAT_VERSION", "6.4");
-        mixxx::qml::QmlApplication qmlApplication(pApp, args);
+        mixxx::qml::QmlApplication qmlApplication(pApp, pCoreServices, mainQmlFilePath);
         exitCode = pApp->exec();
     } else
 #endif
     {
-        auto pCoreServices = std::make_shared<mixxx::CoreServices>(args, pApp);
-
         // This scope ensures that `MixxxMainWindow` is destroyed *before*
         // CoreServices is shut down. Otherwise a debug assertion complaining about
         // leaked COs may be triggered.

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -583,6 +583,12 @@ void DlgPrefInterface::slotApply() {
     if (m_pSkin &&
             (m_pSkin->name() != m_skinNameOnUpdate ||
                     m_colorScheme != m_colorSchemeOnUpdate)) {
+        if (m_pSkin->type() == mixxx::skin::SkinType::QML) {
+            notifyRebootNecessary();
+            m_skinNameOnUpdate = m_pSkin->name();
+            m_colorSchemeOnUpdate = m_colorScheme;
+            return;
+        }
         // ColorSchemeParser::setupLegacyColorSchemes() reads scheme from config
         emit reloadUserInterface();
         // Allow switching skins multiple times without closing the dialog

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -62,8 +62,23 @@ QmlApplication::QmlApplication(
 
     QString configVersion = m_pCoreServices->getSettings()->getValue(
             ConfigKey("[Config]", "Version"), "");
+
+    // The risk check guards against Mixxx 3.0 potentially running different
+    // database upgrade paths that could corrupt 2.x profiles.
+    //
+    // When a QML skin is auto-detected from preferences (--developer, no
+    // --new-ui), the underlying binary and DB schema are identical to a
+    // normal 2.x launch — there is no data corruption risk. Skip the gate.
+    //
+    // When explicitly launched with --new-ui, the full 3.0 application path
+    // is taken and the gate remains in effect as designed.
+    const bool viaNewUiFlag = CmdlineArgs::Instance().isQml();
+
     if (configVersion == VersionStore::FUTURE_UNSTABLE) {
         qDebug() << "Generating a new user profile for safe testing with unstable code";
+    } else if (!viaNewUiFlag) {
+        qDebug() << "QmlApplication: QML skin loaded via preferences, "
+                    "skipping data-corruption risk check (2.x profile is safe)";
     } else if (CmdlineArgs::Instance().isAwareOfRisk()) {
         qCritical() << "Existing user profile detected from" << configVersion
                     << "but you said you wanted to play with fire!";

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -4,6 +4,7 @@
 #include <QQuickStyle>
 #include <QQuickWindow>
 #include <QTextDocument>
+#include <utility>
 
 #include "controllers/controllermanager.h"
 #include "mixer/playermanager.h"
@@ -43,10 +44,13 @@ namespace qml {
 
 QmlApplication::QmlApplication(
         QApplication* app,
-        const CmdlineArgs& args)
-        : m_pCoreServices(std::make_unique<mixxx::CoreServices>(args, app)),
+        std::shared_ptr<CoreServices> pCoreServices,
+        const QString& mainQmlFilePath)
+        : m_pCoreServices(std::move(pCoreServices)),
           m_visualsManager(std::make_unique<VisualsManager>()),
-          m_mainFilePath(m_pCoreServices->getSettings()->getResourcePath() + kMainQmlFileName),
+          m_mainFilePath(mainQmlFilePath.isEmpty()
+                          ? m_pCoreServices->getSettings()->getResourcePath() + kMainQmlFileName
+                          : mainQmlFilePath),
           m_pAppEngine(nullptr),
 #if defined(Q_OS_ANDROID)
           m_perfSession(nullptr),

--- a/src/qml/qmlapplication.h
+++ b/src/qml/qmlapplication.h
@@ -2,6 +2,8 @@
 
 #include <QApplication>
 #include <QQmlApplicationEngine>
+#include <QString>
+#include <memory>
 
 #include "coreservices.h"
 #include "qmlautoreload.h"
@@ -21,7 +23,8 @@ class QmlApplication : public QObject {
   public:
     QmlApplication(
             QApplication* app,
-            const CmdlineArgs& args);
+            std::shared_ptr<CoreServices> pCoreServices,
+            const QString& mainQmlFilePath = QString());
     ~QmlApplication() override;
 
   public slots:
@@ -34,7 +37,7 @@ class QmlApplication : public QObject {
 #endif
 
   private:
-    std::unique_ptr<CoreServices> m_pCoreServices;
+    std::shared_ptr<CoreServices> m_pCoreServices;
     std::unique_ptr<::VisualsManager> m_visualsManager;
 
     QString m_mainFilePath;

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -344,7 +344,9 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     m_pContext->setSkinBasePath(skinPath);
 
     if (m_pParent) {
-        qDebug() << "ERROR: Somehow a parent already exists -- you are probably re-using a LegacySkinParser which is not advisable!";
+        qDebug()
+                << "ERROR: Somehow a parent already exists -- you are probably "
+                   "reusing a LegacySkinParser which is not advisable!";
     }
     QDomElement skinDocument = openSkin(skinPath);
 

--- a/src/skin/qml/qmlskin.cpp
+++ b/src/skin/qml/qmlskin.cpp
@@ -1,0 +1,107 @@
+#include "skin/qml/qmlskin.h"
+
+#include <QDir>
+#include <QScreen>
+#include <QSettings>
+
+namespace {
+
+const QString kSkinManifestFileName(QStringLiteral("skin.ini"));
+const QString kMainQmlFileName(QStringLiteral("main.qml"));
+const QString kSkinGroup(QStringLiteral("Skin"));
+const QString kDescriptionKey(QStringLiteral("description"));
+const QString kMinPixelWidthKey(QStringLiteral("min_pixel_width"));
+const QString kMinPixelHeightKey(QStringLiteral("min_pixel_height"));
+
+} // namespace
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+
+// static
+SkinPointer QmlSkin::fromDirectory(const QDir& dir) {
+    if (dir.exists(kSkinManifestFileName) && dir.exists(kMainQmlFileName)) {
+        return std::make_shared<QmlSkin>(QFileInfo(dir.absolutePath()));
+    }
+    return nullptr;
+}
+
+QmlSkin::QmlSkin(const QFileInfo& path)
+        : m_path(path) {
+    DEBUG_ASSERT(isValid());
+}
+
+bool QmlSkin::isValid() const {
+    return !m_path.filePath().isEmpty() &&
+            m_path.exists() &&
+            QFileInfo::exists(mainQmlFilePath()) &&
+            QFileInfo::exists(skinIniFile().filePath());
+}
+
+QFileInfo QmlSkin::path() const {
+    DEBUG_ASSERT(isValid());
+    return m_path;
+}
+
+QPixmap QmlSkin::preview(const QString&) const {
+    QPixmap preview(m_path.absoluteFilePath() + QStringLiteral("/skin_preview.png"));
+    if (!preview.isNull()) {
+        return preview;
+    }
+    preview.load(":/images/skin_preview_placeholder.png");
+    return preview;
+}
+
+QString QmlSkin::name() const {
+    DEBUG_ASSERT(isValid());
+    return m_path.fileName();
+}
+
+QString QmlSkin::description() const {
+    DEBUG_ASSERT(isValid());
+    QSettings skinSettings(skinIniFile().absoluteFilePath(), QSettings::IniFormat);
+    skinSettings.beginGroup(kSkinGroup);
+    return skinSettings.value(kDescriptionKey).toString();
+}
+
+QList<QString> QmlSkin::colorschemes() const {
+    return {};
+}
+
+bool QmlSkin::fitsScreenSize(const QScreen& screen) const {
+    DEBUG_ASSERT(isValid());
+    QSettings skinSettings(skinIniFile().absoluteFilePath(), QSettings::IniFormat);
+    skinSettings.beginGroup(kSkinGroup);
+    const int minPixelWidth = skinSettings.value(kMinPixelWidthKey).toInt();
+    const int minPixelHeight = skinSettings.value(kMinPixelHeightKey).toInt();
+    if (minPixelWidth <= 0 || minPixelHeight <= 0) {
+        return true;
+    }
+    const QSize screenSize = screen.size();
+    return minPixelWidth <= screenSize.width() &&
+            minPixelHeight <= screenSize.height();
+}
+
+LaunchImage* QmlSkin::loadLaunchImage(QWidget*, UserSettingsPointer) const {
+    return nullptr;
+}
+
+QWidget* QmlSkin::loadSkin(QWidget*,
+        UserSettingsPointer,
+        QSet<ControlObject*>*,
+        mixxx::CoreServices*) const {
+    return nullptr;
+}
+
+QString QmlSkin::mainQmlFilePath() const {
+    return m_path.absoluteFilePath() + QStringLiteral("/") + kMainQmlFileName;
+}
+
+QFileInfo QmlSkin::skinIniFile() const {
+    return QFileInfo(m_path.absoluteFilePath() + QStringLiteral("/") + kSkinManifestFileName);
+}
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx

--- a/src/skin/qml/qmlskin.h
+++ b/src/skin/qml/qmlskin.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <QFileInfo>
+#include <QList>
+#include <QPixmap>
+#include <QString>
+
+#include "skin/skin.h"
+
+class QDir;
+class QScreen;
+
+namespace mixxx {
+namespace skin {
+namespace qml {
+
+class QmlSkin : public mixxx::skin::Skin {
+  public:
+    explicit QmlSkin(const QFileInfo& path);
+
+    static SkinPointer fromDirectory(const QDir& dir);
+
+    mixxx::skin::SkinType type() const override {
+        return mixxx::skin::SkinType::QML;
+    }
+    bool isValid() const override;
+    QFileInfo path() const override;
+    QPixmap preview(const QString& schemeName) const override;
+
+    QString name() const override;
+    QString description() const override;
+    QList<QString> colorschemes() const override;
+
+    bool fitsScreenSize(const QScreen& screen) const override;
+    LaunchImage* loadLaunchImage(QWidget* pParent, UserSettingsPointer pConfig) const override;
+    QWidget* loadSkin(QWidget* pParent,
+            UserSettingsPointer pConfig,
+            QSet<ControlObject*>* pSkinCreatedControls,
+            mixxx::CoreServices* pCoreServices) const override;
+
+    QString mainQmlFilePath() const override;
+
+  private:
+    QFileInfo skinIniFile() const;
+
+    QFileInfo m_path;
+};
+
+} // namespace qml
+} // namespace skin
+} // namespace mixxx

--- a/src/skin/skin.h
+++ b/src/skin/skin.h
@@ -46,6 +46,10 @@ class Skin {
             UserSettingsPointer pConfig,
             QSet<ControlObject*>* pSkinCreatedControls,
             mixxx::CoreServices* pCoreServices) const = 0;
+
+    virtual QString mainQmlFilePath() const {
+        return QString();
+    }
 };
 
 typedef std::shared_ptr<Skin> SkinPointer;

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -11,6 +11,10 @@
 #include "skin/legacy/launchimage.h"
 #include "skin/legacy/legacyskin.h"
 #include "skin/legacy/legacyskinparser.h"
+#ifdef MIXXX_USE_QML
+#include "skin/qml/qmlskin.h"
+#endif
+#include "util/cmdlineargs.h"
 #include "util/debug.h"
 #include "util/timer.h"
 
@@ -20,6 +24,9 @@ namespace mixxx {
 namespace skin {
 
 using legacy::LegacySkin;
+#ifdef MIXXX_USE_QML
+using qml::QmlSkin;
+#endif
 
 SkinLoader::SkinLoader(UserSettingsPointer pConfig)
         : m_pConfig(pConfig),
@@ -104,6 +111,7 @@ SkinPointer SkinLoader::getSkin(const QString& skinName) const {
             }
         }
     }
+
     return nullptr;
 }
 
@@ -130,6 +138,7 @@ SkinPointer SkinLoader::getConfiguredSkin() const {
     if (pSkin && pSkin->isValid()) {
         return pSkin;
     }
+
     qWarning() << "Failed to find configured skin" << configSkin;
 
     // Fallback to default skin as last resort
@@ -237,6 +246,18 @@ SkinPointer SkinLoader::skinFromDirectory(const QDir& dir) const {
     if (pSkin && pSkin->isValid()) {
         return pSkin;
     }
+
+#ifdef MIXXX_USE_QML
+    // This getDeveloper() check is technically redundant because the callers
+    // (getSystemSkins, getSkin) already check it before scanning QML paths.
+    // Kept here for defense-in-depth in case future callers forget the guard.
+    if (CmdlineArgs::Instance().getDeveloper()) {
+        pSkin = qml::QmlSkin::fromDirectory(dir);
+        if (pSkin && pSkin->isValid()) {
+            return pSkin;
+        }
+    }
+#endif
 
     return nullptr;
 }


### PR DESCRIPTION
## Description

This PR integrates QML-based skins (currently LateNight QML) into the standard Mixxx Skin Preferences, allowing developers and early testers to select and boot into the QML interface without strictly relying on the `--qml` CLI flag.

To ensure safety for standard users, the QML UI is treated as unstable and is strictly gated behind Developer Mode.

### Motivation

As the GSoC 2026 LateNight QML port progresses, we need a reliable, standard way to test the UI directly from the preferences menu rather than maintaining a permanently separate CLI flow. This sets up the foundational architecture for when QML skins eventually graduate to stability, giving the end user a direct way to test the QML skin which is the end goal of my GSoC project. So, this PR is the first step towards that goal based on the discussion with my mentor @JoergAtGithub .

### Key Changes

1. **Added `QmlSkin` Adapter:** Created a concrete implementation of the `Skin` interface for QML skins (`src/skin/qml/qmlskin.*`). It detects valid QML skins by the presence of `main.qml` and `skin.ini`.
2. **Developer Mode Gating:** Modified `SkinLoader` to only discover and load QML skins if Mixxx is launched with the `--developer` flag. If a user disables developer mode while a QML skin is still configured, Mixxx will safely log the mismatch and fall back to the default legacy skin.
3. **Refactored Startup (`main.cpp`):** Lifted `CoreServices` instantiation to occur before the QWidget vs. QML decision fork. This allows Mixxx to read the `[Config], ResizableSkin` preference and boot directly into `QmlApplication` if applicable.
4. **Restart over Hot-Reload:** Updated `DlgPrefInterface` so that applying a QML skin triggers a "Restart Necessary" prompt. Unlike legacy skins, QML uses an entirely different application shell (`QmlApplication` vs `MixxxMainWindow`) which cannot be safely swapped at runtime without restarting the process.
5. **CLI Backward Compatibility**: Launching with `--qml` or `--new-ui` completely bypasses the new preference checks, ensuring existing developer CLI workflows remain 100% intact.

## Testing Instructions

1. Launch Mixxx with `./build/mixxx --developer`.
2. Navigate to **Preferences > Interface**.
3. Select `qml` from the Skin dropdown and click **Apply** (you will be prompted to restart).
4. Restart Mixxx using `./build/mixxx --developer --allow-dangerous-data-corruption-risk`.
5. Mixxx should boot directly into the QML shell.
6. Verify safety fallback: Launch Mixxx _without_ `--developer`. It should safely ignore the QML config and load the default legacy skin instead.

## Tracking

GSoC: LateNight QML PR-1
