### PR TITLE
(fix) Computer/Recording: sort correctly by file creation/modification date

### DIFF
--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -173,6 +173,9 @@ void BrowseThread::populateModel() {
                     nullptr,
                     resetMissingTagMetadata);
 
+            // Note: ProxyTrackModel uses Qt::UserRole for sorting which supports
+            // int, double, QString, QDateTime etc. so make sure that the data
+            // stored in Qt::UserRole will result in reasonable sorting.
             item = new QStandardItem(fileAccess.info().fileName());
             item->setToolTip(item->text());
             item->setData(item->text(), Qt::UserRole);
@@ -301,7 +304,7 @@ void BrowseThread::populateModel() {
             item = new QStandardItem(
                     mixxx::ReplayGain::ratioToString(replayGain.getRatio()));
             item->setToolTip(item->text());
-            item->setData(item->text(), Qt::UserRole);
+            item->setData(replayGain.getRatio(), Qt::UserRole);
             row_data.insert(COLUMN_REPLAYGAIN, item);
         }
 

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -17,6 +17,10 @@ ProxyTrackModel::ProxyTrackModel(QAbstractItemModel* pTrackModel,
         return;
     }
     setSourceModel(pTrackModel);
+    // Sort by UserRole, not default DisplayRole (mostly QString).
+    // Note: make sure that the source model has adequate data in Qt::UserRole
+    // Only relevant source is currently BrowseThread::populateModel()
+    setSortRole(Qt::UserRole);
 }
 
 ProxyTrackModel::~ProxyTrackModel() {
@@ -228,7 +232,7 @@ bool ProxyTrackModel::setModelSetting(const QString& name, const QVariant& value
 }
 
 void ProxyTrackModel::sort(int column, Qt::SortOrder order) {
-    if (m_pTrackModel->isColumnSortable(column)) {
+    if (m_pTrackModel && m_pTrackModel->isColumnSortable(column)) {
         QSortFilterProxyModel::sort(column, order);
     }
 }


### PR DESCRIPTION
I've just moved a lot of recordings to my Mixxx Recording directory and noticed that it sorts by 'display value' when trying to sort by "File Modified".

Fixed with `setSortRole(Qt::UserRole)` which also supports QDateTime.
Tested relevant columns, no regressions spotted. Please test!

Plus two small fixes.

Btw the column layout is not stored for Rec/Computer, will look into it.