### PR TITLE
enginefilters: Add more IIR filter templates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1362,7 +1362,9 @@ add_library(
   src/engine/filters/enginefilterbessel4.cpp
   src/engine/filters/enginefilterbessel8.cpp
   src/engine/filters/enginefilterbiquad1.cpp
+  src/engine/filters/enginefilterbutterworth2.cpp
   src/engine/filters/enginefilterbutterworth4.cpp
+  src/engine/filters/enginefilterbutterworth6.cpp
   src/engine/filters/enginefilterbutterworth8.cpp
   src/engine/filters/enginefilterlinkwitzriley2.cpp
   src/engine/filters/enginefilterlinkwitzriley4.cpp

--- a/src/engine/filters/enginefilterbutterworth2.cpp
+++ b/src/engine/filters/enginefilterbutterworth2.cpp
@@ -1,0 +1,53 @@
+#include "engine/filters/enginefilterbutterworth2.h"
+
+#include "moc_enginefilterbutterworth2.cpp"
+
+namespace {
+constexpr char kFidSpecLowPassButterworth2[] = "LpBu2";
+constexpr char kFidSpecBandPassButterworth2[] = "BpBu2";
+constexpr char kFidSpecHighPassButterworth2[] = "HpBu2";
+} // namespace
+
+EngineFilterButterworth2Low::EngineFilterButterworth2Low(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
+    setFrequencyCorners(sampleRate, freqCorner1);
+}
+
+void EngineFilterButterworth2Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
+    // Copy the old coefficients into m_oldCoef
+    setCoefs(kFidSpecLowPassButterworth2,
+            sizeof(kFidSpecLowPassButterworth2),
+            sampleRate,
+            freqCorner1);
+}
+
+EngineFilterButterworth2Band::EngineFilterButterworth2Band(
+        mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
+    setFrequencyCorners(sampleRate, freqCorner1, freqCorner2);
+}
+
+void EngineFilterButterworth2Band::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
+    setCoefs(kFidSpecBandPassButterworth2,
+            sizeof(kFidSpecBandPassButterworth2),
+            sampleRate,
+            freqCorner1,
+            freqCorner2);
+}
+
+EngineFilterButterworth2High::EngineFilterButterworth2High(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
+    setFrequencyCorners(sampleRate, freqCorner1);
+}
+
+void EngineFilterButterworth2High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
+    setCoefs(kFidSpecHighPassButterworth2,
+            sizeof(kFidSpecHighPassButterworth2),
+            sampleRate,
+            freqCorner1);
+}

--- a/src/engine/filters/enginefilterbutterworth2.h
+++ b/src/engine/filters/enginefilterbutterworth2.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "audio/types.h"
+#include "engine/filters/enginefilteriir.h"
+
+class EngineFilterButterworth2Low : public EngineFilterIIR<2, IIR_LP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth2Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+};
+
+class EngineFilterButterworth2Band : public EngineFilterIIR<4, IIR_BP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth2Band(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double freqCorner2);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double freqCorner2);
+};
+
+class EngineFilterButterworth2High : public EngineFilterIIR<2, IIR_HP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth2High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+};

--- a/src/engine/filters/enginefilterbutterworth6.cpp
+++ b/src/engine/filters/enginefilterbutterworth6.cpp
@@ -1,0 +1,53 @@
+#include "engine/filters/enginefilterbutterworth6.h"
+
+#include "moc_enginefilterbutterworth6.cpp"
+
+namespace {
+constexpr char kFidSpecLowPassButterworth6[] = "LpBu6";
+constexpr char kFidSpecBandPassButterworth6[] = "BpBu6";
+constexpr char kFidSpecHighPassButterworth6[] = "HpBu6";
+} // namespace
+
+EngineFilterButterworth6Low::EngineFilterButterworth6Low(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
+    setFrequencyCorners(sampleRate, freqCorner1);
+}
+
+void EngineFilterButterworth6Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
+    // Copy the old coefficients into m_oldCoef
+    setCoefs(kFidSpecLowPassButterworth6,
+            sizeof(kFidSpecLowPassButterworth6),
+            sampleRate,
+            freqCorner1);
+}
+
+EngineFilterButterworth6Band::EngineFilterButterworth6Band(
+        mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
+    setFrequencyCorners(sampleRate, freqCorner1, freqCorner2);
+}
+
+void EngineFilterButterworth6Band::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
+    setCoefs(kFidSpecBandPassButterworth6,
+            sizeof(kFidSpecBandPassButterworth6),
+            sampleRate,
+            freqCorner1,
+            freqCorner2);
+}
+
+EngineFilterButterworth6High::EngineFilterButterworth6High(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
+    setFrequencyCorners(sampleRate, freqCorner1);
+}
+
+void EngineFilterButterworth6High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
+    setCoefs(kFidSpecHighPassButterworth6,
+            sizeof(kFidSpecHighPassButterworth6),
+            sampleRate,
+            freqCorner1);
+}

--- a/src/engine/filters/enginefilterbutterworth6.h
+++ b/src/engine/filters/enginefilterbutterworth6.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "audio/types.h"
+#include "engine/filters/enginefilteriir.h"
+
+class EngineFilterButterworth6Low : public EngineFilterIIR<6, IIR_LP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth6Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+};
+
+class EngineFilterButterworth6Band : public EngineFilterIIR<12, IIR_BP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth6Band(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double freqCorner2);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double freqCorner2);
+};
+
+class EngineFilterButterworth6High : public EngineFilterIIR<6, IIR_HP> {
+    Q_OBJECT
+  public:
+    EngineFilterButterworth6High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+};

--- a/src/engine/filters/enginefilteriir.h
+++ b/src/engine/filters/enginefilteriir.h
@@ -322,6 +322,7 @@ class EngineFilterIIR : public EngineFilterIIRBase {
     bool m_startFromDry;
 };
 
+// clang-format off
 template<>
 inline double EngineFilterIIR<2, IIR_LP>::processSample(double* coef,
                                                         double* buf,
@@ -347,6 +348,27 @@ inline double EngineFilterIIR<2, IIR_BP>::processSample(double* coef,
     iir -= coef[2] * buf[0];
     fir += iir;
     buf[1] = iir; val = fir;
+    return val;
+}
+
+template<>
+inline double EngineFilterIIR<4, IIR_BP>::processSample(double* coef,
+                                                        double* buf,
+                                                        double val) {
+    double tmp, fir, iir;
+    tmp = buf[0]; buf[0] = buf[1]; buf[1] = buf[2]; buf[2] = buf[3];
+    iir = val * coef[0];
+    iir -= coef[1] * tmp; fir = tmp;
+    iir -= coef[2] * buf[0]; fir += -buf[0] - buf[0];
+    fir += iir;
+    tmp = buf[1];
+    buf[1] = iir;
+    val = fir;
+    iir = val;
+    iir -= coef[3] * tmp; fir = tmp;
+    iir -= coef[4] * buf[2]; fir += buf[2] + buf[2];
+    fir += iir;
+    buf[3] = iir; val = fir;
     return val;
 }
 
@@ -429,6 +451,98 @@ inline double EngineFilterIIR<4, IIR_HP>::processSample(double* coef,
     iir -= coef[4] * buf[2]; fir += -buf[2] - buf[2];
     fir += iir;
     buf[3] = iir; val = fir;
+    return val;
+}
+
+template<>
+inline double EngineFilterIIR<6, IIR_LP>::processSample(double* coef,
+                                                        double* buf,
+                                                        double val) {
+    double tmp, fir, iir;
+    tmp = buf[0]; buf[0] = buf[1]; buf[1] = buf[2]; buf[2] = buf[3];
+    buf[3] = buf[4]; buf[4] = buf[5];
+    iir = val * coef[0];
+    iir -= coef[1] * tmp; fir = tmp;
+    iir -= coef[2] * buf[0]; fir += buf[0] + buf[0];
+    fir += iir;
+    tmp = buf[1]; buf[1] = iir; val = fir;
+    iir = val;
+    iir -= coef[3] * tmp; fir = tmp;
+    iir -= coef[4] * buf[2]; fir += buf[2] + buf[2];
+    fir += iir;
+    tmp = buf[3]; buf[3] = iir; val = fir;
+    iir = val;
+    iir -= coef[5] * tmp; fir = tmp;
+    iir -= coef[6] * buf[4]; fir += buf[4] + buf[4];
+    fir += iir;
+    buf[5] = iir; val = fir;
+    return val;
+}
+
+template<>
+inline double EngineFilterIIR<12, IIR_BP>::processSample(double* coef,
+                                                         double* buf,
+                                                         double val) {
+    double tmp, fir, iir;
+    tmp = buf[0];  buf[0]  = buf[1];  buf[1]  = buf[2];  buf[2]  = buf[3];
+    buf[3]  = buf[4];  buf[4]  = buf[5];  buf[5]  = buf[6];  buf[6]  = buf[7];
+    buf[7]  = buf[8];  buf[8]  = buf[9];  buf[9]  = buf[10]; buf[10] = buf[11];
+    iir = val * coef[0];
+    iir -= coef[1] * tmp; fir = tmp;
+    iir -= coef[2] * buf[0]; fir += -buf[0] - buf[0];
+    fir += iir;
+    tmp = buf[1]; buf[1] = iir; val = fir;
+    iir = val;
+    iir -= coef[3] * tmp; fir = tmp;
+    iir -= coef[4] * buf[2]; fir += -buf[2] - buf[2];
+    fir += iir;
+    tmp = buf[3]; buf[3] = iir; val = fir;
+    iir = val;
+    iir -= coef[5] * tmp; fir = tmp;
+    iir -= coef[6] * buf[4]; fir += -buf[4] - buf[4];
+    fir += iir;
+    tmp = buf[5]; buf[5] = iir; val = fir;
+    iir = val;
+    iir -= coef[7] * tmp; fir = tmp;
+    iir -= coef[8] * buf[6]; fir += buf[6] + buf[6];
+    fir += iir;
+    tmp = buf[7]; buf[7] = iir; val = fir;
+    iir = val;
+    iir -= coef[9] * tmp; fir = tmp;
+    iir -= coef[10] * buf[8]; fir += buf[8] + buf[8];
+    fir += iir;
+    tmp = buf[9]; buf[9] = iir; val = fir;
+    iir = val;
+    iir -= coef[11] * tmp; fir = tmp;
+    iir -= coef[12] * buf[10]; fir += buf[10] + buf[10];
+    fir += iir;
+    buf[11] = iir; val = fir;
+    return val;
+}
+
+template<>
+inline double EngineFilterIIR<6, IIR_HP>::processSample(double* coef,
+                                                        double* buf,
+                                                        double val) {
+    double tmp, fir, iir;
+
+    tmp = buf[0]; buf[0] = buf[1]; buf[1] = buf[2]; buf[2] = buf[3];
+    buf[3] = buf[4]; buf[4] = buf[5];
+    iir = val * coef[0];
+    iir -= coef[1] * tmp; fir = tmp;
+    iir -= coef[2] * buf[0]; fir += -buf[0] - buf[0];
+    fir += iir;
+    tmp = buf[1]; buf[1] = iir; val = fir;
+    iir = val;
+    iir -= coef[3] * tmp; fir = tmp;
+    iir -= coef[4] * buf[2]; fir += -buf[2] - buf[2];
+    fir += iir;
+    tmp = buf[3]; buf[3] = iir; val = fir;
+    iir = val;
+    iir -= coef[5] * tmp; fir = tmp;
+    iir -= coef[6] * buf[4]; fir += -buf[4] - buf[4];
+    fir += iir;
+    buf[5] = iir; val = fir;
     return val;
 }
 


### PR DESCRIPTION
Adds templates for a 2nd order BP, and 6th order HP, LP and BP