### PR TITLE
VinylControl: limit writing of VinylSignalQualityReport to MIXXX_VINY…

### DIFF
--- a/src/vinylcontrol/defs_vinylcontrol.h
+++ b/src/vinylcontrol/defs_vinylcontrol.h
@@ -60,7 +60,8 @@ constexpr int VINYL_STATUS_ERROR = 3;
 
 #define MIXXX_VC_DEFAULT_LEADINTIME 0
 
-#define MIXXX_VINYL_SCOPE_UPDATE_LATENCY_MS 66
+// Period for updating the vinyl quality scopes, ~15 Hz
+#define MIXXX_VINYL_SCOPE_UPDATE_PERIOD_MS 66
 #define MIXXX_VINYL_SCOPE_SIZE 100
 
 constexpr int kMaximumVinylControlInputs = 4;

--- a/src/vinylcontrol/vinylcontrolmanager.cpp
+++ b/src/vinylcontrol/vinylcontrolmanager.cpp
@@ -22,7 +22,6 @@ VinylControlManager::VinylControlManager(QObject* pParent,
         : QObject(pParent),
           m_pConfig(pConfig),
           m_pProcessor(new VinylControlProcessor(this, pConfig)),
-          m_iTimerId(-1),
           m_pNumDecks(nullptr),
           m_iNumConfiguredDecks(0) {
     // Register every possible VC input with SoundManager to route to the
@@ -35,6 +34,10 @@ VinylControlManager::VinylControlManager(QObject* pParent,
                         i),
                 m_pProcessor);
     }
+    connect(m_pProcessor,
+            &VinylControlProcessor::qualityReportWritten,
+            this,
+            &VinylControlManager::updateSignalQualityListeners);
 }
 
 VinylControlManager::~VinylControlManager() {
@@ -142,20 +145,12 @@ int VinylControlManager::vinylInputFromGroup(const QString& group) {
 void VinylControlManager::addSignalQualityListener(VinylSignalQualityListener* pListener) {
     m_listeners.insert(pListener);
     m_pProcessor->setSignalQualityReporting(true);
-
-    if (m_iTimerId == -1) {
-        m_iTimerId = startTimer(MIXXX_VINYL_SCOPE_UPDATE_LATENCY_MS);
-    }
 }
 
 void VinylControlManager::removeSignalQualityListener(VinylSignalQualityListener* pListener) {
     m_listeners.remove(pListener);
     if (m_listeners.empty()) {
         m_pProcessor->setSignalQualityReporting(false);
-        if (m_iTimerId != -1) {
-            killTimer(m_iTimerId);
-            m_iTimerId = -1;
-        }
     }
 }
 
@@ -171,8 +166,4 @@ void VinylControlManager::updateSignalQualityListeners() {
             pListener->onVinylSignalQualityUpdate(report);
         }
     }
-}
-
-void VinylControlManager::timerEvent(QTimerEvent*) {
-    updateSignalQualityListeners();
 }

--- a/src/vinylcontrol/vinylcontrolmanager.h
+++ b/src/vinylcontrol/vinylcontrolmanager.h
@@ -7,7 +7,6 @@
 class ControlProxy;
 class SoundManager;
 class VinylControlProcessor;
-class QTimerEvent;
 class VinylSignalQualityListener;
 
 // VinylControlManager is the main-thread interface that other parts of Mixxx
@@ -32,11 +31,9 @@ class VinylControlManager : public QObject {
 
     void addSignalQualityListener(VinylSignalQualityListener* pListener);
     void removeSignalQualityListener(VinylSignalQualityListener* pListener);
-    void updateSignalQualityListeners();
-
-    void timerEvent(QTimerEvent* pEvent);
 
   public slots:
+    void updateSignalQualityListeners();
     void requestReloadConfig();
     void toggleVinylControl(int deck);
 
@@ -51,7 +48,6 @@ class VinylControlManager : public QObject {
     UserSettingsPointer m_pConfig;
     QSet<VinylSignalQualityListener*> m_listeners;
     VinylControlProcessor* m_pProcessor;
-    int m_iTimerId;
     QList<ControlProxy*> m_pVcEnabled;
     ControlProxy* m_pNumDecks;
     int m_iNumConfiguredDecks;

--- a/src/vinylcontrol/vinylcontrolprocessor.cpp
+++ b/src/vinylcontrol/vinylcontrolprocessor.cpp
@@ -92,7 +92,7 @@ void VinylControlProcessor::run() {
 
         bool timeToWriteSignalQualityReport = m_bReportSignalQuality &&
                 reportTimer.elapsed().toIntegerMillis() >=
-                        MIXXX_VINYL_SCOPE_UPDATE_LATENCY_MS;
+                        MIXXX_VINYL_SCOPE_UPDATE_PERIOD_MS;
         if (timeToWriteSignalQualityReport) {
             reportTimer.restart();
         }

--- a/src/vinylcontrol/vinylcontrolprocessor.cpp
+++ b/src/vinylcontrol/vinylcontrolprocessor.cpp
@@ -3,6 +3,7 @@
 #include "control/controlpushbutton.h"
 #include "moc_vinylcontrolprocessor.cpp"
 #include "util/defs.h"
+#include "util/performancetimer.h"
 #include "util/sample.h"
 #include "util/timer.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
@@ -76,13 +77,24 @@ void VinylControlProcessor::requestReloadConfig() {
 }
 
 void VinylControlProcessor::run() {
-    unsigned static id = 0; //the id of this thread, for debugging purposes //XXX copypasta (should factor this out somehow), -kousu 2/2009
+    unsigned static id = 0; // the id of this thread, for debugging purposes
+    // FIXME copypasta (should factor this out somehow), -kousu 2/2009
     QThread::currentThread()->setObjectName(QString("VinylControlProcessor %1").arg(++id));
+
+    PerformanceTimer reportTimer;
+    reportTimer.start();
 
     while (!m_bQuit) {
         if (m_bReloadConfig) {
             reloadConfig();
             m_bReloadConfig = false;
+        }
+
+        bool timeToWriteSignalQualityReport = m_bReportSignalQuality &&
+                reportTimer.elapsed().toIntegerMillis() >=
+                        MIXXX_VINYL_SCOPE_UPDATE_LATENCY_MS;
+        if (timeToWriteSignalQualityReport) {
+            reportTimer.restart();
         }
 
         for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
@@ -108,16 +120,18 @@ void VinylControlProcessor::run() {
                 }
             }
 
-            // TODO(rryan) define a time-based update rate. This will update way
-            // too quickly.
-            if (pProcessor && m_bReportSignalQuality) {
+            // If enabled, update the report at the same rate we use to call
+            // VinylControlManager::updateSignalQualityListeners()
+            if (pProcessor && timeToWriteSignalQualityReport) {
                 VinylSignalQualityReport report;
                 if (pProcessor->writeQualityReport(&report)) {
                     report.processor = i;
-                    if (m_signalQualityFifo.write(&report, 1) != 1) {
+                    if (m_signalQualityFifo.write(&report, 1) == 1) {
+                    } else {
                         qWarning() << "VinylControlProcessor could not write signal quality report for VC index:" << i;
                     }
                 }
+                emit qualityReportWritten();
             }
         }
 

--- a/src/vinylcontrol/vinylcontrolprocessor.h
+++ b/src/vinylcontrol/vinylcontrolprocessor.h
@@ -54,6 +54,9 @@ class VinylControlProcessor : public QThread, public AudioDestination {
     // AudioInput index.
     void receiveBuffer(const AudioInput& input, const CSAMPLE* pBuffer, unsigned int iNumFrames);
 
+  signals:
+    void qualityReportWritten();
+
   protected:
     void run();
 


### PR DESCRIPTION
Same rate as used by `VinylControlManager::updateSignalQualityListeners()` which updates the signal graph in the spinnies (if enabled) and the Vinyl preferences (if visible).