### PR TITLE
(fix) Track: emit loopRemove() only when we actually removed a loop cue

### DIFF
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1175,11 +1175,11 @@ void Track::removeCuesOfType(mixxx::CueType type) {
             dirty = true;
         }
     }
-    // If loop cues are removed, also clear the last active loop
-    if (type == mixxx::CueType::Loop) {
-        emit loopRemove();
-    }
     if (dirty) {
+        // If loop cues have been removed, also clear the last active loop
+        if (type == mixxx::CueType::Loop) {
+            emit loopRemove();
+        }
         markDirtyAndUnlock(&locked);
         emit cuesUpdated();
     }


### PR DESCRIPTION
Just a cleanup, in 2.6 there are no side effects.

Required to make #16455 work as desired.