### PR TITLE
reset track played state on start, cleanup after crash/termination

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -101,6 +101,7 @@ TrackDAO::TrackDAO(CueDAO& cueDao,
           m_trackLocationIdColumn(UndefinedRecordIndex),
           m_queryLibraryIdColumn(UndefinedRecordIndex),
           m_queryLibraryMixxxDeletedColumn(UndefinedRecordIndex) {
+    resetPlayedState();
     connect(&m_playlistDao,
             &PlaylistDAO::tracksRemovedFromPlayedHistory,
             this,
@@ -124,15 +125,7 @@ TrackDAO::~TrackDAO() {
 void TrackDAO::finish() {
     kLogger.debug() << "finish()";
 
-    // clear out played information on exit
-    // crash prevention: if mixxx crashes, played information will be maintained
-    kLogger.debug() << "Clearing played information for this session";
-    QSqlQuery query(m_database);
-    if (!query.exec("UPDATE library SET played=0 where played>0")) {
-        // Note: without where, this call updates every row which takes long
-        LOG_FAILED_QUERY(query)
-                << "Error clearing played value";
-    }
+    resetPlayedState();
 
     // Do housekeeping on the LibraryHashes/track_locations tables.
     kLogger.debug() << "Cleaning LibraryHashes/track_locations tables.";
@@ -149,6 +142,18 @@ void TrackDAO::finish() {
         markTrackLocationsAsDeleted(m_database, dir);
     }
     transaction.commit();
+}
+
+void TrackDAO::resetPlayedState() {
+    // clear out played information on exit
+    // crash prevention: if mixxx crashes, played information will be maintained
+    kLogger.debug() << "Clearing played information for this session";
+    QSqlQuery query(m_database);
+    if (!query.exec("UPDATE library SET played=0 where played>0")) {
+        // Note: without where, this call updates every row which takes long
+        LOG_FAILED_QUERY(query)
+                << "Error clearing played value";
+    }
 }
 
 TrackId TrackDAO::getTrackIdByLocation(const QString& location) const {

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -137,6 +137,8 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     friend class TrackCollection;
     friend class TrackAnalysisScheduler;
 
+    void resetPlayedState();
+
     QList<TrackId> resolveTrackIds(
             const QStringList& pathList,
             ResolveTrackIdFlags flags = ResolveTrackIdFlag::ResolveOnly);


### PR DESCRIPTION
In case Mixxx crashed during shutdown the tracks' `played` flag is not reset until next shutdown.
This adds the cleanup at start, similar to "delete playlists with lees than N tracks".

Not sure what to make of the comment
`crash prevention: if mixxx crashes, played information will be maintained`
Is this just a hint? If not, I don't see how "played information" is of any use?
Since PlaylistDAO commits changes mostly immediatly as far as I can tell, the History playlist is often saved before any potential crash, and the "played information" alone is of no use IMO :man_shrugging: 