### PR TITLE
Track menu: create/update menus only on demand, eg. not for showing the Track Info dialog

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1261,7 +1261,6 @@ void WTrackMenu::loadTrack(
     }
     m_pTrack = pTrack;
     m_deckGroup = deckGroup;
-    updateMenus();
 }
 
 void WTrackMenu::loadTrackModelIndices(
@@ -1277,7 +1276,6 @@ void WTrackMenu::loadTrackModelIndices(
     clearTrackSelection();
 
     m_trackIndexList = trackIndexList;
-    updateMenus();
 }
 
 TrackIdList WTrackMenu::getTrackIds() const {

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -106,6 +106,7 @@ class WTrackMenu : public QMenu {
         m_trackProperty = property;
     }
 
+    void updateMenus();
     // WARNING: This function hides non-virtual QMenu::popup().
     // This has been done on purpose to ensure menu doesn't popup without loaded track(s).
     void popup(const QPoint& pos, QAction* at = nullptr);
@@ -230,7 +231,6 @@ class WTrackMenu : public QMenu {
     void createMenus();
     void createActions();
     void setupActions();
-    void updateMenus();
 
     void generateTrackLoadMenu(const QString& group,
             const QString& label,

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -208,6 +208,7 @@ void WTrackProperty::contextMenuEvent(QContextMenuEvent* pEvent) {
     if (m_pCurrentTrack) {
         ensureTrackMenuIsCreated();
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
+        m_pTrackMenu->updateMenus();
         // Show the right-click menu
         m_pTrackMenu->setTrackPropertyName(m_displayProperty);
         m_pTrackMenu->popup(pEvent->globalPos());

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -613,6 +613,7 @@ void WTrackTableView::showTrackMenu(const QPoint pos, const QModelIndex& index) 
         return;
     }
     m_pTrackMenu->loadTrackModelIndices(indices);
+    m_pTrackMenu->updateMenus();
     m_pTrackMenu->setTrackPropertyName(columnNameOfIndex(index));
 
     saveCurrentIndex();


### PR DESCRIPTION
Currently opening Track Info via hotkey in the tracks table or via double-click on track labels loads the track to the menu.
However, it also updates (recreates) all menus -- which is only needed if we actually want to show the menu.

This separates the load and update calls so that requesting Track Info does just load track(s) to menu -> load track(s) to DlgTrackInfo/~Multi.

_____
Ideally, the instantiation of DlgTrackInfo/~Multi would be decoupled from WTrackMenu so that WTrackProperty and WTrackMenu do it on their own.
And even better if there was only one WTrackMenu and DlgTrackInfo/~Multi instance per deck, but IMO the performance/memory improvement is not worth the effort and the dev time better spent for QML.
