### PR TITLE
add controls for shifting currently focused hotcue (`hotcue_focus`)

### DIFF
--- a/res/skins/LateNight/palemoon/buttons/btn__hotcue_earlier.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__hotcue_earlier.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 17.470841,18.20006 6.5290767,12 17.470841,5.7999401 Z" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="1.6"/>
+  <path d="M 17.470841,18.20006 6.5290767,12 17.470841,5.7999401 Z" fill="#928476"/>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__hotcue_later.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__hotcue_later.svg
@@ -1,0 +1,4 @@
+<svg width="48" height="48" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 6.5291589,18.20006 17.470923,12 6.5291589,5.7999401 Z" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="1.6"/>
+  <path d="M 6.5291589,18.20006 17.470923,12 6.5291589,5.7999401 Z" fill="#928476"/>
+</svg>

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1569,10 +1569,7 @@ WPushButton#FxAssignButton1[displayValue="0"],
 WEffectSelector:!editable,
 #fadeModeCombobox:!editable,
 #LibraryFeatureControls QPushButton:enabled,
-#CueDeleteButton,
-#CueStandardButton,
-#CueSavedLoopButton,
-#CueSavedJumpButton {
+WCueMenuPopup QPushButton {
   outline: none;
   border-width: 2px;
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library.svg) 2 2 2 2;
@@ -1592,20 +1589,14 @@ WEffectSelector:!editable,
   #BroadcastButton[displayValue="3"],
   #BroadcastButton[displayValue="4"],
   #SkinSettingsToggle[displayValue="1"],
-  #LibraryFeatureControls QPushButton:pressed
+  #LibraryFeatureControls QPushButton:pressed,
   QPushButton#pushButtonAutoDJ:checked,
   QPushButton#pushButtonRepeatPlaylist:checked,
   QPushButton#pushButtonAnalyze:checked,
   QPushButton#pushButtonRecording:checked,
   WEffectSelector:!editable:on,
   #fadeModeCombobox:!editable:on,
-  #CueDeleteButton[pressed="true"],
-  #CueStandardButton[pressed="true"],
-  #CueStandardButton:checked,
-  #CueSavedLoopButton[pressed="true"],
-  #CueSavedLoopButton:checked,
-  #CueSavedJumpButton[pressed="true"],
-  #CueSavedJumpButton:checked {
+  WCueMenuPopup QPushButton:pressed {
     border-width: 2px;
     border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library_active.svg) 2 2 2 2;
   }
@@ -1739,10 +1730,7 @@ WBpmEditor QDoubleSpinBox {
   }
   /* bright buttons in dimmed containers
   #BeatgridControls WPushButton[displayValue="0"], */
-  #CueDeleteButton,
-  #CueStandardButton,
-  #CueSavedLoopButton,
-  #CueSavedJumpButton,
+  WCueMenuPopup QPushButton,
   #SplitCue[displayValue="0"],
   #PlayPreview[displayValue="0"],
   /* library controls */
@@ -1780,9 +1768,13 @@ WPushButton#Reverse[pressed="true"],
 WPushButton#StemMuteButton,
 #PassthroughButton[displayValue="1"],
 #BroadcastButton[displayValue="4"], /* warning */
+#CueStandardButton:pressed, #CueStandardButton:checked,
+#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked,
+#CueSavedJumpButton:pressed, #CueSavedJumpButton:checked,
 QPushButton#pushButtonAutoDJ:checked,
 QPushButton#pushButtonAnalyze:checked {
   background-color: #b24c12;
+  outline: none;
   }
   /* Orange border for Play buttons when previewing from
     Cue or Hotcue */
@@ -2863,31 +2855,56 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
 
 /* widgets in cue popup menu */
 WCueMenuPopup #CueDeleteButton {
-  icon: url(skins:LateNight/palemoon/buttons/btn__delete.svg);
-  width: 24px;
-  height: 24px;
-  icon-size: 18px;
+  /* For QPushButtons, the border is added (here: 2px in each direction).
+     This sets the minimum size, the button may expand depending on the
+     layout and stretch options set in src/widget/wcuemenupopup.cpp */
+  width: 44px;
+  height: 20px;
+  icon: url(skin:../LateNight/palemoon/buttons/btn__delete.svg);
+  /* make the icon slightly larger than default 16px */
+  /* icon-size: 18px; */
 }
+WCueMenuPopup #CueShiftEarlier,
+WCueMenuPopup #CueShiftLater {
+  /* Try to make these look like other square buttons (decks, mixer etc.)
+     which have a visible area of 24x24 px..
+     Here however border (2px) is ADDED to the set size, hence subtract 2px on each side. */
+  width: 20px;
+  height: 20px;
+  qproperty-iconSize: 20px;
+}
+
+WCueMenuPopup #CueShiftEarlier {
+  qproperty-icon: url(skin:../LateNight/palemoon/buttons/btn__hotcue_earlier.svg);
+}
+WCueMenuPopup #CueShiftLater {
+  qproperty-icon: url(skin:../LateNight/palemoon/buttons/btn__hotcue_later.svg);
+}
+
+WCueMenuPopup #CueStandardButton,
+WCueMenuPopup #CueSavedLoopButton,
+WCueMenuPopup #CueSavedJumpButton {
+  width: 44px;
+  /* don't let the type buttons make the dialog expand */
+  /* Note: we could try min-height / max-height if we want more control */
+  /* height: 32px; */
+  icon-size: 20px;
+}
+
 WCueMenuPopup #CueStandardButton {
   icon: url(skins:LateNight/palemoon/buttons/btn__beats_hotcues_later.svg);
-  width: 24px;
-  height: 42px;
-  /* make the icon slightly larger than default 16px */
-  icon-size: 24px;
 }
+#CueStandardButton:pressed, #CueStandardButton:checked {
+  icon: url(skins:LateNight/palemoon/buttons/btn__beats_hotcues_later_active.svg);
+}
+
 WCueMenuPopup #CueSavedLoopButton {
   icon: url(skins:LateNight/palemoon/buttons/btn__loop.svg);
-  width: 24px;
-  height: 42px;
-  /* make the icon slightly larger than default 16px */
-  icon-size: 24px;
 }
-WCueMenuPopup #CueSavedJumpButton {
-  width: 24px;
-  height: 42px;
-  /* make the icon slightly larger than default 16px */
-  icon-size: 24px;
+#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
+  icon: url(skins:LateNight/palemoon/buttons/btn__loop_active.svg);
 }
+
 WCueMenuPopup #CueSavedJumpButton[direction="impossible"],
 WCueMenuPopup #CueSavedJumpButton[direction="forward"] {
   icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_right.svg);
@@ -2896,38 +2913,11 @@ WCueMenuPopup #CueSavedJumpButton[direction="backward"] {
   icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_left.svg);
 }
 
-#CueDeleteButton:hover {
-  background-color: #6c2e2e;
-}
-
-#CueDeleteButton[pressed="true"], #CueDeleteButton:pressed, #CueDeleteButton:clicked {
-  background-color: #dc4141 !important;
-  outline: none;
-}
-
-#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
-  background-color: #b24c12;
-  outline: none;
-  icon: url(skins:LateNight/palemoon/buttons/btn__loop_active.svg);
-}
-#CueSavedJumpButton:pressed, #CueSavedJumpButton:checked {
-  background-color: #b24c12;
-  outline: none;
-}
-#CueSavedJumpButton[direction="impossible"] {
-  background-color: #787878 !important;
-  outline: none;
-}
 #CueSavedJumpButton[direction="forward"]:pressed, #CueSavedJumpButton[direction="forward"]:checked {
   icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_right_active.svg);
 }
 #CueSavedJumpButton[direction="backward"]:pressed, #CueSavedJumpButton[direction="backward"]:checked {
   icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_left_active.svg);
-}
-#CueStandardButton:pressed, #CueStandardButton:checked {
-  background-color: #b24c12;
-  outline: none;
-  icon: url(skins:LateNight/palemoon/buttons/btn__beats_hotcues_later_active.svg);
 }
 
 WCueMenuPopup #CueLabelEdit {

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -11,6 +11,7 @@
 #include "mixer/playermanager.h"
 #include "moc_controlpickermenu.cpp"
 #include "recording/defs_recording.h"
+#include "track/cue.h"
 #include "util/defs.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
 
@@ -557,22 +558,6 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // Hotcues
     QMenu* pHotcueMainMenu = addSubmenu(tr("Hotcues"));
-    addDeckControl("shift_cues_earlier",
-            tr("Shift cue points earlier"),
-            tr("Shift cue points 10 milliseconds earlier"),
-            pHotcueMainMenu);
-    addDeckControl("shift_cues_earlier_small",
-            tr("Shift cue points earlier (fine)"),
-            tr("Shift cue points 1 millisecond earlier"),
-            pHotcueMainMenu);
-    addDeckControl("shift_cues_later",
-            tr("Shift cue points later"),
-            tr("Shift cue points 10 milliseconds later"),
-            pHotcueMainMenu);
-    addDeckControl("shift_cues_later_small",
-            tr("Shift cue points later (fine)"),
-            tr("Shift cue points 1 millisecond later"),
-            pHotcueMainMenu);
     addDeckControl("sort_hotcues",
             tr("Sort hotcues by position"),
             tr("Sort hotcues by position"),
@@ -581,6 +566,53 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Sort hotcues by position (remove offsets)"),
             tr("Sort hotcues by position (remove offsets)"),
             pHotcueMainMenu);
+
+    QMenu* pHotcueShiftMenu = addSubmenu(tr("Shift all cues"), pHotcueMainMenu);
+    addDeckControl("shift_cues_earlier",
+            tr("Shift cue points earlier"),
+            tr("Shift cue points 10 milliseconds earlier"),
+            pHotcueShiftMenu);
+    addDeckControl("shift_cues_earlier_small",
+            tr("Shift cue points earlier (fine)"),
+            tr("Shift cue points 1 millisecond earlier"),
+            pHotcueShiftMenu);
+    addDeckControl("shift_cues_later",
+            tr("Shift cue points later"),
+            tr("Shift cue points 10 milliseconds later"),
+            pHotcueShiftMenu);
+    addDeckControl("shift_cues_later_small",
+            tr("Shift cue points later (fine)"),
+            tr("Shift cue points 1 millisecond later"),
+            pHotcueShiftMenu);
+
+    QMenu* pHotcueShiftFocusedMenu = addSubmenu(tr("Shift focused hotcue"), pHotcueMainMenu);
+    const QString shiftFocusedHotcueNextDescription =
+            tr("If Quantize is enabled the hotcue is shifted to the next beat.");
+    const QString shiftFocusedHotcuePrevDescription =
+            tr("If Quantize is enabled the hotcue is shifted to the previous beat.");
+    addDeckControl("shift_focused_hotcue_earlier",
+            tr("Shift focused hotcue earlier"),
+            tr("Shift focused hotcue %1 milliseconds earlier").arg(Cue::kShiftCuesOffsetMillis) +
+                    shiftFocusedHotcuePrevDescription,
+            pHotcueShiftFocusedMenu);
+    addDeckControl("shift_focused_hotcue_earlier_small",
+            tr("Shift focused hotcue earlier (fine)"),
+            tr("Shift focused hotcue %1 millisecond earlier")
+                            .arg(Cue::kShiftCuesOffsetMillisSmall) +
+                    shiftFocusedHotcuePrevDescription,
+            pHotcueShiftFocusedMenu);
+    addDeckControl("shift_focused_hotcue_later",
+            tr("Shift focused hotcue later"),
+            tr("Shift focused hotcue %1 milliseconds later").arg(Cue::kShiftCuesOffsetMillis) +
+                    shiftFocusedHotcueNextDescription,
+            pHotcueShiftFocusedMenu);
+    addDeckControl("shift_focused_hotcue_later_small",
+            tr("Shift focused hotcue later (fine)"),
+            tr("Shift focused hotcue %1 millisecond later").arg(Cue::kShiftCuesOffsetMillisSmall) +
+                    shiftFocusedHotcueNextDescription,
+            pHotcueShiftFocusedMenu);
+
+    pHotcueMainMenu->addSeparator();
 
     const QString hotcueActivateTitle = tr("Hotcue %1");
     const QString hotcueClearTitle = tr("Clear Hotcue %1");

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -321,46 +321,48 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             this,
             &BaseTrackPlayerImpl::slotShiftCuesMillis);
     // the same for the currently focused (last touched) hotcue, if there is one
-    m_pShiftFocusedHotcueEarlier = std::make_unique<ControlPushButton>(
-            ConfigKey(getGroup(), "shift_focused_hotcue_earlier"));
-    connect(m_pShiftFocusedHotcueEarlier.get(),
-            &ControlObject::valueChanged,
-            this,
-            [this](double value) {
-                slotShiftFocusedHotcueMillisButton(
-                        value, -Cue::kShiftCuesOffsetMillis);
-            });
-    m_pShiftFocusedHotcueLater = std::make_unique<ControlPushButton>(
-            ConfigKey(getGroup(), "shift_focused_hotcue_later"));
-    connect(m_pShiftFocusedHotcueLater.get(),
-            &ControlObject::valueChanged,
-            this,
-            [this](double value) {
-                slotShiftFocusedHotcueMillisButton(
-                        value, Cue::kShiftCuesOffsetMillis);
-            });
-    m_pShiftFocusedHotcueEarlierSmall = std::make_unique<ControlPushButton>(
-            ConfigKey(getGroup(), "shift_focused_hotcue_earlier_small"));
-    connect(m_pShiftFocusedHotcueEarlierSmall.get(),
-            &ControlObject::valueChanged,
-            this,
-            [this](double value) {
-                slotShiftFocusedHotcueMillisButton(value, -Cue::kShiftCuesOffsetMillisSmall);
-            });
-    m_pShiftFocusedHotcueLaterSmall = std::make_unique<ControlPushButton>(
-            ConfigKey(getGroup(), "shift_focused_hotcue_later_small"));
-    connect(m_pShiftFocusedHotcueLaterSmall.get(),
-            &ControlObject::valueChanged,
-            this,
-            [this](double value) {
-                slotShiftFocusedHotcueMillisButton(value, Cue::kShiftCuesOffsetMillisSmall);
-            });
-    m_pShiftFocusedHotcue = std::make_unique<ControlObject>(
-            ConfigKey(getGroup(), "shift_focused_hotcue"));
-    connect(m_pShiftFocusedHotcue.get(),
-            &ControlObject::valueChanged,
-            this,
-            &BaseTrackPlayerImpl::slotShiftFocusedHotcueMillis);
+    if (primaryDeck) {
+        m_pShiftFocusedHotcueEarlier = std::make_unique<ControlPushButton>(
+                ConfigKey(getGroup(), "shift_focused_hotcue_earlier"));
+        connect(m_pShiftFocusedHotcueEarlier.get(),
+                &ControlObject::valueChanged,
+                this,
+                [this](double value) {
+                    slotShiftFocusedHotcueMillisButton(
+                            value, -Cue::kShiftCuesOffsetMillis);
+                });
+        m_pShiftFocusedHotcueLater = std::make_unique<ControlPushButton>(
+                ConfigKey(getGroup(), "shift_focused_hotcue_later"));
+        connect(m_pShiftFocusedHotcueLater.get(),
+                &ControlObject::valueChanged,
+                this,
+                [this](double value) {
+                    slotShiftFocusedHotcueMillisButton(
+                            value, Cue::kShiftCuesOffsetMillis);
+                });
+        m_pShiftFocusedHotcueEarlierSmall = std::make_unique<ControlPushButton>(
+                ConfigKey(getGroup(), "shift_focused_hotcue_earlier_small"));
+        connect(m_pShiftFocusedHotcueEarlierSmall.get(),
+                &ControlObject::valueChanged,
+                this,
+                [this](double value) {
+                    slotShiftFocusedHotcueMillisButton(value, -Cue::kShiftCuesOffsetMillisSmall);
+                });
+        m_pShiftFocusedHotcueLaterSmall = std::make_unique<ControlPushButton>(
+                ConfigKey(getGroup(), "shift_focused_hotcue_later_small"));
+        connect(m_pShiftFocusedHotcueLaterSmall.get(),
+                &ControlObject::valueChanged,
+                this,
+                [this](double value) {
+                    slotShiftFocusedHotcueMillisButton(value, Cue::kShiftCuesOffsetMillisSmall);
+                });
+        m_pShiftFocusedHotcue = std::make_unique<ControlObject>(
+                ConfigKey(getGroup(), "shift_focused_hotcue"));
+        connect(m_pShiftFocusedHotcue.get(),
+                &ControlObject::valueChanged,
+                this,
+                &BaseTrackPlayerImpl::slotShiftFocusedHotcueMillis);
+    }
 
     // BPM and key of the current song
     m_pFileBPM = std::make_unique<ControlObject>(ConfigKey(getGroup(), "file_bpm"));

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -84,9 +84,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             // signal-to-signal
             &BaseTrackPlayerImpl::noVinylControlInputConfigured);
 
-    // PollingControlProxy would be preferred, but CO is not available at init
-    // since it's created by CueControl which is created by EngineBuffer
-    m_focusedHotcueIndexCO = PollingControlProxy(getGroup(), "hotcue_focus");
+    m_focusedHotcueIndexCO = PollingControlProxy(getGroup(), QStringLiteral("hotcue_focus"));
     m_pQuantizeEnabled = PollingControlProxy(getGroup(), QStringLiteral("quantize"));
 
     m_pEject = std::make_unique<ControlPushButton>(ConfigKey(getGroup(), "eject"));

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -16,6 +16,7 @@
 #include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
 #include "moc_basetrackplayer.cpp"
+#include "track/cue.h"
 #include "track/track.h"
 #include "util/sandbox.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
@@ -24,8 +25,6 @@
 namespace {
 
 constexpr double kNoTrackColor = -1;
-constexpr double kShiftCuesOffsetMillis = 10;
-constexpr double kShiftCuesOffsetSmallMillis = 1;
 const QString kEffectGroupFormat = QStringLiteral("[EqualizerRack1_%1_Effect1]");
 
 inline double trackColorToDouble(mixxx::RgbColor::optional_t color) {
@@ -53,7 +52,9 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
           m_pLoadedTrack(),
           m_pPrevFailedTrackId(),
           m_replaygainPending(false),
-          m_pChannelToCloneFrom(nullptr) {
+          m_pChannelToCloneFrom(nullptr),
+          m_focusedHotcueIndexCO(ControlFlag::AllowMissingOrInvalid),
+          m_pQuantizeEnabled(ControlFlag::AllowMissingOrInvalid) {
     auto channel = std::make_unique<EngineDeck>(handleGroup,
             pConfig,
             pMixingEngine,
@@ -82,6 +83,11 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             this,
             // signal-to-signal
             &BaseTrackPlayerImpl::noVinylControlInputConfigured);
+
+    // PollingControlProxy would be preferred, but CO is not available at init
+    // since it's created by CueControl which is created by EngineBuffer
+    m_focusedHotcueIndexCO = PollingControlProxy(getGroup(), "hotcue_focus");
+    m_pQuantizeEnabled = PollingControlProxy(getGroup(), QStringLiteral("quantize"));
 
     m_pEject = std::make_unique<ControlPushButton>(ConfigKey(getGroup(), "eject"));
     connect(m_pEject.get(),
@@ -283,20 +289,24 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
     connect(m_pShiftCuesEarlier.get(),
             &ControlObject::valueChanged,
             this,
-            [this](double value) { slotShiftCuesMillisButton(value, -kShiftCuesOffsetMillis); });
+            [this](double value) {
+                slotShiftCuesMillisButton(value, -Cue::kShiftCuesOffsetMillis);
+            });
     m_pShiftCuesLater = std::make_unique<ControlPushButton>(
             ConfigKey(getGroup(), "shift_cues_later"));
     connect(m_pShiftCuesLater.get(),
             &ControlObject::valueChanged,
             this,
-            [this](double value) { slotShiftCuesMillisButton(value, kShiftCuesOffsetMillis); });
+            [this](double value) {
+                slotShiftCuesMillisButton(value, Cue::kShiftCuesOffsetMillis);
+            });
     m_pShiftCuesEarlierSmall = std::make_unique<ControlPushButton>(
             ConfigKey(getGroup(), "shift_cues_earlier_small"));
     connect(m_pShiftCuesEarlierSmall.get(),
             &ControlObject::valueChanged,
             this,
             [this](double value) {
-                slotShiftCuesMillisButton(value, -kShiftCuesOffsetSmallMillis);
+                slotShiftCuesMillisButton(value, -Cue::kShiftCuesOffsetMillisSmall);
             });
     m_pShiftCuesLaterSmall = std::make_unique<ControlPushButton>(
             ConfigKey(getGroup(), "shift_cues_later_small"));
@@ -304,7 +314,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             &ControlObject::valueChanged,
             this,
             [this](double value) {
-                slotShiftCuesMillisButton(value, kShiftCuesOffsetSmallMillis);
+                slotShiftCuesMillisButton(value, -Cue::kShiftCuesOffsetMillisSmall);
             });
     m_pShiftCues = std::make_unique<ControlObject>(
             ConfigKey(getGroup(), "shift_cues"));
@@ -312,6 +322,47 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             &ControlObject::valueChanged,
             this,
             &BaseTrackPlayerImpl::slotShiftCuesMillis);
+    // the same for the currently focused (last touched) hotcue, if there is one
+    m_pShiftFocusedHotcueEarlier = std::make_unique<ControlPushButton>(
+            ConfigKey(getGroup(), "shift_focused_hotcue_earlier"));
+    connect(m_pShiftFocusedHotcueEarlier.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                slotShiftFocusedHotcueMillisButton(
+                        value, -Cue::kShiftCuesOffsetMillis);
+            });
+    m_pShiftFocusedHotcueLater = std::make_unique<ControlPushButton>(
+            ConfigKey(getGroup(), "shift_focused_hotcue_later"));
+    connect(m_pShiftFocusedHotcueLater.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                slotShiftFocusedHotcueMillisButton(
+                        value, Cue::kShiftCuesOffsetMillis);
+            });
+    m_pShiftFocusedHotcueEarlierSmall = std::make_unique<ControlPushButton>(
+            ConfigKey(getGroup(), "shift_focused_hotcue_earlier_small"));
+    connect(m_pShiftFocusedHotcueEarlierSmall.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                slotShiftFocusedHotcueMillisButton(value, -Cue::kShiftCuesOffsetMillisSmall);
+            });
+    m_pShiftFocusedHotcueLaterSmall = std::make_unique<ControlPushButton>(
+            ConfigKey(getGroup(), "shift_focused_hotcue_later_small"));
+    connect(m_pShiftFocusedHotcueLaterSmall.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                slotShiftFocusedHotcueMillisButton(value, Cue::kShiftCuesOffsetMillisSmall);
+            });
+    m_pShiftFocusedHotcue = std::make_unique<ControlObject>(
+            ConfigKey(getGroup(), "shift_focused_hotcue"));
+    connect(m_pShiftFocusedHotcue.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BaseTrackPlayerImpl::slotShiftFocusedHotcueMillis);
 
     // BPM and key of the current song
     m_pFileBPM = std::make_unique<ControlObject>(ConfigKey(getGroup(), "file_bpm"));
@@ -1108,6 +1159,30 @@ void BaseTrackPlayerImpl::slotShiftCuesMillisButton(double value, double millise
         return;
     }
     slotShiftCuesMillis(milliseconds);
+}
+
+void BaseTrackPlayerImpl::slotShiftFocusedHotcueMillis(double milliseconds) {
+    if (!m_pLoadedTrack) {
+        return;
+    }
+    // `hotcue_focus` control is 1-based, track hotcues are 0-based
+    int hotcueIndex = static_cast<int>(m_focusedHotcueIndexCO.get()) - 1;
+    if (hotcueIndex == Cue::kNoHotCue) {
+        return;
+    }
+
+    if (m_pQuantizeEnabled.toBool()) {
+        m_pLoadedTrack->shiftHotcuePositionBeats(hotcueIndex, milliseconds > 0 ? 1 : -1);
+    } else {
+        m_pLoadedTrack->shiftHotcuePositionMillis(hotcueIndex, milliseconds);
+    }
+}
+
+void BaseTrackPlayerImpl::slotShiftFocusedHotcueMillisButton(double value, double milliseconds) {
+    if (value <= 0) {
+        return;
+    }
+    slotShiftFocusedHotcueMillis(milliseconds);
 }
 
 void BaseTrackPlayerImpl::slotUpdateReplayGainFromPregain(double pressed) {

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -1162,7 +1162,7 @@ void BaseTrackPlayerImpl::slotShiftCuesMillisButton(double value, double millise
 }
 
 void BaseTrackPlayerImpl::slotShiftFocusedHotcueMillis(double milliseconds) {
-    if (!m_pLoadedTrack) {
+    if (!m_pLoadedTrack || milliseconds == 0) {
         return;
     }
     // `hotcue_focus` control is 1-based, track hotcues are 0-based
@@ -1179,7 +1179,7 @@ void BaseTrackPlayerImpl::slotShiftFocusedHotcueMillis(double milliseconds) {
 }
 
 void BaseTrackPlayerImpl::slotShiftFocusedHotcueMillisButton(double value, double milliseconds) {
-    if (value <= 0) {
+    if (value <= 0 || milliseconds == 0) {
         return;
     }
     slotShiftFocusedHotcueMillis(milliseconds);

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -8,6 +8,7 @@
 #ifdef __STEM__
 #include "engine/engine.h"
 #endif
+#include "control/pollingcontrolproxy.h"
 #include "engine/channels/enginechannel.h"
 #include "mixer/baseplayer.h"
 #include "preferences/colorpalettesettings.h"
@@ -153,6 +154,8 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void slotWaveformZoomSetDefault(double pressed);
     void slotShiftCuesMillis(double milliseconds);
     void slotShiftCuesMillisButton(double value, double milliseconds);
+    void slotShiftFocusedHotcueMillis(double milliseconds);
+    void slotShiftFocusedHotcueMillisButton(double value, double milliseconds);
     void slotUpdateReplayGainFromPregain(double pressed);
 
   private:
@@ -223,6 +226,15 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     std::unique_ptr<ControlPushButton> m_pShiftCuesLater;
     std::unique_ptr<ControlPushButton> m_pShiftCuesLaterSmall;
     std::unique_ptr<ControlObject> m_pShiftCues;
+
+    std::unique_ptr<ControlPushButton> m_pShiftFocusedHotcueEarlier;
+    std::unique_ptr<ControlPushButton> m_pShiftFocusedHotcueEarlierSmall;
+    std::unique_ptr<ControlPushButton> m_pShiftFocusedHotcueLater;
+    std::unique_ptr<ControlPushButton> m_pShiftFocusedHotcueLaterSmall;
+    std::unique_ptr<ControlObject> m_pShiftFocusedHotcue;
+
+    PollingControlProxy m_focusedHotcueIndexCO;
+    PollingControlProxy m_pQuantizeEnabled;
 
     std::unique_ptr<ControlPushButton> m_pShowTrackMenuControl;
 

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -25,6 +25,9 @@ class Cue : public QObject {
     static_assert(kNoHotCue != mixxx::kFirstHotCueIndex,
             "Conflicting definitions of invalid and first hot cue index");
 
+    static constexpr double kShiftCuesOffsetMillis = 10;
+    static constexpr double kShiftCuesOffsetMillisSmall = 1;
+
     struct StartAndEndPositions {
         mixxx::audio::FramePos startPosition;
         mixxx::audio::FramePos endPosition;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -980,6 +980,10 @@ void Track::setMainCuePosition(mixxx::audio::FramePos position) {
 }
 
 void Track::shiftCuePositionsMillis(double milliseconds) {
+    if (milliseconds == 0) {
+        return;
+    }
+
     auto locked = lockMutex(&m_qMutex);
 
     VERIFY_OR_DEBUG_ASSERT(m_record.getStreamInfoFromSource()) {
@@ -994,6 +998,10 @@ void Track::shiftCuePositionsMillis(double milliseconds) {
 }
 
 void Track::shiftHotcuePositionMillis(int hotcue, double milliseconds) {
+    if (milliseconds == 0) {
+        return;
+    }
+
     auto locked = lockMutex(&m_qMutex);
 
     CuePointer pHotcue = findHotcueByIndex(hotcue);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -993,6 +993,71 @@ void Track::shiftCuePositionsMillis(double milliseconds) {
     markDirtyAndUnlock(&locked);
 }
 
+void Track::shiftHotcuePositionMillis(int hotcue, double milliseconds) {
+    auto locked = lockMutex(&m_qMutex);
+
+    CuePointer pHotcue = findHotcueByIndex(hotcue);
+    if (!pHotcue) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_record.getStreamInfoFromSource()) {
+        return;
+    }
+    double frames = m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(milliseconds);
+    pHotcue->shiftPositionFrames(frames);
+
+    markDirtyAndUnlock(&locked);
+}
+
+void Track::shiftHotcuePositionBeats(int hotcue, int direction) {
+    if (direction == 0) {
+        return;
+    }
+    if (!m_pBeats) {
+        return;
+    }
+    direction = direction > 0 ? 1 : -1;
+
+    auto locked = lockMutex(&m_qMutex);
+    CuePointer pHotcue = findHotcueByIndex(hotcue);
+    if (!pHotcue) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_record.getStreamInfoFromSource()) {
+        return;
+    }
+
+    auto currPos = pHotcue->getPosition();
+    VERIFY_OR_DEBUG_ASSERT(currPos.isValid()) {
+        return;
+    };
+
+    // This is called by `shift_focused_hotcue_later|earlier[_small]` when
+    // `quantize` is enabled.
+    // Hence the purpose is to shift the cue to the prev or next beat position.
+    // In case the cue is currently not quantized (like when cue has been set
+    // without quantize or beatgrid has been shifted since setting it) we shift
+    // it to the closest beat first.
+    // The user may then shift to the prev/next beat.
+
+    // If the cue is be exactly on a beat findNthBeat(pos, n) would return that
+    // same position. In that case we need to look one beat further.
+    auto newPos = currPos;
+    int offset = 1;
+    while (newPos == currPos) {
+        VERIFY_OR_DEBUG_ASSERT(offset <= 2) {
+            qWarning() << "Could not shift cue point, couldn't find next/prev beat";
+            return;
+        }
+        newPos = m_pBeats->findNthBeat(currPos, direction * offset);
+        offset++;
+    }
+
+    pHotcue->shiftPositionFrames(newPos - currPos);
+
+    markDirtyAndUnlock(&locked);
+}
+
 void Track::setHotcueIndicesSortedByPosition(HotcueSortMode sortMode) {
     auto locked = lockMutex(&m_qMutex);
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1012,6 +1012,16 @@ void Track::shiftHotcuePositionMillis(int hotcue, double milliseconds) {
         return;
     }
     double frames = m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(milliseconds);
+
+    const auto dur = m_record.getStreamInfoFromSource()->getDuration();
+    const auto totalFrames =
+            m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(
+                    dur.toDoubleMillis());
+    const auto endPos = pHotcue->getPosition();
+    if (endPos + frames >= mixxx::audio::FramePos(totalFrames)) {
+        qWarning() << "Rejecting to shift hotcue" << hotcue << "past the track end";
+        return;
+    }
     pHotcue->shiftPositionFrames(frames);
 
     markDirtyAndUnlock(&locked);
@@ -1059,6 +1069,15 @@ void Track::shiftHotcuePositionBeats(int hotcue, int direction) {
         }
         newPos = m_pBeats->findNthBeat(currPos, direction * offset);
         offset++;
+    }
+
+    const auto dur = m_record.getStreamInfoFromSource()->getDuration();
+    const auto totalFrames =
+            m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(
+                    dur.toDoubleMillis());
+    if (newPos >= mixxx::audio::FramePos(totalFrames)) {
+        qWarning() << "Rejecting to shift hotcue" << hotcue << "past the track end";
+        return;
     }
 
     pHotcue->shiftPositionFrames(newPos - currPos);

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -305,6 +305,10 @@ class Track : public QObject {
     void setMainCuePosition(mixxx::audio::FramePos position);
     /// Shift all cues by a constant offset
     void shiftCuePositionsMillis(mixxx::audio::FrameDiff_t milliseconds);
+    /// Shift position of specific hotcue by millis
+    void shiftHotcuePositionMillis(int hotcue, double milliseconds);
+    /// Shift position of specific hotcue by +-1 beat
+    void shiftHotcuePositionBeats(int hotcue, int direction);
     /// Set hoctues' indices sorted by their frame position.
     /// If compress is true, indices are consecutive and start at 0.
     /// Set false to sort only, ie. keep empty hotcues before and in between.

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -150,6 +150,47 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
             this,
             &WCueMenuPopup::slotSavedJumpCueManual);
 
+    m_pShiftCueEarlier = std::make_unique<CueMenuPushButton>(this);
+    m_pShiftCueEarlier->setToolTip(tr(
+            "Shift this cue backwards by %1 milliseconds.\n"
+            "Right-click to shift this cue backwards by %2 milliseconds.\n"
+            "If quantize is enabled shift this cue to the previous beat.")
+                    .arg(QString::number(Cue::kShiftCuesOffsetMillis),
+                            QString::number(Cue::kShiftCuesOffsetMillisSmall)));
+    m_pShiftCueEarlier->setObjectName("CueShiftEarlier");
+    connect(m_pShiftCueEarlier.get(),
+            &QPushButton::clicked,
+            this,
+            [this]() {
+                shiftCue(-1);
+            });
+    connect(m_pShiftCueEarlier.get(),
+            &CueMenuPushButton::rightClicked,
+            this,
+            [this]() {
+                shiftCueSmall(-1);
+            });
+    m_pShiftCueLater = std::make_unique<CueMenuPushButton>(this);
+    m_pShiftCueLater->setToolTip(tr(
+            "Shift this cue forwards by %1 milliseconds.\n"
+            "Right-click to shift this cue forwards by %2 milliseconds.\n"
+            "If quantize is enabled shift this cue to the next beat.")
+                    .arg(QString::number(Cue::kShiftCuesOffsetMillis),
+                            QString::number(Cue::kShiftCuesOffsetMillisSmall)));
+    m_pShiftCueLater->setObjectName("CueShiftLater");
+    connect(m_pShiftCueLater.get(),
+            &QPushButton::clicked,
+            this,
+            [this]() {
+                shiftCue(1);
+            });
+    connect(m_pShiftCueLater.get(),
+            &CueMenuPushButton::rightClicked,
+            this,
+            [this]() {
+                shiftCueSmall(1);
+            });
+
     QHBoxLayout* pLabelLayout = new QHBoxLayout();
     pLabelLayout->addWidget(m_pCueNumber.get());
     pLabelLayout->addStretch(1);
@@ -160,8 +201,16 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
     pLeftLayout->addWidget(m_pEditLabel.get());
     pLeftLayout->addWidget(m_pColorPicker.get());
 
+    QHBoxLayout* pShiftLayout = new QHBoxLayout();
+    pShiftLayout->setObjectName("CueMenuShiftLayout");
+    pShiftLayout->addWidget(m_pShiftCueEarlier.get());
+    pShiftLayout->addWidget(m_pShiftCueLater.get());
+    // no margin, make it look like the beatjump button grid
+    pShiftLayout->setSpacing(0);
+
     QVBoxLayout* pRightLayout = new QVBoxLayout();
     pRightLayout->addWidget(m_pDeleteCue.get());
+    pRightLayout->addLayout(pShiftLayout);
     pRightLayout->addWidget(m_pStandardCue.get());
     pRightLayout->addStretch(1);
     pRightLayout->addWidget(m_pSavedLoopCue.get());
@@ -173,7 +222,7 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
     pMainLayout->addSpacing(5);
     pMainLayout->addLayout(pRightLayout);
     setLayout(pMainLayout);
-    // we need to update the the layout here since the size is used to
+    // we need to update the layout here since the size is used to
     // calculate the positioning later
     layout()->update();
     layout()->activate();
@@ -333,6 +382,46 @@ void WCueMenuPopup::slotDeleteCue() {
     }
     m_pTrack->removeCue(m_pCue);
     hide();
+}
+
+void WCueMenuPopup::shiftCue(int direction) {
+    VERIFY_OR_DEBUG_ASSERT(m_pCue != nullptr) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_pTrack != nullptr) {
+        return;
+    }
+    if (direction == 0) {
+        return;
+    }
+    direction = direction > 0 ? 1 : -1;
+
+    if (m_pQuantizeEnabled.toBool()) {
+        m_pTrack->shiftHotcuePositionBeats(m_pCue->getHotCue(), direction);
+    } else {
+        m_pTrack->shiftHotcuePositionMillis(
+                m_pCue->getHotCue(), Cue::kShiftCuesOffsetMillis * direction);
+    }
+}
+
+void WCueMenuPopup::shiftCueSmall(int direction) {
+    VERIFY_OR_DEBUG_ASSERT(m_pCue != nullptr) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_pTrack != nullptr) {
+        return;
+    }
+    if (direction == 0) {
+        return;
+    }
+    direction = direction > 0 ? 1 : -1;
+
+    if (m_pQuantizeEnabled.toBool()) {
+        m_pTrack->shiftHotcuePositionBeats(m_pCue->getHotCue(), direction);
+    } else {
+        m_pTrack->shiftHotcuePositionMillis(m_pCue->getHotCue(),
+                Cue::kShiftCuesOffsetMillisSmall * direction);
+    }
 }
 
 void WCueMenuPopup::slotStandardCue() {

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -78,17 +78,17 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
     setAttribute(Qt::WA_StyledBackground);
     setObjectName("WCueMenuPopup");
 
-    m_pCueNumber = std::make_unique<QLabel>(this);
+    m_pCueNumber = make_parented<QLabel>(this);
     m_pCueNumber->setToolTip(tr("Cue number"));
     m_pCueNumber->setObjectName("CueNumberLabel");
     m_pCueNumber->setAlignment(Qt::AlignLeft);
 
-    m_pCuePosition = std::make_unique<QLabel>(this);
+    m_pCuePosition = make_parented<QLabel>(this);
     m_pCuePosition->setToolTip(tr("Cue position"));
     m_pCuePosition->setObjectName("CuePositionLabel");
     m_pCuePosition->setAlignment(Qt::AlignRight);
 
-    m_pEditLabel = std::make_unique<QLineEdit>(this);
+    m_pEditLabel = make_parented<QLineEdit>(this);
     m_pEditLabel->setToolTip(tr("Edit cue label"));
     m_pEditLabel->setObjectName("CueLabelEdit");
     m_pEditLabel->setPlaceholderText(tr("Label..."));
@@ -96,7 +96,7 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
     connect(m_pEditLabel.get(), &QLineEdit::returnPressed, this, &WCueMenuPopup::hide);
 
     m_pColorPicker =
-            std::make_unique<WColorPicker>(WColorPicker::Option::NoOptions,
+            make_parented<WColorPicker>(WColorPicker::Option::NoOptions,
                     m_colorPaletteSettings.getHotcueColorPalette(),
                     this);
     m_pColorPicker->setObjectName("CueColorPicker");
@@ -105,12 +105,12 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
             this,
             &WCueMenuPopup::slotChangeCueColor);
 
-    m_pDeleteCue = std::make_unique<CueMenuPushButton>(this);
+    m_pDeleteCue = make_parented<CueMenuPushButton>(this);
     m_pDeleteCue->setToolTip(tr("Delete this cue"));
     m_pDeleteCue->setObjectName("CueDeleteButton");
     connect(m_pDeleteCue.get(), &QPushButton::clicked, this, &WCueMenuPopup::slotDeleteCue);
 
-    m_pStandardCue = std::make_unique<CueMenuPushButton>(this);
+    m_pStandardCue = make_parented<CueMenuPushButton>(this);
     m_pStandardCue->setToolTip(
             tr("Turn this cue into a regular hotcue"));
     m_pStandardCue->setObjectName("CueStandardButton");
@@ -120,7 +120,7 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
             this,
             &WCueMenuPopup::slotStandardCue);
 
-    m_pSavedLoopCue = std::make_unique<CueMenuPushButton>(this);
+    m_pSavedLoopCue = make_parented<CueMenuPushButton>(this);
     m_pSavedLoopCue->setToolTip(tr("Turn this cue into a saved loop") + "\n\n" +
             tr("Left-click: Use the old size if known or the current beatloop "
                "size as the loop size") +
@@ -138,7 +138,7 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
             this,
             &WCueMenuPopup::slotSavedLoopCueManual);
 
-    m_pSavedJumpCue = std::make_unique<CueMenuPushButton>(this);
+    m_pSavedJumpCue = make_parented<CueMenuPushButton>(this);
     m_pSavedJumpCue->setObjectName("CueSavedJumpButton");
     m_pSavedJumpCue->setCheckable(true);
     connect(m_pSavedJumpCue.get(),
@@ -150,7 +150,7 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
             this,
             &WCueMenuPopup::slotSavedJumpCueManual);
 
-    m_pShiftCueEarlier = std::make_unique<CueMenuPushButton>(this);
+    m_pShiftCueEarlier = make_parented<CueMenuPushButton>(this);
     m_pShiftCueEarlier->setToolTip(tr(
             "Shift this cue backwards by %1 milliseconds.\n"
             "Right-click to shift this cue backwards by %2 milliseconds.\n"
@@ -170,7 +170,7 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
             [this]() {
                 shiftCueSmall(-1);
             });
-    m_pShiftCueLater = std::make_unique<CueMenuPushButton>(this);
+    m_pShiftCueLater = make_parented<CueMenuPushButton>(this);
     m_pShiftCueLater->setToolTip(tr(
             "Shift this cue forwards by %1 milliseconds.\n"
             "Right-click to shift this cue forwards by %2 milliseconds.\n"

--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -83,6 +83,9 @@ class WCueMenuPopup : public QWidget {
     void updateTypeAndColorIfDefault(mixxx::CueType newType);
     mixxx::audio::FramePos getCurrentPlayPositionWithQuantize() const;
 
+    void shiftCue(int direction);
+    void shiftCueSmall(int direction);
+
     UserSettingsPointer m_pConfig;
     ColorPaletteSettings m_colorPaletteSettings;
     PollingControlProxy m_pBeatLoopSize;
@@ -97,6 +100,8 @@ class WCueMenuPopup : public QWidget {
     std::unique_ptr<QLineEdit> m_pEditLabel;
     std::unique_ptr<WColorPicker> m_pColorPicker;
     std::unique_ptr<CueMenuPushButton> m_pDeleteCue;
+    std::unique_ptr<CueMenuPushButton> m_pShiftCueEarlier;
+    std::unique_ptr<CueMenuPushButton> m_pShiftCueLater;
     std::unique_ptr<CueMenuPushButton> m_pStandardCue;
     std::unique_ptr<CueMenuPushButton> m_pSavedLoopCue;
     std::unique_ptr<CueMenuPushButton> m_pSavedJumpCue;

--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -37,14 +37,14 @@ class WCueMenuPopup : public QWidget {
     void setTrackCueGroup(TrackPointer pTrack, const CuePointer& pCue, const QString& group);
 
     void setColorPalette(const ColorPalette& palette) {
-        if (m_pColorPicker != nullptr) {
+        if (m_pColorPicker) {
             m_pColorPicker->setColorPalette(palette);
         }
     }
 
     void popup(const QPoint& p) {
-        auto parentWidget = qobject_cast<QWidget*>(parent());
-        QPoint topLeft = mixxx::widgethelper::mapPopupToScreen(*parentWidget, p, size());
+        auto* pParentWidget = qobject_cast<QWidget*>(parent());
+        QPoint topLeft = mixxx::widgethelper::mapPopupToScreen(*pParentWidget, p, size());
         move(topLeft);
         show();
     }
@@ -95,16 +95,16 @@ class WCueMenuPopup : public QWidget {
     CuePointer m_pCue;
     TrackPointer m_pTrack;
 
-    std::unique_ptr<QLabel> m_pCueNumber;
-    std::unique_ptr<QLabel> m_pCuePosition;
-    std::unique_ptr<QLineEdit> m_pEditLabel;
-    std::unique_ptr<WColorPicker> m_pColorPicker;
-    std::unique_ptr<CueMenuPushButton> m_pDeleteCue;
-    std::unique_ptr<CueMenuPushButton> m_pShiftCueEarlier;
-    std::unique_ptr<CueMenuPushButton> m_pShiftCueLater;
-    std::unique_ptr<CueMenuPushButton> m_pStandardCue;
-    std::unique_ptr<CueMenuPushButton> m_pSavedLoopCue;
-    std::unique_ptr<CueMenuPushButton> m_pSavedJumpCue;
+    parented_ptr<QLabel> m_pCueNumber;
+    parented_ptr<QLabel> m_pCuePosition;
+    parented_ptr<QLineEdit> m_pEditLabel;
+    parented_ptr<WColorPicker> m_pColorPicker;
+    parented_ptr<CueMenuPushButton> m_pDeleteCue;
+    parented_ptr<CueMenuPushButton> m_pShiftCueEarlier;
+    parented_ptr<CueMenuPushButton> m_pShiftCueLater;
+    parented_ptr<CueMenuPushButton> m_pStandardCue;
+    parented_ptr<CueMenuPushButton> m_pSavedLoopCue;
+    parented_ptr<CueMenuPushButton> m_pSavedJumpCue;
 
   protected:
     void closeEvent(QCloseEvent* event) override;


### PR DESCRIPTION
This is another take to implement #12367 (and #15252)
(previous attempt was #12367 with shift controls per hotcue)

Adds new per-deck controls
* `shift_focused_hotcue_earlier`
* `shift_focused_hotcue_earlier_small`
* `shift_focused_hotcue_later`
* `shift_focused_hotcue_later_small`

They shift the currently **focused hotcue** (last set, activated or edited, or manually assigned to `hotcue_focus` control) by 10 ms / 1 ms.
There is also the `shift_focused_hotcue` ControlObject which allows to shift by arbitrary values.

**TODO** in order to not add yet another 5 controls for _every deck_ (incl. 64 samplers) we may consider to restrict these to main decks 1-4. Since we have waveforms only for the main decks I don't expect anyone to edit hotcue positions in samplers anyway.

I added buttons to the Hotcue menu (left-click: 10 ms, right-click: 1 ms)
<img width="274" height="243" alt="Screenshot_2026-05-29_00-19-28" src="https://github.com/user-attachments/assets/dc8b72dd-5e98-4b48-b226-c570d42c043c" />
