### PR TITLE
Waveforms: allow dragging hotcue when paused

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -351,9 +351,19 @@ void allshader::WaveformRenderMark::update() {
             continue;
         }
 
-        const float currentMarkPos = static_cast<float>(
-                m_waveformRenderer->transformSamplePositionInRendererWorld(
-                        samplePosition, positionType));
+        // If this is the hotcue we are currently dragging (starts on left click)
+        // we adopt the position registered by WWaveformViewer
+        float currentMarkPos = 0.f;
+        if (pMark->getHotCue() != Cue::kNoHotCue &&
+                m_waveformRenderer->hotcueDragInProgress() &&
+                pMark->getHotCue() == m_waveformRenderer->getHotcueDragIndex()) {
+            currentMarkPos = static_cast<float>(m_waveformRenderer->getHotcueDragPos());
+        } else {
+            currentMarkPos = static_cast<float>(
+                    m_waveformRenderer->transformSamplePositionInRendererWorld(
+                            samplePosition, positionType));
+        }
+
         auto* pMarkEndGraphics = pMark->m_pEndGraphics.get();
         auto* pMarkEndNodeGraphics = static_cast<WaveformMarkNodeGraphics*>(pMarkEndGraphics);
         VERIFY_OR_DEBUG_ASSERT(pMarkEndNodeGraphics) {

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -33,8 +33,19 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
         const double samplePosition = pMark->getSamplePosition();
         if (samplePosition != Cue::kNoPosition) {
-            const double currentMarkPoint =
-                    m_waveformRenderer->transformSamplePositionInRendererWorld(samplePosition);
+            // If this is the hotcue we are currently dragging (starts on left click)
+            // we adopt the position registered by WWaveformViewer
+            double currentMarkPoint = 0.0;
+            if (m_waveformRenderer->hotcueDragInProgress() &&
+                    pMark->getHotCue() != Cue::kNoHotCue &&
+                    pMark->getHotCue() == m_waveformRenderer->getHotcueDragIndex()) {
+                currentMarkPoint = m_waveformRenderer->getHotcueDragPos();
+            } else {
+                currentMarkPoint =
+                        m_waveformRenderer
+                                ->transformSamplePositionInRendererWorld(
+                                        samplePosition);
+            }
             const double sampleEndPosition = pMark->getSampleEndPosition();
             if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
                 const int markWidth = std::lround(image.width() /

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -47,6 +47,8 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const QString& group)
           m_scaleFactor(1.0),
           m_playMarkerPosition(s_defaultPlayMarkerPosition),
           m_pContext(nullptr),
+          m_hotcueDragInProgress(false),
+          m_hotcueDragIndex(Cue::kNoHotCue),
           m_passthroughEnabled(false) {
     //qDebug() << "WaveformWidgetRenderer";
     for (int type = ::WaveformRendererAbstract::Play;

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -120,6 +120,15 @@ class WaveformWidgetRenderer {
         return (samplePosition - m_firstDisplayedPosition[type] * m_trackSamples) /
                 2 / m_audioSamplePerPixel;
     }
+    // the reverse function, pixel to track sample
+    inline double transformRendererPositionToSamplePosition(QPoint pos) {
+        int pixelPos = getOrientation() == Qt::Horizontal ? pos.x() : pos.y();
+        double posRange = getLastDisplayedPosition() - getFirstDisplayedPosition();
+        double eventRelPos =
+                static_cast<double>(pixelPos) / getLength();
+        double absPos = (eventRelPos * posRange) + getFirstDisplayedPosition();
+        return getTrackSamples() * absPos;
+    }
 
     int getPlayPosVSample(::WaveformRendererAbstract::PositionSource type =
                                   ::WaveformRendererAbstract::Play) const {
@@ -200,6 +209,28 @@ class WaveformWidgetRenderer {
         m_playMarkerPosition = newPos;
     }
 
+    // FIXME Wrap state/data set/get in one function each?
+    void setHotcueDragInProgress(bool enabled) {
+        m_hotcueDragInProgress = enabled;
+    }
+    bool hotcueDragInProgress() {
+        return m_hotcueDragInProgress;
+    }
+    // Index of the dragged hotcue, 0-based
+    void setHotcueDragIndex(int index) {
+        m_hotcueDragIndex = index;
+    }
+    int getHotcueDragIndex() const {
+        return m_hotcueDragIndex;
+    }
+    // The sample pos where the hotcue is being dragged to
+    void setHotcueDragPos(double dragPos) {
+        m_hotcueDragPos = dragPos;
+    }
+    double getHotcueDragPos() const {
+        return m_hotcueDragPos;
+    }
+
     void setPassThroughEnabled(bool enabled);
 
     bool shouldOnlyDrawBackground() const {
@@ -276,6 +307,10 @@ private:
             QPointF p2,
             QPointF p3);
     void drawPassthroughLabel(QPainter* painter);
+
+    bool m_hotcueDragInProgress;
+    double m_hotcueDragPos;
+    int m_hotcueDragIndex;
 
     bool m_passthroughEnabled;
     double m_pos[2];

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -22,6 +22,8 @@ WWaveformViewer::WWaveformViewer(
           m_zoomZoneWidth(20),
           m_bScratching(false),
           m_bBending(false),
+          m_hotcueDragging(false),
+          m_draggedHotcue(Cue::kNoHotCue),
           m_pCueMenuPopup(make_parented<WCueMenuPopup>(pConfig, this)),
           m_waveformWidget(nullptr) {
     setMouseTracking(true);
@@ -80,6 +82,10 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
     if (!m_waveformWidget || m_waveformWidget->getType() == WaveformWidgetType::Empty) {
         return;
     }
+    const auto pCurrentTrack = m_waveformWidget->getTrackInfo();
+    if (!pCurrentTrack) {
+        return;
+    }
 
     m_mouseAnchor = event->pos();
 
@@ -90,19 +96,49 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
             m_pWheel->setParameter(0.5);
             m_bBending = false;
         }
-        m_bScratching = true;
-        int eventPosValue = m_waveformWidget->getOrientation() == Qt::Horizontal ?
-                    event->pos().x() : event->pos().y();
-        double audioSamplePerPixel = m_waveformWidget->getAudioSamplePerPixel();
-        double targetPosition = -1.0 * eventPosValue * audioSamplePerPixel * 2;
-        m_pScratchPosition->set(targetPosition);
-        m_pScratchPositionEnable->set(1.0);
+        // If we're clicking a hotcue mark -> start hotcue dragging
+        if (!isPlaying() && m_pHoveredMark) {
+            auto pCueAtClickPos = getCuePointerFromCueMark(m_pHoveredMark);
+            if (pCueAtClickPos) {
+                // Unhighlight mark so can darg the original cue mark image
+                unhighlightMark(m_pHoveredMark);
+                // Before we enable hotcue drag here and in WaveformWidgetRenderer
+                // (and subsequently in allshader::WaveformRenderMark and
+                // legacy WaveformRenderMark) we need to set the start position.
+                //
+                // We calculate the offset between pointer event ad cue position
+                // so set the sample (target) position on every move and the dragged
+                // mark can be rendered correctly.
+                // We also store the initial event pos to avoid that a single-/
+                // double-click shifts the cue due to random rounding offsets.
+                const double cuePos = m_waveformWidget->transformSamplePositionInRendererWorld(
+                        m_pHoveredMark->getSamplePosition());
+                const int eventPos = m_waveformWidget->getOrientation() == Qt::Horizontal
+                        ? m_mouseAnchor.x()
+                        : m_mouseAnchor.y();
+                m_hotcueDragMouseOffset = cuePos - eventPos;
+                m_waveformWidget->setHotcueDragPos(eventPos + m_hotcueDragMouseOffset);
+                m_hotcueDragging = true;
+                m_draggedHotcue = pCueAtClickPos->getHotCue();
+                m_waveformWidget->setHotcueDragIndex(m_draggedHotcue);
+                m_waveformWidget->setHotcueDragInProgress(true);
+            }
+        } else {
+            m_bScratching = true;
+            int eventPosValue =
+                    m_waveformWidget->getOrientation() == Qt::Horizontal
+                    ? m_mouseAnchor.x()
+                    : m_mouseAnchor.y();
+            double audioSamplePerPixel = m_waveformWidget->getAudioSamplePerPixel();
+            double targetPosition = -1.0 * eventPosValue * audioSamplePerPixel * 2;
+            m_pScratchPosition->set(targetPosition);
+            m_pScratchPositionEnable->set(1.0);
+        }
     } else if (event->button() == Qt::RightButton) {
-        const auto currentTrack = m_waveformWidget->getTrackInfo();
         if (!isPlaying() && m_pHoveredMark) {
             auto cueAtClickPos = getCuePointerFromCueMark(m_pHoveredMark);
             if (cueAtClickPos) {
-                m_pCueMenuPopup->setTrackCueGroup(currentTrack, cueAtClickPos, m_group);
+                m_pCueMenuPopup->setTrackCueGroup(pCurrentTrack, cueAtClickPos, m_group);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                 m_pCueMenuPopup->popup(event->globalPosition().toPoint());
 #else
@@ -116,13 +152,16 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
                 m_pScratchPositionEnable->set(0.0);
                 m_bScratching = false;
             }
+            if (m_hotcueDragging) {
+                stopHotcueDragging();
+            }
             m_pWheel->setParameter(0.5);
             m_bBending = true;
         }
     }
 
     // Set the cursor to a hand while the mouse is down (when cue menu is not open).
-    if (!m_pCueMenuPopup->isVisible()) {
+    if (!m_pCueMenuPopup->isVisible() && !m_hotcueDragging) {
         setCursor(Qt::ClosedHandCursor);
     }
 }
@@ -156,7 +195,18 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
         // clamp to [0.0, 1.0]
         v = math_clamp(v, 0.0, 1.0);
         m_pWheel->setParameter(v);
-    } else if (!isPlaying()) {
+    } else if (m_hotcueDragging) {
+        if (isPlaying()) {
+            // Abort hotcue dragging if play was toggled since drag start
+            stopHotcueDragging();
+            return;
+        }
+        // Get cursor pos, apply offset and send pos to widget
+        const int eventPos = m_waveformWidget->getOrientation() == Qt::Horizontal
+                ? event->pos().x()
+                : event->pos().y();
+        m_waveformWidget->setHotcueDragPos(eventPos + m_hotcueDragMouseOffset);
+    } else {
         WaveformMarkPointer pMark;
         pMark = m_waveformWidget->getCueMarkAtPoint(event->pos());
         if (pMark && getCuePointerFromCueMark(pMark)) {
@@ -177,7 +227,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
     }
 }
 
-void WWaveformViewer::mouseReleaseEvent(QMouseEvent* /*event*/) {
+void WWaveformViewer::mouseReleaseEvent(QMouseEvent* pEvent) {
     if (m_bScratching) {
         m_pScratchPositionEnable->set(0.0);
         m_bScratching = false;
@@ -185,6 +235,29 @@ void WWaveformViewer::mouseReleaseEvent(QMouseEvent* /*event*/) {
     if (m_bBending) {
         m_pWheel->setParameter(0.5);
         m_bBending = false;
+    }
+    if (m_hotcueDragging) {
+        stopHotcueDragging();
+
+        auto pHotcue = m_waveformWidget->getCuePointerFromIndex(m_draggedHotcue);
+        if (!pHotcue) {
+            return;
+        }
+
+        // Ignore no-op
+        if (pEvent->pos() != m_mouseAnchor) {
+            QPoint offset;
+            if (m_waveformWidget->getOrientation() == Qt::Horizontal) {
+                offset.setX(std::lround(m_hotcueDragMouseOffset));
+            } else {
+                offset.setY(std::lround(m_hotcueDragMouseOffset));
+            }
+            double newSamPos =
+                    m_waveformWidget->transformRendererPositionToSamplePosition(
+                            pEvent->pos() + offset);
+            auto newCuePos = mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(newSamPos);
+            pHotcue->setStartPosition(newCuePos);
+        }
     }
     m_mouseAnchor = QPoint();
 
@@ -249,14 +322,17 @@ void WWaveformViewer::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOld
 }
 
 void WWaveformViewer::onZoomChange(double zoom) {
-    //qDebug() << "WaveformWidgetRenderer::onZoomChange" << this << zoom;
+    // qDebug() << "WaveformWidgetRenderer::onZoomChange" << this << zoom;
     setZoom(zoom);
     // notify back the factory to sync zoom if needed
     WaveformWidgetFactory::instance()->notifyZoomChange(this);
 }
 
 void WWaveformViewer::setZoom(double zoom) {
-    //qDebug() << "WaveformWidgetRenderer::setZoom" << zoom;
+    // qDebug() << "WaveformWidgetRenderer::setZoom" << zoom;
+    // Stop hotcue dragging since zooming changes the sample/renderworld relation
+    // the drag pos propagation is based on.
+    stopHotcueDragging();
     if (m_waveformWidget) {
         m_waveformWidget->setZoom(zoom);
     }
@@ -348,6 +424,19 @@ void WWaveformViewer::unhighlightMark(WaveformMarkPointer pMark) {
     if (pCue) {
         QColor originalColor = mixxx::RgbColor::toQColor(pCue->getColor());
         pMark->setBaseColor(originalColor, m_dimBrightThreshold);
+    }
+}
+
+void WWaveformViewer::stopHotcueDragging() {
+    m_hotcueDragging = false;
+    m_waveformWidget->setHotcueDragInProgress(false);
+    m_waveformWidget->setHotcueDragIndex(Cue::kNoHotCue);
+    // Both after Track::cuesUpdated() triggered a renderer update and
+    // when this was a no-op the mark is now be underneath the cursor.
+    // FIXME Doesn't work after shifting the cue. Though hover is not required
+    // to drag it again.
+    if (m_pHoveredMark) {
+        highlightMark(m_pHoveredMark);
     }
 }
 

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -79,6 +79,9 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     parented_ptr<ControlProxy> m_pPassthroughEnabled;
     bool m_bScratching;
     bool m_bBending;
+    bool m_hotcueDragging;
+    int m_draggedHotcue;
+    double m_hotcueDragMouseOffset;
     QPoint m_mouseAnchor;
     parented_ptr<WCueMenuPopup> m_pCueMenuPopup;
     WaveformMarkPointer m_pHoveredMark;
@@ -92,5 +95,6 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     CuePointer getCuePointerFromCueMark(WaveformMarkPointer pMark) const;
     void highlightMark(WaveformMarkPointer pMark);
     void unhighlightMark(WaveformMarkPointer pMark);
+    void stopHotcueDragging();
     bool isPlaying() const;
 };


### PR DESCRIPTION
--- coffee break project alert ; ) ---
I was curious how hard it would be to implement [#12367 Add a quick way to nudge a hotcue earlier or later / left and right](https://github.com/mixxxdj/mixxx/issues/12367) _via waveforms drag'n'drop_ (the request focuses more the controller way to do it).

Current implementation:
* pause track
* hover hotcue mark in waveform
* drag to desired position
* release

UI feedback is perfect: on second look I managed to simply shift the existing hotcue mark image.
Both in allshader and legacy renderers.