### PR TITLE
Preferences: Resolve screen from active application window

### DIFF
--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -352,7 +352,8 @@ void DlgPreferences::onShow() {
     int newWidth = m_geometry[2].toInt();
     int newHeight = m_geometry[3].toInt();
 
-    const QScreen* const pScreen = mixxx::widgethelper::getScreen(*this);
+    const QScreen* const pScreen =
+            mixxx::widgethelper::getScreenForWidgetOrApplication(*this);
     QRect screenAvailableGeometry;
     VERIFY_OR_DEBUG_ASSERT(pScreen) {
         qWarning() << "Assuming screen size of 800x600px.";
@@ -571,7 +572,8 @@ void DlgPreferences::resizeEvent(QResizeEvent* e) {
 
 QRect DlgPreferences::getDefaultGeometry() {
     adjustSize();
-    const auto* const pScreen = mixxx::widgethelper::getScreen(*this);
+    const auto* const pScreen =
+            mixxx::widgethelper::getScreenForWidgetOrApplication(*this);
     VERIFY_OR_DEBUG_ASSERT(pScreen) {
         return QRect();
     }

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -3,7 +3,6 @@
 #include <QDir>
 #include <QList>
 #include <QLocale>
-#include <QMainWindow>
 #include <QScreen>
 #include <QVariant>
 #include <QtGlobal>
@@ -61,18 +60,7 @@ DlgPrefInterface::DlgPrefInterface(
           m_dDevicePixelRatio(1.0) {
     setupUi(this);
 
-    // get the pixel ratio to display a crisp skin preview when Mixxx is scaled
-    m_dDevicePixelRatio = devicePixelRatioF();
-
-    // Calculate the minimum scale factor that leads to a device pixel ratio of 1.0
-    // m_dDevicePixelRatio must not drop below 1.0 because this creates an
-    // unusable GUI with visual artefacts
-    double initialScaleFactor = CmdlineArgs::Instance().getScaleFactor();
-    if (initialScaleFactor <= 0) {
-        initialScaleFactor = 1.0;
-    }
-    double unscaledDevicePixelRatio = m_dDevicePixelRatio / initialScaleFactor;
-    m_minScaleFactor = 1 / unscaledDevicePixelRatio;
+    updateScreenMetrics();
 
     // Locale setting
     // Iterate through the available locales and add them to the combobox
@@ -235,26 +223,36 @@ DlgPrefInterface::DlgPrefInterface(
 }
 
 QScreen* DlgPrefInterface::getScreen() const {
-    QScreen* pScreen = nullptr;
-    const QWidgetList topLevelWidgets = QApplication::topLevelWidgets();
-    for (QWidget* pWidget : topLevelWidgets) {
-        // Ignore other popups and hidden track menus
-        QMainWindow* pMainWindow = qobject_cast<QMainWindow*>(pWidget);
-        if (pMainWindow) {
-            pScreen = mixxx::widgethelper::getScreen(*pMainWindow);
-            break;
-        }
-    }
-    VERIFY_OR_DEBUG_ASSERT(pScreen) {
-        pScreen = mixxx::widgethelper::getScreen(*this);
-    }
-    if (!pScreen) {
-        // Obtain the primary screen. This is necessary if no window is
-        // available before the widget is displayed.
-        pScreen = qGuiApp->primaryScreen();
-    }
+    QScreen* pScreen = mixxx::widgethelper::getScreenForWidgetOrApplication(*this);
     DEBUG_ASSERT(pScreen);
     return pScreen;
+}
+
+void DlgPrefInterface::updateScreenMetrics() {
+    QScreen* pScreen = getScreen();
+    if (pScreen) {
+        // Use the resolved application screen instead of this page's DPR. In
+        // QML mode the preferences dialog can be constructed before the QML
+        // window exists, and this page might not yet be associated with the
+        // correct monitor.
+        m_dDevicePixelRatio = pScreen->devicePixelRatio();
+    } else {
+        m_dDevicePixelRatio = devicePixelRatioF();
+    }
+
+    // Calculate the minimum scale factor that leads to a device pixel ratio of 1.0
+    // m_dDevicePixelRatio must not drop below 1.0 because this creates an
+    // unusable GUI with visual artefacts
+    double initialScaleFactor = CmdlineArgs::Instance().getScaleFactor();
+    if (initialScaleFactor <= 0) {
+        initialScaleFactor = 1.0;
+    }
+    double unscaledDevicePixelRatio = m_dDevicePixelRatio / initialScaleFactor;
+    if (unscaledDevicePixelRatio > 0) {
+        m_minScaleFactor = 1 / unscaledDevicePixelRatio;
+    } else {
+        m_minScaleFactor = 1.0;
+    }
 }
 
 void DlgPrefInterface::slotUpdateSkins() {
@@ -353,6 +351,8 @@ void DlgPrefInterface::slotUpdateSchemes() {
 }
 
 void DlgPrefInterface::slotUpdate() {
+    updateScreenMetrics();
+
     if (m_pSkinLoader) {
         slotUpdateSkins();
 

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -19,7 +19,7 @@ class SkinLoader;
 }
 } // namespace mixxx
 
-class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg  {
+class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg {
     Q_OBJECT
   public:
     DlgPrefInterface(
@@ -51,6 +51,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
   private:
     void notifyRebootNecessary();
     void loadTooltipPreferenceFromConfig();
+    void updateScreenMetrics();
 
     // Because the CueDefault list is out of order, we have to set the combo
     // box using the user data, not the index.  Returns the index of the item

--- a/src/util/widgethelper.cpp
+++ b/src/util/widgethelper.cpp
@@ -1,13 +1,37 @@
 #include "util/widgethelper.h"
 
+#include <QApplication>
+#include <QGuiApplication>
 #include <QScreen>
 #include <QStyle>
+#include <QWindow>
 
 #include "util/math.h"
 
 namespace mixxx {
 
 namespace widgethelper {
+
+namespace {
+
+QScreen* screenForVisibleWindow(QWindow* pWindow) {
+    if (!pWindow || !pWindow->isVisible()) {
+        return nullptr;
+    }
+
+    switch (pWindow->type()) {
+    case Qt::Popup:
+    case Qt::ToolTip:
+    case Qt::SplashScreen:
+        return nullptr;
+    default:
+        break;
+    }
+
+    return pWindow->screen();
+}
+
+} // namespace
 
 QPoint mapPopupToScreen(
         const QWidget& widget,
@@ -46,6 +70,51 @@ QWindow* getWindow(
         return nativeParent->windowHandle();
     }
     return nullptr;
+}
+
+QScreen* getScreenForWidgetOrApplication(
+        const QWidget& widget) {
+    if (!qGuiApp) {
+        qWarning() << "Unable to detect an application screen without QGuiApplication.";
+        return nullptr;
+    }
+
+    if (QScreen* pScreen = screenForVisibleWindow(qGuiApp->focusWindow())) {
+        return pScreen;
+    }
+
+    if (QWidget* pActiveWindow = QApplication::activeWindow()) {
+        if (QScreen* pScreen = getScreen(*pActiveWindow)) {
+            return pScreen;
+        }
+    }
+
+    if (widget.isVisible()) {
+        if (QScreen* pScreen = getScreen(widget)) {
+            return pScreen;
+        }
+    }
+
+    const QWindowList topLevelWindows = qGuiApp->topLevelWindows();
+    for (QWindow* pWindow : topLevelWindows) {
+        if (QScreen* pScreen = screenForVisibleWindow(pWindow)) {
+            return pScreen;
+        }
+    }
+
+    if (QScreen* pScreen = getScreen(widget)) {
+        return pScreen;
+    }
+
+    QScreen* pScreen = qGuiApp->primaryScreen();
+    if (!pScreen) {
+        qWarning() << "Unable to detect an application screen.";
+    } else {
+        qWarning() << "Unable to detect an application window screen. "
+                      "Using primary screen"
+                   << pScreen->name();
+    }
+    return pScreen;
 }
 
 void growListWidget(QListWidget& listWidget, const QWidget& parent) {

--- a/src/util/widgethelper.cpp
+++ b/src/util/widgethelper.cpp
@@ -74,8 +74,7 @@ QWindow* getWindow(
 
 QScreen* getScreenForWidgetOrApplication(
         const QWidget& widget) {
-    if (!qGuiApp) {
-        qWarning() << "Unable to detect an application screen without QGuiApplication.";
+    VERIFY_OR_DEBUG_ASSERT(qGuiApp) {
         return nullptr;
     }
 
@@ -107,13 +106,12 @@ QScreen* getScreenForWidgetOrApplication(
     }
 
     QScreen* pScreen = qGuiApp->primaryScreen();
-    if (!pScreen) {
-        qWarning() << "Unable to detect an application screen.";
-    } else {
-        qWarning() << "Unable to detect an application window screen. "
-                      "Using primary screen"
-                   << pScreen->name();
+    VERIFY_OR_DEBUG_ASSERT(pScreen) {
+        return nullptr;
     }
+    qWarning() << "Unable to detect an application window screen. "
+                  "Using primary screen"
+               << pScreen->name();
     return pScreen;
 }
 

--- a/src/util/widgethelper.h
+++ b/src/util/widgethelper.h
@@ -50,6 +50,14 @@ inline QScreen* getScreen(
 #endif
 }
 
+/// Obtains the screen for the active application window or the given widget.
+///
+/// This supports both QWidget and QML top-level windows. A visible widget's
+/// screen is used before scanning all top-level windows. Falls back to the
+/// primary screen if no application or widget screen is available yet.
+QScreen* getScreenForWidgetOrApplication(
+        const QWidget& widget);
+
 /// QSize for stretching a list widget attempting to show entire column
 void growListWidget(QListWidget& listWidget, const QWidget& parent);
 


### PR DESCRIPTION
## Summary

- Fix a debug-build crash exposed by opening Preferences from the LateNightQML skin
- Add a shared widget helper that resolves the screen from the active/focused application window, including QML top-level windows
- Use that helper for Preferences geometry and Interface-page skin/DPI checks
- Keep `primaryScreen()` only as a defensive fallback instead of the normal QML path

## Motivation

LateNightQML runs Mixxx through a QML ApplicationWindow instead of the traditional legacy `QMainWindow`. `DlgPrefInterface::getScreen()` assumed a `QMainWindow` existed, so opening Preferences from LateNightQML could hit a debug assertion while resolving the screen for skin-size and HiDPI calculations.

A direct `primaryScreen()` fallback avoids the crash, but it is not accurate on multi-monitor setups because Preferences needs the screen that actually contains the Mixxx UI. This resolves the active application window screen instead, covering both QWidget and QML modes.

## Testing

Verify Preferences > Interface in legacy and LateNightQML mode, especially with Mixxx on a non-primary / different-DPI monitor.