### PR TITLE
backport to 2.5: #16453 update midi mappings to cover xone k3

### DIFF
--- a/res/controllers/Allen and Heath Xone K2.midi.xml
+++ b/res/controllers/Allen and Heath Xone K2.midi.xml
@@ -1,10 +1,10 @@
 <?xml version='1.0' encoding='utf-8'?>
 <MixxxControllerPreset mixxxVersion="2.1" schemaVersion="1">
     <info>
-        <name>Allen&amp;Heath Xone K2/K1</name>
+        <name>Allen&amp;Heath Xone K1/K2/K3</name>
         <author>Be</author>
         <manual>allen_heath_xone_k2_k1</manual>
-        <description>This mapping can used with one or multiple Xone K2s/K1s. Multiple Xone K2s/K1s can be connected to each other via X-Link with one of them connected to the computer via USB. Alternatively, when using 2 K2s/K1s, they can both be connected with their own USB cable and this same mapping can be loaded for each.
+        <description>This mapping can be used with one or multiple Xone K1s/K2s/K3s. Multiple Xone K1s/K2s/K3s can be connected to each other via X-Link with one of them connected to the computer via USB. Alternatively, when using 2 K1s/K2s/K3s, they can both be connected with their own USB cable and this same mapping can be loaded for each.
 
 The layout of the mapping depends on the configured MIDI channel of the controller. Change the MIDI channel of the controller by pressing the bottom right encoder (labeled "Power On Setup/Scroll/Set") while plugging in the controller. Scroll with the encoder to select a MIDI channel. The letter in parentheses corresponds to the last lit button when selecting the channel:
 Channel 15 (O, default out of the box): two decks + two effect units with decks in the middle
@@ -16,7 +16,7 @@ Channel 10 (J): four decks ordered 1 2 3 4
 Channel 9 (I): four effect units ordered 3 1 2 4
 Channel 8 (H): four effect units ordered 1 2 3 4
 
-If you are using K2s, they must have Latching Layers turned off, which is the default (the K1 does not have Latching Layers). Refer to the Xone K2/K1 product manual from Allen &amp; Heath for details.</description>
+If you are using K2s, they must have Latching Layers turned off, which is the default (the K1 does not have Latching Layers). If you are using the Xone K3, update it to firmware v1.0.4 r 93846 before using this mapping. Refer to the Mixxx manual for details.</description>
     </info>
     <controller id="XONE:K2">
         <scriptfiles>

--- a/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
+++ b/res/controllers/Allen-and-Heath-Xone-K2-scripts.js
@@ -24,7 +24,7 @@ XoneK2.deckBottomButtonLayers = [
     { name: 'hotcue', layerButtonNoteNumber: XoneK2.layerButtonColors.red },
     { name: 'loop', layerButtonNoteNumber: XoneK2.layerButtonColors.green }, ];
 
-// Multiple K2s/K1s can be connected via X-Link and plugged in with one USB
+// Multiple K1s/K2s/K3s can be connected via X-Link and plugged in with one USB
 // cable. The MIDI messages of the controllers can be distinguished by setting
 // each one to its own MIDI channel. The XoneK2.controllers array maintains state
 // for each controller. This also allows the same mapping to  be loaded for


### PR DESCRIPTION
#16453 went to main unfortunately