### PR TITLE
DDJ-400: Map shift+cue to start_stop

### DIFF
--- a/res/controllers/Pioneer-DDJ-400.midi.xml
+++ b/res/controllers/Pioneer-DDJ-400.midi.xml
@@ -145,9 +145,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE +SHIFT (DECK1) - press - Jump to track start</description>
+                <description>CUE +SHIFT (DECK1) - press - Jump to track start (no auto-play)</description>
                 <group>[Channel1]</group>
-                <key>start_play</key>
+                <key>start_stop</key>
                 <status>0x90</status>
                 <midino>0x48</midino>
                 <options>
@@ -165,9 +165,9 @@
                 </options>
             </control>
             <control>
-                <description>CUE +SHIFT (DECK2) - press - Jump to track start</description>
+                <description>CUE +SHIFT (DECK2) - press - Jump to track start (no auto-play)</description>
                 <group>[Channel2]</group>
-                <key>start_play</key>
+                <key>start_stop</key>
                 <status>0x91</status>
                 <midino>0x48</midino>
                 <options>


### PR DESCRIPTION
The DDJ-400's SHIFT+CUE was bound to `start_play`, causing it to jump to
track start and immediately begin playback. The expected behaviour is to
return to the start and remain paused. Which mirrors the behaviour of Rekordbox.

This mirrors the fix applied to the DDJ-FLX4 in f545c4fb42 for the same
issue.

Fixes same issue raised #15998 but for the DDJ-400.