### PR TITLE
Fix recording to FLAC

### DIFF
--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -93,3 +93,7 @@ void EncoderSndfileFlac::initStream() {
         sf_command(m_pSndfile, SFC_SET_CLIPPING, nullptr, SF_FALSE);
     }
 }
+
+void EncoderSndfileFlac::flush() {
+    sf_write_sync(m_pSndfile);
+}

--- a/src/encoder/encodersndfileflac.h
+++ b/src/encoder/encodersndfileflac.h
@@ -20,6 +20,7 @@ class EncoderSndfileFlac : public EncoderWave {
 
     void setEncoderSettings(const EncoderSettings& settings) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
+    void flush() override;
 
   protected:
     void initStream() override;


### PR DESCRIPTION
Fixes #16520 which was introduced in 548094e4cb689ebdf1283b0716b64aa193907f83.

The problem here is that FLAC file encoding uses the class `EncoderSndfileFlac` which is a subclass of `EncoderWave`. When the new support for tracklists in comments was introduced, implicit changes to the encoding process of FLAC files were introduced too; however, these apparently do not work for FLAC. I have not investigated why this does not work. If I may guess, I'd say that this might be due to different comment styles, since FLAC uses Vorbis comments and WAV does not (if I am not mistaken?).

This PR overrides the `flush` function, which introduced the incompatible changes, in `EncoderSndfileFlac`, and restores the old behaviour for `EncoderSndfileFlac`.