### PR TITLE
(fix) Track Info: expand only Comment editor when expanding vertically

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -53,7 +53,8 @@ DlgTrackInfo::DlgTrackInfo(
                           // TODO(xxx) remove this once the preferences are themed via QSS
                           WColorPicker::Option::NoExtStyleSheet,
                   ColorPaletteSettings(m_pUserSettings).getTrackColorPalette(),
-                  this)) {
+                  this)),
+          m_widgetSizesFixed(false) {
     init();
 }
 
@@ -879,16 +880,29 @@ void DlgTrackInfo::slotImportMetadataFromMusicBrainz() {
     }
     m_pDlgTagFetcher->show();
 }
+void DlgTrackInfo::showEvent(QShowEvent* pEvent) {
+    QDialog::showEvent(pEvent);
+    adjustWidgetSizes();
+}
 
 void DlgTrackInfo::resizeEvent(QResizeEvent* pEvent) {
     QDialog::resizeEvent(pEvent);
+    adjustWidgetSizes();
+}
 
+void DlgTrackInfo::adjustWidgetSizes() {
     if (!isVisible()) {
         // Likely one of the resize events before show().
         // Widgets don't have their final size, yet, so it
         // makes no sense to resize the cover label.
         return;
     }
+
+    if (m_widgetSizesFixed) {
+        return;
+    }
+    // Set this now to avoid re-entrance on multiple resize events in quick succession
+    m_widgetSizesFixed = true;
 
     // Set a maximum size on the cover label so it can use the available space
     // but doesn't force-expand the dialog.
@@ -907,4 +921,13 @@ void DlgTrackInfo::resizeEvent(QResizeEvent* pEvent) {
     // Also clamp height of the cover's parent widget. Keeping its height minimal
     // can't be accomplished with QSizePolicies alone unfortunately.
     coverWidget->setFixedHeight(totalHeight);
+
+    // Set fixed height on stars widget so it doesn't make the adjacent
+    // txtAlbumArtist expand vertically
+    m_pWStarRating->setFixedHeight(txtAlbumArtist->height());
+
+    // Set the minimum height for the Comment editor to at least 3 line. Let's
+    // use the triple the height of a QLineEdit because they are sized correctly.
+    // The editor can expand vertically when the dialog is resized.
+    txtComment->setMinimumHeight(txtTrackNumber->geometry().height() * 3);
 }

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -46,8 +46,10 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void previous();
 
   protected:
-    // used to set the maximum size of the cover label
+    /// These two call adjustWidgetSizes() in order to fix some layout
+    /// quirks and set the minimum height of the Comment editor
     void resizeEvent(QResizeEvent* pEvent) override;
+    void showEvent(QShowEvent* pEvent) override;
 
   private slots:
     void slotNextButton();
@@ -93,6 +95,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void saveTrack();
     void clear();
     void init();
+    void adjustWidgetSizes();
 
     void updateKeyText();
     void displayKeyText();
@@ -135,4 +138,6 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     parented_ptr<WColorPickerAction> m_pColorPicker;
 
     std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
+
+    bool m_widgetSizesFixed;
 };

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -47,7 +47,7 @@
       <attribute name="title">
        <string>Summary</string>
       </attribute>
-      <layout class="QVBoxLayout" name="summary_layout">
+      <layout class="QVBoxLayout" name="summary_layout" stretch="1,0,0">
        <item>
         <widget class="QGroupBox" name="groupBox">
          <layout class="QGridLayout" name="tags_layout" columnstretch="0,10,0,2">
@@ -414,7 +414,7 @@
           <item row="8" column="1" colspan="3">
            <widget class="QPushButton" name="btnColorPicker">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -683,22 +683,6 @@
 
          </layout>
         </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::MinimumExpanding</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>2</height>
-          </size>
-         </property>
-        </spacer>
        </item>
       </layout>
      </widget>

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -117,7 +117,8 @@ DlgTrackInfoMulti::DlgTrackInfoMulti(UserSettingsPointer pUserSettings)
                           // TODO(xxx) remove this once the preferences are themed via QSS
                           WColorPicker::Option::NoExtStyleSheet,
                   ColorPaletteSettings(m_pUserSettings).getTrackColorPalette(),
-                  this)) {
+                  this)),
+          m_widgetSizesFixed(false) {
     init();
 }
 
@@ -614,8 +615,17 @@ void DlgTrackInfoMulti::addValuesToCommentBox(QSet<QString>& comments) {
     txtComment->blockSignals(false);
 }
 
+void DlgTrackInfoMulti::showEvent(QShowEvent* pEvent) {
+    QDialog::showEvent(pEvent);
+    adjustWidgetSizes();
+}
+
 void DlgTrackInfoMulti::resizeEvent(QResizeEvent* pEvent) {
-    Q_UNUSED(pEvent);
+    QDialog::resizeEvent(pEvent);
+    adjustWidgetSizes();
+}
+
+void DlgTrackInfoMulti::adjustWidgetSizes() {
     if (!isVisible()) {
         // Likely one of the resize events before show().
         // Dialog & widgets don't have their final size, yet,
@@ -627,6 +637,12 @@ void DlgTrackInfoMulti::resizeEvent(QResizeEvent* pEvent) {
     // but is still much better than letting the popup expand to screen width,
     // which it would do regrardless if it's actually necessary.
     txtCommentBox->view()->parentWidget()->setMaximumWidth(width());
+
+    if (m_widgetSizesFixed) {
+        return;
+    }
+    // Set this now to avoid re-entrance on multiple resize events in quick succession
+    m_widgetSizesFixed = true;
 
     // Set a maximum size on the cover label so it can use the available space
     // but doesn't force-expand the dialog.
@@ -645,6 +661,15 @@ void DlgTrackInfoMulti::resizeEvent(QResizeEvent* pEvent) {
     // Also clamp height of the cover's parent widget. Keeping its height minimal
     // can't be accomplished with QSizePolicies alone unfortunately.
     coverWidget->setFixedHeight(totalHeight);
+
+    // Set fixed height on stars widget so it doesn't make the adjacent
+    // txtAlbumArtist expand vertically
+    m_pWStarRating->setFixedHeight(txtAlbumArtist->height());
+
+    // Set the minimum height for the Comment editor to at least 3 line. Let's
+    // use the triple the height of a QLineEdit because they are sized correctly.
+    // The editor can expand vertically when the dialog is resized.
+    txtComment->setMinimumHeight(txtTrackNumber->geometry().height() * 3);
 }
 
 void DlgTrackInfoMulti::saveTracks() {

--- a/src/library/dlgtrackinfomulti.h
+++ b/src/library/dlgtrackinfomulti.h
@@ -32,10 +32,10 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
     void focusField(const QString& property);
 
   protected:
-    /// We need this to set the max width of the comment QComboBox which has
-    /// issues with long lines / multi-line content. See init() for details.
-    /// Also used to set the maximum size of the cover label
-    void resizeEvent(QResizeEvent* event) override;
+    /// These two call adjustWidgetSizes() in order to fix some layout
+    /// quirks and set the minimum height of the Comment editor
+    void resizeEvent(QResizeEvent* pEvent) override;
+    void showEvent(QShowEvent* pEvent) override;
     bool eventFilter(QObject* pObj, QEvent* pEvent) override;
 
   private slots:
@@ -71,6 +71,8 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
 
   private:
     void init();
+    void adjustWidgetSizes();
+
     void loadTracksInternal(const QList<TrackPointer>& pTracks);
     void saveTracks();
 
@@ -118,4 +120,6 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
     bool m_colorChanged;
     mixxx::RgbColor::optional_t m_newColor;
     parented_ptr<WColorPickerAction> m_pColorPicker;
+
+    bool m_widgetSizesFixed;
 };

--- a/src/library/dlgtrackinfomulti.ui
+++ b/src/library/dlgtrackinfomulti.ui
@@ -25,7 +25,7 @@
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="main_layout">
+  <layout class="QVBoxLayout" name="main_layout" stretch="1,0,0">
 
    <item>
     <widget class="QGroupBox" name="tags_groupBox">
@@ -397,7 +397,7 @@
       <item row="8" column="1" colspan="3">
        <widget class="QPlainTextEdit" name="txtComment">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -421,7 +421,7 @@
       <item row="9" column="1" colspan="3">
        <widget class="QPushButton" name="btnColorPicker">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -457,12 +457,12 @@
    <item>
     <widget class="QGroupBox" name="properties_groupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QGridLayout" name="properties_layout" rowstretch="0,0,0,0,0,0" columnstretch="0,1,0,1">
+     <layout class="QGridLayout" name="properties_layout" columnstretch="0,1,0,1">
 
       <item row="0" column="0">
        <widget class="QLabel" name="lblDuration">
@@ -628,20 +628,6 @@
          </spacer>
         </item>
        </layout>
-      </item>
-
-      <item row="5" column="1" colspan="3">
-       <spacer name="properties_bottom_spacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>10</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
In both the single- and multi-track editor the Color button or the bottom spacer where also expanding.