### PR TITLE
fix: add QML fader/slider relative dragging, remove click-to-set and add knob/fader right-click reset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3887,6 +3887,7 @@ if(QML)
     RESOURCE_PREFIX /mixxx.org/imports
     OPTIONAL_IMPORTS Mixxx
     QML_FILES
+      res/qml/Mixxx/Controls/Slider.qml
       res/qml/Mixxx/Controls/Knob.qml
       res/qml/Mixxx/Controls/Fader.qml
       res/qml/Mixxx/Controls/Spinny.qml

--- a/res/qml/ControlFader.qml
+++ b/res/qml/ControlFader.qml
@@ -10,7 +10,9 @@ Skin.Fader {
 
     value: control.parameter
 
-    onMoved: control.parameter = value
+    onMoved: function(value) {
+        control.parameter = value;
+    }
 
     Mixxx.ControlProxy {
         id: control
@@ -20,5 +22,9 @@ Skin.Fader {
     }
     TapHandler {
         onDoubleTapped: control.reset()
+    }
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        onTapped: control.reset()
     }
 }

--- a/res/qml/ControlKnob.qml
+++ b/res/qml/ControlKnob.qml
@@ -18,4 +18,8 @@ Skin.Knob {
     TapHandler {
         onDoubleTapped: control.reset()
     }
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        onTapped: control.reset()
+    }
 }

--- a/res/qml/Fader.qml
+++ b/res/qml/Fader.qml
@@ -6,6 +6,12 @@ import "Theme"
 MixxxControls.Fader {
     id: root
 
+    enum SnapMode {
+        NoSnap,
+        SnapAlways,
+        SnapOnRelease
+    }
+
     property alias bg: backgroundImage.source
     property alias fg: handleImage.source
     property alias handleImage: handleImage

--- a/res/qml/Fader.qml
+++ b/res/qml/Fader.qml
@@ -6,12 +6,6 @@ import "Theme"
 MixxxControls.Fader {
     id: root
 
-    enum SnapMode {
-        NoSnap,
-        SnapAlways,
-        SnapOnRelease
-    }
-
     property alias bg: backgroundImage.source
     property alias fg: handleImage.source
     property alias handleImage: handleImage

--- a/res/qml/Mixxx/Controls/Fader.qml
+++ b/res/qml/Mixxx/Controls/Fader.qml
@@ -3,12 +3,6 @@ import QtQuick 2.12
 Slider {
     id: root
 
-    enum SnapMode {
-        NoSnap,
-        SnapAlways,
-        SnapOnRelease
-    }
-
     orientation: Qt.Vertical
     wheelEnabled: true
 }

--- a/res/qml/Mixxx/Controls/Fader.qml
+++ b/res/qml/Mixxx/Controls/Fader.qml
@@ -1,40 +1,14 @@
 import QtQuick 2.12
-import QtQuick.Controls 2.12
-import QtQuick.Shapes 1.12
 
 Slider {
     id: root
 
-    property bool bar: false
-    property alias barColor: barPath.strokeColor
-    property real barMargin: 0
-    property real barStart: 0
-    property alias barWidth: barPath.strokeWidth
+    enum SnapMode {
+        NoSnap,
+        SnapAlways,
+        SnapOnRelease
+    }
 
     orientation: Qt.Vertical
     wheelEnabled: true
-
-    Shape {
-        id: barShape
-
-        anchors.fill: parent
-        anchors.margins: root.barMargin
-        antialiasing: true
-        visible: root.bar
-
-        ShapePath {
-            id: barPath
-
-            fillColor: "transparent"
-            startX: barShape.width * (root.horizontal ? (1 - root.barStart) : 0.5)
-            startY: barShape.height * (root.vertical ? (1 - root.barStart) : 0.5)
-            strokeColor: "transparent"
-            strokeWidth: 2
-
-            PathLine {
-                x: root.horizontal ? (barShape.width * root.value) : barPath.startX
-                y: root.vertical ? (barShape.height * (1 - root.value)) : barPath.startY
-            }
-        }
-    }
 }

--- a/res/qml/Mixxx/Controls/Slider.qml
+++ b/res/qml/Mixxx/Controls/Slider.qml
@@ -1,18 +1,118 @@
 import QtQuick 2.12
-import QtQuick.Controls 2.12
 import QtQuick.Shapes 1.12
 
-Slider {
+Item {
     id: root
 
+    enum SnapMode {
+        NoSnap,
+        SnapAlways,
+        SnapOnRelease
+    }
+
     property bool bar: false
+    property alias background: backgroundItem.data
     property real barMargin: 0
     property alias barColor: barPath.strokeColor
     property alias barWidth: barPath.strokeWidth
     property real barStart: 0
+    property real bottomPadding: 0
+    property real from: 0
+    property alias handle: handleItem.data
+    property real leftPadding: 0
+    property bool live: true
+    property int orientation: Qt.Vertical
+    property real rightPadding: 0
+    property int snapMode: Slider.NoSnap
+    property real stepSize: 0
+    property real to: 1
+    property real topPadding: 0
+    property real value: from
+    property bool wheelEnabled: true
+    property real wheelStepSize: (root.to - root.from) / 100
 
-    orientation: Qt.Vertical
-    wheelEnabled: true
+    readonly property real availableHeight: Math.max(0, height - topPadding - bottomPadding)
+    readonly property real availableWidth: Math.max(0, width - leftPadding - rightPadding)
+    readonly property bool horizontal: orientation === Qt.Horizontal
+    readonly property real position: valueToPosition(displayValue)
+    readonly property bool pressed: dragHandler.active
+    readonly property bool vertical: orientation === Qt.Vertical
+    readonly property real visualPosition: vertical ? 1 - position : position
+
+    readonly property real displayValue: dragHandler.active ? dragHandler.value : value
+
+    signal moved(real value)
+
+    activeFocusOnTab: true
+    implicitHeight: Math.max(backgroundItem.implicitHeight, handleItem.implicitHeight)
+    implicitWidth: Math.max(backgroundItem.implicitWidth, handleItem.implicitWidth)
+
+    function clamp(targetValue) {
+        return Math.max(Math.min(root.from, root.to), Math.min(Math.max(root.from, root.to), targetValue));
+    }
+
+    function snapValue(targetValue, isFinal) {
+        if (root.stepSize <= 0 || root.snapMode === Slider.NoSnap || (!isFinal && root.snapMode !== Slider.SnapAlways)) {
+            return targetValue;
+        }
+
+        const stepSize = Math.abs(root.stepSize);
+        return root.from + Math.round((targetValue - root.from) / stepSize) * stepSize;
+    }
+
+    function stepValue(direction) {
+        const rangeDirection = root.to >= root.from ? 1 : -1;
+        return root.clamp(root.value + direction * rangeDirection * Math.abs(root.stepSize || root.wheelStepSize));
+    }
+
+    function valueAt(targetPosition) {
+        targetPosition = Math.max(0, Math.min(1, targetPosition));
+        return snapValue(root.from + targetPosition * (root.to - root.from), false);
+    }
+
+    function valueToPosition(targetValue) {
+        if (root.from === root.to) {
+            return 0;
+        }
+        return Math.max(0, Math.min(1, (targetValue - root.from) / (root.to - root.from)));
+    }
+
+    function applyInteractiveValue(targetValue, isFinal) {
+        dragHandler.value = clamp(snapValue(targetValue, isFinal));
+        if (root.live || isFinal) {
+            root.moved(dragHandler.value);
+        }
+    }
+
+    Keys.onPressed: event => {
+        if (event.key === Qt.Key_Left || event.key === Qt.Key_Down) {
+            root.moved(stepValue(-1));
+            event.accepted = true;
+        } else if (event.key === Qt.Key_Right || event.key === Qt.Key_Up) {
+            root.moved(stepValue(1));
+            event.accepted = true;
+        } else if (event.key === Qt.Key_Home) {
+            root.moved(root.from);
+            event.accepted = true;
+        } else if (event.key === Qt.Key_End) {
+            root.moved(root.to);
+            event.accepted = true;
+        }
+    }
+
+    Item {
+        id: backgroundItem
+
+        anchors.fill: parent
+        z: 0
+    }
+
+    Item {
+        id: handleItem
+
+        anchors.fill: parent
+        z: 2
+    }
 
     Shape {
         id: barShape
@@ -21,6 +121,7 @@ Slider {
         anchors.margins: root.barMargin
         antialiasing: true
         visible: root.bar
+        z: 1
 
         ShapePath {
             id: barPath
@@ -32,9 +133,59 @@ Slider {
             startY: barShape.height * (root.vertical ? (1 - root.barStart) : 0.5)
 
             PathLine {
-                x: root.horizontal ? (barShape.width * root.value) : barPath.startX
-                y: root.vertical ? (barShape.height * (1 - root.value)) : barPath.startY
+                x: root.horizontal ? (barShape.width * root.position) : barPath.startX
+                y: root.vertical ? (barShape.height * (1 - root.position)) : barPath.startY
             }
+        }
+    }
+
+    DragHandler {
+        id: dragHandler
+
+        property bool dragged: false
+        property vector2d lastTranslation: Qt.vector2d(0, 0)
+        property real value: root.value
+
+        acceptedButtons: Qt.LeftButton
+        enabled: root.enabled
+        target: null
+
+        onActiveChanged: {
+            if (active) {
+                root.forceActiveFocus();
+                value = root.value;
+                dragged = false;
+                lastTranslation = Qt.vector2d(0, 0);
+            } else if (dragged && (!root.live || root.snapMode === Slider.SnapOnRelease)) {
+                root.applyInteractiveValue(value, true);
+            }
+        }
+        onTranslationChanged: {
+            const diff = root.horizontal ? (translation.x - lastTranslation.x) : -(translation.y - lastTranslation.y);
+            lastTranslation = translation;
+            if (diff === 0) {
+                return;
+            }
+            dragged = true;
+            const length = Math.max(1, root.horizontal ? root.availableWidth : root.availableHeight);
+            root.applyInteractiveValue(value + (diff / length) * (root.to - root.from), false);
+        }
+    }
+    Binding {
+        property: "value"
+        target: root
+        value: dragHandler.value
+        when: dragHandler.active && root.live
+    }
+
+    // TODO: Replace this with a WheelHandler once we switch to Qt >= 5.14.
+    MouseArea {
+        acceptedButtons: Qt.NoButton
+        anchors.fill: parent
+        enabled: root.enabled && root.wheelEnabled
+
+        onWheel: {
+            root.moved(root.stepValue(wheel.angleDelta.y < 0 ? 1 : -1));
         }
     }
 }

--- a/res/qml/Mixxx/Controls/Slider.qml
+++ b/res/qml/Mixxx/Controls/Slider.qml
@@ -178,7 +178,6 @@ Item {
         when: dragHandler.active && root.live
     }
 
-    // TODO: Replace this with a WheelHandler once we switch to Qt >= 5.14.
     MouseArea {
         acceptedButtons: Qt.NoButton
         anchors.fill: parent

--- a/res/qml/OrientationToggleButton.qml
+++ b/res/qml/OrientationToggleButton.qml
@@ -29,11 +29,9 @@ Item {
         value: control.value
         orientation: Qt.Horizontal
         snapMode: Fader.SnapOnRelease
-        onMoved: {
-            // The slider's `value` is not updated until after the move ended.
-            const val = valueAt(visualPosition);
-            if (val != control.value)
-                control.value = val;
+        onMoved: function(value) {
+            if (value != control.value)
+                control.value = value;
         }
 
         background: Rectangle {

--- a/res/qml/OrientationToggleButton.qml
+++ b/res/qml/OrientationToggleButton.qml
@@ -1,5 +1,6 @@
 import "." as Skin
 import Mixxx 1.0 as Mixxx
+import Mixxx.Controls 1.0 as MixxxControls
 import QtQuick 2.12
 
 Item {
@@ -28,7 +29,7 @@ Item {
         stepSize: 1
         value: control.value
         orientation: Qt.Horizontal
-        snapMode: Fader.SnapOnRelease
+        snapMode: MixxxControls.Slider.SnapOnRelease
         onMoved: function(value) {
             if (value != control.value)
                 control.value = value;


### PR DESCRIPTION
Fixes #14530

## What changed

This PR removes the default Qt Quick Controls 2 click-to-set behavior from the QML `Slider`/`Fader` controls. A left press on the control body no longer jumps the value to the pointer position; values now change only from relative drag movement, matching the behavior users already expect from QML knobs.

## Interaction behavior

- Left click without dragging: no value change.
- Left drag: adjusts relative to the value at press time, scaled by the control width or height.
- Mouse wheel: increments/decrements by `wheelStepSize`, respecting reversed ranges.
- Keyboard: arrow keys step the value; Home/End jump to range endpoints.
- Double-click reset: unchanged for `ControlFader`/`ControlKnob`.
- Right-click reset: added for `ControlFader`/`ControlKnob`.