### PR TITLE
Expose KeyUtils to QML for engine key controls formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3013,6 +3013,7 @@ if(BUILD_TESTING)
         src/test/controller_mapping_file_handler_test.cpp
         src/test/controllerrenderingengine_test.cpp
         src/test/qmlcontrolproxytest.cpp
+        src/test/qmlkeyutilstest.cpp
         src/test/themeqml_test.cpp
     )
   endif()
@@ -3938,6 +3939,7 @@ if(QML)
       src/qml/qmleffectmanifestparametersmodel.cpp
       src/qml/qmleffectslotproxy.cpp
       src/qml/qmleffectsmanagerproxy.cpp
+      src/qml/qmlkeyutils.cpp
       src/qml/qmllegacylibraryitem.cpp
       src/qml/qmllibraryproxy.cpp
       src/qml/qmllibrarysource.cpp

--- a/src/qml/qmlkeyutils.cpp
+++ b/src/qml/qmlkeyutils.cpp
@@ -1,0 +1,48 @@
+#include "qml/qmlkeyutils.h"
+
+#include <QQmlEngine>
+
+#include "moc_qmlkeyutils.cpp"
+#include "track/keyutils.h"
+
+namespace mixxx {
+namespace qml {
+
+QmlKeyUtils::QmlKeyUtils(QObject* parent)
+        : QObject(parent) {
+}
+
+QString QmlKeyUtils::keyToString(double numericKey) const {
+    const auto key = KeyUtils::keyFromNumericValue(numericKey);
+    return KeyUtils::keyToString(key);
+}
+
+QString QmlKeyUtils::keyToString(double numericKey, double notationValue) const {
+    const auto key = KeyUtils::keyFromNumericValue(numericKey);
+    const auto notation = KeyUtils::keyNotationFromNumericValue(notationValue);
+    return KeyUtils::keyToString(key, notation);
+}
+
+int QmlKeyUtils::keyToOpenKeyNumber(double numericKey) const {
+    const auto key = KeyUtils::keyFromNumericValue(numericKey);
+    return KeyUtils::keyToOpenKeyNumber(key);
+}
+
+double QmlKeyUtils::scaleKeySteps(double numericKey, int steps) const {
+    const auto key = KeyUtils::keyFromNumericValue(numericKey);
+    const auto scaledKey = KeyUtils::scaleKeySteps(key, steps);
+    return KeyUtils::keyToNumericValue(scaledKey);
+}
+
+bool QmlKeyUtils::keyIsValid(double numericKey) const {
+    const auto key = KeyUtils::keyFromNumericValue(numericKey);
+    return key != mixxx::track::io::key::INVALID;
+}
+
+// static
+QmlKeyUtils* QmlKeyUtils::create(QQmlEngine* pQmlEngine, [[maybe_unused]] QJSEngine* pJsEngine) {
+    return new QmlKeyUtils(pQmlEngine);
+}
+
+} // namespace qml
+} // namespace mixxx

--- a/src/qml/qmlkeyutils.h
+++ b/src/qml/qmlkeyutils.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QString>
+
+#include "track/keyutils.h"
+
+namespace mixxx {
+namespace qml {
+
+class QmlKeyUtils : public QObject {
+    Q_OBJECT
+    QML_NAMED_ELEMENT(KeyUtils)
+    QML_SINGLETON
+
+  public:
+    explicit QmlKeyUtils(QObject* parent = nullptr);
+
+    Q_INVOKABLE QString keyToString(double numericKey) const;
+    Q_INVOKABLE QString keyToString(double numericKey, double notationValue) const;
+    Q_INVOKABLE int keyToOpenKeyNumber(double numericKey) const;
+    Q_INVOKABLE double scaleKeySteps(double numericKey, int steps) const;
+    Q_INVOKABLE bool keyIsValid(double numericKey) const;
+
+    static QmlKeyUtils* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
+};
+
+} // namespace qml
+} // namespace mixxx

--- a/src/test/qmlkeyutilstest.cpp
+++ b/src/test/qmlkeyutilstest.cpp
@@ -74,7 +74,7 @@ TEST_F(QmlKeyUtilsTest, KeyToStringWithExplicitNotation) {
     EXPECT_EQ(m_qmlKeyUtils->keyToString(22.0, traditionalNotation), QStringLiteral("Am"));
 
     // INVALID key returns empty string
-    EXPECT_EQ(m_qmlKeyUtils->keyToString(0.0, traditionalNotation), QStringLiteral(""));
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(0.0, traditionalNotation), QString());
 }
 
 TEST_F(QmlKeyUtilsTest, KeyToStringUsesCustomNotation) {
@@ -92,7 +92,7 @@ TEST_F(QmlKeyUtilsTest, KeyToStringUsesCustomNotation) {
     EXPECT_EQ(m_qmlKeyUtils->keyToString(22.0), QStringLiteral("Custom22"));
 
     // INVALID key still returns empty string
-    EXPECT_EQ(m_qmlKeyUtils->keyToString(0.0), QStringLiteral(""));
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(0.0), QString());
 
     // Reset global KeyUtils state to avoid influencing other tests.
     KeyUtils::setNotation({});

--- a/src/test/qmlkeyutilstest.cpp
+++ b/src/test/qmlkeyutilstest.cpp
@@ -1,0 +1,98 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QQmlEngine>
+#include <memory>
+
+#include "qml/qmlkeyutils.h"
+#include "test/mixxxtest.h"
+#include "track/keyutils.h"
+
+using namespace mixxx::qml;
+
+namespace {
+
+class QmlKeyUtilsTest : public MixxxTest {
+  protected:
+    void SetUp() override {
+        m_qmlKeyUtils = std::make_unique<QmlKeyUtils>();
+    }
+
+    std::unique_ptr<QmlKeyUtils> m_qmlKeyUtils;
+};
+
+TEST_F(QmlKeyUtilsTest, KeyIsValid) {
+    // 1 is C_MAJOR (valid)
+    EXPECT_TRUE(m_qmlKeyUtils->keyIsValid(1.0));
+    // 22 is A_MINOR (valid)
+    EXPECT_TRUE(m_qmlKeyUtils->keyIsValid(22.0));
+    // 0 is INVALID
+    EXPECT_FALSE(m_qmlKeyUtils->keyIsValid(0.0));
+    // Out of bounds
+    EXPECT_FALSE(m_qmlKeyUtils->keyIsValid(-1.0));
+    EXPECT_FALSE(m_qmlKeyUtils->keyIsValid(99.0));
+}
+
+TEST_F(QmlKeyUtilsTest, KeyToOpenKeyNumber) {
+    // C_MAJOR (1) -> 1
+    EXPECT_EQ(m_qmlKeyUtils->keyToOpenKeyNumber(1.0), 1);
+    // A_MINOR (22) -> 1
+    EXPECT_EQ(m_qmlKeyUtils->keyToOpenKeyNumber(22.0), 1);
+    // INVALID (0) -> 0
+    EXPECT_EQ(m_qmlKeyUtils->keyToOpenKeyNumber(0.0), 0);
+}
+
+TEST_F(QmlKeyUtilsTest, ScaleKeySteps) {
+    // C_MAJOR (1) + 2 steps -> D_MAJOR (3)
+    EXPECT_DOUBLE_EQ(m_qmlKeyUtils->scaleKeySteps(1.0, 2), 3.0);
+    // C_MAJOR (1) - 1 step -> B_MAJOR (12)
+    EXPECT_DOUBLE_EQ(m_qmlKeyUtils->scaleKeySteps(1.0, -1), 12.0);
+    // INVALID (0) scaled stays INVALID (0)
+    EXPECT_DOUBLE_EQ(m_qmlKeyUtils->scaleKeySteps(0.0, 5), 0.0);
+}
+
+TEST_F(QmlKeyUtilsTest, KeyToStringWithExplicitNotation) {
+    // OpenKey (2)
+    double openKeyNotation = static_cast<double>(KeyUtils::KeyNotation::OpenKey);
+    // C_MAJOR (1) -> "1d"
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(1.0, openKeyNotation), QStringLiteral("1d"));
+    // A_MINOR (22) -> "1m"
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(22.0, openKeyNotation), QStringLiteral("1m"));
+
+    // Lancelot (3)
+    double lancelotNotation = static_cast<double>(KeyUtils::KeyNotation::Lancelot);
+    // C_MAJOR (1) -> "8B"
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(1.0, lancelotNotation), QStringLiteral("8B"));
+    // A_MINOR (22) -> "8A"
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(22.0, lancelotNotation), QStringLiteral("8A"));
+
+    // Traditional (4)
+    double traditionalNotation = static_cast<double>(KeyUtils::KeyNotation::Traditional);
+    // C_MAJOR (1) -> "C"
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(1.0, traditionalNotation), QStringLiteral("C"));
+    // A_MINOR (22) -> "Am"
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(22.0, traditionalNotation), QStringLiteral("Am"));
+
+    // INVALID key returns empty string
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(0.0, traditionalNotation), QStringLiteral(""));
+}
+
+TEST_F(QmlKeyUtilsTest, KeyToStringUsesCustomNotation) {
+    // Set up a custom notation map
+    QMap<mixxx::track::io::key::ChromaticKey, QString> customNotation;
+    for (int i = 1; i <= 24; ++i) {
+        customNotation[static_cast<mixxx::track::io::key::ChromaticKey>(i)] =
+                QStringLiteral("Custom%1").arg(i);
+    }
+    KeyUtils::setNotation(customNotation);
+
+    // C_MAJOR (1) -> "Custom1"
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(1.0), QStringLiteral("Custom1"));
+    // A_MINOR (22) -> "Custom22"
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(22.0), QStringLiteral("Custom22"));
+
+    // INVALID key still returns empty string
+    EXPECT_EQ(m_qmlKeyUtils->keyToString(0.0), QStringLiteral(""));
+}
+
+} // namespace

--- a/src/test/qmlkeyutilstest.cpp
+++ b/src/test/qmlkeyutilstest.cpp
@@ -93,6 +93,9 @@ TEST_F(QmlKeyUtilsTest, KeyToStringUsesCustomNotation) {
 
     // INVALID key still returns empty string
     EXPECT_EQ(m_qmlKeyUtils->keyToString(0.0), QStringLiteral(""));
+
+    // Reset global KeyUtils state to avoid influencing other tests.
+    KeyUtils::setNotation({});
 }
 
 } // namespace


### PR DESCRIPTION
Exposes existing C++ KeyUtils functionality to QML so QML skins can display and interact with engine key controls correctly without duplicating key formatting logic or relying on JavaScript helper files.

## Why is it needed?
- **Pitch & Key Shift Actions:** Legacy widgets like `WKey` display the key using `KeyUtils` and respect the active Mixxx key notation preference. Currently, QML skins do not have a direct shared way to format numeric key controls like `key` or `visual_key`.
- **Accuracy:** QML skins previously fell back to `currentTrack.keyText`, which does not reflect real-time pitch/key shift adjustments.
- **Shared Codebase:** Exposing the utility globally ensures all current and future QML skins can use a single, shared, robust formatting mechanism.

## Changes
- **QML Singleton Registration:** Registered `KeyUtils` as a singleton in the `Mixxx` QML namespace.
- **Key Formatting Overloads:** Added QML-invokable methods to convert chromatic keys (numeric values) to formatted strings, either automatically adopting the user's configured notation preference or matching an explicitly passed notation.
- **Harmonic Utilities:** Exposed helper methods to obtain the OpenKey/Camelot circle number from a key, and to shift keys by a specified number of semitone steps for math actions.
- **Validation:** Added checks to easily verify if a numeric key value represents a valid musical key.
