### PR TITLE
Import playlist files passed on startup

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -822,3 +822,17 @@ LibraryTableModel* Library::trackTableModel() const {
 
     return m_pMixxxLibraryFeature->trackTableModel();
 }
+
+void Library::importPlaylistFromFile(const QString& playlistFile,
+        bool activatePlaylist) {
+    if (playlistFile.isEmpty()) {
+        return;
+    }
+    const int playlistId = m_pPlaylistFeature->createImportPlaylist(playlistFile);
+    if (playlistId == kInvalidPlaylistId) {
+        return;
+    }
+    if (activatePlaylist) {
+        m_pPlaylistFeature->activatePlaylist(playlistId);
+    }
+}

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -114,6 +114,9 @@ class Library: public QObject {
     bool requestRemoveDir(const QString& directory, LibraryRemovalType removalType);
     bool requestRelocateDir(const QString& previousDirectory, const QString& newDirectory);
 
+    void importPlaylistFromFile(const QString& playlistFile,
+            bool activatePlaylist = true);
+
 #ifdef __ENGINEPRIME__
     std::unique_ptr<mixxx::LibraryExporter> makeLibraryExporter(QWidget* parent);
 #endif

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -567,29 +567,39 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
 
     // For each selected element create a different playlist.
     for (const QString& playlistFile : playlistFiles) {
-        const QFileInfo fileInfo(playlistFile);
-        // Get a valid name
-        const QString baseName = fileInfo.completeBaseName();
-        QString name = baseName;
-        // Check if there already is a playlist by that name. If yes, add
-        // increasing suffix (1++) until we find an unused name.
-        int i = 1;
-        while (m_playlistDao.getPlaylistIdFromName(name) != kInvalidPlaylistId) {
-            name = baseName + QChar(' ') + QString::number(i);
-            ++i;
-        }
-
-        lastPlaylistId = m_playlistDao.createPlaylist(name);
+        lastPlaylistId = createImportPlaylist(playlistFile);
         if (lastPlaylistId == kInvalidPlaylistId) {
             QMessageBox::warning(nullptr,
                     tr("Playlist Creation Failed"),
-                    tr("An unknown error occurred while creating playlist: ") + name);
+                    tr("An unknown error occurred while creating playlist: ") +
+                            QFileInfo(playlistFile).completeBaseName());
             return;
         }
-
-        slotImportPlaylistFile(playlistFile, lastPlaylistId);
     }
     activatePlaylist(lastPlaylistId);
+}
+
+int BasePlaylistFeature::createImportPlaylist(const QString& playlistFile) {
+    const QFileInfo fileInfo(playlistFile);
+    // Get a valid name
+    const QString baseName = fileInfo.completeBaseName();
+    QString name = baseName;
+    // Check if there already is a playlist by that name. If yes, add
+    // increasing suffix (1++) until we find an unused name.
+    int i = 1;
+    while (m_playlistDao.getPlaylistIdFromName(name) != kInvalidPlaylistId) {
+        name = baseName + QChar(' ') + QString::number(i);
+        ++i;
+    }
+
+    int lastPlaylistId = m_playlistDao.createPlaylist(name);
+    if (lastPlaylistId == kInvalidPlaylistId) {
+        qWarning() << "Failed to create playlist" << name;
+        return kInvalidPlaylistId;
+    }
+
+    slotImportPlaylistFile(playlistFile, lastPlaylistId);
+    return lastPlaylistId;
 }
 
 void BasePlaylistFeature::slotExportPlaylist() {

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -39,6 +39,8 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void selectPlaylistInSidebar(int playlistId, bool select = true);
     int getSiblingPlaylistIdOf(QModelIndex& start);
 
+    int createImportPlaylist(const QString& playlistFile);
+
   public slots:
     void activateChild(const QModelIndex& index) override;
     virtual void activatePlaylist(int playlistId);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -38,6 +38,7 @@
 #include "library/library.h"
 #include "library/library_decl.h"
 #include "library/library_prefs.h"
+#include "library/parser.h"
 #ifdef __ENGINEPRIME__
 #include "library/export/libraryexporter.h"
 #endif
@@ -456,6 +457,21 @@ void MixxxMainWindow::initialize() {
             &PlayerInfo::currentPlayingTrackChanged,
             this,
             &MixxxMainWindow::slotUpdateWindowTitle);
+
+    // Import playlist files passed as command line arguments.
+    // Activate only the last one to avoid repeated sidebar updates.
+    const QList<QString>& musicFiles = CmdlineArgs::Instance().getMusicFiles();
+    QStringList playlistArgs;
+    for (const QString& file : musicFiles) {
+        if (Parser::isPlaylistFilenameSupported(file)) {
+            playlistArgs.append(file);
+        }
+    }
+    for (int i = 0; i < playlistArgs.count(); ++i) {
+        m_pCoreServices->getLibrary()->importPlaylistFromFile(
+                playlistArgs.at(i),
+                /*activatePlaylist=*/i == playlistArgs.count() - 1);
+    }
 
     // Start Auto DJ if the cmdline arg is passed.
     if (CmdlineArgs::Instance().getStartAutoDJ()) {


### PR DESCRIPTION
This makes opening playlist files with Mixxx do the expected thing: when Mixxx is started with an `.m3u`, `.m3u8` or `.pls` file, the file is imported as a new playlist and that playlist is selected in the library.

Audio files passed on the command line still use the existing deck-loading path. Playlist files are skipped there, so they are not also treated like tracks.

Closes #11178.

## Notes

There have been a few earlier attempts at this:

* #11211 was an early WIP.
* #11618 started in the same direction, but never got to wiring the import into  `BasePlaylistFeature`.
* #12243 went further and also added Auto DJ command line options, but got stuck.

This PR keeps the scope smaller: it only implements the basic import-on-open behavior. The shared playlist creation/import code is extracted from `slotCreateImportPlaylist()` so the new startup path and the existing file-picker path use the same logic.

Auto DJ routing can still be added later, but it seems easier to review and merge this part first.