### PR TITLE
(fix) Library sidebar: fix bold state for root items when a trackset contains the selected track

### DIFF
--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -282,6 +282,19 @@ QVariant SidebarModel::data(const QModelIndex& index, int role) const {
             return m_sFeatures[index.row()]->icon();
         case SidebarModel::IconNameRole:
             return m_sFeatures[index.row()]->iconName();
+        case Qt::FontRole: {
+            auto* pFeature = m_sFeatures[index.row()];
+            TreeItem* pTreeItem = nullptr;
+            auto* pChildModel = pFeature->sidebarModel();
+            if (pChildModel) {
+                pTreeItem = pChildModel->getRootItem();
+            }
+            QFont font;
+            if (pTreeItem) {
+                font.setBold(pTreeItem->isBold());
+            }
+            return font;
+        }
         default:
             return QVariant();
         }
@@ -509,6 +522,16 @@ QModelIndex SidebarModel::translateIndex(
     QModelIndex translatedIndex;
 
     if (index.isValid()) {
+        if (!index.parent().isValid()) {
+            // This is the top-level root item of the child model.
+            // Find the feature it belongs to
+            for (int i = 0; i < m_sFeatures.size(); ++i) {
+                if (m_sFeatures[i]->sidebarModel() == pModel) {
+                    return createIndex(i, index.column(), this);
+                }
+            }
+        }
+
         TreeItem* pItem = static_cast<TreeItem*>(index.internalPointer());
         translatedIndex = createIndex(index.row(), index.column(), pItem);
     } else {

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -49,6 +49,7 @@ class SidebarModel : public QAbstractItemModel {
 
     void clear(const QModelIndex& index);
     void paste(const QModelIndex& index);
+
   public slots:
     void pressed(const QModelIndex& index);
     void clicked(const QModelIndex& index);

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -889,37 +889,44 @@ void BasePlaylistFeature::slotTrackSelected(TrackId trackId) {
     m_selectedTrackId = trackId;
     m_playlistDao.getPlaylistsTrackIsIn(m_selectedTrackId, &m_playlistIdsOfSelectedTrack);
 
+    bool shouldRootBeBold = false;
+
     for (int row = 0; row < m_pSidebarModel->rowCount(); ++row) {
         QModelIndex index = m_pSidebarModel->index(row, 0);
         TreeItem* pTreeItem = m_pSidebarModel->getItem(index);
         DEBUG_ASSERT(pTreeItem != nullptr);
-        markTreeItem(pTreeItem);
+
+        // If any child item is marked bold, the root item must be, too
+        if (markTreeItem(pTreeItem)) {
+            shouldRootBeBold = true;
+        }
     }
+
+    m_pSidebarModel->getRootItem()->setBold(shouldRootBeBold);
 
     m_pSidebarModel->triggerRepaint();
 }
 
-void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
+bool BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
     bool ok;
+    bool isBold = false;
     int playlistId = pTreeItem->getData().toInt(&ok);
     if (ok) {
-        bool shouldBold = m_playlistIdsOfSelectedTrack.contains(playlistId);
-        pTreeItem->setBold(shouldBold);
-        if (shouldBold && pTreeItem->hasParent()) {
-            TreeItem* item = pTreeItem;
-            // extra parents, because -Werror=parentheses
-            while ((item = item->parent())) {
-                item->setBold(true);
+        isBold = m_playlistIdsOfSelectedTrack.contains(playlistId);
+    }
+
+    if (pTreeItem->hasChildren()) {
+        QList<TreeItem*> children = pTreeItem->children();
+        for (int i = 0; i < children.size(); i++) {
+            if (markTreeItem(children.at(i))) {
+                isBold = true;
             }
         }
     }
-    if (pTreeItem->hasChildren()) {
-        QList<TreeItem*> children = pTreeItem->children();
 
-        for (int i = 0; i < children.size(); i++) {
-            markTreeItem(children.at(i));
-        }
-    }
+    pTreeItem->setBold(isBold);
+
+    return isBold;
 }
 
 QString BasePlaylistFeature::createPlaylistLabel(const QString& name,

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -139,7 +139,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void initActions();
     void connectPlaylistDAO();
     virtual QString getRootViewHtml() const = 0;
-    void markTreeItem(TreeItem* pTreeItem);
+    bool markTreeItem(TreeItem* pTreeItem);
     QString fetchPlaylistLabel(int playlistId);
 
 

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -950,6 +950,8 @@ void CrateFeature::slotTrackSelected(TrackId trackId) {
         pTreeItem->setBold(crateContainsSelectedTrack);
     }
 
+    pRootItem->setBold(m_selectedTrackId.isValid() && sortedTrackCrates.size() > 0);
+
     m_pSidebarModel->triggerRepaint();
 }
 

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -217,4 +217,9 @@ void TreeItemModel::triggerRepaint() {
     QModelIndex left = index(0, 0);
     QModelIndex right = index(rowCount() - 1, columnCount() - 1);
     emit dataChanged(left, right);
+
+    // Also include the root item in case this has been called in order to
+    // enforce FontRole updates via TreeItem::isBold()
+    QModelIndex rootIdx = getRootIndex();
+    emit dataChanged(rootIdx, rootIdx);
 }


### PR DESCRIPTION
When you select a track in the track view, sidebar items that contain it are painted bold.
However, this was not working for the respective root items due to
1) a reset flaw in `BasePlaylistFeature::markTreeItem()`
and even if that worked
2) `TreeItemModel::triggerRepaint()` didn't emit `dataChanged()` for the feature's root index
3) missing `Qt::FontRole` case for root items