### PR TITLE
Subscribe live waveform marks to CO position changes

### DIFF
--- a/src/waveform/renderers/waveformrendermarkbase.cpp
+++ b/src/waveform/renderers/waveformrendermarkbase.cpp
@@ -14,6 +14,13 @@ WaveformRenderMarkBase::WaveformRenderMarkBase(
 void WaveformRenderMarkBase::setup(const QDomNode& node, const SkinContext& context) {
     WaveformSignalColors signalColors = *m_waveformRenderer->getWaveformSignalColors();
     m_marks.setup(m_waveformRenderer->getGroup(), node, context, signalColors);
+    // The loop_start_position and loop_end_position marks are driven by CO
+    // value changes, not by Track::cuesUpdated, so we must subscribe to the
+    // position controls here. e5d207c8 restored the equivalent connection for
+    // the Overview after 1adf980e/831aff08 removed it; the live waveform was
+    // missed by that fix.
+    m_marks.connectSamplePositionChanged(this, &WaveformRenderMarkBase::onMarkChanged);
+    m_marks.connectSampleEndPositionChanged(this, &WaveformRenderMarkBase::onMarkChanged);
     m_marks.connectVisibleChanged(this, &WaveformRenderMarkBase::onMarkChanged);
 }
 


### PR DESCRIPTION
## Summary

Loop in/out marks on the **live waveform** never appear for a regular (non-saved) loop on a freshly loaded track. They only become visible after some other cue write occurs — e.g. saving a loop to a hotcue — at which point they remain visible for all subsequent loops on that track.

## Root cause

The marks driven by the `loop_start_position` / `loop_end_position` controls are CO-driven (`LoopingControl` writes the COs directly), not `Cue::updated()`-driven. After 1adf980e and 831aff08 removed the position connections with the rationale that they were "redundant via Cue::updated()", the live waveform stopped receiving updates for regular loops — only saved-loop hotcues continued to work because those still emit `Cue::updated()` → `slotCuesUpdated()` → `m_marks.update()` and rebuild ``m_marksToRender``.

e5d207c8 restored the equivalent connection on the **Overview** but the live waveform path in ``WaveformRenderMarkBase::setup()`` was missed by that fix.

## Fix

Add ``connectSamplePositionChanged`` / ``connectSampleEndPositionChanged`` next to the existing ``connectVisibleChanged`` call in ``WaveformRenderMarkBase::setup()``. This is the same shape of restoration e5d207c8 made for the overview, in the path shared by all live waveform renderers.

The redundant per-hotcue position connections that were removed in 1adf980e / 831aff08 are intentionally **not** re-added — those updates continue to flow through ``Cue::updated()`` as designed.

## Test plan

- [x] Load a track in a deck, no saved loops exist.
- [x] Activate a beat loop (e.g. ``beatloop_4_activate``) — loop in/out marks appear immediately on the live waveform.
- [x] Deactivate / reactivate / move the loop — marks update without lag.
- [x] Verify saved-loop hotcues still render correctly (no regression on the `Cue::updated()` path).

Tested on Windows 11, allshader waveform renderer, LateNight skin.