### PR TITLE
fix(waveform): mark QML marker nodes dirty

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -51,6 +51,7 @@ class WaveformMarkNode : public rendergraph::GeometryNode {
                 .setTexture(std::make_unique<Texture>(pContext, image));
         m_textureWidth = image.width();
         m_textureHeight = image.height();
+        markDirtyMaterial();
     }
     void update(float x, float y, float devicePixelRatio) {
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
@@ -66,6 +67,7 @@ class WaveformMarkNode : public rendergraph::GeometryNode {
                         y + m_textureHeight / devicePixelRatio},
                 {0.f, 0.f},
                 {1.f, 1.f});
+        markDirtyGeometry();
     }
     float textureWidth() const {
         return m_textureWidth;
@@ -272,6 +274,8 @@ void allshader::WaveformRenderMark::updateRangeNode(GeometryNode* pNode,
             {posx1, posy1}, {posx2, posy2}, {r, g, b, a}, {r, g, b, 0.f});
     vertexUpdater.addRectangleVGradient(
             {posx1, posy4}, {posx2, posy3}, {r, g, b, a}, {r, g, b, 0.f});
+    pNode->markDirtyGeometry();
+    pNode->markDirtyMaterial();
 }
 
 bool allshader::WaveformRenderMark::isSubtreeBlocked() const {
@@ -456,6 +460,7 @@ void allshader::WaveformRenderMark::update() {
                 {drawOffset + kPlayPosWidth, static_cast<float>(m_waveformRenderer->getBreadth())},
                 {0.f, 0.f},
                 {1.f, 1.f});
+        m_pPlayPosNode->markDirtyGeometry();
     }
 
     if (m_untilMarkShowBeats || m_untilMarkShowTime) {
@@ -584,6 +589,7 @@ void allshader::WaveformRenderMark::updatePlayPosMarkTexture(rendergraph::Contex
 
     dynamic_cast<TextureMaterial&>(m_pPlayPosNode->material())
             .setTexture(std::make_unique<Texture>(pContext, image));
+    m_pPlayPosNode->markDirtyMaterial();
 }
 
 void allshader::WaveformRenderMark::drawTriangle(QPainter* painter,


### PR DESCRIPTION
## Description

This PR fixes a QML waveform rendering artifact where the play-position marker could visually disconnect after resizing an empty waveform display.

The issue was found while testing the LateNight QML skin, but the root cause is in the shared all-shader waveform mark renderer rather than in the skin or layout code.

### Motivation

`allshader::WaveformRenderMark` updates scene graph geometry and textures for cue marks, mark ranges, and the play-position marker. Some of those updates changed vertex data or textures without marking the corresponding render graph nodes dirty.

That can leave Qt's scene graph using stale uploaded geometry/material state after a resize. In the empty-deck case this is especially visible because the play-position marker is one of the only things drawn in the waveform area.

### Key Changes

1. Mark `WaveformMarkNode` material dirty after replacing its texture.
2. Mark `WaveformMarkNode` geometry dirty after updating its rectangle vertices.
3. Mark mark-range nodes dirty after updating their gradient geometry/material.
4. Mark the play-position marker node dirty after updating its geometry and texture.

## Testing Instructions

- Launch a LateNightQML UI with empty decks.
- Resize the waveform area.
- Verify that the play-position marker stays continuous and does not retain stale height/geometry.

## Verification

Tested locally on my LateNightQML branch.

The QML UI (Mixxx 3.0) doesn't have this problem during rendering due to other reasons, but this fix is required to proceed with the LateNightQML skin.
