### PR TITLE
LateNight: use 'Buffer %' for the latency meter label

### DIFF
--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -191,7 +191,7 @@
                 <TooltipId>audio_latency_usage</TooltipId>
                 <Size>0min,10f</Size>
                 <Alignment>center</Alignment>
-                <Text>CPU Load</Text>
+                <Text>Buffer %</Text>
               </Label>
             </Children>
           </WidgetGroup><!-- LatencyMeterBox -->


### PR DESCRIPTION
This should avoid the confusion stemming from the 'CPU' label, see #15855 for example