### PR TITLE
Merge 2.6 into main and resolve audiounitbackend.mm conflict (#15633)

### DIFF
--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -191,7 +191,7 @@
                 <TooltipId>audio_latency_usage</TooltipId>
                 <Size>0min,10f</Size>
                 <Alignment>center</Alignment>
-                <Text>CPU Load</Text>
+                <Text>Buffer %</Text>
               </Label>
             </Children>
           </WidgetGroup><!-- LatencyMeterBox -->

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -265,7 +265,7 @@ bool HidIoThread::sendNextCachedOutputReport() {
         return true;
     }
 
-    // 2.) If non non-skipping reports were in the FIFO, send the skipable reports
+    // 2.) If non non-skipping reports were in the FIFO, send the skippable reports
     // from the m_outputReports cache
 
     // m_outputReports.size() doesn't need mutex protection, because the value of i is not used.

--- a/src/effects/backends/audiounit/audiounitbackend.mm
+++ b/src/effects/backends/audiounit/audiounitbackend.mm
@@ -68,28 +68,36 @@ class AudioUnitBackend : public EffectsBackend {
         // See
         // https://developer.apple.com/documentation/audiotoolbox/audio_unit_v3_plug-ins/incorporating_audio_effects_and_instruments?language=objc
 
-        // Create a query for audio components
-        AudioComponentDescription description = {
-                .componentType = kAudioUnitType_Effect,
-                .componentSubType = 0,
-                .componentManufacturer = 0,
-                .componentFlags = 0,
-                .componentFlagsMask = 0,
-        };
-
-        // Find the audio units
-        // TODO: Should we perform this asynchronously (e.g. using Qt's
-        // threading or GCD)?
+        // Discover all AU components of both types first, then load all
+        // manifests in a single parallel batch. This avoids the performance
+        // penalty of two sequential discovery passes each with their own
+        // blocking wait.
         auto manager =
                 [AVAudioUnitComponentManager sharedAudioUnitComponentManager];
-        auto components = [manager componentsMatchingDescription:description];
+
+        NSMutableArray<AVAudioUnitComponent*>* allComponents =
+                [[NSMutableArray alloc] init];
+
+        for (OSType componentType :
+                {kAudioUnitType_Effect, kAudioUnitType_MusicEffect}) {
+            AudioComponentDescription description = {
+                    .componentType = componentType,
+                    .componentSubType = 0,
+                    .componentManufacturer = 0,
+                    .componentFlags = 0,
+                    .componentFlagsMask = 0,
+            };
+            auto components =
+                    [manager componentsMatchingDescription:description];
+            [allComponents addObjectsFromArray:components];
+        }
 
         // Assign ids to the components
         NSMutableDictionary<NSString*, AVAudioUnitComponent*>* componentsById =
                 [[NSMutableDictionary alloc] init];
         QHash<QString, EffectManifestPointer> manifestsById;
 
-        for (AVAudioUnitComponent* component in components) {
+        for (AVAudioUnitComponent* component in allComponents) {
             qDebug() << "Found audio unit" << [component name];
 
             QString effectId = QString::fromNSString(

--- a/src/effects/backends/audiounit/audiounitbackend.mm
+++ b/src/effects/backends/audiounit/audiounitbackend.mm
@@ -18,7 +18,7 @@
 /// An effects backend for Audio Unit (AU) plugins. macOS-only.
 class AudioUnitBackend : public EffectsBackend {
   public:
-    AudioUnitBackend() : m_componentsById([[NSDictionary alloc] init]) {
+    AudioUnitBackend() : m_componentsById([NSDictionary dictionary]) {
         loadAudioUnits();
     }
 
@@ -76,7 +76,7 @@ class AudioUnitBackend : public EffectsBackend {
                 [AVAudioUnitComponentManager sharedAudioUnitComponentManager];
 
         NSMutableArray<AVAudioUnitComponent*>* allComponents =
-                [[NSMutableArray alloc] init];
+                [NSMutableArray array];
 
         for (OSType componentType :
                 {kAudioUnitType_Effect, kAudioUnitType_MusicEffect}) {
@@ -94,7 +94,7 @@ class AudioUnitBackend : public EffectsBackend {
 
         // Assign ids to the components
         NSMutableDictionary<NSString*, AVAudioUnitComponent*>* componentsById =
-                [[NSMutableDictionary alloc] init];
+                [NSMutableDictionary dictionary];
         QHash<QString, EffectManifestPointer> manifestsById;
 
         for (AVAudioUnitComponent* component in allComponents) {

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -344,7 +344,9 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     m_pContext->setSkinBasePath(skinPath);
 
     if (m_pParent) {
-        qDebug() << "ERROR: Somehow a parent already exists -- you are probably re-using a LegacySkinParser which is not advisable!";
+        qDebug()
+                << "ERROR: Somehow a parent already exists -- you are probably "
+                   "reusing a LegacySkinParser which is not advisable!";
     }
     QDomElement skinDocument = openSkin(skinPath);
 

--- a/tools/clang_format.py
+++ b/tools/clang_format.py
@@ -11,7 +11,6 @@ import typing
 
 import githelper
 
-
 # We recommend a maximum line length of 80, but do allow up to 100 characters
 # if deemed necessary by the developer. Lines that exceed that limit will
 # be wrapped after 80 characters automatically.


### PR DESCRIPTION
Resolves merge conflict reported in #15633 between `2.6` and `main`.\n\nSpecifically, this merge:\n- Reconciles `loadAudioUnits` thread pooling/semaphore logic from `main` with the `allComponents` array collection logic introduced in `2.6`.\n- Applies pre-commit formatting fixes on top of the merge.\n\nFixes #15633