### PR TITLE
Fix single-finger touch scrolling in library views on Windows

### DIFF
--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -1,6 +1,7 @@
 #include "widget/wlibrarysidebar.h"
 
 #include <QHeaderView>
+#include <QScroller>
 #include <QUrl>
 #include <QtDebug>
 
@@ -29,6 +30,17 @@ WLibrarySidebar::WLibrarySidebar(QWidget* parent)
     header()->setStretchLastSection(false);
     header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     header()->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+    // Required for QScroller-driven kinetic touch scrolling to map finger
+    // movement 1:1 to pixels. Without this, the vertical scrollbar's range
+    // is in row-units, so QScroller scrolls by a number of rows proportional
+    // to the drag distance, which feels amplified and worsens on long lists.
+    setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+
+    // Enable kinetic scrolling via touch (single-finger swipe) on touchscreens.
+    // Without this, Qt's Windows platform plugin converts single-finger touch
+    // to mouse-press + mouse-move, which is interpreted as drag-and-drop
+    // instead of scrolling.
+    QScroller::grabGesture(viewport(), QScroller::TouchGesture);
 }
 
 void WLibrarySidebar::contextMenuEvent(QContextMenuEvent* pEvent) {

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -45,6 +45,11 @@ WLibraryTableView::WLibraryTableView(QWidget* parent,
     //Work around a Qt bug that lets you make your columns so wide you
     //can't reach the divider to make them small again.
     setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+    // Required for QScroller-driven kinetic touch scrolling to map finger
+    // movement 1:1 to pixels. Without this, the vertical scrollbar's range
+    // is in row-units, so QScroller scrolls by a number of rows proportional
+    // to the drag distance, which feels amplified and worsens on long lists.
+    setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
 
     verticalHeader()->hide();
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -3,6 +3,7 @@
 #include <QDrag>
 #include <QModelIndex>
 #include <QScrollBar>
+#include <QScroller>
 #include <QShortcut>
 #include <QStylePainter>
 #include <QUrl>
@@ -58,6 +59,12 @@ WTrackTableView::WTrackTableView(QWidget* pParent,
           m_selectionChangedSinceLastGuiTick(true),
           m_loadCachedOnly(false),
           m_dropRow(-1) {
+    // Enable kinetic scrolling via touch (single-finger swipe) on touchscreens.
+    // Without this, Qt's Windows platform plugin converts single-finger touch
+    // to mouse-press + mouse-move, which Mixxx interprets as drag-and-drop
+    // instead of scrolling.
+    QScroller::grabGesture(viewport(), QScroller::TouchGesture);
+
     // Connect slots and signals to make the world go 'round.
     connect(this, &WTrackTableView::doubleClicked, this, &WTrackTableView::slotMouseDoubleClicked);
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -704,7 +704,13 @@ void WTrackTableView::mouseMoveEvent(QMouseEvent* pEvent) {
     }
     //qDebug() << "MouseMoveEvent";
 
-    if (DragAndDropHelper::mouseMoveInitiatesDrag(pEvent)) {
+    // Don't start a track drag for touch input: on touchscreens this event
+    // is a synthesized mouse-move from a single-finger swipe, which is
+    // handled as kinetic scrolling (see QScroller::grabGesture() in the
+    // constructor). Starting a blocking QDrag here would race with and
+    // sometimes win over gesture recognition, hijacking swipes into drags.
+    if (pEvent->source() == Qt::MouseEventNotSynthesized &&
+            DragAndDropHelper::mouseMoveInitiatesDrag(pEvent)) {
         // Iterate over selected rows and append each item's location url to a list.
         QList<QString> locations;
         const QModelIndexList indices = getSelectedRows();


### PR DESCRIPTION
## Summary

On Windows touchscreens (tested on the ASUS ROG Ally), a single-finger
swipe in the library track table or sidebar is misinterpreted as a
mouse drag instead of a scroll — Qt's Windows platform plugin reports
touch input as synthesized mouse-press/move events, and Mixxx has no
gesture recognition wired up to claim them as scrolling first. The
practical effect: swiping to browse the library either selects/drags
rows or starts a track drag-and-drop under your finger, instead of
scrolling like every other touch-aware Windows application.

This PR makes single-finger swipes scroll the library naturally:

1. **Enable kinetic touch scrolling** — grab `QScroller::TouchGesture`
   on `WTrackTableView` and `WLibrarySidebar`'s viewports, and ensure
   both views use `ScrollPerPixel` on both scroll axes (a prerequisite
   for QScroller to track the finger 1:1 in pixels — without it on the
   vertical axis, scrolling jumps by a number of rows proportional to
   swipe distance, worsening on long lists).
2. **Stop touch input from starting track drags** — gate
   `WTrackTableView`'s drag-and-drop initiation on
   `QMouseEvent::source() == Qt::MouseEventNotSynthesized`, so a
   touch-synthesized mouse-move can never win the race against
   QScroller's gesture recognition and hijack a swipe into a drag.

## Test plan

- [x] Built locally (Release, MSVC/Ninja) and manually verified on an
      ASUS ROG Ally touchscreen: single-finger swipes now kinetically
      scroll the library track table and sidebar at a natural,
      finger-tracking speed, with no accidental track drags or row
      selection, across short and long playlists.
- [ ] Maintainers/reviewers: please verify mouse-driven selection,
      drag-and-drop (track-to-deck, playlist reordering), and
      sidebar drag targets are unaffected, since I could only test the
      touch path on real hardware.

## Note on touch drag-and-drop

This intentionally disables *touch-originated* track drag-and-drop
(e.g. dragging a track from the library to a deck/playlist with a
finger) in favor of reliable scrolling, since the two could not be
reliably distinguished from a single-finger gesture. Touch users can
still use load buttons / context menus to move tracks. Mouse-driven
drag-and-drop is untouched.