### PR TITLE
library: Add "Mark as Played" context menu action across track views

### DIFF
--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -108,6 +108,12 @@ void CrateFeature::initActions() {
             this,
             &CrateFeature::slotAnalyzeCrate);
 
+    m_pMarkTracksPlayedAction = make_parented<QAction>(tr("Mark all tracks played"), this);
+    connect(m_pMarkTracksPlayedAction.get(),
+            &QAction::triggered,
+            this,
+            &CrateFeature::slotMarkTracksPlayed);
+
     m_pImportPlaylistAction = make_parented<QAction>(tr("Import Crate"), this);
     connect(m_pImportPlaylistAction.get(),
             &QAction::triggered,
@@ -405,6 +411,7 @@ void CrateFeature::onRightClickChild(
     menu.addAction(m_pAutoDjTrackSourceAction.get());
     menu.addSeparator();
     menu.addAction(m_pAnalyzeCrateAction.get());
+    menu.addAction(m_pMarkTracksPlayedAction.get());
     menu.addSeparator();
     menu.addAction(m_pImportPlaylistAction.get());
     menu.addAction(m_pExportPlaylistAction.get());
@@ -766,6 +773,32 @@ void CrateFeature::slotAnalyzeCrate() {
                 }
             }
             emit analyzeTracks(tracks);
+        }
+    }
+}
+
+void CrateFeature::slotMarkTracksPlayed() {
+    if (!m_lastRightClickedIndex.isValid()) {
+        return;
+    }
+
+    CrateId crateId = crateIdFromIndex(m_lastRightClickedIndex);
+    if (!crateId.isValid()) {
+        return;
+    }
+
+    std::unique_ptr<CrateTableModel> pCrateTableModel =
+            std::make_unique<CrateTableModel>(this, m_pLibrary->trackCollectionManager());
+    pCrateTableModel->selectCrate(crateId);
+    pCrateTableModel->select();
+    int rows = pCrateTableModel->rowCount();
+    for (int i = 0; i < rows; ++i) {
+        QModelIndex index = pCrateTableModel->index(i, 0);
+        if (index.isValid()) {
+            TrackPointer pTrack = pCrateTableModel->getTrack(index);
+            if (pTrack) {
+                pTrack->updatePlayedStatusKeepPlayCount(true);
+            }
         }
     }
 }

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -69,6 +69,7 @@ class CrateFeature : public BaseTrackSetFeature {
     // Copy all of the tracks in a crate to a new directory (like a thumbdrive).
     void slotExportTrackFiles();
     void slotAnalyzeCrate();
+    void slotMarkTracksPlayed();
     void slotCrateTableChanged(CrateId crateId);
     void slotCrateContentChanged(CrateId crateId);
     void htmlLinkClicked(const QUrl& link);
@@ -125,6 +126,7 @@ class CrateFeature : public BaseTrackSetFeature {
     parented_ptr<QAction> m_pCreateImportPlaylistAction;
     parented_ptr<QAction> m_pExportPlaylistAction;
     parented_ptr<QAction> m_pExportTrackFilesAction;
+    parented_ptr<QAction> m_pMarkTracksPlayedAction;
 #ifdef __ENGINEPRIME__
     parented_ptr<QAction> m_pExportAllCratesAction;
     parented_ptr<QAction> m_pExportCrateAction;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -59,6 +59,12 @@ PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
             &QAction::triggered,
             this,
             &PlaylistFeature::slotDeleteAllUnlockedPlaylists);
+
+    m_pMarkTracksPlayedAction = make_parented<QAction>(tr("Mark all tracks played"), this);
+    connect(m_pMarkTracksPlayedAction,
+            &QAction::triggered,
+            this,
+            &PlaylistFeature::slotMarkTracksPlayed);
 }
 
 QVariant PlaylistFeature::title() {
@@ -109,6 +115,7 @@ void PlaylistFeature::onRightClickChild(
     menu.addAction(m_pDuplicatePlaylistAction);
     menu.addAction(m_pDeletePlaylistAction);
     menu.addAction(m_pLockPlaylistAction);
+    menu.addAction(m_pMarkTracksPlayedAction);
     menu.addSeparator();
     menu.addAction(m_pAddToAutoDJAction);
     menu.addAction(m_pAddToAutoDJTopAction);
@@ -299,6 +306,37 @@ void PlaylistFeature::slotOrderTracksByCurrentPosition() {
 
 void PlaylistFeature::slotUnlockAllPlaylists() {
     m_playlistDao.setPlaylistsLockedByType(PlaylistDAO::PLHT_NOT_HIDDEN, false);
+}
+
+void PlaylistFeature::slotMarkTracksPlayed() {
+    if (!m_lastRightClickedIndex.isValid()) {
+        return;
+    }
+
+    int clickedPlaylistId = playlistIdFromIndex(m_lastRightClickedIndex);
+    if (clickedPlaylistId == kInvalidPlaylistId) {
+        return;
+    }
+
+    // Right-clicked playlist may not be loaded. Use a temporary model to
+    // keep sidebar selection and table view in sync
+    std::unique_ptr<PlaylistTableModel> pPlaylistTableModel =
+            std::make_unique<PlaylistTableModel>(this,
+                    m_pLibrary->trackCollectionManager(),
+                    "mixxx.db.model.playlist_mark_played");
+    pPlaylistTableModel->selectPlaylist(clickedPlaylistId);
+    pPlaylistTableModel->select();
+    int rows = pPlaylistTableModel->rowCount();
+    for (int i = 0; i < rows; ++i) {
+        QModelIndex index = pPlaylistTableModel->index(i, 0);
+        if (index.isValid()) {
+            TrackPointer pTrack = pPlaylistTableModel->getTrack(index);
+            if (pTrack) {
+                // Do not update the play count, just set played status.
+                pTrack->updatePlayedStatusKeepPlayCount(true);
+            }
+        }
+    }
 }
 
 void PlaylistFeature::slotDeleteAllUnlockedPlaylists() {

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -40,6 +40,7 @@ class PlaylistFeature : public BasePlaylistFeature {
     void slotOrderTracksByCurrentPosition();
     void slotUnlockAllPlaylists();
     void slotDeleteAllUnlockedPlaylists();
+    void slotMarkTracksPlayed();
 
   protected:
     void decorateChild(TreeItem* pChild, int playlistId) override;
@@ -53,4 +54,5 @@ class PlaylistFeature : public BasePlaylistFeature {
     parented_ptr<QAction> m_pOrderByCurrentPosAction;
     parented_ptr<QAction> m_pUnlockPlaylistsAction;
     parented_ptr<QAction> m_pDeleteAllUnlockedPlaylistsAction;
+    parented_ptr<QAction> m_pMarkTracksPlayedAction;
 };

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -421,6 +421,8 @@ void WTrackMenu::createActions() {
                         slotUpdateExternalTrackCollection(pExternalTrackCollection);
                     });
         }
+        m_pMarkAsPlayedAction = make_parented<QAction>(tr("Mark as Played"), m_pMetadataMenu);
+        connect(m_pMarkAsPlayedAction, &QAction::triggered, this, &WTrackMenu::slotMarkAsPlayed);
     }
 
     if (featureIsEnabled(Feature::Reset)) {
@@ -720,6 +722,9 @@ void WTrackMenu::setupActions() {
         m_pHotcueMenu->addAction(m_pSortHotcuesByPositionCompressAction);
         m_pHotcueMenu->addAction(m_pSortHotcuesByPositionAction);
         addMenu(m_pHotcueMenu);
+
+        m_pMetadataMenu->addSeparator();
+        m_pMetadataMenu->addAction(m_pMarkAsPlayedAction);
     }
 
     if (featureIsEnabled(Feature::Reset)) {
@@ -2053,6 +2058,24 @@ void WTrackMenu::slotClearPlayCount() {
             tr("Resetting play count of %n track(s)", "", getTrackCount());
     const auto trackOperator =
             ResetPlayCounterTrackPointerOperation();
+    applyTrackPointerOperation(
+            progressLabelText,
+            &trackOperator);
+}
+
+void WTrackMenu::slotMarkAsPlayed() {
+    const auto progressLabelText =
+            tr("Marking %n track(s) as played", "", getTrackCount());
+
+    class MarkPlayedTrackPointerOperation : public mixxx::TrackPointerOperation {
+      private:
+        void doApply(
+                const TrackPointer& pTrack) const override {
+            pTrack->updatePlayedStatusKeepPlayCount(true);
+        }
+    };
+
+    const auto trackOperator = MarkPlayedTrackPointerOperation();
     applyTrackPointerOperation(
             progressLabelText,
             &trackOperator);

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -145,6 +145,7 @@ class WTrackMenu : public QMenu {
     // Reset
     void slotClearBeats();
     void slotClearPlayCount();
+    void slotMarkAsPlayed();
     void slotClearRating();
     void slotClearComment();
     void slotResetMainCue();
@@ -365,6 +366,7 @@ class WTrackMenu : public QMenu {
     // Clear track metadata actions
     parented_ptr<QAction> m_pClearBeatsAction;
     parented_ptr<QAction> m_pClearPlayCountAction;
+    parented_ptr<QAction> m_pMarkAsPlayedAction;
     parented_ptr<QAction> m_pClearRatingAction;
     parented_ptr<QAction> m_pClearMainCueAction;
     parented_ptr<QAction> m_pClearHotCuesAction;


### PR DESCRIPTION
What this PR does: This PR extends the "Mark as Played" context menu action so that it is available when right-clicking tracks in the main library view, as well as when right-clicking Playlists and Crates in the sidebar.

Previously, this feature was only accessible from the History section (which was added in #8948 ). This update allows DJs to manually mark tracks (or entire sets/crates) as played, changing their visual played status without artificially incrementing the track's total play count.

Implementation details:

- General Library (WTrackMenu): Added the "Mark as Played" action to the Metadata right-click menu, utilizing applyTrackPointerOperation to natively support multi-track batch selections.
- Playlists (PlaylistFeature) & Crates (CrateFeature): Added right-click actions to the sidebar items to mark all contained tracks as played.
- Safety: When updating tracks inside of a Playlist or Crate that isn't currently loaded into the main view, the feature instantiates a temporary background model (PlaylistTableModel / CrateTableModel). This allows the tracks to be safely iterated over and updated (updatePlayedStatusKeepPlayCount(true)) without interfering with the user's active UI state or active search models.

Testing:

- Verified that marking single and multiple tracks in the main library successfully updates their visual played status.
- Verified that right-clicking Playlists and Crates marks all containing tracks as played.
- Ensured play counts correctly remain unchanged during these operations.
- Verified stability (no null pointer dereferences) in release builds.
- Note that I had to test by compiling with -DAU_EFFECTS=OFF because Mixxx crashes on load on my system without that flag due to the new way it loads AUs, but I don't see how that could have any interaction with the changes in this PR.