### PR TITLE
debian_buildenv.sh: Fix race condition in fonts-ubuntu check

### DIFF
--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -63,21 +63,21 @@ case "$1" in
         fi
 
         # Check if fonts-ubuntu is available (from non-free repository)
-        if ! apt-cache show fonts-ubuntu 2>/dev/null | grep -q "Package: fonts-ubuntu"; then
+        if apt-cache show fonts-ubuntu 2>/dev/null >/dev/null; then
+            sudo apt-get install -y --no-install-recommends fonts-ubuntu
+        else
             echo ""
             echo "WARNING: The package 'fonts-ubuntu' is not available."
             echo "This package is required for Mixxx and is located in the Debian non-free repository."
             echo ""
             echo "See also: https://wiki.debian.org/SourcesList"
             echo ""
-            read -p "Would you like to exit to enable 'non-free' now? (y = Exit / n = Continue without fonts): " -n 1 -r
+            read -p "Would you like to exit to manually enable 'non-free' now? (y = Exit / n = Continue without fonts): " -n 1 -r
             echo
             if [[ $REPLY =~ ^[Yy]$ ]]; then
                 echo "Please edit your /etc/apt/sources.list, run 'sudo apt update', and restart this script."
                 exit 1
             fi
-        else
-            FONTS_UBUNTU_AVAILABLE=true
         fi
 
         sudo apt-get install -y --no-install-recommends -- \
@@ -90,7 +90,6 @@ case "$1" in
             docbook-to-man \
             dput \
             fonts-open-sans \
-            "$([ "$FONTS_UBUNTU_AVAILABLE" = true ] && echo "fonts-ubuntu")" \
             g++ \
             lcov \
             libavformat-dev \


### PR DESCRIPTION
This fixes a nasty bug that happens only on a slow virtual machine. It requires a deep dive into bash internals to understand. Here my findings: 

```
if ! apt-cache show fonts-ubuntu 2>/dev/null | grep -q "Package: fonts-ubuntu"; then
```
This was true (executing the if branch) on a slow machine, because `grep -q` closes the pipe as soon as the search pattern is found. This crashes the `apt-cache show` with SIGPIPE which cause the if condition to become true even if fonts-ubuntu was found. 
Interestingly this does not happen if I do it outside the if condition which probably effects the timing. 

Luckily the grep is not required at all, because the `apt-cache show` has already a usable exit code. So I have streamlined the code with the checks above. 

This is a regression fix and shall be merged soon to not cause headaches for new Ubuntu contributors on virtual machines.  




