### PR TITLE
(fix) Library: use correct directory in relocate query

### DIFF
--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -285,9 +285,10 @@ std::pair<DirectoryDAO::RelocateResult, QList<RelocatedTrack>> DirectoryDAO::rel
             "UPDATE track_locations SET location=:newloc, directory=:newdir WHERE id=:id");
     FwdSqlQuery relocateTracksQuery(m_database, relocateTracksStatement);
     for (int i = 0; i < loc_ids.size(); ++i) {
-        relocateTracksQuery.bindValue(QStringLiteral(":newloc"),
-                relocatedTracks.at(i).updatedTrackRef().getLocation());
-        relocateTracksQuery.bindValue(QStringLiteral(":newdir"), newDirectory);
+        const QString newLoc = relocatedTracks.at(i).updatedTrackRef().getLocation();
+        relocateTracksQuery.bindValue(QStringLiteral(":newloc"), newLoc);
+        const QString newDir = newLoc.left(newLoc.lastIndexOf('/'));
+        relocateTracksQuery.bindValue(QStringLiteral(":newdir"), newDir);
         relocateTracksQuery.bindValue(QStringLiteral(":id"), loc_ids.at(i).toVariant());
         if (!relocateTracksQuery.execPrepared()) {
             LOG_FAILED_QUERY(relocateTracksQuery) << "could not relocate path of track";


### PR DESCRIPTION
fixup for #12462

from https://github.com/mixxxdj/mixxx/pull/12462#issuecomment-4644800386
The relocate method unconditionally sets `directory` to the new **root** dir for all relocated tracks.

This will probably not be noticed. Afaict `directory` is not used, eg. "Search related.." -> Directory uses the `location` of the track, and a later relocate action will also work.
But there may be issues after purging tracks where the track file has not been deleted, see https://github.com/mixxxdj/mixxx/blob/43d6356a2fc4aa00d0399d1f12d0c3d0c04b66d4/src/library/dao/trackdao.cpp#L1116

And the `dir:` filter will not yield all results -- which partially broke #14683 for me :|