### PR TITLE
feat(engine): add toggle to prevent jogging before track start (disable pre-roll)

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -701,12 +701,12 @@ void CueControl::seekOnLoad(mixxx::audio::FramePos seekOnLoadPosition) {
     DEBUG_ASSERT(seekOnLoadPosition.isValid());
     seekExact(seekOnLoadPosition);
     // When pre-roll is disabled, EngineBuffer clamps the resulting position to
-    // track start. Record the effective position so trackAnalyzed() can correctly
-    // detect whether the user has manually repositioned the deck.
+    // the pre-roll limit. Record the effective position so trackAnalyzed() can
+    // correctly detect whether the user has manually repositioned the deck.
+    const auto clampPos = getEngineBuffer()->preRollClampPos();
     const auto effectivePosition =
-            (m_disablePreRoll.toBool() &&
-                    seekOnLoadPosition < mixxx::audio::kStartFramePos)
-            ? mixxx::audio::kStartFramePos
+            (m_disablePreRoll.toBool() && seekOnLoadPosition < clampPos)
+            ? clampPos
             : seekOnLoadPosition;
     m_usedSeekOnLoadPosition.setValue(effectivePosition);
 }
@@ -2374,12 +2374,13 @@ CueControl::TrackAt CueControl::getTrackAt() const {
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
                     m_pCuePoint->get());
     if (mainCuePosition.isValid()) {
-        // When pre-roll is disabled, EngineBuffer clamps playback to track
-        // start. A cue stored in negative pre-roll space is effectively at
-        // position 0, so clamp our comparison target to match.
-        if (m_disablePreRoll.toBool() &&
-                mainCuePosition < mixxx::audio::kStartFramePos) {
-            mainCuePosition = mixxx::audio::kStartFramePos;
+        // When pre-roll is disabled, a cue stored beyond the pre-roll limit is
+        // effectively at the limit, so clamp our comparison target to match.
+        if (m_disablePreRoll.toBool()) {
+            const auto clampPos = getEngineBuffer()->preRollClampPos();
+            if (mainCuePosition < clampPos) {
+                mainCuePosition = clampPos;
+            }
         }
         if (fabs(info.currentPosition - mainCuePosition) < 0.5) {
             return TrackAt::Cue;

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -99,6 +99,7 @@ CueControl::CueControl(const QString& group,
           m_pPlay(ControlObject::getControl(ConfigKey(group, "play"))),
           m_pStopButton(ControlObject::getControl(ConfigKey(group, "stop"))),
           m_bypassCueSetByPlay(false),
+          m_disablePreRoll(group, "disable_preroll", ControlFlag::AllowMissingOrInvalid),
           m_pCurrentSavedLoopControl(nullptr),
           m_trackMutex(QT_RECURSIVE_MUTEX_INIT) {
     createControls();
@@ -699,7 +700,15 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
 void CueControl::seekOnLoad(mixxx::audio::FramePos seekOnLoadPosition) {
     DEBUG_ASSERT(seekOnLoadPosition.isValid());
     seekExact(seekOnLoadPosition);
-    m_usedSeekOnLoadPosition.setValue(seekOnLoadPosition);
+    // When pre-roll is disabled, EngineBuffer clamps the resulting position to
+    // track start. Record the effective position so trackAnalyzed() can correctly
+    // detect whether the user has manually repositioned the deck.
+    const auto effectivePosition =
+            (m_disablePreRoll.toBool() &&
+                    seekOnLoadPosition < mixxx::audio::kStartFramePos)
+            ? mixxx::audio::kStartFramePos
+            : seekOnLoadPosition;
+    m_usedSeekOnLoadPosition.setValue(effectivePosition);
 }
 
 void CueControl::slotCueModeChanged(double) {
@@ -2361,11 +2370,20 @@ CueControl::TrackAt CueControl::getTrackAt() const {
     if (info.trackEndPosition.isValid() && info.currentPosition >= info.trackEndPosition) {
         return TrackAt::End;
     }
-    const auto mainCuePosition =
+    auto mainCuePosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
                     m_pCuePoint->get());
-    if (mainCuePosition.isValid() && fabs(info.currentPosition - mainCuePosition) < 0.5) {
-        return TrackAt::Cue;
+    if (mainCuePosition.isValid()) {
+        // When pre-roll is disabled, EngineBuffer clamps playback to track
+        // start. A cue stored in negative pre-roll space is effectively at
+        // position 0, so clamp our comparison target to match.
+        if (m_disablePreRoll.toBool() &&
+                mainCuePosition < mixxx::audio::kStartFramePos) {
+            mainCuePosition = mixxx::audio::kStartFramePos;
+        }
+        if (fabs(info.currentPosition - mainCuePosition) < 0.5) {
+            return TrackAt::Cue;
+        }
     }
     return TrackAt::ElseWhere;
 }

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -6,6 +6,7 @@
 #include <QAtomicPointer>
 #include <QList>
 
+#include "control/pollingcontrolproxy.h"
 #include "engine/controls/enginecontrol.h"
 #include "preferences/colorpalettesettings.h"
 #include "preferences/usersettings.h"
@@ -322,6 +323,7 @@ class CueControl : public EngineControl {
     parented_ptr<ControlProxy> m_pBeatLoopSize;
     bool m_bypassCueSetByPlay;
     ControlValueAtomic<mixxx::audio::FramePos> m_usedSeekOnLoadPosition;
+    PollingControlProxy m_disablePreRoll;
 
     QList<HotcueControl*> m_hotcueControls;
 

--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -68,6 +68,10 @@ EngineBuffer* EngineControl::getEngineBuffer() {
     return m_pEngineBuffer;
 }
 
+EngineBuffer* EngineControl::getEngineBuffer() const {
+    return m_pEngineBuffer;
+}
+
 void EngineControl::setBeatLoop(mixxx::audio::FramePos startPosition, bool enabled) {
     if (m_pEngineBuffer) {
         m_pEngineBuffer->setBeatLoop(startPosition, enabled);

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -112,6 +112,7 @@ class EngineControl : public QObject {
     UserSettingsPointer getConfig();
     EngineMixer* getEngineMixer();
     EngineBuffer* getEngineBuffer();
+    EngineBuffer* getEngineBuffer() const;
 
     const QString m_group;
     UserSettingsPointer m_pConfig;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -85,6 +85,7 @@ EngineBuffer::EngineBuffer(const QString& group,
           m_bSlipEnabledProcessing(false),
           m_slipModeState(SlipModeState::Disabled),
           m_quantize(ControlFlag::AllowMissingOrInvalid),
+          m_disablePreRoll(ControlFlag::AllowMissingOrInvalid),
           m_pRepeat(nullptr),
           m_startButton(nullptr),
           m_endButton(nullptr),
@@ -195,6 +196,10 @@ EngineBuffer::EngineBuffer(const QString& group,
     QuantizeControl* pQuantize_control = new QuantizeControl(group, pConfig);
     addControl(pQuantize_control);
     m_quantize = PollingControlProxy(ConfigKey(group, "quantize"));
+
+    m_pDisablePreRoll = new ControlPushButton(ConfigKey(group, "disable_preroll"));
+    m_pDisablePreRoll->setButtonMode(mixxx::control::ButtonMode::Toggle);
+    m_disablePreRoll = PollingControlProxy(ConfigKey(group, "disable_preroll"));
 
     // Create the Loop Controller
     m_pLoopingControl = new LoopingControl(group, pConfig);
@@ -324,6 +329,7 @@ EngineBuffer::~EngineBuffer() {
     delete m_playposSlider;
 
     delete m_pSlipButton;
+    delete m_pDisablePreRoll;
     delete m_pRepeat;
     delete m_pSampleRate;
 
@@ -480,6 +486,10 @@ void EngineBuffer::readToCrossfadeBuffer(const std::size_t bufferSize) {
 void EngineBuffer::setNewPlaypos(mixxx::audio::FramePos position) {
     if (kLogger.traceEnabled()) {
         kLogger.trace() << "setNewPlaypos" << m_group << position;
+    }
+
+    if (m_disablePreRoll.toBool()) {
+        position = std::max(position, mixxx::audio::kStartFramePos);
     }
 
     m_playPos = position;
@@ -1138,6 +1148,10 @@ void EngineBuffer::processTrackLocked(
             // Adjust filepos_play by the amount we processed.
             m_playPos = m_pReadAheadManager->getFilePlaypositionFromLog(
                     m_playPos, framesRead, m_channelCount);
+        }
+
+        if (m_disablePreRoll.toBool()) {
+            m_playPos = std::max(m_playPos, mixxx::audio::kStartFramePos);
         }
         // Note: The last buffer of a track is padded with silence.
         // This silence is played together with the last samples in the last

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -86,6 +86,7 @@ EngineBuffer::EngineBuffer(const QString& group,
           m_slipModeState(SlipModeState::Disabled),
           m_quantize(ControlFlag::AllowMissingOrInvalid),
           m_disablePreRoll(ControlFlag::AllowMissingOrInvalid),
+          m_preRollLimitBeats(ControlFlag::AllowMissingOrInvalid),
           m_pRepeat(nullptr),
           m_startButton(nullptr),
           m_endButton(nullptr),
@@ -200,6 +201,10 @@ EngineBuffer::EngineBuffer(const QString& group,
     m_pDisablePreRoll = new ControlPushButton(ConfigKey(group, "disable_preroll"));
     m_pDisablePreRoll->setButtonMode(mixxx::control::ButtonMode::Toggle);
     m_disablePreRoll = PollingControlProxy(ConfigKey(group, "disable_preroll"));
+
+    m_pPreRollLimitBeats = new ControlObject(ConfigKey(group, "preroll_limit_beats"));
+    m_pPreRollLimitBeats->set(4.0);
+    m_preRollLimitBeats = PollingControlProxy(ConfigKey(group, "preroll_limit_beats"));
 
     // Create the Loop Controller
     m_pLoopingControl = new LoopingControl(group, pConfig);
@@ -330,6 +335,7 @@ EngineBuffer::~EngineBuffer() {
 
     delete m_pSlipButton;
     delete m_pDisablePreRoll;
+    delete m_pPreRollLimitBeats;
     delete m_pRepeat;
     delete m_pSampleRate;
 
@@ -489,7 +495,7 @@ void EngineBuffer::setNewPlaypos(mixxx::audio::FramePos position) {
     }
 
     if (m_disablePreRoll.toBool()) {
-        position = std::max(position, mixxx::audio::kStartFramePos);
+        position = std::max(position, preRollClampPos());
     }
 
     m_playPos = position;
@@ -1151,7 +1157,7 @@ void EngineBuffer::processTrackLocked(
         }
 
         if (m_disablePreRoll.toBool()) {
-            m_playPos = std::max(m_playPos, mixxx::audio::kStartFramePos);
+            m_playPos = std::max(m_playPos, preRollClampPos());
         }
         // Note: The last buffer of a track is padded with silence.
         // This silence is played together with the last samples in the last
@@ -1634,6 +1640,20 @@ bool EngineBuffer::isTrackLoaded() const {
 
 TrackPointer EngineBuffer::getLoadedTrack() const {
     return m_pCurrentTrack;
+}
+
+mixxx::audio::FramePos EngineBuffer::preRollClampPos() const {
+    const double beats = m_preRollLimitBeats.get();
+    const double sampleRate = m_pSampleRate->get();
+    if (beats > 0 && sampleRate > 0) {
+        const double bpm = m_pBpmControl ? m_pBpmControl->getBpm().valueOr(0.0) : 0.0;
+        if (bpm > 0) {
+            return mixxx::audio::FramePos(-(beats * 60.0 / bpm) * sampleRate);
+        }
+        // No BPM available — fall back to 1 second of pre-roll.
+        return mixxx::audio::FramePos(-sampleRate);
+    }
+    return mixxx::audio::kStartFramePos;
 }
 
 mixxx::audio::FramePos EngineBuffer::getExactPlayPos() const {

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -422,8 +422,10 @@ class EngineBuffer : public EngineObject {
     ControlPushButton* m_stopButton;
 
     ControlPushButton* m_pSlipButton;
+    ControlPushButton* m_pDisablePreRoll;
 
     PollingControlProxy m_quantize;
+    PollingControlProxy m_disablePreRoll;
     ControlPotmeter* m_playposSlider;
     ControlProxy* m_pSampleRate;
     ControlProxy* m_pKeylockEngine;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -155,6 +155,7 @@ class EngineBuffer : public EngineObject {
     void ejectTrack();
 
     mixxx::audio::FramePos getExactPlayPos() const;
+    mixxx::audio::FramePos preRollClampPos() const;
     double getVisualPlayPos() const;
     mixxx::audio::FramePos getTrackEndPosition() const;
     void setTrackEndPosition(mixxx::audio::FramePos position);
@@ -423,9 +424,11 @@ class EngineBuffer : public EngineObject {
 
     ControlPushButton* m_pSlipButton;
     ControlPushButton* m_pDisablePreRoll;
+    ControlObject* m_pPreRollLimitBeats;
 
     PollingControlProxy m_quantize;
     PollingControlProxy m_disablePreRoll;
+    PollingControlProxy m_preRollLimitBeats;
     ControlPotmeter* m_playposSlider;
     ControlProxy* m_pSampleRate;
     ControlProxy* m_pKeylockEngine;

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -227,6 +227,14 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
             this,
             &DlgPrefDeck::slotCloneDeckOnLoadDoubleTapCheckbox);
 
+    m_bDisablePreRoll = m_pConfig->getValue(
+            ConfigKey(kControlsGroup, QStringLiteral("DisablePreRoll")), false);
+    checkBoxDisablePreRoll->setChecked(m_bDisablePreRoll);
+    connect(checkBoxDisablePreRoll,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefDeck::slotDisablePreRollCheckbox);
+
     m_bRateDownIncreasesSpeed = m_pConfig->getValue(
             ConfigKey(kControlsGroup, QStringLiteral("RateDir")), kDefaultRateDirectionInverted);
     setRateDirectionForAllDecks(m_bRateDownIncreasesSpeed);
@@ -450,6 +458,9 @@ void DlgPrefDeck::slotUpdate() {
     checkBoxCloneDeckOnLoadDoubleTap->setChecked(m_pConfig->getValue(
             ConfigKey(kControlsGroup, QStringLiteral("CloneDeckOnLoadDoubleTap")), true));
 
+    checkBoxDisablePreRoll->setChecked(m_pConfig->getValue(
+            ConfigKey(kControlsGroup, QStringLiteral("DisablePreRoll")), false));
+
     double rateRange = m_rateRangeControls[0]->get();
     int index = ComboBoxRateRange->findData(static_cast<int>(rateRange * 100.0));
     if (index == -1) {
@@ -535,6 +546,8 @@ void DlgPrefDeck::slotResetToDefaults() {
 
     // Clone decks by double-tapping Load button.
     checkBoxCloneDeckOnLoadDoubleTap->setChecked(kDefaultCloneDeckOnLoad);
+
+    checkBoxDisablePreRoll->setChecked(false);
 
     // Mixxx cue mode
     ComboBoxCueMode->setCurrentIndex(0);
@@ -625,6 +638,10 @@ void DlgPrefDeck::slotCueModeCombobox(int index) {
 
 void DlgPrefDeck::slotCloneDeckOnLoadDoubleTapCheckbox(bool checked) {
     m_bCloneDeckOnLoadDoubleTap = checked;
+}
+
+void DlgPrefDeck::slotDisablePreRollCheckbox(bool checked) {
+    m_bDisablePreRoll = checked;
 }
 
 void DlgPrefDeck::slotSetTrackTimeDisplay(QAbstractButton* b) {
@@ -719,6 +736,12 @@ void DlgPrefDeck::slotApply() {
     m_pConfig->setValue(ConfigKey(kControlsGroup, QStringLiteral("CueRecall")), m_seekOnLoadMode);
     m_pConfig->setValue(ConfigKey(kControlsGroup, QStringLiteral("CloneDeckOnLoadDoubleTap")),
             m_bCloneDeckOnLoadDoubleTap);
+
+    m_pConfig->setValue(ConfigKey(kControlsGroup, QStringLiteral("DisablePreRoll")),
+            m_bDisablePreRoll);
+    for (ControlProxy* pControl : std::as_const(m_disablePreRollControls)) {
+        pControl->set(m_bDisablePreRoll ? 1.0 : 0.0);
+    }
 
     // Set rate range
     // Set the config value before setting the CO values in setRateRangeForAllDecks()
@@ -817,6 +840,9 @@ void DlgPrefDeck::slotNumDecksChanged(double new_count, bool initializing) {
         m_keyunlockModeControls.push_back(new ControlProxy(
                 group, "keyunlockMode"));
         m_keyunlockModeControls.last()->set(static_cast<double>(m_keyunlockMode));
+        m_disablePreRollControls.push_back(new ControlProxy(
+                group, "disable_preroll"));
+        m_disablePreRollControls.last()->set(m_bDisablePreRoll ? 1.0 : 0.0);
     }
 
     m_iNumConfiguredDecks = numdecks;
@@ -850,6 +876,9 @@ void DlgPrefDeck::slotNumSamplersChanged(double new_count, bool initializing) {
         m_keyunlockModeControls.push_back(new ControlProxy(
                 group, "keyunlockMode"));
         m_keyunlockModeControls.last()->set(static_cast<double>(m_keyunlockMode));
+        m_disablePreRollControls.push_back(new ControlProxy(
+                group, "disable_preroll"));
+        m_disablePreRollControls.last()->set(m_bDisablePreRoll ? 1.0 : 0.0);
     }
 
     m_iNumConfiguredSamplers = numsamplers;

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -235,6 +235,14 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
             this,
             &DlgPrefDeck::slotDisablePreRollCheckbox);
 
+    m_iPreRollLimitBeats = m_pConfig->getValue(
+            ConfigKey(kControlsGroup, QStringLiteral("PreRollLimitBeats")), 4);
+    spinBoxPreRollLimitBeats->setValue(m_iPreRollLimitBeats);
+    connect(spinBoxPreRollLimitBeats,
+            QOverload<int>::of(&QSpinBox::valueChanged),
+            this,
+            &DlgPrefDeck::slotPreRollLimitBeatsSpinBox);
+
     m_bRateDownIncreasesSpeed = m_pConfig->getValue(
             ConfigKey(kControlsGroup, QStringLiteral("RateDir")), kDefaultRateDirectionInverted);
     setRateDirectionForAllDecks(m_bRateDownIncreasesSpeed);
@@ -461,6 +469,9 @@ void DlgPrefDeck::slotUpdate() {
     checkBoxDisablePreRoll->setChecked(m_pConfig->getValue(
             ConfigKey(kControlsGroup, QStringLiteral("DisablePreRoll")), false));
 
+    spinBoxPreRollLimitBeats->setValue(m_pConfig->getValue(
+            ConfigKey(kControlsGroup, QStringLiteral("PreRollLimitBeats")), 4));
+
     double rateRange = m_rateRangeControls[0]->get();
     int index = ComboBoxRateRange->findData(static_cast<int>(rateRange * 100.0));
     if (index == -1) {
@@ -548,6 +559,7 @@ void DlgPrefDeck::slotResetToDefaults() {
     checkBoxCloneDeckOnLoadDoubleTap->setChecked(kDefaultCloneDeckOnLoad);
 
     checkBoxDisablePreRoll->setChecked(false);
+    spinBoxPreRollLimitBeats->setValue(4);
 
     // Mixxx cue mode
     ComboBoxCueMode->setCurrentIndex(0);
@@ -642,6 +654,10 @@ void DlgPrefDeck::slotCloneDeckOnLoadDoubleTapCheckbox(bool checked) {
 
 void DlgPrefDeck::slotDisablePreRollCheckbox(bool checked) {
     m_bDisablePreRoll = checked;
+}
+
+void DlgPrefDeck::slotPreRollLimitBeatsSpinBox(int value) {
+    m_iPreRollLimitBeats = value;
 }
 
 void DlgPrefDeck::slotSetTrackTimeDisplay(QAbstractButton* b) {
@@ -741,6 +757,12 @@ void DlgPrefDeck::slotApply() {
             m_bDisablePreRoll);
     for (ControlProxy* pControl : std::as_const(m_disablePreRollControls)) {
         pControl->set(m_bDisablePreRoll ? 1.0 : 0.0);
+    }
+
+    m_pConfig->setValue(ConfigKey(kControlsGroup, QStringLiteral("PreRollLimitBeats")),
+            m_iPreRollLimitBeats);
+    for (ControlProxy* pControl : std::as_const(m_preRollLimitBeatsControls)) {
+        pControl->set(static_cast<double>(m_iPreRollLimitBeats));
     }
 
     // Set rate range
@@ -843,6 +865,9 @@ void DlgPrefDeck::slotNumDecksChanged(double new_count, bool initializing) {
         m_disablePreRollControls.push_back(new ControlProxy(
                 group, "disable_preroll"));
         m_disablePreRollControls.last()->set(m_bDisablePreRoll ? 1.0 : 0.0);
+        m_preRollLimitBeatsControls.push_back(new ControlProxy(
+                group, "preroll_limit_beats"));
+        m_preRollLimitBeatsControls.last()->set(static_cast<double>(m_iPreRollLimitBeats));
     }
 
     m_iNumConfiguredDecks = numdecks;
@@ -879,6 +904,9 @@ void DlgPrefDeck::slotNumSamplersChanged(double new_count, bool initializing) {
         m_disablePreRollControls.push_back(new ControlProxy(
                 group, "disable_preroll"));
         m_disablePreRollControls.last()->set(m_bDisablePreRoll ? 1.0 : 0.0);
+        m_preRollLimitBeatsControls.push_back(new ControlProxy(
+                group, "preroll_limit_beats"));
+        m_preRollLimitBeatsControls.last()->set(static_cast<double>(m_iPreRollLimitBeats));
     }
 
     m_iNumConfiguredSamplers = numsamplers;

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -53,6 +53,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotSetTrackLoadMode(int comboboxIndex);
     void slotLoadWhenDeckPlayingIndexChanged(int comboboxIndex);
     void slotCloneDeckOnLoadDoubleTapCheckbox(bool);
+    void slotDisablePreRollCheckbox(bool);
     void slotRateRampingModeLinearButton(bool);
     void slotRateRampSensitivitySlider(int);
 
@@ -84,6 +85,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
 
     QList<ControlProxy*> m_cueControls;
     QList<ControlProxy*> m_rateControls;
+    QList<ControlProxy*> m_disablePreRollControls;
     QList<ControlProxy*> m_rateDirectionControls;
     QList<ControlProxy*> m_rateRangeControls;
     QList<ControlProxy*> m_keylockModeControls;
@@ -98,6 +100,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
 
     bool m_bSetIntroStartAtMainCue;
     bool m_bCloneDeckOnLoadDoubleTap;
+    bool m_bDisablePreRoll;
 
     int m_iRateRangePercent;
     bool m_bRateDownIncreasesSpeed;

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -54,6 +54,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotLoadWhenDeckPlayingIndexChanged(int comboboxIndex);
     void slotCloneDeckOnLoadDoubleTapCheckbox(bool);
     void slotDisablePreRollCheckbox(bool);
+    void slotPreRollLimitBeatsSpinBox(int);
     void slotRateRampingModeLinearButton(bool);
     void slotRateRampSensitivitySlider(int);
 
@@ -86,6 +87,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     QList<ControlProxy*> m_cueControls;
     QList<ControlProxy*> m_rateControls;
     QList<ControlProxy*> m_disablePreRollControls;
+    QList<ControlProxy*> m_preRollLimitBeatsControls;
     QList<ControlProxy*> m_rateDirectionControls;
     QList<ControlProxy*> m_rateRangeControls;
     QList<ControlProxy*> m_keylockModeControls;
@@ -101,6 +103,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     bool m_bSetIntroStartAtMainCue;
     bool m_bCloneDeckOnLoadDoubleTap;
     bool m_bDisablePreRoll;
+    int m_iPreRollLimitBeats;
 
     int m_iRateRangePercent;
     bool m_bRateDownIncreasesSpeed;

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -212,6 +212,56 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
         </property>
        </widget>
       </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="labelPreRollLimitBeats">
+        <property name="text">
+         <string>Pre-roll limit</string>
+        </property>
+        <property name="buddy">
+         <cstring>spinBoxPreRollLimitBeats</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1" colspan="2">
+       <layout class="QHBoxLayout">
+        <item>
+         <widget class="QSpinBox" name="spinBoxPreRollLimitBeats">
+          <property name="toolTip">
+           <string>How many beats of pre-roll space to allow before clamping. Set to 0 to clamp hard at track start. Has no effect when "Prevent jogging before track start" is disabled.</string>
+          </property>
+          <property name="minimum">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <number>32</number>
+          </property>
+          <property name="value">
+           <number>4</number>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelPreRollLimitBeatsUnit">
+          <property name="text">
+           <string>beats (0 = hard clamp at track start; uses 1 second if BPM unknown)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer>
+          <property name="orientation">
+           <enum>Qt::Orientation::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>
@@ -690,6 +740,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
   <tabstop>comboBoxLoadWhenDeckPlaying</tabstop>
   <tabstop>checkBoxCloneDeckOnLoadDoubleTap</tabstop>
   <tabstop>checkBoxDisablePreRoll</tabstop>
+  <tabstop>spinBoxPreRollLimitBeats</tabstop>
   <tabstop>ComboBoxRateRange</tabstop>
   <tabstop>checkBoxInvertSpeedSlider</tabstop>
   <tabstop>checkBoxResetPitch</tabstop>

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -192,6 +192,26 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
         </property>
        </widget>
       </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="labelDisablePreRoll">
+        <property name="text">
+         <string>Jog wheel / track start</string>
+        </property>
+        <property name="buddy">
+         <cstring>checkBoxDisablePreRoll</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" colspan="2">
+       <widget class="QCheckBox" name="checkBoxDisablePreRoll">
+        <property name="toolTip">
+         <string>When enabled, jogging or scrubbing backward past the start of a track will hold at the beginning instead of entering the pre-roll (negative) region. Applies to jog wheels, scratch, and keyboard navigation.</string>
+        </property>
+        <property name="text">
+         <string>Prevent jogging before track start</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -669,6 +689,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
   <tabstop>comboBoxLoadPoint</tabstop>
   <tabstop>comboBoxLoadWhenDeckPlaying</tabstop>
   <tabstop>checkBoxCloneDeckOnLoadDoubleTap</tabstop>
+  <tabstop>checkBoxDisablePreRoll</tabstop>
   <tabstop>ComboBoxRateRange</tabstop>
   <tabstop>checkBoxInvertSpeedSlider</tabstop>
   <tabstop>checkBoxResetPitch</tabstop>

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -594,28 +594,30 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
 // main cue point was stored at a negative (pre-roll) position.
 
 TEST_F(CueControlTest, DisablePreRoll_NegativeCuePoint_GatedCueStartsPlay) {
-    // Regression test: with disable_preroll enabled, a CDJ-mode CUE press
-    // while paused at track start must start gated playback even when the
-    // stored main cue position is negative (i.e. in pre-roll space).
+    // Regression test: with disable_preroll enabled and limit=0 (hard clamp),
+    // a CDJ-mode CUE press while paused at track start must start gated
+    // playback even when the stored cue is in pre-roll space. getTrackAt()
+    // must clamp the cue comparison to the pre-roll limit so the deck is
+    // recognised as being at the cue.
     ControlProxy disablePreRoll(m_sGroup1, "disable_preroll");
+    ControlProxy preRollLimit(m_sGroup1, "preroll_limit_beats");
     ControlProxy cueCdj(m_sGroup1, "cue_cdj");
     ControlProxy play(m_sGroup1, "play");
 
     disablePreRoll.set(1.0);
+    preRollLimit.set(0.0); // hard clamp at track start
 
     TrackPointer pTrack = createTestTrack();
-    // Simulate a cue that was placed in pre-roll before disable_preroll was on.
     pTrack->setMainCuePosition(mixxx::audio::FramePos(-100.0));
 
     loadTrack(pTrack);
 
-    // EngineBuffer must clamp the play position to track start.
+    // With limit=0, EngineBuffer clamps the deck to track start.
     EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, getCurrentFramePos());
-    // Playback must not have started automatically.
     EXPECT_FALSE(play.toBool());
 
-    // Press CDJ CUE. With the fix, getTrackAt() should recognise that the
-    // deck is effectively at the cue point (both at 0) and start gated play.
+    // getTrackAt() clamps the cue (-100) to the limit (0), so deck and cue
+    // are both seen as 0 → gated play starts.
     cueCdj.set(1.0);
     ProcessBuffer();
 

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -1,4 +1,5 @@
 #include "engine/controls/cuecontrol.h"
+
 #include "test/signalpathtest.h"
 
 class CueControlTest : public BaseSignalPathTest {
@@ -587,4 +588,75 @@ TEST_F(CueControlTest, OutroCue_SetStartEnd_ClearStartEnd) {
     EXPECT_FALSE(m_pOutroEndEnabled->toBool());
 
     EXPECT_EQ(nullptr, pTrack->findCueByType(mixxx::CueType::Outro));
+}
+
+// Tests for the disable_preroll feature: gated CUE must work even when the
+// main cue point was stored at a negative (pre-roll) position.
+
+TEST_F(CueControlTest, DisablePreRoll_NegativeCuePoint_GatedCueStartsPlay) {
+    // Regression test: with disable_preroll enabled, a CDJ-mode CUE press
+    // while paused at track start must start gated playback even when the
+    // stored main cue position is negative (i.e. in pre-roll space).
+    ControlProxy disablePreRoll(m_sGroup1, "disable_preroll");
+    ControlProxy cueCdj(m_sGroup1, "cue_cdj");
+    ControlProxy play(m_sGroup1, "play");
+
+    disablePreRoll.set(1.0);
+
+    TrackPointer pTrack = createTestTrack();
+    // Simulate a cue that was placed in pre-roll before disable_preroll was on.
+    pTrack->setMainCuePosition(mixxx::audio::FramePos(-100.0));
+
+    loadTrack(pTrack);
+
+    // EngineBuffer must clamp the play position to track start.
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, getCurrentFramePos());
+    // Playback must not have started automatically.
+    EXPECT_FALSE(play.toBool());
+
+    // Press CDJ CUE. With the fix, getTrackAt() should recognise that the
+    // deck is effectively at the cue point (both at 0) and start gated play.
+    cueCdj.set(1.0);
+    ProcessBuffer();
+
+    EXPECT_TRUE(play.toBool());
+}
+
+TEST_F(CueControlTest, DisablePreRoll_NegativeCuePoint_DeckClampsToTrackStart) {
+    // When disable_preroll is on, loading a track whose main cue is in pre-roll
+    // must leave the deck at position 0, not at the negative cue position.
+    ControlProxy disablePreRoll(m_sGroup1, "disable_preroll");
+
+    disablePreRoll.set(1.0);
+
+    TrackPointer pTrack = createTestTrack();
+    pTrack->setMainCuePosition(mixxx::audio::FramePos(-200.0));
+
+    loadTrack(pTrack);
+
+    EXPECT_FRAMEPOS_EQ(mixxx::audio::kStartFramePos, getCurrentFramePos());
+}
+
+TEST_F(CueControlTest, DisablePreRoll_Off_NegativeCuePoint_NormalBehavior) {
+    // With disable_preroll disabled, a CDJ CUE press while paused away from
+    // the cue should move the cue to the current position (existing behaviour).
+    ControlProxy disablePreRoll(m_sGroup1, "disable_preroll");
+    ControlProxy cueCdj(m_sGroup1, "cue_cdj");
+    ControlProxy play(m_sGroup1, "play");
+
+    disablePreRoll.set(0.0);
+
+    TrackPointer pTrack = createTestTrack();
+    pTrack->setMainCuePosition(mixxx::audio::FramePos(500.0));
+    loadTrack(pTrack);
+
+    // Manually move away from the cue.
+    setCurrentFramePos(mixxx::audio::FramePos(100.0));
+
+    cueCdj.set(1.0);
+    ProcessBuffer();
+
+    // CDJ CUE when not at cue point and not playing → cueSet, no play.
+    EXPECT_FALSE(play.toBool());
+    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::FramePos(100.0), m_pCuePoint);
 }

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -571,6 +571,46 @@ TEST_F(EngineBufferTest, RateTempTest) {
     ControlObject::set(ConfigKey(m_sGroup1, "rate_temp_down_small"), 0);
 }
 
+// ---- disable_preroll tests ----
+
+TEST_F(EngineBufferTest, DisablePreRoll_SeekClampedAtStart) {
+    // When disable_preroll is on, seeking to a negative position must clamp to 0.
+    ControlObject::set(ConfigKey(m_sGroup1, "disable_preroll"), 1.0);
+    m_pChannel1->getEngineBuffer()->queueNewPlaypos(
+            mixxx::audio::FramePos(-500), EngineBuffer::SEEK_EXACT);
+    ProcessBuffer();
+    EXPECT_DOUBLE_EQ(0.0, m_pChannel1->getEngineBuffer()->getPlayPos().value());
+}
+
+TEST_F(EngineBufferTest, DisablePreRoll_SeekAllowedWhenOff) {
+    // When disable_preroll is off (default), seeking to a negative position is
+    // permitted so the pre-roll region remains accessible.
+    ControlObject::set(ConfigKey(m_sGroup1, "disable_preroll"), 0.0);
+    m_pChannel1->getEngineBuffer()->queueNewPlaypos(
+            mixxx::audio::FramePos(-500), EngineBuffer::SEEK_EXACT);
+    ProcessBuffer();
+    EXPECT_DOUBLE_EQ(-500.0, m_pChannel1->getEngineBuffer()->getPlayPos().value());
+}
+
+TEST_F(EngineBufferTest, DisablePreRoll_ReverseHoldsAtStart) {
+    // When disable_preroll is on, reverse-scratching from position 0 must hold
+    // the deck at the start rather than entering negative (pre-roll) territory.
+    ControlObject::set(ConfigKey(m_sGroup1, "disable_preroll"), 1.0);
+    ControlObject::set(ConfigKey(m_sGroup1, "scratch2_enable"), 1.0);
+    ControlObject::set(ConfigKey(m_sGroup1, "scratch2"), -1.0);
+    ProcessBuffer();
+    EXPECT_GE(m_pChannel1->getEngineBuffer()->getPlayPos().value(), 0.0);
+}
+
+TEST_F(EngineBufferTest, DisablePreRoll_ReverseAllowedWhenOff) {
+    // When disable_preroll is off, reverse-scratching past the start must be
+    // allowed (original pre-roll behaviour).
+    ControlObject::set(ConfigKey(m_sGroup1, "disable_preroll"), 0.0);
+    ControlObject::set(ConfigKey(m_sGroup1, "scratch2_enable"), 1.0);
+    ControlObject::set(ConfigKey(m_sGroup1, "scratch2"), -1.0);
+    ProcessBuffer();
+    EXPECT_LT(m_pChannel1->getEngineBuffer()->getPlayPos().value(), 0.0);
+}
 
 TEST_F(EngineBufferTest, RatePermTest) {
     RateControl::setPermanentRateChangeCoarseAmount(4);

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -574,8 +574,10 @@ TEST_F(EngineBufferTest, RateTempTest) {
 // ---- disable_preroll tests ----
 
 TEST_F(EngineBufferTest, DisablePreRoll_SeekClampedAtStart) {
-    // When disable_preroll is on, seeking to a negative position must clamp to 0.
+    // With limit=0 (hard clamp), any negative seek must land at exactly 0
+    // regardless of BPM or sample rate.
     ControlObject::set(ConfigKey(m_sGroup1, "disable_preroll"), 1.0);
+    ControlObject::set(ConfigKey(m_sGroup1, "preroll_limit_beats"), 0.0);
     m_pChannel1->getEngineBuffer()->queueNewPlaypos(
             mixxx::audio::FramePos(-500), EngineBuffer::SEEK_EXACT);
     ProcessBuffer();
@@ -593,9 +595,10 @@ TEST_F(EngineBufferTest, DisablePreRoll_SeekAllowedWhenOff) {
 }
 
 TEST_F(EngineBufferTest, DisablePreRoll_ReverseHoldsAtStart) {
-    // When disable_preroll is on, reverse-scratching from position 0 must hold
-    // the deck at the start rather than entering negative (pre-roll) territory.
+    // With limit=0 (hard clamp), reverse-scratching from position 0 must hold
+    // the deck at exactly the start.
     ControlObject::set(ConfigKey(m_sGroup1, "disable_preroll"), 1.0);
+    ControlObject::set(ConfigKey(m_sGroup1, "preroll_limit_beats"), 0.0);
     ControlObject::set(ConfigKey(m_sGroup1, "scratch2_enable"), 1.0);
     ControlObject::set(ConfigKey(m_sGroup1, "scratch2"), -1.0);
     ProcessBuffer();


### PR DESCRIPTION
## Summary

- Adds a `disable_preroll` ControlObject (toggle) on each deck and sampler that, when enabled, clamps the play position to a configurable pre-roll limit — preventing jog wheels, scratch, and keyboard navigation from entering deep into the negative pre-roll region.
- Adds a **Prevent jogging before track start** checkbox and a **Pre-roll limit** spin box (0–32 beats, default 4) to the Deck preferences page. Setting beats to 0 hard-clamps at track start; otherwise the limit is beat-based with a 1-second fallback when BPM is unknown.
- Fixes gated CUE behaviour in CDJ mode when `disable_preroll` is active: if the main cue point was stored at a negative position, both `seekOnLoad` and `getTrackAt` now treat it as the clamped position so a CDJ CUE press while paused at track start correctly starts gated playback.

## Motivation

Visually impaired DJs (and beginners) using jog wheels or keyboard shortcuts can accidentally scratch backward past the start of a track, entering the silent pre-roll region with no audio feedback. This feature gives users the option to clamp the deck near position 0, with enough room (default 4 beats) to scratch around the cue point without going back infinitely.

## Changes

| File | What changed |
|------|-------------|
| `src/engine/enginebuffer.cpp/.h` | Creates `disable_preroll` and `preroll_limit_beats` COs; exposes `preRollClampPos()` used to clamp `m_playPos` in `setNewPlaypos()` and `processTrackLocked()` |
| `src/engine/controls/cuecontrol.cpp/.h` | Reads `disable_preroll` via `PollingControlProxy`; delegates to `preRollClampPos()` in `seekOnLoad()` and `getTrackAt()` |
| `src/preferences/dialog/dlgprefdeck.cpp/.h` | Adds checkbox and spin box, per-deck/sampler ControlProxy lists; wired into `slotUpdate`, `slotApply`, `slotResetToDefaults` |
| `src/preferences/dialog/dlgprefdeckdlg.ui` | Adds label + checkbox (row 7) and pre-roll limit spin box (row 8) in the Jog wheel section |
| `src/test/enginebuffertest.cpp` | 4 new tests: seek clamped at start, seek allowed when off, reverse holds at start, reverse allowed when off |
| `src/test/cuecontrol_test.cpp` | 3 new tests: negative cue point gated CUE starts play, deck clamps to track start on load, normal behaviour when off |

## Screenshots

UI Changes:

Pre Change:
<img width="935" height="687" alt="pre-pre-roll-disabled" src="https://github.com/user-attachments/assets/28adc4b9-e9c0-4d5d-896a-43524d3e572f" />

Post Change Toggle Added:
<img width="1310" height="873" alt="Screenshot 2026-06-09 at 21 41 31" src="https://github.com/user-attachments/assets/a5ba27b2-9fc0-4965-8ff6-dfc2336681a7" />

## Test plan

- [ ] `ctest -R "EngineBufferTest|CueControlTest"` passes
- [ ] Enable the checkbox: jog/scratch backward from track start holds within the pre-roll limit
- [ ] Set beats to 0: jog/scratch backward hard-clamps at position 0
- [ ] Disable the checkbox: jog/scratch backward enters pre-roll as normal
- [ ] CDJ CUE press while paused at track start starts gated playback with option enabled
- [ ] Setting persists across Mixxx restarts
- [ ] Works on Deck A and Deck B
