### PR TITLE
Resolve merge conflicts between 2.5 and 2.6 for AudioUnitBackend

### DIFF
--- a/src/effects/backends/audiounit/audiounitbackend.mm
+++ b/src/effects/backends/audiounit/audiounitbackend.mm
@@ -68,28 +68,36 @@ class AudioUnitBackend : public EffectsBackend {
         // See
         // https://developer.apple.com/documentation/audiotoolbox/audio_unit_v3_plug-ins/incorporating_audio_effects_and_instruments?language=objc
 
-        // Create a query for audio components
-        AudioComponentDescription description = {
-                .componentType = kAudioUnitType_Effect,
-                .componentSubType = 0,
-                .componentManufacturer = 0,
-                .componentFlags = 0,
-                .componentFlagsMask = 0,
-        };
-
-        // Find the audio units
-        // TODO: Should we perform this asynchronously (e.g. using Qt's
-        // threading or GCD)?
+        // Discover all AU components of both types first, then load all
+        // manifests in a single parallel batch. This avoids the performance
+        // penalty of two sequential discovery passes each with their own
+        // blocking wait.
         auto manager =
                 [AVAudioUnitComponentManager sharedAudioUnitComponentManager];
-        auto components = [manager componentsMatchingDescription:description];
+
+        NSMutableArray<AVAudioUnitComponent*>* allComponents =
+                [[NSMutableArray alloc] init];
+
+        for (OSType componentType :
+                {kAudioUnitType_Effect, kAudioUnitType_MusicEffect}) {
+            AudioComponentDescription description = {
+                    .componentType = componentType,
+                    .componentSubType = 0,
+                    .componentManufacturer = 0,
+                    .componentFlags = 0,
+                    .componentFlagsMask = 0,
+            };
+            auto components =
+                    [manager componentsMatchingDescription:description];
+            [allComponents addObjectsFromArray:components];
+        }
 
         // Assign ids to the components
         NSMutableDictionary<NSString*, AVAudioUnitComponent*>* componentsById =
                 [[NSMutableDictionary alloc] init];
         QHash<QString, EffectManifestPointer> manifestsById;
 
-        for (AVAudioUnitComponent* component in components) {
+        for (AVAudioUnitComponent* component in allComponents) {
             qDebug() << "Found audio unit" << [component name];
 
             QString effectId = QString::fromNSString(

--- a/src/effects/backends/audiounit/audiounitbackend.mm
+++ b/src/effects/backends/audiounit/audiounitbackend.mm
@@ -18,7 +18,7 @@
 /// An effects backend for Audio Unit (AU) plugins. macOS-only.
 class AudioUnitBackend : public EffectsBackend {
   public:
-    AudioUnitBackend() : m_componentsById([[NSDictionary alloc] init]) {
+    AudioUnitBackend() : m_componentsById([NSDictionary dictionary]) {
         loadAudioUnits();
     }
 
@@ -76,7 +76,7 @@ class AudioUnitBackend : public EffectsBackend {
                 [AVAudioUnitComponentManager sharedAudioUnitComponentManager];
 
         NSMutableArray<AVAudioUnitComponent*>* allComponents =
-                [[NSMutableArray alloc] init];
+                [NSMutableArray array];
 
         for (OSType componentType :
                 {kAudioUnitType_Effect, kAudioUnitType_MusicEffect}) {
@@ -94,7 +94,7 @@ class AudioUnitBackend : public EffectsBackend {
 
         // Assign ids to the components
         NSMutableDictionary<NSString*, AVAudioUnitComponent*>* componentsById =
-                [[NSMutableDictionary alloc] init];
+                [NSMutableDictionary dictionary];
         QHash<QString, EffectManifestPointer> manifestsById;
 
         for (AVAudioUnitComponent* component in allComponents) {


### PR DESCRIPTION
Fixes #15589 

This PR resolves the merge conflicts encountered when syncing the `2.5` branch into `2.6`.

The conflict in `src/effects/backends/audiounit/audiounitbackend.mm` arose because:
1. `2.5` optimized the discovery pass into a single loop for both Effect and MusicEffect AUs.
2. `2.6` added Grand Central Dispatch (GCD) parallelization for loading manifests, but kept the sequential discovery passes.

This resolution combines both improvements: it performs a single pass to discover both types of AUs (from `2.5`), and retains the GCD concurrency to load the manifests in parallel (from `2.6`).