### PR TITLE
Library: highlight harmonically compatible tracks for the loaded deck's key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [2.7.0](https://github.com/mixxxdj/mixxx/milestone/47) (Unreleased)
 
+* Highlight harmonically compatible tracks in the library for the loaded deck's key [#14823](https://github.com/mixxxdj/mixxx/issues/14823)
+
 ## [2.6.0](https://github.com/mixxxdj/mixxx/milestone/44) (Unreleased)
 
 ### STEM file support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1436,6 +1436,7 @@ add_library(
   src/library/itunes/itunesplaylistmodel.cpp
   src/library/itunes/itunestrackmodel.cpp
   src/library/itunes/itunesxmlimporter.cpp
+  src/library/keyhighlightmanager.cpp
   src/library/library_prefs.cpp
   src/library/library.cpp
   src/library/librarycontrol.cpp
@@ -2931,6 +2932,7 @@ if(BUILD_TESTING)
     src/test/indexrange_test.cpp
     src/test/itunesxmlimportertest.cpp
     src/test/keyfactorytest.cpp
+    src/test/keyhighlightmanagertest.cpp
     src/test/keyutilstest.cpp
     src/test/lcstest.cpp
     src/test/learningutilstest.cpp

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -84,6 +84,8 @@ passthrough Ctrl+j
 vinylcontrol_mode Ctrl+Shift+Y
 vinylcontrol_cueing Ctrl+Alt+Y
 
+key_highlight Alt+1
+
 [Channel2]
 play l
 cue_set Shift+l
@@ -136,6 +138,8 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
+
+key_highlight Alt+2
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,11 +96,17 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.7.0" type="development" date="2026-04-03" timestamp="1775221182">
+    <release version="2.7.0" type="development" date="2026-06-03" timestamp="1780503206">
       <description>
+ <ul>
+  <li>
+   Highlight harmonically compatible tracks in the library for the loaded deck's key
+   #14823
+  </li>
+ </ul>
 </description>
     </release>
-    <release version="2.6.0" type="development" date="2026-04-03" timestamp="1775221182">
+    <release version="2.6.0" type="development" date="2026-06-03" timestamp="1780503206">
       <description>
  <p>
   STEM file support
@@ -1954,7 +1960,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.5.5" type="development" date="2026-04-03" timestamp="1775221182">
+    <release version="2.5.5" type="development" date="2026-06-03" timestamp="1780503206">
       <description>
  <p>
   Note: Version 2.5.5 has been skipped following an issue in the release workflow.

--- a/src/engine/controls/keycontrol.cpp
+++ b/src/engine/controls/keycontrol.cpp
@@ -33,6 +33,7 @@ KeyControl::KeyControl(const QString& group,
                   ConfigKey(group, "reset_key"))),
           m_keylockMode(std::make_unique<ControlPushButton>(ConfigKey(group, "keylockMode"))),
           m_keyunlockMode(std::make_unique<ControlPushButton>(ConfigKey(group, "keyunlockMode"))),
+          m_pKeyHighlight(std::make_unique<ControlPushButton>(ConfigKey(group, "key_highlight"))),
           m_pFileKey(std::make_unique<ControlObject>(ConfigKey(group, "file_key"))),
           m_pEngineKey(std::make_unique<ControlObject>(ConfigKey(group, "key"))),
           m_pEngineKeyDistance(std::make_unique<ControlPotmeter>(
@@ -55,6 +56,8 @@ KeyControl::KeyControl(const QString& group,
     m_keylockMode->setButtonMode(mixxx::control::ButtonMode::Toggle);
 
     m_keyunlockMode->setButtonMode(mixxx::control::ButtonMode::Toggle);
+
+    m_pKeyHighlight->setButtonMode(mixxx::control::ButtonMode::Toggle);
 
     connect(m_pPitch.get(),
             &ControlObject::valueChanged,

--- a/src/engine/controls/keycontrol.h
+++ b/src/engine/controls/keycontrol.h
@@ -63,6 +63,12 @@ class KeyControl : public EngineControl {
     std::unique_ptr<ControlPushButton> m_keylockMode;
     std::unique_ptr<ControlPushButton> m_keyunlockMode;
 
+    // Per-deck toggle for the harmonic key highlighter in the library.
+    // When enabled, the library track table is tinted by each track's
+    // harmonic relationship to this deck's current engine key.
+    // Read by KeyHighlightManager via a ControlProxy.
+    std::unique_ptr<ControlPushButton> m_pKeyHighlight;
+
     // The current loaded file's detected key
     std::unique_ptr<ControlObject> m_pFileKey;
 

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -9,6 +9,7 @@
 #include "base/Pitch.h"
 #include "library/coverartcache.h"
 #include "library/dao/trackschema.h"
+#include "library/keyhighlightmanager.h"
 #include "library/starrating.h"
 #include "library/tabledelegates/bpmdelegate.h"
 #include "library/tabledelegates/checkboxdelegate.h"
@@ -41,6 +42,47 @@
 namespace {
 
 const mixxx::Logger kLogger("BaseTrackTableModel");
+
+// Background palette for the harmonic key highlighter. The green tiers shade by
+// harmonic closeness (perfect = darkest); yellow marks a +/-1 semitone shift;
+// red is out of key. Played tracks get a dark blue that takes precedence. These
+// are sensible defaults; a skin/QSS override hook can be added later.
+const QColor kKeyHighlightGreenPerfect(0x1B, 0x78, 0x37);
+const QColor kKeyHighlightGreenNeighbour(0x7F, 0xBF, 0x7B);
+const QColor kKeyHighlightYellow(0xF4, 0xD0, 0x3F);
+const QColor kKeyHighlightRed(0xC0, 0x39, 0x2B);
+const QColor kKeyHighlightPlayed(0x1A, 0x2A, 0x44);
+
+// Returns a text colour with enough contrast to read on the given highlight
+// background. The light tiers (neighbour green, yellow) need dark text; the
+// dark tiers need light text.
+QColor keyHighlightForeground(KeyUtils::KeyHighlightClass highlightClass) {
+    switch (highlightClass) {
+    case KeyUtils::KeyHighlightClass::GreenNeighbour:
+    case KeyUtils::KeyHighlightClass::Yellow:
+        return QColor(Qt::black);
+    default:
+        return QColor(Qt::white);
+    }
+}
+
+// Returns the background colour for a highlight class, or an invalid QColor for
+// None (caller falls through to default behaviour).
+QColor keyHighlightBackground(KeyUtils::KeyHighlightClass highlightClass) {
+    switch (highlightClass) {
+    case KeyUtils::KeyHighlightClass::GreenPerfect:
+        return kKeyHighlightGreenPerfect;
+    case KeyUtils::KeyHighlightClass::GreenNeighbour:
+        return kKeyHighlightGreenNeighbour;
+    case KeyUtils::KeyHighlightClass::Yellow:
+        return kKeyHighlightYellow;
+    case KeyUtils::KeyHighlightClass::Red:
+        return kKeyHighlightRed;
+    case KeyUtils::KeyHighlightClass::None:
+        return QColor();
+    }
+    return QColor();
+}
 
 constexpr double kRelativeHeightOfCoverartToolTip =
         0.165; // Height of the image for the cover art tooltip (Relative to the available screen size)
@@ -86,6 +128,7 @@ int BaseTrackTableModel::s_bpmColumnPrecision =
         kBpmColumnPrecisionDefault;
 bool BaseTrackTableModel::s_keyColorsEnabled = kKeyColorsEnabledDefault;
 std::optional<ColorPalette> BaseTrackTableModel::s_keyColorPalette;
+mixxx::KeyHighlightManager* BaseTrackTableModel::s_pKeyHighlightManager = nullptr;
 
 // static
 void BaseTrackTableModel::setBpmColumnPrecision(int precision) {
@@ -106,6 +149,12 @@ void BaseTrackTableModel::setKeyColorsEnabled(bool keyColorsEnabled) {
 // static
 void BaseTrackTableModel::setKeyColorPalette(const ColorPalette& palette) {
     s_keyColorPalette = palette;
+}
+
+// static
+void BaseTrackTableModel::setKeyHighlightManager(
+        mixxx::KeyHighlightManager* pManager) {
+    s_pKeyHighlightManager = pManager;
 }
 
 bool BaseTrackTableModel::s_bApplyPlayedTrackColor =
@@ -147,6 +196,12 @@ BaseTrackTableModel::BaseTrackTableModel(
                 &CoverArtCache::coverFound,
                 this,
                 &BaseTrackTableModel::slotCoverFound);
+    }
+    if (s_pKeyHighlightManager) {
+        connect(s_pKeyHighlightManager,
+                &mixxx::KeyHighlightManager::highlightChanged,
+                this,
+                &BaseTrackTableModel::slotKeyHighlightChanged);
     }
 }
 
@@ -415,6 +470,38 @@ QVariant BaseTrackTableModel::data(
     }
 
     if (role == Qt::BackgroundRole) {
+        // While the harmonic key highlighter is active it tints the whole row,
+        // overriding the per-track colour label. Played tracks take precedence
+        // and get a dark blue (you usually don't want to replay them).
+        if (s_pKeyHighlightManager && s_pKeyHighlightManager->isActive()) {
+            // A missing file is a more important warning than the harmonic hint;
+            // fall through to the default background so it doesn't get a green
+            // tint fighting the red "missing" text set in the ForegroundRole
+            // branch below. Mirrors the precedence there.
+            const auto missingRaw = rawSiblingValue(
+                    index,
+                    ColumnCache::COLUMN_TRACKLOCATIONSTABLE_FSDELETED);
+            const bool missing = !missingRaw.isNull() &&
+                    missingRaw.canConvert<bool>() && missingRaw.toBool();
+            if (!missing) {
+                if (s_bApplyPlayedTrackColor) {
+                    const auto playedRaw = rawSiblingValue(
+                            index,
+                            ColumnCache::COLUMN_LIBRARYTABLE_PLAYED);
+                    if (!playedRaw.isNull() &&
+                            playedRaw.canConvert<bool>() &&
+                            playedRaw.toBool()) {
+                        return QBrush(kKeyHighlightPlayed);
+                    }
+                }
+                const auto bgColor =
+                        keyHighlightBackground(keyHighlightClassForIndex(index));
+                if (bgColor.isValid()) {
+                    return QBrush(bgColor);
+                }
+            }
+            // Missing, or no key on this track -> fall through to the default.
+        }
         const auto rgbColorValue = rawSiblingValue(
                 index,
                 ColumnCache::COLUMN_LIBRARYTABLE_COLOR);
@@ -432,7 +519,8 @@ QVariant BaseTrackTableModel::data(
         // Custom text color for missing tracks
         // Visible in playlists, crates and Missing feature.
         // Check this first so played, missing tracks (unlikely case, but possible)
-        // get the 'missing' color.
+        // get the 'missing' color. This also takes precedence over the key
+        // highlighter, since a missing file is a more important warning.
         // Note: this is not helpful in Tracks -> Missing, so override it with
         // the regular track color (WTrackTableView { color: #xxx; }) like this:
         // #DlgMissing WTrackTableView { qproperty-trackMissingColor: #xxx; }
@@ -444,18 +532,35 @@ QVariant BaseTrackTableModel::data(
                 missingRaw.toBool()) {
             return QVariant::fromValue(m_trackMissingColor);
         }
+        // Read PLAYED once and reuse it for both the highlighter-active branch
+        // (light text on the dark-blue played background) and the regular
+        // played-track text colour below.
+        QVariant playedRaw;
+        bool played = false;
         if (s_bApplyPlayedTrackColor) {
-            // Custom text color for played tracks
-            auto playedRaw = rawSiblingValue(
-                    index,
-                    ColumnCache::COLUMN_LIBRARYTABLE_PLAYED);
-            if (!playedRaw.isNull() &&
-                    playedRaw.canConvert<bool>() &&
-                    playedRaw.toBool()) {
-                // TODO Maybe adjust color for bright track colors?
-                // Here or in DefaultDelegate
-                return QVariant::fromValue(m_trackPlayedColor);
+            playedRaw = rawSiblingValue(
+                    index, ColumnCache::COLUMN_LIBRARYTABLE_PLAYED);
+            played = !playedRaw.isNull() &&
+                    playedRaw.canConvert<bool>() && playedRaw.toBool();
+        }
+        // When the key highlighter paints a row background, pick a contrasting
+        // text colour. Played tracks get a dark blue background, so use light
+        // text there too.
+        if (s_pKeyHighlightManager && s_pKeyHighlightManager->isActive()) {
+            if (played) {
+                return QVariant::fromValue(QColor(Qt::white));
             }
+            const auto highlightClass = keyHighlightClassForIndex(index);
+            if (highlightClass != KeyUtils::KeyHighlightClass::None) {
+                return QVariant::fromValue(
+                        keyHighlightForeground(highlightClass));
+            }
+        }
+        if (played) {
+            // Custom text color for played tracks
+            // TODO Maybe adjust color for bright track colors?
+            // Here or in DefaultDelegate
+            return QVariant::fromValue(m_trackPlayedColor);
         }
     }
 
@@ -511,6 +616,29 @@ QVariant BaseTrackTableModel::rawSiblingValue(
     }
     const QModelIndex siblingIndex = index.sibling(index.row(), siblingColumn);
     return rawValue(siblingIndex);
+}
+
+KeyUtils::KeyHighlightClass BaseTrackTableModel::keyHighlightClassForIndex(
+        const QModelIndex& index) const {
+    if (!s_pKeyHighlightManager || !s_pKeyHighlightManager->isActive()) {
+        return KeyUtils::KeyHighlightClass::None;
+    }
+    const QVariant keyCodeValue = rawSiblingValue(
+            index,
+            ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID);
+    if (keyCodeValue.isNull()) {
+        return KeyUtils::KeyHighlightClass::None;
+    }
+    bool ok;
+    const int keyCode = keyCodeValue.toInt(&ok);
+    if (!ok) {
+        return KeyUtils::KeyHighlightClass::None;
+    }
+    const auto key = KeyUtils::keyFromNumericValue(keyCode);
+    if (key == mixxx::track::io::key::INVALID) {
+        return KeyUtils::KeyHighlightClass::None;
+    }
+    return s_pKeyHighlightManager->classOf(key);
 }
 
 bool BaseTrackTableModel::setData(
@@ -1145,6 +1273,21 @@ void BaseTrackTableModel::slotRefreshOverviewRows(const QList<int>& rows) {
 
 void BaseTrackTableModel::slotRefreshAllRows() {
     select();
+}
+
+void BaseTrackTableModel::slotKeyHighlightChanged() {
+    const int rows = rowCount();
+    const int columns = columnCount();
+    if (rows <= 0 || columns <= 0) {
+        return;
+    }
+    // The highlighter tints the whole row, so repaint every visible cell. We
+    // only changed how the background/foreground are derived, so restrict the
+    // notification to those roles to avoid unnecessary re-layout. This does not
+    // re-query the database.
+    emit dataChanged(index(0, 0),
+            index(rows - 1, columns - 1),
+            {Qt::BackgroundRole, Qt::ForegroundRole});
 }
 
 void BaseTrackTableModel::slotTracksRemoved(const QSet<TrackId>& trackIds) {

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -470,10 +470,14 @@ QVariant BaseTrackTableModel::data(
     }
 
     if (role == Qt::BackgroundRole) {
-        // While the harmonic key highlighter is active it tints the whole row,
-        // overriding the per-track colour label. Played tracks take precedence
-        // and get a dark blue (you usually don't want to replay them).
-        if (s_pKeyHighlightManager && s_pKeyHighlightManager->isActive()) {
+        // While the harmonic key highlighter is active it tints only the Key
+        // cell (Rekordbox-style), overriding the per-track colour label there.
+        // Played tracks take precedence and get a dark blue (you usually don't
+        // want to replay them). Non-key cells fall through to the normal
+        // per-track-colour background below.
+        if (s_pKeyHighlightManager && s_pKeyHighlightManager->isActive() &&
+                mapColumn(index.column()) ==
+                        ColumnCache::COLUMN_LIBRARYTABLE_KEY) {
             // A missing file is a more important warning than the harmonic hint;
             // fall through to the default background so it doesn't get a green
             // tint fighting the red "missing" text set in the ForegroundRole
@@ -543,10 +547,14 @@ QVariant BaseTrackTableModel::data(
             played = !playedRaw.isNull() &&
                     playedRaw.canConvert<bool>() && playedRaw.toBool();
         }
-        // When the key highlighter paints a row background, pick a contrasting
-        // text colour. Played tracks get a dark blue background, so use light
-        // text there too.
-        if (s_pKeyHighlightManager && s_pKeyHighlightManager->isActive()) {
+        // When the key highlighter paints the Key cell background, pick a
+        // contrasting text colour there. Played tracks get a dark blue
+        // background, so use light text too. This is scoped to the Key column to
+        // match the cell-only background; non-key cells keep their normal text
+        // colour (played/track colour) handled below.
+        if (s_pKeyHighlightManager && s_pKeyHighlightManager->isActive() &&
+                mapColumn(index.column()) ==
+                        ColumnCache::COLUMN_LIBRARYTABLE_KEY) {
             if (played) {
                 return QVariant::fromValue(QColor(Qt::white));
             }
@@ -585,6 +593,17 @@ QVariant BaseTrackTableModel::data(
         return QVariant();
     }
 
+    // Handle the harmonic key-highlight transpose-direction role for the key
+    // column. Only Yellow tracks carry a non-None direction; the delegate uses
+    // this to draw an up/down arrow beside the key.
+    if (role == kKeyShiftDirectionRole) {
+        const auto field = mapColumn(index.column());
+        if (field == ColumnCache::COLUMN_LIBRARYTABLE_KEY) {
+            return static_cast<int>(keyShiftDirectionForIndex(index));
+        }
+        return QVariant();
+    }
+
     // Only retrieve a value for supported roles
     if (role != Qt::DisplayRole &&
             role != Qt::EditRole &&
@@ -618,27 +637,44 @@ QVariant BaseTrackTableModel::rawSiblingValue(
     return rawValue(siblingIndex);
 }
 
+mixxx::track::io::key::ChromaticKey BaseTrackTableModel::keyFromIndex(
+        const QModelIndex& index) const {
+    const QVariant keyCodeValue = rawSiblingValue(
+            index,
+            ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID);
+    if (keyCodeValue.isNull()) {
+        return mixxx::track::io::key::INVALID;
+    }
+    bool ok;
+    const int keyCode = keyCodeValue.toInt(&ok);
+    if (!ok) {
+        return mixxx::track::io::key::INVALID;
+    }
+    return KeyUtils::keyFromNumericValue(keyCode);
+}
+
 KeyUtils::KeyHighlightClass BaseTrackTableModel::keyHighlightClassForIndex(
         const QModelIndex& index) const {
     if (!s_pKeyHighlightManager || !s_pKeyHighlightManager->isActive()) {
         return KeyUtils::KeyHighlightClass::None;
     }
-    const QVariant keyCodeValue = rawSiblingValue(
-            index,
-            ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID);
-    if (keyCodeValue.isNull()) {
-        return KeyUtils::KeyHighlightClass::None;
-    }
-    bool ok;
-    const int keyCode = keyCodeValue.toInt(&ok);
-    if (!ok) {
-        return KeyUtils::KeyHighlightClass::None;
-    }
-    const auto key = KeyUtils::keyFromNumericValue(keyCode);
+    const auto key = keyFromIndex(index);
     if (key == mixxx::track::io::key::INVALID) {
         return KeyUtils::KeyHighlightClass::None;
     }
     return s_pKeyHighlightManager->classOf(key);
+}
+
+KeyUtils::YellowShift BaseTrackTableModel::keyShiftDirectionForIndex(
+        const QModelIndex& index) const {
+    if (!s_pKeyHighlightManager || !s_pKeyHighlightManager->isActive()) {
+        return KeyUtils::YellowShift::None;
+    }
+    const auto key = keyFromIndex(index);
+    if (key == mixxx::track::io::key::INVALID) {
+        return KeyUtils::YellowShift::None;
+    }
+    return s_pKeyHighlightManager->directionOf(key);
 }
 
 bool BaseTrackTableModel::setData(
@@ -1277,17 +1313,20 @@ void BaseTrackTableModel::slotRefreshAllRows() {
 
 void BaseTrackTableModel::slotKeyHighlightChanged() {
     const int rows = rowCount();
-    const int columns = columnCount();
-    if (rows <= 0 || columns <= 0) {
+    if (rows <= 0) {
         return;
     }
-    // The highlighter tints the whole row, so repaint every visible cell. We
-    // only changed how the background/foreground are derived, so restrict the
-    // notification to those roles to avoid unnecessary re-layout. This does not
-    // re-query the database.
-    emit dataChanged(index(0, 0),
-            index(rows - 1, columns - 1),
-            {Qt::BackgroundRole, Qt::ForegroundRole});
+    // The highlighter now tints only the Key cell, so repaint just that column.
+    // We only changed how the background/foreground and the shift-direction
+    // arrow are derived, so restrict the notification to those roles to avoid
+    // unnecessary re-layout. This does not re-query the database.
+    const int keyColumn = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY);
+    if (keyColumn < 0) {
+        return;
+    }
+    emit dataChanged(index(0, keyColumn),
+            index(rows - 1, keyColumn),
+            {Qt::BackgroundRole, Qt::ForegroundRole, kKeyShiftDirectionRole});
 }
 
 void BaseTrackTableModel::slotTracksRemoved(const QSet<TrackId>& trackIds) {

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -639,6 +639,26 @@ QVariant BaseTrackTableModel::rawSiblingValue(
 
 mixxx::track::io::key::ChromaticKey BaseTrackTableModel::keyFromIndex(
         const QModelIndex& index) const {
+    // If this row's track is loaded on a pitched, highlighting deck, classify it
+    // by the key it is *currently playing*, not its stored key. The playing key
+    // is the highlighter's reference key, so a self-comparison yields
+    // GreenPerfect with no transpose arrow - a deck is perfectly mixable with
+    // itself. Using the stored key here would mislabel the pitched row as
+    // Yellow with a "pitch me one semitone" arrow it is already playing past.
+    //
+    // This substitution is exercised indirectly by
+    // KeyHighlightManagerTest.LoadedPitchedRowMatchesItself, which asserts the
+    // manager invariant it relies on (classOf(playingKey) == GreenPerfect,
+    // directionOf(playingKey) == None). A direct model-level data() test would
+    // need a TrackCollection/SQL fixture that does not yet exist for this model;
+    // see the PR follow-up note.
+    if (s_pKeyHighlightManager) {
+        const auto playingKey =
+                s_pKeyHighlightManager->playingKeyForTrack(getTrackId(index));
+        if (playingKey != mixxx::track::io::key::INVALID) {
+            return playingKey;
+        }
+    }
     const QVariant keyCodeValue = rawSiblingValue(
             index,
             ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID);
@@ -961,12 +981,29 @@ QVariant BaseTrackTableModel::roleValue(
             }
             return freq;
         }
-        case ColumnCache::COLUMN_LIBRARYTABLE_KEY:
+        case ColumnCache::COLUMN_LIBRARYTABLE_KEY: {
             // The Key value is determined by either the KEY_ID or KEY column
-            return KeyUtils::keyFromKeyTextAndIdFields(
+            const QVariant keyValue = KeyUtils::keyFromKeyTextAndIdFields(
                     rawValue,
                     rawSiblingValue(
                             index, ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID));
+            // When this track is loaded on a deck whose harmonic highlighter is
+            // on and whose pitch shifts the playing key away from the stored
+            // key, append the currently playing key in parentheses, e.g.
+            // "8A (9A)". Display only - tooltip and CSV export keep the plain
+            // stored key (they fall through to this case, so gate on the role).
+            if (role == Qt::DisplayRole && s_pKeyHighlightManager) {
+                const auto playingKey =
+                        s_pKeyHighlightManager->playingKeyForTrack(
+                                getTrackId(index));
+                if (playingKey != mixxx::track::io::key::INVALID) {
+                    return QVariant(keyValue.toString() +
+                            QStringLiteral(" (") +
+                            KeyUtils::keyToString(playingKey) + QChar(')'));
+                }
+            }
+            return keyValue;
+        }
         case ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN: {
             if (rawValue.isNull()) {
                 return QVariant();
@@ -1317,16 +1354,20 @@ void BaseTrackTableModel::slotKeyHighlightChanged() {
         return;
     }
     // The highlighter now tints only the Key cell, so repaint just that column.
-    // We only changed how the background/foreground and the shift-direction
-    // arrow are derived, so restrict the notification to those roles to avoid
-    // unnecessary re-layout. This does not re-query the database.
+    // We only changed how the background/foreground, the shift-direction arrow
+    // and the displayed key text (the pitched "(playing key)" suffix) are
+    // derived, so restrict the notification to those roles to avoid unnecessary
+    // re-layout. This does not re-query the database.
     const int keyColumn = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY);
     if (keyColumn < 0) {
         return;
     }
     emit dataChanged(index(0, keyColumn),
             index(rows - 1, keyColumn),
-            {Qt::BackgroundRole, Qt::ForegroundRole, kKeyShiftDirectionRole});
+            {Qt::BackgroundRole,
+                    Qt::ForegroundRole,
+                    Qt::DisplayRole,
+                    kKeyShiftDirectionRole});
 }
 
 void BaseTrackTableModel::slotTracksRemoved(const QSet<TrackId>& trackIds) {

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -7,11 +7,16 @@
 
 #include "library/columncache.h"
 #include "library/trackmodel.h"
+#include "track/keyutils.h"
 #include "track/track_decl.h"
 #include "util/color/colorpalette.h"
 #include "util/datetime.h"
 
 class TrackCollectionManager;
+
+namespace mixxx {
+class KeyHighlightManager;
+} // namespace mixxx
 
 /// Base class for tabular track list views.
 ///
@@ -129,6 +134,12 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     static void setKeyColorsEnabled(bool keyColorsEnabled);
 
     static void setKeyColorPalette(const ColorPalette& palette);
+
+    /// Sets the process-wide harmonic key highlighter coordinator consulted by
+    /// data() to tint rows. Owned by Library; may be nullptr (highlighter off).
+    /// Must be called before track table models are constructed so they can
+    /// connect to its highlightChanged() signal.
+    static void setKeyHighlightManager(mixxx::KeyHighlightManager* pManager);
 
     static constexpr bool kApplyPlayedTrackColorDefault = true;
     static void setApplyPlayedTrackColor(bool apply);
@@ -270,6 +281,11 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     void slotRefreshAllRows();
 
+    /// Repaints the visible rows when the key highlighter classification
+    /// changes. Emits dataChanged() for the Background/Foreground roles only;
+    /// it does not re-query the database.
+    void slotKeyHighlightChanged();
+
     void slotTracksRemoved(const QSet<TrackId>& trackIds);
 
     void slotCoverFound(
@@ -281,6 +297,12 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     QVariant rawSiblingValue(
             const QModelIndex& index,
             ColumnCache::Column siblingField) const;
+
+    // Returns the harmonic highlight class for the track at the given index
+    // against the currently active decks, or None if the highlighter is
+    // inactive or the track has no key.
+    KeyUtils::KeyHighlightClass keyHighlightClassForIndex(
+            const QModelIndex& index) const;
 
     // Track models may reference tracks by an external id
     // TODO: TrackId should only be used for tracks from
@@ -320,6 +342,10 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     // The value need to be left uninitialized (std::nullopt) to avoid static
     // initialization order issues
     static std::optional<ColorPalette> s_keyColorPalette;
+
+    // Process-wide harmonic key highlighter coordinator (owned by Library).
+    // nullptr when no Library has installed one.
+    static mixxx::KeyHighlightManager* s_pKeyHighlightManager;
 
     static bool s_bApplyPlayedTrackColor;
     static QString s_dateFormat;

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -298,10 +298,21 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
             const QModelIndex& index,
             ColumnCache::Column siblingField) const;
 
+    // Decodes the track's discrete key at the given index from its KEY_ID
+    // sibling column, or INVALID if absent/unparsable. Shared by the highlight
+    // class and shift-direction lookups.
+    mixxx::track::io::key::ChromaticKey keyFromIndex(
+            const QModelIndex& index) const;
+
     // Returns the harmonic highlight class for the track at the given index
     // against the currently active decks, or None if the highlighter is
     // inactive or the track has no key.
     KeyUtils::KeyHighlightClass keyHighlightClassForIndex(
+            const QModelIndex& index) const;
+
+    // Returns the semitone transpose direction for a Yellow track at the given
+    // index, or None if the highlighter is inactive or the track is not Yellow.
+    KeyUtils::YellowShift keyShiftDirectionForIndex(
             const QModelIndex& index) const;
 
     // Track models may reference tracks by an external id

--- a/src/library/keyhighlightmanager.cpp
+++ b/src/library/keyhighlightmanager.cpp
@@ -5,8 +5,10 @@
 #include <utility>
 
 #include "control/controlproxy.h"
+#include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
 #include "moc_keyhighlightmanager.cpp"
+#include "track/track.h"
 #include "util/defs.h"
 
 namespace mixxx {
@@ -21,6 +23,12 @@ KeyHighlightManager::KeyHighlightManager(QObject* pParent)
     m_directionTable.fill(KeyUtils::YellowShift::None);
     m_pNumDecks->connectValueChanged(
             this, &KeyHighlightManager::slotNumDecksChanged);
+    // Follow track load/eject on every deck so the playing-key suffix can be
+    // scoped to the loaded deck's row(s).
+    connect(&PlayerInfo::instance(),
+            &PlayerInfo::trackChanged,
+            this,
+            &KeyHighlightManager::slotTrackChanged);
     slotNumDecksChanged(m_pNumDecks->get());
 }
 
@@ -48,6 +56,30 @@ KeyUtils::YellowShift KeyHighlightManager::directionOf(
     return m_directionTable[index];
 }
 
+mixxx::track::io::key::ChromaticKey KeyHighlightManager::playingKeyForTrack(
+        TrackId trackId) const {
+    using mixxx::track::io::key::INVALID;
+    // The suffix is part of the highlighter feature: only show it while a deck
+    // is actively highlighting, and only for a track loaded on an enabled deck.
+    if (!m_active || !trackId.isValid()) {
+        return INVALID;
+    }
+    for (const DeckState& deck : std::as_const(m_decks)) {
+        if (!deck.enabled || deck.loadedTrackId != trackId) {
+            continue;
+        }
+        // Only a discrete pitch shift (playing key differs from the stored key)
+        // warrants the parenthetical; an unpitched deck shows just the key.
+        if (deck.key != INVALID && deck.fileKey != INVALID &&
+                deck.key != deck.fileKey) {
+            return deck.key;
+        }
+        // Mutual exclusion: at most one enabled deck, and it holds this track.
+        return INVALID;
+    }
+    return INVALID;
+}
+
 void KeyHighlightManager::slotNumDecksChanged(double dNumDecks) {
     int numDecks = static_cast<int>(dNumDecks);
     if (numDecks > kMaxNumberOfDecks) {
@@ -65,13 +97,41 @@ void KeyHighlightManager::slotNumDecksChanged(double dNumDecks) {
                 group, QStringLiteral("key_highlight"), this);
         deck.pKey = new ControlProxy(
                 group, QStringLiteral("key"), this);
+        deck.pFileKey = new ControlProxy(
+                group, QStringLiteral("file_key"), this);
         deck.pHighlight->connectValueChanged(
                 this, [this] { recompute(); });
         deck.pKey->connectValueChanged(
                 this, [this] { recompute(); });
+        // file_key changes on (re)analysis; keep the stored-key snapshot fresh.
+        deck.pFileKey->connectValueChanged(
+                this, [this] { recompute(); });
         m_decks.append(deck);
     }
     recompute();
+}
+
+void KeyHighlightManager::slotTrackChanged(
+        const QString& group,
+        TrackPointer pNewTrack,
+        TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack);
+    int deckNumber = -1;
+    if (!PlayerManager::isDeckGroup(group, &deckNumber)) {
+        return;
+    }
+    // isDeckGroup() yields a 1-based deck number; DeckState is 0-indexed.
+    const int deckIndex = deckNumber - 1;
+    if (deckIndex < 0 || deckIndex >= m_decks.size()) {
+        return;
+    }
+    const TrackId newTrackId = pNewTrack ? pNewTrack->getId() : TrackId();
+    if (m_decks[deckIndex].loadedTrackId == newTrackId) {
+        return;
+    }
+    m_decks[deckIndex].loadedTrackId = newTrackId;
+    // The set of pitched/loaded rows changed; refresh so the suffix follows.
+    emit highlightChanged();
 }
 
 void KeyHighlightManager::recompute() {
@@ -118,10 +178,14 @@ void KeyHighlightManager::recompute() {
         DeckState& deck = m_decks[i];
         const bool enabled = i < activeDecks && deck.pHighlight->toBool();
         const auto key = KeyUtils::keyFromNumericValue(deck.pKey->get());
-        if (enabled != deck.enabled || key != deck.key) {
+        const auto fileKey =
+                KeyUtils::keyFromNumericValue(deck.pFileKey->get());
+        if (enabled != deck.enabled || key != deck.key ||
+                fileKey != deck.fileKey) {
             discreteChanged = true;
             deck.enabled = enabled;
             deck.key = key;
+            deck.fileKey = fileKey;
         }
     }
     if (!discreteChanged) {

--- a/src/library/keyhighlightmanager.cpp
+++ b/src/library/keyhighlightmanager.cpp
@@ -1,0 +1,149 @@
+#include "library/keyhighlightmanager.h"
+
+#include <QString>
+#include <algorithm>
+
+#include "control/controlproxy.h"
+#include "mixer/playermanager.h"
+#include "moc_keyhighlightmanager.cpp"
+#include "util/defs.h"
+
+namespace mixxx {
+
+KeyHighlightManager::KeyHighlightManager(QObject* pParent)
+        : QObject(pParent),
+          m_pNumDecks(new ControlProxy(
+                  QStringLiteral("[App]"),
+                  QStringLiteral("num_decks"),
+                  this)) {
+    m_table.fill(KeyUtils::KeyHighlightClass::None);
+    m_pNumDecks->connectValueChanged(
+            this, &KeyHighlightManager::slotNumDecksChanged);
+    slotNumDecksChanged(m_pNumDecks->get());
+}
+
+KeyUtils::KeyHighlightClass KeyHighlightManager::classOf(
+        mixxx::track::io::key::ChromaticKey trackKey) const {
+    if (!m_active) {
+        return KeyUtils::KeyHighlightClass::None;
+    }
+    const int index = static_cast<int>(trackKey);
+    if (index < 0 || index >= static_cast<int>(m_table.size())) {
+        return KeyUtils::KeyHighlightClass::None;
+    }
+    return m_table[index];
+}
+
+void KeyHighlightManager::slotNumDecksChanged(double dNumDecks) {
+    int numDecks = static_cast<int>(dNumDecks);
+    if (numDecks > kMaxNumberOfDecks) {
+        numDecks = kMaxNumberOfDecks;
+    }
+    m_numDecks = numDecks;
+    // Only ever grow the set of watched proxies; mirrors VinylControlManager.
+    // num_decks can also shrink, in which case the surplus DeckStates remain in
+    // m_decks but are excluded from classification by the index < m_numDecks
+    // guards in recompute().
+    for (int i = m_decks.size(); i < numDecks; ++i) {
+        const QString group = PlayerManager::groupForDeck(i);
+        DeckState deck;
+        deck.pHighlight = new ControlProxy(
+                group, QStringLiteral("key_highlight"), this);
+        deck.pKey = new ControlProxy(
+                group, QStringLiteral("key"), this);
+        deck.pHighlight->connectValueChanged(
+                this, [this] { recompute(); });
+        deck.pKey->connectValueChanged(
+                this, [this] { recompute(); });
+        m_decks.append(deck);
+    }
+    recompute();
+}
+
+void KeyHighlightManager::recompute() {
+    // Guard against re-entrancy: enforceSingleActiveDeck() below clears the
+    // key_highlight control on other decks, and each such write loops back here
+    // via the connected proxies. We only need the outermost pass to rebuild.
+    if (m_recomputing) {
+        return;
+    }
+    m_recomputing = true;
+
+    // m_decks only grows, but num_decks can shrink; only decks below the current
+    // count participate. Surplus decks are forced inactive in the snapshot below.
+    const int activeDecks =
+            std::min(static_cast<int>(m_decks.size()), m_numDecks);
+
+    // The highlighter is mutually exclusive across decks: enabling one deck's
+    // highlight turns any other deck's off. We enforce this by writing 0 to the
+    // losing decks' key_highlight controls (rather than only suppressing them in
+    // our internal state) so a mapped controller LED / skin button reflects the
+    // true state. Detect a deck that has *just* been enabled (off in our
+    // snapshot, on now) and treat it as the winner.
+    int newlyEnabled = -1;
+    for (int i = 0; i < activeDecks; ++i) {
+        if (!m_decks[i].enabled && m_decks[i].pHighlight->toBool()) {
+            newlyEnabled = i;
+            // Last writer wins if (improbably) two flip on in the same cycle.
+        }
+    }
+    if (newlyEnabled >= 0) {
+        for (int i = 0; i < activeDecks; ++i) {
+            if (i != newlyEnabled && m_decks[i].pHighlight->toBool()) {
+                m_decks[i].pHighlight->set(0.0);
+            }
+        }
+    }
+
+    // Re-read every deck's enable flag and discrete key, and detect whether
+    // anything discrete actually changed (debounce against continuous pitch).
+    // Decks at or beyond the current num_decks are treated as disabled so a
+    // shrink stops them from contributing.
+    bool discreteChanged = false;
+    for (int i = 0; i < m_decks.size(); ++i) {
+        DeckState& deck = m_decks[i];
+        const bool enabled = i < activeDecks && deck.pHighlight->toBool();
+        const auto key = KeyUtils::keyFromNumericValue(deck.pKey->get());
+        if (enabled != deck.enabled || key != deck.key) {
+            discreteChanged = true;
+            deck.enabled = enabled;
+            deck.key = key;
+        }
+    }
+    if (!discreteChanged) {
+        m_recomputing = false;
+        return;
+    }
+
+    // Collect the reference keys of all enabled decks with a valid key.
+    QList<mixxx::track::io::key::ChromaticKey> refKeys;
+    for (const DeckState& deck : m_decks) {
+        if (deck.enabled && deck.key != mixxx::track::io::key::INVALID) {
+            refKeys.append(deck.key);
+        }
+    }
+
+    const bool active = !refKeys.isEmpty();
+
+    // Rebuild the table: for each possible track key, take the best (lowest
+    // severity) class across all reference keys. KeyHighlightClass is ordered
+    // so that the numerically smallest value is the most mixable.
+    for (int i = 0; i < static_cast<int>(m_table.size()); ++i) {
+        const auto trackKey =
+                static_cast<mixxx::track::io::key::ChromaticKey>(i);
+        KeyUtils::KeyHighlightClass best = KeyUtils::KeyHighlightClass::None;
+        for (const auto refKey : refKeys) {
+            const auto c = KeyUtils::classifyAgainst(trackKey, refKey);
+            if (static_cast<int>(c) < static_cast<int>(best)) {
+                best = c;
+            }
+        }
+        m_table[i] = best;
+    }
+
+    m_active = active;
+    m_recomputing = false;
+    emit highlightChanged();
+}
+
+} // namespace mixxx

--- a/src/library/keyhighlightmanager.cpp
+++ b/src/library/keyhighlightmanager.cpp
@@ -2,6 +2,7 @@
 
 #include <QString>
 #include <algorithm>
+#include <utility>
 
 #include "control/controlproxy.h"
 #include "mixer/playermanager.h"
@@ -17,6 +18,7 @@ KeyHighlightManager::KeyHighlightManager(QObject* pParent)
                   QStringLiteral("num_decks"),
                   this)) {
     m_table.fill(KeyUtils::KeyHighlightClass::None);
+    m_directionTable.fill(KeyUtils::YellowShift::None);
     m_pNumDecks->connectValueChanged(
             this, &KeyHighlightManager::slotNumDecksChanged);
     slotNumDecksChanged(m_pNumDecks->get());
@@ -32,6 +34,18 @@ KeyUtils::KeyHighlightClass KeyHighlightManager::classOf(
         return KeyUtils::KeyHighlightClass::None;
     }
     return m_table[index];
+}
+
+KeyUtils::YellowShift KeyHighlightManager::directionOf(
+        mixxx::track::io::key::ChromaticKey trackKey) const {
+    if (!m_active) {
+        return KeyUtils::YellowShift::None;
+    }
+    const int index = static_cast<int>(trackKey);
+    if (index < 0 || index >= static_cast<int>(m_directionTable.size())) {
+        return KeyUtils::YellowShift::None;
+    }
+    return m_directionTable[index];
 }
 
 void KeyHighlightManager::slotNumDecksChanged(double dNumDecks) {
@@ -117,7 +131,7 @@ void KeyHighlightManager::recompute() {
 
     // Collect the reference keys of all enabled decks with a valid key.
     QList<mixxx::track::io::key::ChromaticKey> refKeys;
-    for (const DeckState& deck : m_decks) {
+    for (const DeckState& deck : std::as_const(m_decks)) {
         if (deck.enabled && deck.key != mixxx::track::io::key::INVALID) {
             refKeys.append(deck.key);
         }
@@ -127,18 +141,30 @@ void KeyHighlightManager::recompute() {
 
     // Rebuild the table: for each possible track key, take the best (lowest
     // severity) class across all reference keys. KeyHighlightClass is ordered
-    // so that the numerically smallest value is the most mixable.
+    // so that the numerically smallest value is the most mixable. We also track
+    // which reference key produced that best class, so the transpose direction
+    // we store corresponds to the same deck whose colour the track gets (the
+    // direction is meaningless otherwise). Today mutual exclusion guarantees a
+    // single reference key, but capturing the winner keeps this correct if that
+    // is ever relaxed.
     for (int i = 0; i < static_cast<int>(m_table.size()); ++i) {
         const auto trackKey =
                 static_cast<mixxx::track::io::key::ChromaticKey>(i);
         KeyUtils::KeyHighlightClass best = KeyUtils::KeyHighlightClass::None;
+        auto winningRefKey = mixxx::track::io::key::INVALID;
         for (const auto refKey : refKeys) {
             const auto c = KeyUtils::classifyAgainst(trackKey, refKey);
             if (static_cast<int>(c) < static_cast<int>(best)) {
                 best = c;
+                winningRefKey = refKey;
             }
         }
         m_table[i] = best;
+        // Only Yellow tracks carry a direction; force None for everything else
+        // so a stale arrow never leaks onto a green or red cell.
+        m_directionTable[i] = (best == KeyUtils::KeyHighlightClass::Yellow)
+                ? KeyUtils::yellowShiftDirection(trackKey, winningRefKey)
+                : KeyUtils::YellowShift::None;
     }
 
     m_active = active;

--- a/src/library/keyhighlightmanager.h
+++ b/src/library/keyhighlightmanager.h
@@ -40,6 +40,14 @@ class KeyHighlightManager : public QObject {
     KeyUtils::KeyHighlightClass classOf(
             mixxx::track::io::key::ChromaticKey trackKey) const;
 
+    /// For a track key classified Yellow, the direction it must be transposed by
+    /// one semitone to become compatible. O(1) table lookup; the stored value
+    /// comes from the same reference key that produced classOf()'s class, so the
+    /// hint always matches the colour. Returns None for non-Yellow keys or when
+    /// inactive.
+    KeyUtils::YellowShift directionOf(
+            mixxx::track::io::key::ChromaticKey trackKey) const;
+
   signals:
     /// Emitted whenever the classification table or the active state changes,
     /// so observers (the track table models) can repaint.
@@ -76,6 +84,12 @@ class KeyHighlightManager : public QObject {
     std::array<KeyUtils::KeyHighlightClass,
             mixxx::track::io::key::ChromaticKey_ARRAYSIZE>
             m_table;
+    // Parallel table of transpose directions, only meaningful for keys whose
+    // m_table entry is Yellow; None elsewhere. Filled from the reference key
+    // that won the best-class comparison in recompute().
+    std::array<KeyUtils::YellowShift,
+            mixxx::track::io::key::ChromaticKey_ARRAYSIZE>
+            m_directionTable;
     bool m_active = false;
     // Re-entrancy guard for recompute(): enforcing single-active-deck writes to
     // other decks' key_highlight controls, which loop back into recompute().

--- a/src/library/keyhighlightmanager.h
+++ b/src/library/keyhighlightmanager.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <QList>
+#include <QObject>
+#include <array>
+
+#include "proto/keys.pb.h"
+#include "track/keyutils.h"
+
+class ControlProxy;
+
+namespace mixxx {
+
+/// Coordinates the per-deck "harmonic key highlighter" for the library track
+/// table. It watches `[App],num_decks` and, for each deck, the
+/// `[ChannelN],key_highlight` toggle and the `[ChannelN],key` engine key. From
+/// the set of enabled decks it precomputes a lookup table mapping every
+/// ChromaticKey to a KeyUtils::KeyHighlightClass, so the model can colour each
+/// row with an O(1) lookup.
+///
+/// Recomputation is debounced on the *discrete* key: the engine key control
+/// updates continuously as the pitch changes, but the classification only
+/// depends on the rounded ChromaticKey, so the table is only rebuilt (and
+/// highlightChanged() only emitted) when a deck's discrete key or enable flag
+/// actually changes.
+class KeyHighlightManager : public QObject {
+    Q_OBJECT
+  public:
+    explicit KeyHighlightManager(QObject* pParent = nullptr);
+    ~KeyHighlightManager() override = default;
+
+    /// Whether at least one deck has the highlighter enabled and a valid key,
+    /// i.e. whether the library should currently be tinted at all.
+    bool isActive() const {
+        return m_active;
+    }
+
+    /// The highlight class for a track key given the currently active decks.
+    /// O(1) table lookup. Returns None for INVALID keys or when inactive.
+    KeyUtils::KeyHighlightClass classOf(
+            mixxx::track::io::key::ChromaticKey trackKey) const;
+
+  signals:
+    /// Emitted whenever the classification table or the active state changes,
+    /// so observers (the track table models) can repaint.
+    void highlightChanged();
+
+  private slots:
+    void slotNumDecksChanged(double dNumDecks);
+
+  private:
+    /// Per-deck state, snapshotted to debounce continuous key changes. The
+    /// ControlProxy pointers are owned by this QObject (Qt parent ownership),
+    /// like VinylControlManager's deck proxies.
+    struct DeckState {
+        ControlProxy* pHighlight = nullptr;
+        ControlProxy* pKey = nullptr;
+        bool enabled = false;
+        mixxx::track::io::key::ChromaticKey key =
+                mixxx::track::io::key::INVALID;
+    };
+
+    /// Re-reads every deck's enable flag and discrete key. If anything discrete
+    /// changed, rebuilds the table and emits highlightChanged().
+    void recompute();
+
+    ControlProxy* m_pNumDecks;
+    QList<DeckState> m_decks;
+    // The current deck count. m_decks only ever grows (proxies persist), but
+    // num_decks can shrink; decks at index >= m_numDecks are inactive and must
+    // not contribute reference keys. See recompute().
+    int m_numDecks = 0;
+
+    // Lookup table indexed by ChromaticKey (0 == INVALID .. 24). Entry 0 is
+    // always None.
+    std::array<KeyUtils::KeyHighlightClass,
+            mixxx::track::io::key::ChromaticKey_ARRAYSIZE>
+            m_table;
+    bool m_active = false;
+    // Re-entrancy guard for recompute(): enforcing single-active-deck writes to
+    // other decks' key_highlight controls, which loop back into recompute().
+    bool m_recomputing = false;
+};
+
+} // namespace mixxx

--- a/src/library/keyhighlightmanager.h
+++ b/src/library/keyhighlightmanager.h
@@ -2,10 +2,13 @@
 
 #include <QList>
 #include <QObject>
+#include <QString>
 #include <array>
 
 #include "proto/keys.pb.h"
 #include "track/keyutils.h"
+#include "track/track_decl.h"
+#include "track/trackid.h"
 
 class ControlProxy;
 
@@ -13,10 +16,12 @@ namespace mixxx {
 
 /// Coordinates the per-deck "harmonic key highlighter" for the library track
 /// table. It watches `[App],num_decks` and, for each deck, the
-/// `[ChannelN],key_highlight` toggle and the `[ChannelN],key` engine key. From
-/// the set of enabled decks it precomputes a lookup table mapping every
-/// ChromaticKey to a KeyUtils::KeyHighlightClass, so the model can colour each
-/// row with an O(1) lookup.
+/// `[ChannelN],key_highlight` toggle, the `[ChannelN],key` engine (playing) key
+/// and the `[ChannelN],file_key` stored key. From the set of enabled decks it
+/// precomputes a lookup table mapping every ChromaticKey to a
+/// KeyUtils::KeyHighlightClass, so the model can colour each row with an O(1)
+/// lookup. It also tracks each deck's loaded track so the model can show the
+/// pitched playing key beside the stored key on that track's row.
 ///
 /// Recomputation is debounced on the *discrete* key: the engine key control
 /// updates continuously as the pitch changes, but the classification only
@@ -48,6 +53,16 @@ class KeyHighlightManager : public QObject {
     KeyUtils::YellowShift directionOf(
             mixxx::track::io::key::ChromaticKey trackKey) const;
 
+    /// The currently playing (pitch-shifted) key to display in parentheses next
+    /// to a track's stored key, or INVALID when no suffix should be shown.
+    /// Returns a valid key only when the highlighter is active, an enabled deck
+    /// has this track loaded, and that deck's discrete playing key differs from
+    /// the track's stored (file) key - i.e. the deck is pitched far enough to
+    /// change the discrete key. Mutual exclusion means at most one enabled deck
+    /// today, so the first match wins.
+    mixxx::track::io::key::ChromaticKey playingKeyForTrack(
+            TrackId trackId) const;
+
   signals:
     /// Emitted whenever the classification table or the active state changes,
     /// so observers (the track table models) can repaint.
@@ -55,6 +70,12 @@ class KeyHighlightManager : public QObject {
 
   private slots:
     void slotNumDecksChanged(double dNumDecks);
+    /// Tracks which track is loaded on each deck so playingKeyForTrack() can
+    /// scope the "(playing key)" suffix to the loaded deck's row(s).
+    void slotTrackChanged(
+            const QString& group,
+            TrackPointer pNewTrack,
+            TrackPointer pOldTrack);
 
   private:
     /// Per-deck state, snapshotted to debounce continuous key changes. The
@@ -63,9 +84,17 @@ class KeyHighlightManager : public QObject {
     struct DeckState {
         ControlProxy* pHighlight = nullptr;
         ControlProxy* pKey = nullptr;
+        ControlProxy* pFileKey = nullptr;
         bool enabled = false;
         mixxx::track::io::key::ChromaticKey key =
                 mixxx::track::io::key::INVALID;
+        // The loaded track's stored/analysed key, snapshotted alongside `key`.
+        // Compared against `key` to detect a pitch shift worth displaying.
+        mixxx::track::io::key::ChromaticKey fileKey =
+                mixxx::track::io::key::INVALID;
+        // The track currently loaded on this deck (invalid if none), updated by
+        // slotTrackChanged(). Used to map a library row to a pitched deck.
+        TrackId loadedTrackId;
     };
 
     /// Re-reads every deck's enable flag and discrete key. If anything discrete

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -9,12 +9,14 @@
 #include "library/analysis/analysisfeature.h"
 #include "library/autodj/autodjfeature.h"
 #include "library/banshee/bansheefeature.h"
+#include "library/basetracktablemodel.h"
 #include "library/browse/browsefeature.h"
 #ifdef __ENGINEPRIME__
 #include "library/export/libraryexporter.h"
 #endif
 #include "library/externaltrackcollection.h"
 #include "library/itunes/itunesfeature.h"
+#include "library/keyhighlightmanager.h"
 #include "library/library_prefs.h"
 #include "library/librarycontrol.h"
 #include "library/libraryfeature.h"
@@ -71,10 +73,17 @@ Library::Library(
           m_pTrackCollectionManager(pTrackCollectionManager),
           m_pSidebarModel(make_parented<SidebarModel>(this)),
           m_pLibraryControl(make_parented<LibraryControl>(this)),
+          m_pKeyHighlightManager(
+                  make_parented<mixxx::KeyHighlightManager>(this)),
           m_pLibraryWidget(nullptr),
           m_pKeyNotation(std::make_unique<ControlObject>(
                   mixxx::library::prefs::kKeyNotationConfigKey, false)) {
     qRegisterMetaType<LibraryRemovalType>("LibraryRemovalType");
+
+    // Make the harmonic key highlighter available to all track table models.
+    // Must happen before any feature (and thus any model) is constructed so the
+    // models connect to its highlightChanged() signal.
+    BaseTrackTableModel::setKeyHighlightManager(m_pKeyHighlightManager.get());
 
     connect(m_pTrackCollectionManager,
             &TrackCollectionManager::libraryScanFinished,
@@ -269,7 +278,11 @@ Library::Library(
             kEditMetadataSelectedClickDefault);
 }
 
-Library::~Library() = default;
+Library::~Library() {
+    // The manager is owned by this Library; clear the process-wide pointer so
+    // no model can dereference it after we are gone.
+    BaseTrackTableModel::setKeyHighlightManager(nullptr);
+}
 
 TrackCollectionManager* Library::trackCollectionManager() const {
     // Cannot be implemented inline due to forward declarations

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -24,6 +24,9 @@ class LibraryControl;
 class LibraryFeature;
 class LibraryTableModel;
 class KeyboardEventFilter;
+namespace mixxx {
+class KeyHighlightManager;
+} // namespace mixxx
 class MixxxLibraryFeature;
 class PlayerManager;
 class PlaylistFeature;
@@ -193,6 +196,7 @@ class Library: public QObject {
 
     parented_ptr<SidebarModel> m_pSidebarModel;
     parented_ptr<LibraryControl> m_pLibraryControl;
+    parented_ptr<mixxx::KeyHighlightManager> m_pKeyHighlightManager;
 
     QList<LibraryFeature*> m_features;
     const static QString m_sTrackViewName;

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -3,9 +3,11 @@
 #include <QPainter>
 #include <QStyle>
 #include <QTableView>
+#include <algorithm>
 
 #include "library/trackmodel.h"
 #include "moc_keydelegate.cpp"
+#include "track/keyutils.h"
 
 namespace {
 // Unicode symbols for tuning indicators
@@ -20,6 +22,15 @@ constexpr double kStandardTuningLowHz = kStandardTuningHz - kTuningToleranceHz;
 constexpr double kStandardTuningHighHz = kStandardTuningHz + kTuningToleranceHz;
 constexpr double k432LowHz = k432Hz - kTuningToleranceHz;
 constexpr double k432HighHz = k432Hz + kTuningToleranceHz;
+
+// Harmonic key-highlight transpose-direction arrows, shown on Yellow Key cells:
+// the track must be pitched up (+1), down (-1), or either way by one semitone to
+// become mixable with the highlighted deck. Drawn just left of any tuning
+// symbol. The glyphs mirror KeyUtils::YellowShift (None/Up/Down/Both).
+const QString kShiftArrowUp = QStringLiteral("↑");   // up arrow, pitch +1
+const QString kShiftArrowDown = QStringLiteral("↓"); // down arrow, pitch -1
+const QString kShiftArrowBoth = QStringLiteral("↕"); // up-down arrow, either
+constexpr int kShiftArrowWidth = 14;
 } // namespace
 
 void KeyDelegate::paintItem(
@@ -31,6 +42,8 @@ void KeyDelegate::paintItem(
     const QString keyText = index.data().value<QString>();
     const QVariantMap colorRect = index.data(Qt::DecorationRole).value<QVariantMap>();
     const double tuningFrequencyHz = index.data(TrackModel::kTuningFrequencyRole).toDouble();
+    const auto shiftDirection = static_cast<KeyUtils::YellowShift>(
+            index.data(TrackModel::kKeyShiftDirectionRole).toInt());
     int leftMargin = 0;
 
     const QColor colorTop = colorRect["top"].value<QColor>();
@@ -84,25 +97,52 @@ void KeyDelegate::paintItem(
         symbolColor = QColor(255, 99, 71); // Tomato red
     }
 
-    // Reserve space for tuning symbol if needed
-    int rightMargin = !tuningSymbol.isEmpty() ? kTuningSymbolWidth : 0;
+    // Pick the harmonic transpose-direction arrow (Yellow cells only). It sits
+    // just left of the tuning symbol, so reserve space for both independently.
+    QString shiftArrow;
+    switch (shiftDirection) {
+    case KeyUtils::YellowShift::Up:
+        shiftArrow = kShiftArrowUp;
+        break;
+    case KeyUtils::YellowShift::Down:
+        shiftArrow = kShiftArrowDown;
+        break;
+    case KeyUtils::YellowShift::Both:
+        shiftArrow = kShiftArrowBoth;
+        break;
+    case KeyUtils::YellowShift::None:
+        break;
+    }
 
-    // Display the key text with the user-provided notation
+    // Reserve space for the tuning symbol (far right) and, inside it, the
+    // harmonic arrow if present.
+    const int tuningMargin = !tuningSymbol.isEmpty() ? kTuningSymbolWidth : 0;
+    const int shiftMargin = !shiftArrow.isEmpty() ? kShiftArrowWidth : 0;
+    int rightMargin = tuningMargin + shiftMargin;
+
+    // Display the key text with the user-provided notation. Clamp the available
+    // width to >= 0: with both a swatch and two right-edge glyphs a narrow Key
+    // column could otherwise pass a negative width to elidedText.
+    const int textWidth =
+            std::max(0, columnWidth(index) - leftMargin - rightMargin);
     QString elidedText = option.fontMetrics.elidedText(
             keyText,
             Qt::ElideRight,
-            columnWidth(index) - leftMargin - rightMargin);
+            textWidth);
 
     // This is not picking up the 'missing' or 'played' text color via
     // ForegroundRole from BaseTrackTableModel::data().
     // Set the palette colors manually and select the appropriate one.
     QStyleOptionViewItem opt = option;
     setTextColor(opt, index);
-    if (opt.state & QStyle::State_Selected) {
-        painter->setPen(QPen(opt.palette.highlightedText().color()));
-    } else {
-        painter->setPen(QPen(opt.palette.text().color()));
-    }
+    // The colour the key glyph is drawn in. Reused for the direction arrow below
+    // so the arrow is always exactly as legible as the key text beside it, on
+    // any background the highlighter produces - a fixed colour could otherwise
+    // vanish (e.g. a dark arrow on the played dark-blue cell).
+    const QColor textColor = (opt.state & QStyle::State_Selected)
+            ? opt.palette.highlightedText().color()
+            : opt.palette.text().color();
+    painter->setPen(QPen(textColor));
 
     painter->drawText(option.rect.x() + leftMargin,
             option.rect.y(),
@@ -129,6 +169,27 @@ void KeyDelegate::paintItem(
                 option.rect.height(),
                 Qt::AlignVCenter | Qt::AlignRight,
                 tuningSymbol);
+        painter->restore();
+    }
+
+    // Draw the harmonic transpose-direction arrow just left of the tuning
+    // symbol (the tuning symbol stays anchored at the far-right edge). It uses
+    // the same colour as the key text, so it stays legible against whatever
+    // background the highlighter painted for this cell.
+    if (!shiftArrow.isEmpty()) {
+        painter->save();
+        painter->setPen(textColor);
+        QFont arrowFont = option.font;
+        arrowFont.setBold(true);
+        painter->setFont(arrowFont);
+        painter->drawText(
+                option.rect.x() + option.rect.width() - tuningMargin -
+                        kShiftArrowWidth,
+                option.rect.y(),
+                kShiftArrowWidth,
+                option.rect.height(),
+                Qt::AlignVCenter | Qt::AlignRight,
+                shiftArrow);
         painter->restore();
     }
 

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -39,6 +39,27 @@ void KeyDelegate::paintItem(
         const QModelIndex& index) const {
     paintItemBackground(painter, option, index);
 
+    // The harmonic key highlighter tints this cell via the model's
+    // BackgroundRole. Capture it once: it both has to survive row selection
+    // (below) and signals that the text colour must come from the model's
+    // contrasting ForegroundRole rather than the skin default (further down).
+    const QVariant bgValue = index.data(Qt::BackgroundRole);
+    const QColor highlightBg = bgValue.canConvert<QBrush>()
+            ? qvariant_cast<QBrush>(bgValue).color()
+            : QColor();
+
+    // paintItemBackground() deliberately skips selected rows so the standard
+    // selection highlight shows through. The harmonic key tint, however, is the
+    // whole point of this column and must survive selection - otherwise the cell
+    // reverts to the plain selection colour and the DJ loses the harmonic hint on
+    // the row they just clicked. Re-apply the tint on top of the selection,
+    // semi-transparent so the selection is still legible underneath.
+    if ((option.state & QStyle::State_Selected) && highlightBg.isValid()) {
+        QColor tint = highlightBg;
+        tint.setAlphaF(0.65f);
+        painter->fillRect(option.rect, tint);
+    }
+
     const QString keyText = index.data().value<QString>();
     const QVariantMap colorRect = index.data(Qt::DecorationRole).value<QVariantMap>();
     const double tuningFrequencyHz = index.data(TrackModel::kTuningFrequencyRole).toDouble();
@@ -130,18 +151,33 @@ void KeyDelegate::paintItem(
             Qt::ElideRight,
             textWidth);
 
-    // This is not picking up the 'missing' or 'played' text color via
-    // ForegroundRole from BaseTrackTableModel::data().
-    // Set the palette colors manually and select the appropriate one.
+    // Set the palette colours manually and select the appropriate one.
     QStyleOptionViewItem opt = option;
     setTextColor(opt, index);
     // The colour the key glyph is drawn in. Reused for the direction arrow below
     // so the arrow is always exactly as legible as the key text beside it, on
     // any background the highlighter produces - a fixed colour could otherwise
     // vanish (e.g. a dark arrow on the played dark-blue cell).
-    const QColor textColor = (opt.state & QStyle::State_Selected)
+    QColor textColor = (opt.state & QStyle::State_Selected)
             ? opt.palette.highlightedText().color()
             : opt.palette.text().color();
+    // When the harmonic highlighter tinted this cell, draw the key in the
+    // model's contrasting ForegroundRole (black on the light yellow/green tiers,
+    // white on the dark ones) instead of the skin default. The KeyDelegate paints
+    // the text itself rather than through the style, so the skin's default Text
+    // colour would otherwise win and render light text invisible on a light tint.
+    // Since the tint now persists under selection too, this applies in both
+    // states. Gated on a real highlight background so non-highlighted cells keep
+    // their normal played/selected text colour from setTextColor() above.
+    if (highlightBg.isValid()) {
+        const auto fgData = index.data(Qt::ForegroundRole);
+        if (fgData.canConvert<QColor>()) {
+            const QColor fgColor = fgData.value<QColor>();
+            if (fgColor.isValid()) {
+                textColor = fgColor;
+            }
+        }
+    }
     painter->setPen(QPen(textColor));
 
     painter->drawText(option.rect.x() + leftMargin,

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -20,6 +20,9 @@ class TrackModel {
     static constexpr int kDataExportRole = Qt::UserRole + 2;
     // This role provides the tuning frequency in Hz
     static constexpr int kTuningFrequencyRole = Qt::UserRole + 3;
+    // This role provides the harmonic key-highlight transpose direction for the
+    // Key column as a KeyUtils::YellowShift cast to int (0 == None).
+    static constexpr int kKeyShiftDirectionRole = Qt::UserRole + 4;
 
     TrackModel(const QSqlDatabase& db,
             const char* settingsNamespace)

--- a/src/test/keyhighlightmanagertest.cpp
+++ b/src/test/keyhighlightmanagertest.cpp
@@ -1,0 +1,250 @@
+#include <gtest/gtest.h>
+
+#include <QSignalSpy>
+#include <memory>
+
+#include "control/controlobject.h"
+#include "control/controlpushbutton.h"
+#include "library/keyhighlightmanager.h"
+#include "mixer/playermanager.h"
+#include "proto/keys.pb.h"
+#include "test/mixxxtest.h"
+#include "track/keyutils.h"
+
+namespace {
+
+using mixxx::KeyHighlightManager;
+using Class = KeyUtils::KeyHighlightClass;
+namespace key = mixxx::track::io::key;
+
+class KeyHighlightManagerTest : public MixxxTest {
+  protected:
+    void SetUp() override {
+        m_pNumDecks = std::make_unique<ControlObject>(
+                ConfigKey(QStringLiteral("[App]"), QStringLiteral("num_decks")));
+        // Create the per-deck controls the manager subscribes to. Two decks is
+        // enough to cover the multi-deck union; key_highlight is a toggle
+        // button just like the real KeyControl control.
+        for (int i = 0; i < kDecks; ++i) {
+            const QString group = PlayerManager::groupForDeck(i);
+            m_highlight[i] = std::make_unique<ControlPushButton>(
+                    ConfigKey(group, QStringLiteral("key_highlight")));
+            m_highlight[i]->setButtonMode(mixxx::control::ButtonMode::Toggle);
+            m_key[i] = std::make_unique<ControlObject>(
+                    ConfigKey(group, QStringLiteral("key")));
+        }
+        m_pNumDecks->set(kDecks);
+    }
+
+    void setDeckKey(int deck, key::ChromaticKey k) {
+        m_key[deck]->set(KeyUtils::keyToNumericValue(k));
+    }
+    void setHighlight(int deck, bool on) {
+        m_highlight[deck]->set(on ? 1.0 : 0.0);
+    }
+
+    static constexpr int kDecks = 2;
+    std::unique_ptr<ControlObject> m_pNumDecks;
+    std::unique_ptr<ControlPushButton> m_highlight[kDecks];
+    std::unique_ptr<ControlObject> m_key[kDecks];
+};
+
+TEST_F(KeyHighlightManagerTest, InactiveByDefault) {
+    KeyHighlightManager manager;
+    EXPECT_FALSE(manager.isActive());
+    EXPECT_EQ(Class::None, manager.classOf(key::C_MAJOR));
+    EXPECT_EQ(Class::None, manager.classOf(key::A_MINOR));
+}
+
+TEST_F(KeyHighlightManagerTest, SingleDeckClassification) {
+    const auto ref = key::A_MINOR;
+    setDeckKey(0, ref);
+    setHighlight(0, true);
+
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    // classOf must agree with the pure classifier for every valid key.
+    for (int i = static_cast<int>(key::C_MAJOR);
+            i <= static_cast<int>(key::B_MINOR);
+            ++i) {
+        const auto trackKey = static_cast<key::ChromaticKey>(i);
+        EXPECT_EQ(KeyUtils::classifyAgainst(trackKey, ref),
+                manager.classOf(trackKey))
+                << "track=" << i;
+    }
+    // INVALID is never highlighted.
+    EXPECT_EQ(Class::None, manager.classOf(key::INVALID));
+}
+
+TEST_F(KeyHighlightManagerTest, ToggleOnOff) {
+    setDeckKey(0, key::A_MINOR);
+    KeyHighlightManager manager;
+    ASSERT_FALSE(manager.isActive());
+
+    QSignalSpy spy(&manager, &KeyHighlightManager::highlightChanged);
+
+    setHighlight(0, true);
+    EXPECT_TRUE(manager.isActive());
+    EXPECT_EQ(1, spy.count());
+
+    setHighlight(0, false);
+    EXPECT_FALSE(manager.isActive());
+    EXPECT_EQ(Class::None, manager.classOf(key::C_MAJOR));
+    EXPECT_EQ(2, spy.count());
+}
+
+TEST_F(KeyHighlightManagerTest, MutuallyExclusiveAcrossDecks) {
+    // The highlighter is single-deck: enabling one deck's highlight turns any
+    // other deck's off, so the classification reflects exactly one reference
+    // key at a time.
+    const auto ref0 = key::A_MINOR;
+    const auto ref1 = key::F_SHARP_MAJOR; // harmonically distant from A minor
+    setDeckKey(0, ref0);
+    setDeckKey(1, ref1);
+
+    KeyHighlightManager manager;
+    ASSERT_FALSE(manager.isActive());
+
+    // Enable deck 0: classifies against A minor.
+    setHighlight(0, true);
+    ASSERT_TRUE(manager.isActive());
+    EXPECT_EQ(Class::GreenPerfect, manager.classOf(key::A_MINOR));
+
+    // Enable deck 1 while deck 0 is on: deck 0 must be cleared, and the
+    // classification must now reflect F# major only.
+    setHighlight(1, true);
+    EXPECT_TRUE(manager.isActive());
+    // The manager cleared deck 0's control as a side effect.
+    EXPECT_DOUBLE_EQ(0.0, m_highlight[0]->get());
+    EXPECT_DOUBLE_EQ(1.0, m_highlight[1]->get());
+    // F# major is now the sole reference -> GreenPerfect for itself.
+    EXPECT_EQ(Class::GreenPerfect, manager.classOf(key::F_SHARP_MAJOR));
+    // A minor is no longer a reference, so it is classified *against* F# major
+    // (distant), not GreenPerfect anymore.
+    EXPECT_EQ(KeyUtils::classifyAgainst(key::A_MINOR, ref1),
+            manager.classOf(key::A_MINOR));
+
+    // Every track key now matches the single-deck (F# major) classification.
+    for (int i = static_cast<int>(key::C_MAJOR);
+            i <= static_cast<int>(key::B_MINOR);
+            ++i) {
+        const auto trackKey = static_cast<key::ChromaticKey>(i);
+        EXPECT_EQ(KeyUtils::classifyAgainst(trackKey, ref1),
+                manager.classOf(trackKey))
+                << "track=" << i;
+    }
+}
+
+TEST_F(KeyHighlightManagerTest, MutualExclusionEmitsAndDoesNotOscillate) {
+    setDeckKey(0, key::A_MINOR);
+    setDeckKey(1, key::F_SHARP_MAJOR);
+
+    KeyHighlightManager manager;
+    QSignalSpy spy(&manager, &KeyHighlightManager::highlightChanged);
+
+    setHighlight(0, true);
+    ASSERT_TRUE(manager.isActive());
+    const int afterDeck0 = spy.count();
+    EXPECT_GT(afterDeck0, 0);
+
+    // Switching to deck 1 clears deck 0. This involves a re-entrant write to
+    // deck 0's control; the re-entrancy guard must keep this convergent (a
+    // bounded number of emits, no infinite loop) and leave a single active deck.
+    setHighlight(1, true);
+    EXPECT_TRUE(manager.isActive());
+    EXPECT_DOUBLE_EQ(0.0, m_highlight[0]->get());
+    EXPECT_DOUBLE_EQ(1.0, m_highlight[1]->get());
+    EXPECT_EQ(Class::GreenPerfect, manager.classOf(key::F_SHARP_MAJOR));
+    // Convergent: a switch produces only a small, bounded number of repaints.
+    EXPECT_LE(spy.count() - afterDeck0, 3);
+
+    // Turning the sole active deck off deactivates the highlighter entirely.
+    setHighlight(1, false);
+    EXPECT_FALSE(manager.isActive());
+    EXPECT_EQ(Class::None, manager.classOf(key::F_SHARP_MAJOR));
+}
+
+TEST_F(KeyHighlightManagerTest, KeylessDeckContributesNothing) {
+    // Deck 0 enabled but has no key -> not active, nothing highlighted.
+    setDeckKey(0, key::INVALID);
+    setHighlight(0, true);
+
+    KeyHighlightManager manager;
+    EXPECT_FALSE(manager.isActive());
+    EXPECT_EQ(Class::None, manager.classOf(key::C_MAJOR));
+
+    // Add a second, keyed+enabled deck -> only that one contributes.
+    setDeckKey(1, key::A_MINOR);
+    setHighlight(1, true);
+    EXPECT_TRUE(manager.isActive());
+    EXPECT_EQ(KeyUtils::classifyAgainst(key::E_MINOR, key::A_MINOR),
+            manager.classOf(key::E_MINOR));
+}
+
+TEST_F(KeyHighlightManagerTest, DiscreteKeyDebounce) {
+    setDeckKey(0, key::A_MINOR);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    QSignalSpy spy(&manager, &KeyHighlightManager::highlightChanged);
+
+    // A sub-semitone change that still floors to the same ChromaticKey must
+    // NOT trigger a recompute/emit (this guards the perf claim).
+    const double base = KeyUtils::keyToNumericValue(key::A_MINOR);
+    m_key[0]->set(base + 0.4);
+    EXPECT_EQ(0, spy.count());
+    m_key[0]->set(base + 0.9);
+    EXPECT_EQ(0, spy.count());
+
+    // Crossing into a new discrete key emits exactly once.
+    setDeckKey(0, key::B_MINOR);
+    EXPECT_EQ(1, spy.count());
+}
+
+TEST_F(KeyHighlightManagerTest, NumDecksGrowth) {
+    // Start the manager when num_decks reports a single deck, then grow.
+    m_pNumDecks->set(1);
+    setDeckKey(0, key::A_MINOR);
+    setHighlight(0, true);
+
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    QSignalSpy spy(&manager, &KeyHighlightManager::highlightChanged);
+
+    // Grow to two decks; the newly-added deck must start participating. Enabling
+    // deck 1 clears deck 0 (mutual exclusion), so F# major becomes the sole
+    // reference.
+    m_pNumDecks->set(2);
+    setDeckKey(1, key::F_SHARP_MAJOR);
+    setHighlight(1, true);
+
+    EXPECT_TRUE(manager.isActive());
+    EXPECT_EQ(Class::GreenPerfect, manager.classOf(key::F_SHARP_MAJOR));
+    EXPECT_DOUBLE_EQ(0.0, m_highlight[0]->get()); // deck 0 was cleared
+    EXPECT_GT(spy.count(), 0);
+
+    // Lowering num_decks must drop the now-out-of-range deck's contribution.
+    // Only deck 1 (F# major) was enabled; shrinking below it must deactivate
+    // the highlighter rather than leave a stale reference key active.
+    m_pNumDecks->set(1);
+    EXPECT_FALSE(manager.isActive());
+    EXPECT_EQ(Class::None, manager.classOf(key::F_SHARP_MAJOR));
+}
+
+TEST_F(KeyHighlightManagerTest, NumDecksShrinkKeepsInRangeDeck) {
+    // Two decks, deck 0 enabled (A minor). Shrinking to one deck must keep the
+    // still-in-range deck 0 active.
+    setDeckKey(0, key::A_MINOR);
+    KeyHighlightManager manager;
+    setHighlight(0, true);
+    ASSERT_TRUE(manager.isActive());
+
+    m_pNumDecks->set(1);
+    EXPECT_TRUE(manager.isActive());
+    EXPECT_EQ(Class::GreenPerfect, manager.classOf(key::A_MINOR));
+}
+
+} // namespace

--- a/src/test/keyhighlightmanagertest.cpp
+++ b/src/test/keyhighlightmanagertest.cpp
@@ -6,10 +6,12 @@
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
 #include "library/keyhighlightmanager.h"
+#include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
 #include "proto/keys.pb.h"
 #include "test/mixxxtest.h"
 #include "track/keyutils.h"
+#include "track/track.h"
 
 namespace {
 
@@ -18,6 +20,9 @@ using Class = KeyUtils::KeyHighlightClass;
 using Shift = KeyUtils::YellowShift;
 namespace key = mixxx::track::io::key;
 
+const QString kTrackLocation =
+        QStringLiteral("/test/keyhighlight/track.mp3");
+
 class KeyHighlightManagerTest : public MixxxTest {
   protected:
     void SetUp() override {
@@ -25,7 +30,21 @@ class KeyHighlightManagerTest : public MixxxTest {
                 ConfigKey(QStringLiteral("[App]"), QStringLiteral("num_decks")));
         // Create the per-deck controls the manager subscribes to. Two decks is
         // enough to cover the multi-deck union; key_highlight is a toggle
-        // button just like the real KeyControl control.
+        // button just like the real KeyControl control. file_key is the stored
+        // key; key is the (possibly pitch-shifted) engine key.
+        // PlayerInfo's idle timer polls the crossfader and each deck's
+        // play/pregain/volume/orientation to pick the "loudest playing" deck -
+        // machinery unrelated to the highlighter. A full harness (e.g.
+        // PlayerManagerTest) gets these from a real EngineMixer; our lightweight
+        // fixture stubs just the controls that path reads so its debug asserts
+        // for missing controls don't fire. Their values don't matter here.
+        m_pCrossfader = std::make_unique<ControlObject>(ConfigKey(
+                QStringLiteral("[Master]"), QStringLiteral("crossfader")));
+        // PlayerInfo's ctor also binds these [App] counters.
+        m_pNumSamplers = std::make_unique<ControlObject>(ConfigKey(
+                QStringLiteral("[App]"), QStringLiteral("num_samplers")));
+        m_pNumPreviewDecks = std::make_unique<ControlObject>(ConfigKey(
+                QStringLiteral("[App]"), QStringLiteral("num_preview_decks")));
         for (int i = 0; i < kDecks; ++i) {
             const QString group = PlayerManager::groupForDeck(i);
             m_highlight[i] = std::make_unique<ControlPushButton>(
@@ -33,21 +52,78 @@ class KeyHighlightManagerTest : public MixxxTest {
             m_highlight[i]->setButtonMode(mixxx::control::ButtonMode::Toggle);
             m_key[i] = std::make_unique<ControlObject>(
                     ConfigKey(group, QStringLiteral("key")));
+            m_fileKey[i] = std::make_unique<ControlObject>(
+                    ConfigKey(group, QStringLiteral("file_key")));
+            m_playerInfoEnv[i][0] = std::make_unique<ControlObject>(
+                    ConfigKey(group, QStringLiteral("play")));
+            m_playerInfoEnv[i][1] = std::make_unique<ControlObject>(
+                    ConfigKey(group, QStringLiteral("pregain")));
+            m_playerInfoEnv[i][2] = std::make_unique<ControlObject>(
+                    ConfigKey(group, QStringLiteral("volume")));
+            m_playerInfoEnv[i][3] = std::make_unique<ControlObject>(
+                    ConfigKey(group, QStringLiteral("orientation")));
         }
         m_pNumDecks->set(kDecks);
+
+        // Create PlayerInfo only after the controls its proxies bind to exist
+        // (PollingControlProxy binds at construction). The manager connects to
+        // PlayerInfo::trackChanged in its ctor; own the singleton's lifecycle
+        // here so loaded-track state never leaks between tests.
+        PlayerInfo::destroy();
+        PlayerInfo::create();
+    }
+
+    void TearDown() override {
+        PlayerInfo::destroy();
     }
 
     void setDeckKey(int deck, key::ChromaticKey k) {
         m_key[deck]->set(KeyUtils::keyToNumericValue(k));
     }
+    void setDeckFileKey(int deck, key::ChromaticKey k) {
+        m_fileKey[deck]->set(KeyUtils::keyToNumericValue(k));
+    }
+    // Convenience: set both the stored and playing key to the same value (an
+    // unpitched deck) so a test only has to override `key` to simulate pitch.
+    void setDeckKeys(int deck, key::ChromaticKey fileKey, key::ChromaticKey playingKey) {
+        setDeckFileKey(deck, fileKey);
+        setDeckKey(deck, playingKey);
+    }
     void setHighlight(int deck, bool on) {
         m_highlight[deck]->set(on ? 1.0 : 0.0);
+    }
+    // Load (or, with a null id, eject) a track on a deck. We emit
+    // PlayerInfo::trackChanged directly - the exact signal the manager listens
+    // to in production - rather than going through setTrackInfo(), whose
+    // additional "loudest playing deck" bookkeeping reads crossfader/play/volume
+    // controls that are unrelated to this feature.
+    TrackPointer loadTrack(int deck, int trackId) {
+        auto pTrack = Track::newDummy(kTrackLocation, TrackId(QVariant(trackId)));
+        emit PlayerInfo::instance().trackChanged(
+                PlayerManager::groupForDeck(deck), pTrack, m_loaded[deck]);
+        m_loaded[deck] = pTrack;
+        return pTrack;
+    }
+    void ejectTrack(int deck) {
+        emit PlayerInfo::instance().trackChanged(
+                PlayerManager::groupForDeck(deck), TrackPointer(), m_loaded[deck]);
+        m_loaded[deck] = TrackPointer();
     }
 
     static constexpr int kDecks = 2;
     std::unique_ptr<ControlObject> m_pNumDecks;
+    std::unique_ptr<ControlObject> m_pCrossfader;
+    std::unique_ptr<ControlObject> m_pNumSamplers;
+    std::unique_ptr<ControlObject> m_pNumPreviewDecks;
     std::unique_ptr<ControlPushButton> m_highlight[kDecks];
     std::unique_ptr<ControlObject> m_key[kDecks];
+    std::unique_ptr<ControlObject> m_fileKey[kDecks];
+    // play/pregain/volume/orientation per deck - PlayerInfo's loudest-deck
+    // environment, not part of this feature (see SetUp()).
+    std::unique_ptr<ControlObject> m_playerInfoEnv[kDecks][4];
+    // Tracks the last loaded track per deck so we can pass a correct "old track"
+    // when emitting trackChanged.
+    TrackPointer m_loaded[kDecks];
 };
 
 TEST_F(KeyHighlightManagerTest, InactiveByDefault) {
@@ -313,6 +389,231 @@ TEST_F(KeyHighlightManagerTest, NumDecksShrinkKeepsInRangeDeck) {
     m_pNumDecks->set(1);
     EXPECT_TRUE(manager.isActive());
     EXPECT_EQ(Class::GreenPerfect, manager.classOf(key::A_MINOR));
+}
+
+// ---------------------------------------------------------------------------
+// playingKeyForTrack(): the pitched "OriginalKey (PlayingKey)" suffix source.
+// ---------------------------------------------------------------------------
+
+TEST_F(KeyHighlightManagerTest, PlayingKeyDiffersWhenPitched) {
+    // Deck 0 highlighting, track loaded, stored key A minor but pitched up one
+    // semitone so the engine (playing) key is A# minor -> the suffix key is the
+    // playing key.
+    setDeckKeys(0, key::A_MINOR, key::B_FLAT_MINOR);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    const int kId = 7;
+    loadTrack(0, kId);
+
+    EXPECT_EQ(key::B_FLAT_MINOR,
+            manager.playingKeyForTrack(TrackId(QVariant(kId))));
+}
+
+TEST_F(KeyHighlightManagerTest, NoSuffixWhenUnpitched) {
+    // Playing key == stored key -> no parenthetical.
+    setDeckKeys(0, key::A_MINOR, key::A_MINOR);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    const int kId = 7;
+    loadTrack(0, kId);
+
+    EXPECT_EQ(key::INVALID,
+            manager.playingKeyForTrack(TrackId(QVariant(kId))));
+}
+
+TEST_F(KeyHighlightManagerTest, NoSuffixWhenHighlighterOff) {
+    // Pitched, track loaded, but the deck's highlighter is OFF: the suffix is a
+    // highlighter feature, so it must not show.
+    setDeckKeys(0, key::A_MINOR, key::B_FLAT_MINOR);
+    KeyHighlightManager manager;
+    const int kId = 7;
+    loadTrack(0, kId);
+    ASSERT_FALSE(manager.isActive());
+
+    EXPECT_EQ(key::INVALID,
+            manager.playingKeyForTrack(TrackId(QVariant(kId))));
+}
+
+TEST_F(KeyHighlightManagerTest, NoSuffixForUnloadedTrack) {
+    // A track id that is not loaded on any deck never gets a suffix.
+    setDeckKeys(0, key::A_MINOR, key::B_FLAT_MINOR);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+    loadTrack(0, 7);
+
+    EXPECT_EQ(key::INVALID,
+            manager.playingKeyForTrack(TrackId(QVariant(999))));
+    // An invalid TrackId is also never matched.
+    EXPECT_EQ(key::INVALID, manager.playingKeyForTrack(TrackId()));
+}
+
+TEST_F(KeyHighlightManagerTest, SuffixAppearsOnLoadAfterConstruction) {
+    // Loading a track after the manager is constructed must make the suffix
+    // appear (the PlayerInfo::trackChanged wiring drives this) and emit so the
+    // model repaints.
+    setDeckKeys(0, key::A_MINOR, key::B_FLAT_MINOR);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    const int kId = 11;
+    EXPECT_EQ(key::INVALID,
+            manager.playingKeyForTrack(TrackId(QVariant(kId))));
+
+    QSignalSpy spy(&manager, &KeyHighlightManager::highlightChanged);
+    loadTrack(0, kId);
+    EXPECT_GT(spy.count(), 0);
+    EXPECT_EQ(key::B_FLAT_MINOR,
+            manager.playingKeyForTrack(TrackId(QVariant(kId))));
+}
+
+TEST_F(KeyHighlightManagerTest, EjectClearsSuffix) {
+    setDeckKeys(0, key::A_MINOR, key::B_FLAT_MINOR);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    const int kId = 7;
+    loadTrack(0, kId);
+    ASSERT_EQ(key::B_FLAT_MINOR,
+            manager.playingKeyForTrack(TrackId(QVariant(kId))));
+
+    ejectTrack(0);
+    EXPECT_EQ(key::INVALID,
+            manager.playingKeyForTrack(TrackId(QVariant(kId))));
+}
+
+TEST_F(KeyHighlightManagerTest, SuffixFollowsRefDeckOnSwitch) {
+    // Both decks hold a (different) pitched track. Switching the active deck
+    // must move the suffix to the surviving reference deck's track, and clear it
+    // from the deck that was turned off (mutual exclusion).
+    setDeckKeys(0, key::A_MINOR, key::B_FLAT_MINOR); // deck 0 pitched +1
+    setDeckKeys(1, key::C_MAJOR, key::D_FLAT_MAJOR); // deck 1 pitched +1
+    KeyHighlightManager manager;
+    const int kId0 = 1;
+    const int kId1 = 2;
+    loadTrack(0, kId0);
+    loadTrack(1, kId1);
+
+    setHighlight(0, true);
+    ASSERT_TRUE(manager.isActive());
+    EXPECT_EQ(key::B_FLAT_MINOR,
+            manager.playingKeyForTrack(TrackId(QVariant(kId0))));
+    EXPECT_EQ(key::INVALID,
+            manager.playingKeyForTrack(TrackId(QVariant(kId1))));
+
+    // Switch to deck 1: deck 0 is cleared, so only deck 1's track gets a suffix.
+    setHighlight(1, true);
+    ASSERT_TRUE(manager.isActive());
+    EXPECT_DOUBLE_EQ(0.0, m_highlight[0]->get());
+    EXPECT_EQ(key::INVALID,
+            manager.playingKeyForTrack(TrackId(QVariant(kId0))));
+    EXPECT_EQ(key::D_FLAT_MAJOR,
+            manager.playingKeyForTrack(TrackId(QVariant(kId1))));
+}
+
+TEST_F(KeyHighlightManagerTest, AnyPitchAmountNotJustOneSemitone) {
+    // The suffix reflects whatever the discrete playing key is, for any pitch
+    // amount - here +3 semitones (A minor -> C minor) and -2 (C major -> A#
+    // major), not only +/-1.
+    setDeckKeys(0, key::A_MINOR, key::C_MINOR);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+    loadTrack(0, 5);
+    EXPECT_EQ(key::C_MINOR, manager.playingKeyForTrack(TrackId(QVariant(5))));
+
+    // Re-pitch the same deck down two semitones from C major.
+    setDeckKeys(0, key::C_MAJOR, key::B_FLAT_MAJOR);
+    EXPECT_EQ(key::B_FLAT_MAJOR,
+            manager.playingKeyForTrack(TrackId(QVariant(5))));
+}
+
+TEST_F(KeyHighlightManagerTest, ReferenceKeyIsPlayingKeyNotFileKey) {
+    // Requirement-1 regression: with the deck pitched, the *classification* of
+    // the rest of the library must be computed against the playing (engine) key,
+    // not the stored file key. Pick a track key that classifies differently
+    // against the two so a regression to file_key would be caught.
+    const auto fileKey = key::A_MINOR;
+    const auto playingKey = key::B_FLAT_MINOR; // pitched +1
+    setDeckKeys(0, fileKey, playingKey);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    // The manager must agree with classifying against the PLAYING key for every
+    // track key, and differ from the file-key classification on at least one
+    // (proving it is not silently using file_key).
+    bool sawDifference = false;
+    for (int i = static_cast<int>(key::C_MAJOR);
+            i <= static_cast<int>(key::B_MINOR);
+            ++i) {
+        const auto trackKey = static_cast<key::ChromaticKey>(i);
+        EXPECT_EQ(KeyUtils::classifyAgainst(trackKey, playingKey),
+                manager.classOf(trackKey))
+                << "track=" << i;
+        if (KeyUtils::classifyAgainst(trackKey, playingKey) !=
+                KeyUtils::classifyAgainst(trackKey, fileKey)) {
+            sawDifference = true;
+        }
+    }
+    EXPECT_TRUE(sawDifference)
+            << "test keys chosen so playing vs file classification differ";
+}
+
+TEST_F(KeyHighlightManagerTest, LoadedPitchedRowMatchesItself) {
+    // F7 regression: the loaded, pitched deck's OWN library row must not be
+    // labelled Yellow with a "pitch me one semitone" arrow it is already playing
+    // past. The model classifies that row by the key it is *playing*
+    // (playingKeyForTrack), which is the highlighter's own reference key, so the
+    // self-comparison is the strongest match and carries no transpose hint.
+    //
+    // Worked example (the common case): stored A minor pitched +1 semitone plays
+    // B flat minor; that is the reference. classifyAgainst(playing, playing) is
+    // GreenPerfect and directionOf(playing) is None - whereas classifying the
+    // STORED key A minor against the playing B flat minor would (wrongly) be
+    // Yellow + an Up arrow.
+    const auto fileKey = key::A_MINOR;
+    const auto playingKey = key::B_FLAT_MINOR; // pitched +1
+    setDeckKeys(0, fileKey, playingKey);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    const int kId = 7;
+    loadTrack(0, kId);
+
+    // Guard the premise: the stored key really would mislabel against the
+    // playing reference, so the substitution below is doing real work.
+    ASSERT_EQ(Class::Yellow, manager.classOf(fileKey));
+    ASSERT_NE(Shift::None, manager.directionOf(fileKey));
+
+    // The model substitutes the playing key for this row; that is what it
+    // classifies. It must read GreenPerfect with no arrow.
+    const auto rowKey = manager.playingKeyForTrack(TrackId(QVariant(kId)));
+    ASSERT_EQ(playingKey, rowKey);
+    EXPECT_EQ(Class::GreenPerfect, manager.classOf(rowKey));
+    EXPECT_EQ(Shift::None, manager.directionOf(rowKey));
+}
+
+TEST_F(KeyHighlightManagerTest, PlayingKeyInvalidGuards) {
+    // Invalid file or engine key -> no suffix even when loaded+highlighting.
+    setDeckKeys(0, key::INVALID, key::B_FLAT_MINOR);
+    setHighlight(0, true);
+    KeyHighlightManager manager;
+    loadTrack(0, 3);
+    // Deck has no valid stored key; even if active via another path, the suffix
+    // must be suppressed.
+    EXPECT_EQ(key::INVALID, manager.playingKeyForTrack(TrackId(QVariant(3))));
+
+    // Valid stored key but invalid engine key -> also suppressed.
+    setDeckKeys(0, key::A_MINOR, key::INVALID);
+    EXPECT_EQ(key::INVALID, manager.playingKeyForTrack(TrackId(QVariant(3))));
 }
 
 } // namespace

--- a/src/test/keyhighlightmanagertest.cpp
+++ b/src/test/keyhighlightmanagertest.cpp
@@ -15,6 +15,7 @@ namespace {
 
 using mixxx::KeyHighlightManager;
 using Class = KeyUtils::KeyHighlightClass;
+using Shift = KeyUtils::YellowShift;
 namespace key = mixxx::track::io::key;
 
 class KeyHighlightManagerTest : public MixxxTest {
@@ -75,6 +76,73 @@ TEST_F(KeyHighlightManagerTest, SingleDeckClassification) {
     }
     // INVALID is never highlighted.
     EXPECT_EQ(Class::None, manager.classOf(key::INVALID));
+}
+
+TEST_F(KeyHighlightManagerTest, DirectionMatchesClassifier) {
+    const auto ref = key::A_MINOR;
+    setDeckKey(0, ref);
+    setHighlight(0, true);
+
+    KeyHighlightManager manager;
+    ASSERT_TRUE(manager.isActive());
+
+    // directionOf must agree with the pure classifier for every valid key, and
+    // be None for any non-Yellow key (the table only carries directions on
+    // Yellow cells).
+    for (int i = static_cast<int>(key::C_MAJOR);
+            i <= static_cast<int>(key::B_MINOR);
+            ++i) {
+        const auto trackKey = static_cast<key::ChromaticKey>(i);
+        EXPECT_EQ(KeyUtils::yellowShiftDirection(trackKey, ref),
+                manager.directionOf(trackKey))
+                << "track=" << i;
+        if (manager.classOf(trackKey) != Class::Yellow) {
+            EXPECT_EQ(Shift::None, manager.directionOf(trackKey))
+                    << "non-yellow track=" << i;
+        }
+    }
+    // INVALID never carries a direction.
+    EXPECT_EQ(Shift::None, manager.directionOf(key::INVALID));
+}
+
+TEST_F(KeyHighlightManagerTest, DirectionInactiveIsNone) {
+    setDeckKey(0, key::A_MINOR);
+    KeyHighlightManager manager;
+    ASSERT_FALSE(manager.isActive());
+
+    // With the highlighter off, no key carries a direction.
+    for (int i = static_cast<int>(key::C_MAJOR);
+            i <= static_cast<int>(key::B_MINOR);
+            ++i) {
+        EXPECT_EQ(Shift::None,
+                manager.directionOf(static_cast<key::ChromaticKey>(i)))
+                << "track=" << i;
+    }
+}
+
+TEST_F(KeyHighlightManagerTest, DirectionConsistentWithChosenClass) {
+    // After a deck switch, the surviving reference key must drive the direction,
+    // not a stale one. Mirrors MutuallyExclusiveAcrossDecks but checks the
+    // direction table.
+    const auto ref1 = key::F_SHARP_MAJOR;
+    setDeckKey(0, key::A_MINOR);
+    setDeckKey(1, ref1);
+
+    KeyHighlightManager manager;
+    setHighlight(0, true);
+    setHighlight(1, true); // clears deck 0; F# major is now the sole reference
+
+    ASSERT_TRUE(manager.isActive());
+    EXPECT_DOUBLE_EQ(0.0, m_highlight[0]->get());
+
+    for (int i = static_cast<int>(key::C_MAJOR);
+            i <= static_cast<int>(key::B_MINOR);
+            ++i) {
+        const auto trackKey = static_cast<key::ChromaticKey>(i);
+        EXPECT_EQ(KeyUtils::yellowShiftDirection(trackKey, ref1),
+                manager.directionOf(trackKey))
+                << "track=" << i;
+    }
 }
 
 TEST_F(KeyHighlightManagerTest, ToggleOnOff) {

--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -327,6 +327,7 @@ namespace {
 
 using mixxx::track::io::key::ChromaticKey;
 using Class = KeyUtils::KeyHighlightClass;
+using Shift = KeyUtils::YellowShift;
 
 // The first and last valid (non-INVALID) ChromaticKey values.
 constexpr ChromaticKey kFirstKey = mixxx::track::io::key::C_MAJOR; // 1
@@ -494,9 +495,11 @@ TEST_F(KeyUtilsTest, ClassifyExhaustiveConsistency) {
 
             // Yellow <=> not compatible AND +/-1 semitone is compatible
             // (mutual exclusivity with green is implied).
-            const bool semitoneReachable =
-                    compatible.contains(KeyUtils::scaleKeySteps(track, 1)) ||
+            const bool up =
+                    compatible.contains(KeyUtils::scaleKeySteps(track, 1));
+            const bool down =
                     compatible.contains(KeyUtils::scaleKeySteps(track, -1));
+            const bool semitoneReachable = up || down;
             if (c == Class::Yellow) {
                 EXPECT_FALSE(inCompatible);
                 EXPECT_TRUE(semitoneReachable);
@@ -507,8 +510,94 @@ TEST_F(KeyUtilsTest, ClassifyExhaustiveConsistency) {
                 EXPECT_FALSE(inCompatible);
                 EXPECT_FALSE(semitoneReachable);
             }
+
+            // yellowShiftDirection() must agree with the class: non-None exactly
+            // when Yellow, and its Up/Down bits must match per-sign
+            // reachability. This keeps the direction channel from ever drifting
+            // from the classifier.
+            const Shift shift = KeyUtils::yellowShiftDirection(track, ref);
+            EXPECT_EQ(c == Class::Yellow, shift != Shift::None)
+                    << "track=" << static_cast<int>(track)
+                    << " ref=" << static_cast<int>(ref);
+            if (c == Class::Yellow) {
+                const Shift expected = (up && down) ? Shift::Both
+                        : up                        ? Shift::Up
+                                                    : Shift::Down;
+                EXPECT_EQ(expected, shift)
+                        << "track=" << static_cast<int>(track)
+                        << " ref=" << static_cast<int>(ref);
+            }
         }
     }
+}
+
+TEST_F(KeyUtilsTest, YellowShiftDirectionInvalidInputs) {
+    // INVALID on either side is always None, mirroring classifyAgainst().
+    EXPECT_EQ(Shift::None,
+            KeyUtils::yellowShiftDirection(mixxx::track::io::key::INVALID,
+                    mixxx::track::io::key::INVALID));
+    for (ChromaticKey k = kFirstKey; k <= kLastKey; k = incrementKey(k)) {
+        EXPECT_EQ(Shift::None,
+                KeyUtils::yellowShiftDirection(
+                        mixxx::track::io::key::INVALID, k))
+                << "ref=" << static_cast<int>(k);
+        EXPECT_EQ(Shift::None,
+                KeyUtils::yellowShiftDirection(
+                        k, mixxx::track::io::key::INVALID))
+                << "track=" << static_cast<int>(k);
+    }
+}
+
+TEST_F(KeyUtilsTest, YellowShiftDirectionMatchesReachability) {
+    // Against A minor, every Yellow track's reported direction must match the
+    // raw +1/-1 membership test, and every non-Yellow track must be None.
+    const auto ref = mixxx::track::io::key::A_MINOR;
+    const QList<ChromaticKey> compatible = KeyUtils::getCompatibleKeys(ref);
+    bool sawUp = false;
+    bool sawDown = false;
+    for (ChromaticKey track = kFirstKey; track <= kLastKey;
+            track = incrementKey(track)) {
+        const Shift shift = KeyUtils::yellowShiftDirection(track, ref);
+        if (compatible.contains(track)) {
+            EXPECT_EQ(Shift::None, shift)
+                    << "compatible track=" << static_cast<int>(track);
+            continue;
+        }
+        const bool up = compatible.contains(KeyUtils::scaleKeySteps(track, 1));
+        const bool down = compatible.contains(KeyUtils::scaleKeySteps(track, -1));
+        if (up && down) {
+            EXPECT_EQ(Shift::Both, shift) << "track=" << static_cast<int>(track);
+        } else if (up) {
+            EXPECT_EQ(Shift::Up, shift) << "track=" << static_cast<int>(track);
+            sawUp = true;
+        } else if (down) {
+            EXPECT_EQ(Shift::Down, shift) << "track=" << static_cast<int>(track);
+            sawDown = true;
+        } else {
+            EXPECT_EQ(Shift::None, shift) << "track=" << static_cast<int>(track);
+        }
+    }
+    EXPECT_TRUE(sawUp) << "expected at least one Up-only case for A minor";
+    EXPECT_TRUE(sawDown) << "expected at least one Down-only case for A minor";
+}
+
+TEST_F(KeyUtilsTest, YellowShiftDirectionBothExists) {
+    // Somewhere in the 24x24 space a track is reachable by BOTH +1 and -1, and
+    // must report Both. Asserting it exists guards the Both branch from being
+    // collapsed into a single direction by an over-eager else-if chain.
+    bool sawBoth = false;
+    for (ChromaticKey ref = kFirstKey; ref <= kLastKey && !sawBoth;
+            ref = incrementKey(ref)) {
+        for (ChromaticKey track = kFirstKey; track <= kLastKey;
+                track = incrementKey(track)) {
+            if (KeyUtils::yellowShiftDirection(track, ref) == Shift::Both) {
+                sawBoth = true;
+                break;
+            }
+        }
+    }
+    EXPECT_TRUE(sawBoth)
+            << "expected at least one Both (up+down reachable) pair";
 }
 
 TEST_F(KeyUtilsTest, ClassifyIsNotationIndependent) {

--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -2,6 +2,8 @@
 #include <gtest/gtest.h>
 
 #include <QDebug>
+#include <QMap>
+#include <QString>
 
 #include "proto/keys.pb.h"
 #include "track/keyutils.h"
@@ -9,6 +11,12 @@
 using ::testing::UnorderedElementsAre;
 
 class KeyUtilsTest : public testing::Test {
+  protected:
+    void TearDown() override {
+        // KeyUtils holds the display notation in global state. Reset it so a
+        // test that installs a custom notation cannot influence later tests.
+        KeyUtils::setNotation({});
+    }
 };
 
 TEST_F(KeyUtilsTest, OpenKeyNotation) {
@@ -306,4 +314,218 @@ TEST_F(KeyUtilsTest, GetCompatibleKeys) {
                     mixxx::track::io::key::D_MINOR,
                     mixxx::track::io::key::A_MINOR,
                     mixxx::track::io::key::G_MINOR));
+}
+
+// ---------------------------------------------------------------------------
+// classifyAgainst() — harmonic key-highlighter classifier.
+//
+// The full input space is 25x25 = 625 (ChromaticKey, ChromaticKey) pairs, so
+// these tests mix targeted cases with exhaustive sweeps over the valid keys.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+using mixxx::track::io::key::ChromaticKey;
+using Class = KeyUtils::KeyHighlightClass;
+
+// The first and last valid (non-INVALID) ChromaticKey values.
+constexpr ChromaticKey kFirstKey = mixxx::track::io::key::C_MAJOR; // 1
+constexpr ChromaticKey kLastKey = mixxx::track::io::key::B_MINOR;  // 24
+
+} // anonymous namespace
+
+TEST_F(KeyUtilsTest, ClassifyInvalidInputs) {
+    // INVALID on either (or both) sides is always None.
+    EXPECT_EQ(Class::None,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::INVALID,
+                    mixxx::track::io::key::INVALID));
+    for (ChromaticKey k = kFirstKey; k <= kLastKey; k = incrementKey(k)) {
+        EXPECT_EQ(Class::None,
+                KeyUtils::classifyAgainst(mixxx::track::io::key::INVALID, k))
+                << "ref=" << static_cast<int>(k);
+        EXPECT_EQ(Class::None,
+                KeyUtils::classifyAgainst(k, mixxx::track::io::key::INVALID))
+                << "track=" << static_cast<int>(k);
+    }
+}
+
+TEST_F(KeyUtilsTest, ClassifySameKey) {
+    // A key against itself is always the strongest match.
+    for (ChromaticKey k = kFirstKey; k <= kLastKey; k = incrementKey(k)) {
+        EXPECT_EQ(Class::GreenPerfect, KeyUtils::classifyAgainst(k, k))
+                << "key=" << static_cast<int>(k);
+    }
+}
+
+TEST_F(KeyUtilsTest, ClassifyRelativeMajorMinor) {
+    // The relative major/minor sit on the same Circle-of-Fifths radial (same
+    // OpenKey number) but in opposite modes, e.g. C major (8B) / A minor (8A).
+    // Derive each major key's true relative minor from the OpenKey number and
+    // verify both directions for all 12 radials.
+    for (int i = 0; i < 12; ++i) {
+        const auto major = static_cast<ChromaticKey>(
+                static_cast<int>(mixxx::track::io::key::C_MAJOR) + i);
+        const int openKeyNumber = KeyUtils::keyToOpenKeyNumber(major);
+        const auto relativeMinor =
+                KeyUtils::openKeyNumberToKey(openKeyNumber, /*major=*/false);
+        ASSERT_FALSE(KeyUtils::keyIsMajor(relativeMinor));
+        EXPECT_EQ(Class::GreenPerfect,
+                KeyUtils::classifyAgainst(major, relativeMinor))
+                << "major=" << static_cast<int>(major);
+        EXPECT_EQ(Class::GreenPerfect,
+                KeyUtils::classifyAgainst(relativeMinor, major))
+                << "relativeMinor=" << static_cast<int>(relativeMinor);
+    }
+}
+
+TEST_F(KeyUtilsTest, ClassifyCircleNeighbours) {
+    // Non-relative members of the compatible set are GreenNeighbour (4th/5th).
+    // Pin against A minor and F major (the keys GetCompatibleKeys verifies).
+    const auto aMinor = mixxx::track::io::key::A_MINOR;
+    EXPECT_EQ(Class::GreenNeighbour,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::F_MAJOR, aMinor));
+    EXPECT_EQ(Class::GreenNeighbour,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::G_MAJOR, aMinor));
+    EXPECT_EQ(Class::GreenNeighbour,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::D_MINOR, aMinor));
+    EXPECT_EQ(Class::GreenNeighbour,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::E_MINOR, aMinor));
+    // C major is the *relative* major of A minor, so it is GreenPerfect, not
+    // GreenNeighbour.
+    EXPECT_EQ(Class::GreenPerfect,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::C_MAJOR, aMinor));
+
+    const auto fMajor = mixxx::track::io::key::F_MAJOR;
+    EXPECT_EQ(Class::GreenNeighbour,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::C_MAJOR, fMajor));
+    EXPECT_EQ(Class::GreenNeighbour,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::B_FLAT_MAJOR, fMajor));
+    EXPECT_EQ(Class::GreenNeighbour,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::A_MINOR, fMajor));
+    EXPECT_EQ(Class::GreenNeighbour,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::G_MINOR, fMajor));
+    // D minor is the relative minor of F major -> GreenPerfect.
+    EXPECT_EQ(Class::GreenPerfect,
+            KeyUtils::classifyAgainst(mixxx::track::io::key::D_MINOR, fMajor));
+}
+
+TEST_F(KeyUtilsTest, ClassifyYellowSemitoneShift) {
+    // A track is Yellow if it is not compatible itself, but +1 or -1 semitone
+    // lands in the compatible set.
+    const auto ref = mixxx::track::io::key::A_MINOR;
+    const QList<ChromaticKey> compatible = KeyUtils::getCompatibleKeys(ref);
+
+    // Find concrete +1 and -1 reachable examples by construction and assert the
+    // classifier agrees, including the 12<->1 / 24<->13 wrap-around.
+    bool sawPlusOne = false;
+    bool sawMinusOne = false;
+    for (ChromaticKey track = kFirstKey; track <= kLastKey;
+            track = incrementKey(track)) {
+        if (compatible.contains(track)) {
+            continue; // those are green, not yellow
+        }
+        const bool plus = compatible.contains(KeyUtils::scaleKeySteps(track, 1));
+        const bool minus = compatible.contains(KeyUtils::scaleKeySteps(track, -1));
+        if (plus || minus) {
+            EXPECT_EQ(Class::Yellow, KeyUtils::classifyAgainst(track, ref))
+                    << "track=" << static_cast<int>(track);
+            sawPlusOne = sawPlusOne || plus;
+            sawMinusOne = sawMinusOne || minus;
+        }
+    }
+    EXPECT_TRUE(sawPlusOne) << "expected at least one +1-semitone Yellow case";
+    EXPECT_TRUE(sawMinusOne) << "expected at least one -1-semitone Yellow case";
+
+    // Explicit wrap-around spot check: B major (id 12) +1 semitone wraps to
+    // C major (id 1) within the same mode via scaleKeySteps.
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+            KeyUtils::scaleKeySteps(mixxx::track::io::key::B_MAJOR, 1));
+}
+
+TEST_F(KeyUtilsTest, ClassifyRed) {
+    // Keys that are neither compatible nor +/-1-semitone reachable are Red.
+    const auto ref = mixxx::track::io::key::A_MINOR;
+    const QList<ChromaticKey> compatible = KeyUtils::getCompatibleKeys(ref);
+    int redCount = 0;
+    for (ChromaticKey track = kFirstKey; track <= kLastKey;
+            track = incrementKey(track)) {
+        const bool green = compatible.contains(track);
+        const bool yellow = !green &&
+                (compatible.contains(KeyUtils::scaleKeySteps(track, 1)) ||
+                        compatible.contains(KeyUtils::scaleKeySteps(track, -1)));
+        if (!green && !yellow) {
+            EXPECT_EQ(Class::Red, KeyUtils::classifyAgainst(track, ref))
+                    << "track=" << static_cast<int>(track);
+            ++redCount;
+        }
+    }
+    EXPECT_GT(redCount, 0) << "expected at least one Red case for A minor";
+}
+
+TEST_F(KeyUtilsTest, ClassifyExhaustiveConsistency) {
+    // Sweep all 24x24 valid pairs and assert invariants that must hold
+    // regardless of the exact thresholds. This catches off-by-one and ordering
+    // regressions across the whole input space, not just hand-picked points.
+    for (ChromaticKey ref = kFirstKey; ref <= kLastKey; ref = incrementKey(ref)) {
+        const QList<ChromaticKey> compatible = KeyUtils::getCompatibleKeys(ref);
+        for (ChromaticKey track = kFirstKey; track <= kLastKey;
+                track = incrementKey(track)) {
+            const Class c = KeyUtils::classifyAgainst(track, ref);
+
+            // Never None for valid inputs.
+            EXPECT_NE(Class::None, c)
+                    << "track=" << static_cast<int>(track)
+                    << " ref=" << static_cast<int>(ref);
+
+            // Identity is always GreenPerfect.
+            if (track == ref) {
+                EXPECT_EQ(Class::GreenPerfect, c);
+            }
+
+            const bool isGreen =
+                    c == Class::GreenPerfect || c == Class::GreenNeighbour;
+            const bool inCompatible = compatible.contains(track);
+
+            // Green <=> membership in the compatible set (cross-check against
+            // the existing helper).
+            EXPECT_EQ(isGreen, inCompatible)
+                    << "track=" << static_cast<int>(track)
+                    << " ref=" << static_cast<int>(ref);
+
+            // Yellow <=> not compatible AND +/-1 semitone is compatible
+            // (mutual exclusivity with green is implied).
+            const bool semitoneReachable =
+                    compatible.contains(KeyUtils::scaleKeySteps(track, 1)) ||
+                    compatible.contains(KeyUtils::scaleKeySteps(track, -1));
+            if (c == Class::Yellow) {
+                EXPECT_FALSE(inCompatible);
+                EXPECT_TRUE(semitoneReachable);
+            }
+
+            // Red <=> neither compatible nor semitone-reachable.
+            if (c == Class::Red) {
+                EXPECT_FALSE(inCompatible);
+                EXPECT_FALSE(semitoneReachable);
+            }
+        }
+    }
+}
+
+TEST_F(KeyUtilsTest, ClassifyIsNotationIndependent) {
+    // Classification compares ChromaticKey values, never display strings, so
+    // setting a custom display notation must not change the result.
+    const auto track = mixxx::track::io::key::E_MINOR;
+    const auto ref = mixxx::track::io::key::A_MINOR;
+    const Class before = KeyUtils::classifyAgainst(track, ref);
+
+    // Install a bogus custom notation that renames every key, then re-classify.
+    QMap<ChromaticKey, QString> bogus;
+    for (ChromaticKey k = kFirstKey; k <= kLastKey; k = incrementKey(k)) {
+        bogus.insert(k, QStringLiteral("x%1").arg(static_cast<int>(k)));
+    }
+    KeyUtils::setNotation(bogus);
+    const Class after = KeyUtils::classifyAgainst(track, ref);
+
+    EXPECT_EQ(before, after);
+    EXPECT_EQ(Class::GreenNeighbour, after);
 }

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -826,6 +826,37 @@ KeyUtils::KeyHighlightClass KeyUtils::classifyAgainst(
     return KeyHighlightClass::Red;
 }
 
+KeyUtils::YellowShift KeyUtils::yellowShiftDirection(
+        mixxx::track::io::key::ChromaticKey trackKey,
+        mixxx::track::io::key::ChromaticKey refKey) {
+    if (!ChromaticKey_IsValid(trackKey) ||
+            trackKey == mixxx::track::io::key::INVALID ||
+            !ChromaticKey_IsValid(refKey) ||
+            refKey == mixxx::track::io::key::INVALID) {
+        return YellowShift::None;
+    }
+
+    const QList<mixxx::track::io::key::ChromaticKey> compatible =
+            getCompatibleKeys(refKey);
+    // Already compatible -> green, not yellow; no transpose hint applies.
+    if (compatible.contains(trackKey)) {
+        return YellowShift::None;
+    }
+
+    // +1 = pitch the track up a semitone, -1 = down. Both can hold at once.
+    const bool up = compatible.contains(scaleKeySteps(trackKey, 1));
+    const bool down = compatible.contains(scaleKeySteps(trackKey, -1));
+    if (up && down) {
+        return YellowShift::Both;
+    } else if (up) {
+        return YellowShift::Up;
+    } else if (down) {
+        return YellowShift::Down;
+    }
+    // Unreachable by +/-1 -> red.
+    return YellowShift::None;
+}
+
 int KeyUtils::keyToCircleOfFifthsOrder(mixxx::track::io::key::ChromaticKey key,
                                        KeyNotation notation) {
     if (!ChromaticKey_IsValid(key)) {

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -791,6 +791,41 @@ QList<mixxx::track::io::key::ChromaticKey> KeyUtils::getCompatibleKeys(
     return compatible;
 }
 
+KeyUtils::KeyHighlightClass KeyUtils::classifyAgainst(
+        mixxx::track::io::key::ChromaticKey trackKey,
+        mixxx::track::io::key::ChromaticKey refKey) {
+    if (!ChromaticKey_IsValid(trackKey) ||
+            trackKey == mixxx::track::io::key::INVALID ||
+            !ChromaticKey_IsValid(refKey) ||
+            refKey == mixxx::track::io::key::INVALID) {
+        return KeyHighlightClass::None;
+    }
+
+    const QList<mixxx::track::io::key::ChromaticKey> compatible =
+            getCompatibleKeys(refKey);
+    if (compatible.contains(trackKey)) {
+        // Same key, or relative major/minor: a relative pair sits on the same
+        // radial of the Circle of Fifths (same OpenKey number) but differs in
+        // mode (e.g. C major / A minor). This is the strongest harmonic match.
+        if (trackKey == refKey ||
+                (keyToOpenKeyNumber(trackKey) == keyToOpenKeyNumber(refKey) &&
+                        keyIsMajor(trackKey) != keyIsMajor(refKey))) {
+            return KeyHighlightClass::GreenPerfect;
+        }
+        // Otherwise a Circle-of-Fifths neighbour (perfect 4th/5th).
+        return KeyHighlightClass::GreenNeighbour;
+    }
+
+    // Not directly compatible, but transposing the track up or down one
+    // semitone may land on a compatible key.
+    if (compatible.contains(scaleKeySteps(trackKey, 1)) ||
+            compatible.contains(scaleKeySteps(trackKey, -1))) {
+        return KeyHighlightClass::Yellow;
+    }
+
+    return KeyHighlightClass::Red;
+}
+
 int KeyUtils::keyToCircleOfFifthsOrder(mixxx::track::io::key::ChromaticKey key,
                                        KeyNotation notation) {
     if (!ChromaticKey_IsValid(key)) {

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -37,6 +37,25 @@ class KeyUtils {
         Unknown = 7
     };
 
+    /// Harmonic relationship of a track key to a reference (deck) key, used by
+    /// the library key highlighter. Ordered from most to least mixable; the
+    /// numeric order is used to pick the "best" class across multiple decks
+    /// (lower value wins), so do not reorder without updating that logic.
+    enum class KeyHighlightClass {
+        GreenPerfect = 0,   //< Same key, or relative major/minor.
+        GreenNeighbour = 1, //< Other member of the compatible set (4th/5th).
+        Yellow = 2,         //< Not compatible, but +/-1 semitone is compatible.
+        Red = 3,            //< Neither compatible nor reachable by +/-1 semitone.
+        None = 4,           //< Invalid key on either side; not applicable.
+    };
+
+    /// Classifies a track key against a single reference key for the library
+    /// key highlighter. Pure function composed from getCompatibleKeys() and
+    /// scaleKeySteps(); compares ChromaticKey values only (notation-independent).
+    static KeyHighlightClass classifyAgainst(
+            mixxx::track::io::key::ChromaticKey trackKey,
+            mixxx::track::io::key::ChromaticKey refKey);
+
     static QString keyDebugName(mixxx::track::io::key::ChromaticKey key);
 
     static inline bool keyIsMajor(mixxx::track::io::key::ChromaticKey key) {

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -56,6 +56,25 @@ class KeyUtils {
             mixxx::track::io::key::ChromaticKey trackKey,
             mixxx::track::io::key::ChromaticKey refKey);
 
+    /// For a Yellow track (one that classifyAgainst() rates Yellow against the
+    /// same refKey), which way the track must be transposed to become
+    /// compatible. Up means pitch the track up +1 semitone, Down means down -1,
+    /// Both means either works. Returns None for non-Yellow pairs (compatible,
+    /// unreachable, or invalid keys) so it can be queried unconditionally.
+    enum class YellowShift {
+        None = 0, //< Not a Yellow pair; no transpose applies.
+        Up = 1,   //< +1 semitone (pitch the track up) reaches a compatible key.
+        Down = 2, //< -1 semitone (pitch the track down) reaches a compatible key.
+        Both = 3, //< Either +1 or -1 reaches a compatible key.
+    };
+
+    /// Direction(s) in which a track must be transposed by one semitone to be
+    /// compatible with refKey. Mirrors the Yellow branch of classifyAgainst():
+    /// non-None exactly when classifyAgainst() returns Yellow. Pure function.
+    static YellowShift yellowShiftDirection(
+            mixxx::track::io::key::ChromaticKey trackKey,
+            mixxx::track::io::key::ChromaticKey refKey);
+
     static QString keyDebugName(mixxx::track::io::key::ChromaticKey key);
 
     static inline bool keyIsMajor(mixxx::track::io::key::ChromaticKey key) {


### PR DESCRIPTION
Closes #14823

Adds a per-deck "key highlight" toggle that tints the library track table by
how mixable each track's key is with that deck's current key — the
Rekordbox-style "traffic light" requested in #14823.

### What it does
- A new per-deck control `[ChannelN],key_highlight` (toggle), bound to
  `Alt+1` / `Alt+2`, turns the highlighter on for that deck.
- While active, library rows are tinted by harmonic relationship to the
  deck's key:
  - **Green (perfect)** — same key or relative major/minor
  - **Green (neighbour)** — 4th/5th (rest of the compatible set)
  - **Yellow** — not compatible, but a ±1 semitone shift would be
  - **Red** — neither
- The highlighter is **mutually exclusive across decks**: enabling one deck's
  toggle turns the others off, so there is a single reference key at a time.

### How it works
- `KeyUtils::classifyAgainst()` is a pure classifier composed from the existing
  `getCompatibleKeys()` / `scaleKeySteps()` helpers; it compares `ChromaticKey`
  values only, so it's independent of the user's key notation.
- `KeyHighlightManager` watches `[App],num_decks` and each deck's
  `key_highlight` + `key`, and precomputes a `ChromaticKey → class` lookup table
  so `BaseTrackTableModel::data()` colours each row with an O(1) lookup. It is
  installed process-wide by `Library`, mirroring the existing
  `s_keyColorPalette` static pattern.
- Recompute is **debounced on the discrete key** (the engine key updates
  continuously with pitch, but the class only depends on the rounded key), and
  emits `dataChanged()` for the colour roles only — no DB re-query.
- Missing-track colour keeps precedence over the highlight in both the
  Background and Foreground roles.

### Why mutual exclusion writes the control
Enabling one deck writes `0` to the other decks' `key_highlight` controls
(rather than only suppressing them internally) so a mapped controller LED or
skin button reflects the true single-active state.

### Notes / scope
- Colours are currently hardcoded; a skin/QSS palette override and user
  preferences (row-vs-cell, file-vs-engine key) are left for a follow-up.
- `Alt+1`/`Alt+2` chosen because `Ctrl+1..` are taken by the View menu and
  `Shift+<digit>` remaps to punctuation on most layouts.

### Testing
- `KeyUtilsTest.Classify*` — targeted cases + an exhaustive 24×24 sweep of the
  green/yellow invariants and notation independence.
- `KeyHighlightManagerTest.*` — toggle, single-deck classification, mutual
  exclusion + non-oscillation, discrete-key debounce, num_decks grow/shrink.

### Screenshots
<img width="1280" height="659" alt="Peek 2026-06-03 12-23" src="https://github.com/user-attachments/assets/962b51f3-8b61-486d-8ce0-149bc16c5590" />
