### PR TITLE
correct RubberBandWorkerPool::createInstance(); out of #ifdef

### DIFF
--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -99,7 +99,9 @@ class PlayerManagerTest : public MixxxDbTest, SoundSourceProviderRegistration {
                 m_pRecordingManager.get());
 
         m_pPlayerManager->bindToLibrary(m_pLibrary.get());
+#ifdef __RUBBERBAND__
         RubberBandWorkerPool::createInstance();
+#endif
     }
 
     void TearDown() override {


### PR DESCRIPTION
when building without Rubberband, the building of the testsuite fails as

correct RubberBandWorkerPool::createInstance(); 

was out of #ifdef __RUBBERBAND__

corrected to

#ifdef __RUBBERBAND__        
        RubberBandWorkerPool::createInstance();
#endif    