### PR TITLE
(fix/UX) Library Scanner: show progress also when looking for missing tracks

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1961,6 +1961,8 @@ bool TrackDAO::detectMovedTracks(
                 << "Looking for substitute of missing track location"
                 << oldTrackLocation;
 
+        emit mixxx::thisAsNonConst(this)->progressLookingForSubstituteTracks(oldTrackLocation);
+
         newTrackQuery.bindValue(":filename", filename);
         newTrackQuery.bindValue(":duration", duration);
         if (!newTrackQuery.exec()) {

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -121,6 +121,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
 
     void progressVerifyTracksOutside(const QString& path);
     void progressCoverArt(const QString& file);
+    void progressLookingForSubstituteTracks(const QString& path);
     void forceModelUpdate();
     void removeTrackRows(const QSet<TrackId>& trackIds);
 

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -150,6 +150,10 @@ LibraryScanner::LibraryScanner(
             &TrackDAO::progressCoverArt,
             m_pProgressDlg.get(),
             &LibraryScannerDlg::slotUpdateCover);
+    connect(&m_trackDao,
+            &TrackDAO::progressLookingForSubstituteTracks,
+            m_pProgressDlg.get(),
+            &LibraryScannerDlg::slotUpdateSubstitute);
 }
 
 LibraryScanner::~LibraryScanner() {

--- a/src/library/scanner/libraryscannerdlg.cpp
+++ b/src/library/scanner/libraryscannerdlg.cpp
@@ -123,7 +123,7 @@ void LibraryScannerDlg::slotUpdate(const QString& path) {
 void LibraryScannerDlg::slotUpdateCover(const QString& path) {
     // qDebug() << "LibraryScannerDlg slotUpdate" << m_timer.elapsed() << path;
     if (!m_bCancelled && m_timer.elapsed() > mixxx::Duration::fromSeconds(2)) {
-       setVisible(true);
+        setVisible(true);
     }
 
     m_tasksDone++;
@@ -131,6 +131,18 @@ void LibraryScannerDlg::slotUpdateCover(const QString& path) {
         updateProgressBar();
         const QString status = QStringLiteral("%1: %2").arg(
                 tr("Scanning cover art (safe to cancel)"), path);
+        m_pLabelCurrent->setText(status);
+    }
+}
+
+void LibraryScannerDlg::slotUpdateSubstitute(const QString& path) {
+    // qDebug() << "LibraryScannerDlg slotUpdateSubstitute" << m_timer.elapsed() << path;
+    if (!m_bCancelled && m_timer.elapsed() > mixxx::Duration::fromSeconds(2)) {
+        setVisible(true);
+    }
+
+    if (isVisible()) {
+        const QString status = QString("%1: %2").arg(tr("Looking for substitute for"), path);
         m_pLabelCurrent->setText(status);
     }
 }

--- a/src/library/scanner/libraryscannerdlg.h
+++ b/src/library/scanner/libraryscannerdlg.h
@@ -18,6 +18,7 @@ class LibraryScannerDlg : public QDialog {
   public slots:
     void slotUpdate(const QString& path);
     void slotUpdateCover(const QString& path);
+    void slotUpdateSubstitute(const QString& path);
     void slotCancel();
     void slotScanFinished();
     void slotScanStarted();


### PR DESCRIPTION
I noticed that the scan progress got stuck for quite a while, but since I was running from command line I could see TrackDAO was looking for a lot of substitute tracks.

This adds the progress indication like for other scan task.