### PR TITLE
Avoid deprectated avcodec_close()

### DIFF
--- a/src/encoder/encoderffmpegcore.cpp
+++ b/src/encoder/encoderffmpegcore.cpp
@@ -70,7 +70,7 @@ EncoderFfmpegCore::~EncoderFfmpegCore() {
 
 
     if (m_pStream != NULL) {
-        avcodec_close(m_pStream->codec);
+        avcodec_free_context(&m_pStream->codec);
     }
 
     if (m_pEncodeFormatCtx != NULL) {
@@ -432,7 +432,7 @@ int EncoderFfmpegCore::writeAudioFrame(AVFormatContext *formatctx,
 
 
 void EncoderFfmpegCore::closeAudio(AVStream *stream) {
-    avcodec_close(stream->codec);
+    avcodec_free_context(&stream->codec);
     av_free(m_pSamples);
 }
 

--- a/src/encoder/encoderffmpegcore.cpp
+++ b/src/encoder/encoderffmpegcore.cpp
@@ -46,7 +46,7 @@ EncoderFfmpegCore::EncoderFfmpegCore(EncoderCallback* pCallback, CodecID codec)
     m_lDts = 0;
     m_lPts = 0;
     m_lRecordedBytes = 0;
-
+    m_pStream = nullptr;
 }
 
 // Destructor  //call flush before any encoder gets deleted
@@ -433,7 +433,7 @@ int EncoderFfmpegCore::writeAudioFrame(AVFormatContext *formatctx,
 
 void EncoderFfmpegCore::closeAudio(AVStream *stream) {
     avcodec_free_context(&stream->codec);
-    av_free(m_pSamples);
+    av_freep(&m_pSamples);
 }
 
 int EncoderFfmpegCore::openAudio(AVCodec *codec, AVStream *stream) {

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -335,15 +335,6 @@ SoundSourceFFmpeg::AVCodecContextPtr::alloc(
     return context;
 }
 
-void SoundSourceFFmpeg::AVCodecContextPtr::take(AVCodecContext** ppavCodecContext) {
-    DEBUG_ASSERT(ppavCodecContext != nullptr);
-    if (m_pavCodecContext != *ppavCodecContext) {
-        close();
-        m_pavCodecContext = *ppavCodecContext;
-        *ppavCodecContext = nullptr;
-    }
-}
-
 void SoundSourceFFmpeg::AVCodecContextPtr::close() {
     if (m_pavCodecContext != nullptr) {
         avcodec_free_context(&m_pavCodecContext);

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -958,6 +958,26 @@ SINT readNextPacket(
 }
 } // namespace
 
+bool SoundSourceFFmpeg::deepFlushBuffers() {
+    bool ret = false;
+    AVCodecParameters* pParams = avcodec_parameters_alloc();
+    if (!pParams) {
+        return false;
+    }
+    avcodec_parameters_from_context(pParams, m_pavCodecContext);
+    const AVCodec* pCodec = m_pavCodecContext->codec;
+    AVCodecContextPtr pavCodecContext = AVCodecContextPtr::alloc(pCodec);
+    if (pavCodecContext) {
+        avcodec_parameters_to_context(pavCodecContext, pParams);
+        if (avcodec_open2(pavCodecContext, pCodec, nullptr) == 0) {
+            m_pavCodecContext = std::move(pavCodecContext);
+            ret = true;
+        }
+    }
+    avcodec_parameters_free(&pParams);
+    return ret;
+}
+
 bool SoundSourceFFmpeg::adjustCurrentPosition(SINT startIndex) {
     DEBUG_ASSERT(frameIndexRange().containsIndex(startIndex));
 
@@ -989,9 +1009,11 @@ bool SoundSourceFFmpeg::adjustCurrentPosition(SINT startIndex) {
         // was limited to -661 instead of -2111. The workaround here is to reopen
         // the codec which initializes all buffers with zero.
         // Slow: 43 us (Core Ultra 5 125U)
-        const AVCodec* pCodec = m_pavCodecContext->codec;
-        avcodec_close(m_pavCodecContext);
-        avcodec_open2(m_pavCodecContext, pCodec, nullptr);
+        if (!deepFlushBuffers()) {
+            kLogger.warning() << "deepFlushBuffers failed";
+            m_frameBuffer.invalidate();
+            return false;
+        }
     }
 
     // Seek to new position

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -964,14 +964,20 @@ bool SoundSourceFFmpeg::deepFlushBuffers() {
     if (!pParams) {
         return false;
     }
-    avcodec_parameters_from_context(pParams, m_pavCodecContext);
-    const AVCodec* pCodec = m_pavCodecContext->codec;
-    AVCodecContextPtr pavCodecContext = AVCodecContextPtr::alloc(pCodec);
-    if (pavCodecContext) {
-        avcodec_parameters_to_context(pavCodecContext, pParams);
-        if (avcodec_open2(pavCodecContext, pCodec, nullptr) == 0) {
-            m_pavCodecContext = std::move(pavCodecContext);
-            ret = true;
+    if (avcodec_parameters_from_context(pParams, m_pavCodecContext) == 0) {
+        const AVCodec* pCodec = m_pavCodecContext->codec;
+        AVCodecContextPtr pavCodecContext = AVCodecContextPtr::alloc(pCodec);
+        if (pavCodecContext) {
+            pavCodecContext->pkt_timebase = m_pavCodecContext->pkt_timebase;
+            pavCodecContext->request_sample_fmt = m_pavCodecContext->request_sample_fmt;
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(57, 28, 100) // FFmpeg 5.1
+            pavCodecContext->request_channel_layout = m_pavCodecContext->request_channel_layout;
+#endif
+            if (avcodec_parameters_to_context(pavCodecContext, pParams) == 0 &&
+                    avcodec_open2(pavCodecContext, pCodec, nullptr) == 0) {
+                m_pavCodecContext = std::move(pavCodecContext);
+                ret = true;
+            }
         }
     }
     avcodec_parameters_free(&pParams);

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -105,7 +105,6 @@ class SoundSourceFFmpeg : public SoundSource {
             close();
         }
 
-        void take(AVCodecContext** ppavCodecContext);
         void close();
 
         friend void swap(AVCodecContextPtr& lhs, AVCodecContextPtr& rhs) {

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -33,6 +33,10 @@ class SoundSourceFFmpeg : public SoundSource {
   private:
     const CSAMPLE* resampleDecodedAVFrame(AVFrame* pavDecodedFrame);
 
+    // recreates the AVCodecContext for cases where the lightweight
+    // avcodec_flush_buffers() is not sufficient
+    bool deepFlushBuffers();
+
     // Seek to the requested start index (if needed) or return false
     // upon seek errors.
     bool adjustCurrentPosition(


### PR DESCRIPTION
This aims to fix the build failures here https://github.com/mixxxdj/mixxx/pull/16452
because of deprecation warnings. 