### PR TITLE
database: fix incorrect `directory` in `track_locations`

### DIFF
--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -15,6 +15,36 @@ const QString kLocationColumn = QStringLiteral("directory");
 
 } // anonymous namespace
 
+void DirectoryDAO::repairDatabase(const QSqlDatabase& database) {
+    // Ensure the `directory` column in `track_locations` table is correct.
+    // Use the directory part of the `location` column
+    const QString repairDirStatemenet = QStringLiteral(
+            "WITH RECURSIVE dir_path_finder AS ("
+            "    SELECT id, location, length(location) AS idx "
+            "    FROM track_locations "
+            "    UNION ALL "
+            // Looking for a /, starting from the end of `location`
+            // Once found, store the position before that / as idx
+            "    SELECT id, location, idx - 1 FROM dir_path_finder "
+            "    WHERE idx > 1 AND substr(location, idx, 1) != '/'"
+            ") "
+            // For all rows where `directory` is not equal the part of `location`
+            // before the last / (idx)
+            // set `directory` to that `location` substring
+            "UPDATE track_locations "
+            "SET directory = substr(dpf.location, 1, dpf.idx - 1) "
+            "FROM dir_path_finder dpf "
+            "WHERE track_locations.id = dpf.id "
+            "  AND substr(dpf.location, dpf.idx, 1) = '/' "
+            "  AND track_locations.directory "
+            "      IS NOT substr(dpf.location, 1, dpf.idx - 1);");
+
+    FwdSqlQuery query(database, repairDirStatemenet);
+    if (!query.execPrepared()) {
+        LOG_FAILED_QUERY(query) << "Failed to execute track_locations directory path repair";
+    }
+}
+
 QList<mixxx::FileInfo> DirectoryDAO::loadAllDirectories(
         bool skipInvalidOrMissing) const {
     DEBUG_ASSERT(m_database.isOpen());

--- a/src/library/dao/directorydao.h
+++ b/src/library/dao/directorydao.h
@@ -10,6 +10,8 @@ class DirectoryDAO : public DAO {
   public:
     ~DirectoryDAO() override = default;
 
+    void repairDatabase(const QSqlDatabase& database);
+
     QList<mixxx::FileInfo> loadAllDirectories(
             bool skipInvalidOrMissing = false) const;
     /// Same as loadAllDirectories() just with paths as QString.

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -18,6 +18,11 @@ const ConfigKey mixxx::library::prefs::kRescanOnStartupConfigKey =
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("RescanOnStartup")};
 
+const ConfigKey mixxx::library::prefs::kRepairDatabaseOnNextRestartConfigKey =
+        ConfigKey{
+                QStringLiteral("[TrackCollection]"),
+                QStringLiteral("RepairDatabaseOnNextRestart")};
+
 const ConfigKey mixxx::library::prefs::kShowScanSummaryConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -14,6 +14,8 @@ extern const QString kConfigGroup;
 
 extern const ConfigKey kRescanOnStartupConfigKey;
 
+extern const ConfigKey kRepairDatabaseOnNextRestartConfigKey;
+
 extern const ConfigKey kShowScanSummaryConfigKey;
 
 extern const ConfigKey kKeyNotationConfigKey;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -63,6 +63,7 @@ void TrackCollection::repairDatabase(const QSqlDatabase& database) {
 
     kLogger.info() << "Repairing database";
     m_crates.repairDatabase(database);
+    m_directoryDao.repairDatabase(database);
 }
 
 void TrackCollection::connectDatabase(const QSqlDatabase& database) {

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -14,13 +14,11 @@
 #include "util/db/dbconnectionpooled.h"
 #include "util/logger.h"
 
+using namespace mixxx::library::prefs;
+
 namespace {
 
 const mixxx::Logger kLogger("TrackCollectionManager");
-
-const QString kConfigGroup = QStringLiteral("[TrackCollection]");
-
-const ConfigKey kConfigKeyRepairDatabaseOnNextRestart(kConfigGroup, "RepairDatabaseOnNextRestart");
 
 inline
 parented_ptr<TrackCollection> createInternalTrackCollection(
@@ -47,10 +45,10 @@ TrackCollectionManager::TrackCollectionManager(
 
     // TODO(XXX): Add a checkbox in the library preferences for checking
     // and repairing the database on the next restart of the application.
-    if (pConfig->getValue(kConfigKeyRepairDatabaseOnNextRestart, false)) {
+    if (pConfig->getValue(kRepairDatabaseOnNextRestartConfigKey, false)) {
         m_pInternalCollection->repairDatabase(dbConnection);
         // Reset config value
-        pConfig->setValue(kConfigKeyRepairDatabaseOnNextRestart, false);
+        pConfig->setValue(kRepairDatabaseOnNextRestartConfigKey, false);
     }
 
     m_pInternalCollection->connectDatabase(dbConnection);
@@ -313,7 +311,7 @@ ExportTrackMetadataResult TrackCollectionManager::exportTrackMetadataBeforeSavin
             (pTrack->isDirty() &&
                     m_pConfig &&
                     m_pConfig->getValueString(
-                                     mixxx::library::prefs::kSyncTrackMetadataConfigKey)
+                                     kSyncTrackMetadataConfigKey)
                                     .toInt() == 1)) {
         switch (mode) {
         case TrackMetadataExportMode::Immediate: {

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -607,6 +607,12 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
                 correctedWaveformBacked);
         config->setValue<int>(ConfigKey("[Waveform]", "waveform_options"),
                 correctedWaveformOption);
+        // Schedule fix for an inconsistency in the database (it will be run in
+        // TrackCollectionManager ctor):
+        // in `track_locations` table the `directory` column may be incorrect,
+        // see https://github.com/mixxxdj/mixxx/pull/16578
+        config->setValue(mixxx::library::prefs::kRepairDatabaseOnNextRestartConfigKey, true);
+
         // mark the configuration as updated
         configVersion = "2.6.0";
         config->set(ConfigKey("[Config]", "Version"),


### PR DESCRIPTION
Follow-up for #16578

After Relocate Directory for a music directory that has been moved on disk, the `directory` in `track_location` maybe incorrect. Ensure `directory` is exactly the part of `location` before the last /

This db fix is run once when upgrading.

Disclaimer: the repair query has been generated with help of AI, I did my best to review.
Note: apparently the `reverse()` extension could do this faster but it's not guaranteed that sqlite3 provides it.

