### PR TITLE
(fix) save header state of Recording feature

### DIFF
--- a/src/library/analysis/dlganalysis.cpp
+++ b/src/library/analysis/dlganalysis.cpp
@@ -94,6 +94,15 @@ DlgAnalysis::DlgAnalysis(WLibrary* parent,
     slotAnalysisActive(m_bAnalysisActive);
 }
 
+DlgAnalysis::~DlgAnalysis() {
+    qDebug() << "~DlgAnalysis()";
+
+    // Delete m_pAnalysisLibraryTableView before the table models.
+    // This is because the table view saves the header state using the model
+    // in its destructor.
+    delete m_pAnalysisLibraryTableView;
+}
+
 void DlgAnalysis::onShow() {
     if (!radioButtonRecentlyAdded->isChecked() &&
             !radioButtonAllSongs->isChecked()) {

--- a/src/library/analysis/dlganalysis.h
+++ b/src/library/analysis/dlganalysis.h
@@ -20,7 +20,7 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
     DlgAnalysis(WLibrary *parent,
                UserSettingsPointer pConfig,
                Library* pLibrary);
-    ~DlgAnalysis() override = default;
+    ~DlgAnalysis() override;
 
     void onSearch(const QString& text) override;
     void onShow() override;

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -44,8 +44,12 @@ BrowseFeature::BrowseFeature(
         UserSettingsPointer pConfig,
         RecordingManager* pRecordingManager)
         : LibraryFeature(pLibrary, pConfig, QString("computer")),
-          m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
-          m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
+          m_pTrackCollection(
+                  pLibrary->trackCollectionManager()->internalCollection()),
+          m_browseModel(this,
+                  pLibrary->trackCollectionManager(),
+                  pRecordingManager,
+                  "mixxx.db.model.browse"),
           m_proxyModel(&m_browseModel, true),
           m_pSidebarModel(new FolderTreeModel(this)) {
     connect(&m_browseModel,

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -43,9 +43,10 @@ void listAppendOrReplaceAt(QList<T>* pList, int index, const T& value) {
 
 BrowseTableModel::BrowseTableModel(QObject* parent,
         TrackCollectionManager* pTrackCollectionManager,
-        RecordingManager* pRecordingManager)
+        RecordingManager* pRecordingManager,
+        const char* nameSpace)
         : TrackModel(pTrackCollectionManager->internalCollection()->database(),
-                  "mixxx.db.model.browse"),
+                  nameSpace),
           QStandardItemModel(parent),
           m_pTrackCollectionManager(pTrackCollectionManager),
           m_pRecordingManager(pRecordingManager),

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -50,7 +50,10 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
     Q_OBJECT
 
   public:
-    BrowseTableModel(QObject* parent, TrackCollectionManager* pTrackCollectionManager, RecordingManager* pRec);
+    BrowseTableModel(QObject* parent,
+            TrackCollectionManager* pTrackCollectionManager,
+            RecordingManager* pRec,
+            const char* nameSpace);
     virtual ~BrowseTableModel();
 
     // initiate table population, store path

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -16,13 +16,14 @@ DlgRecording::DlgRecording(
         KeyboardEventFilter* pKeyboard)
         : QWidget(parent),
           m_pConfig(pConfig),
-          m_pTrackTableView(
-                  new WTrackTableView(
-                          this,
-                          pConfig,
-                          pLibrary,
-                          parent->getTrackTableBackgroundColorOpacity())),
-          m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
+          m_pTrackTableView(new WTrackTableView(this,
+                  pConfig,
+                  pLibrary,
+                  parent->getTrackTableBackgroundColorOpacity())),
+          m_browseModel(this,
+                  pLibrary->trackCollectionManager(),
+                  pRecordingManager,
+                  "mixxx.db.model.recording"),
           m_proxyModel(&m_browseModel, true),
           m_bytesRecordedStr("--"),
           m_durationRecordedStr("--:--"),

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -100,6 +100,11 @@ DlgRecording::DlgRecording(
 }
 
 DlgRecording::~DlgRecording() {
+    qDebug() << "~DlgRecording()";
+
+    // Delete m_pTrackTableView before the table models. This is because the
+    // table view saves the header state using the model in its destructor.
+    delete m_pTrackTableView;
 }
 
 bool DlgRecording::hasFocus() const {

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -288,7 +288,7 @@ void WTrackTableViewHeader::restoreHeaderState() {
     }
 
     const QString headerStateString = pTrackModel->getModelSetting("header_state_pb");
-    if (headerStateString.isNull()) {
+    if (headerStateString.isEmpty()) {
         loadDefaultHeaderState();
     } else {
         // Load the previous header state (stored as serialized protobuf).


### PR DESCRIPTION
Follow-up for #16527, kind of

Allow to have a individual, persistent header state for Recording.

This fixes two issues:
1. Computer and Recording initially have the same column layout and sorting
-> both were using BrowseTableModel with the same model namespace
**Fix:** set separate namespaces
2. in Recording then column changes (layout/sorting) were not saved, only the state from Computer was
-> the Recording proxy model and/or the Browse model was destroyed before the WTrackTableView which saves the header state
Fix: ensure correct destruction order by adding the same destruction override like in AutoDJ (and other views with their own track table)

Note: I acknowledge that it may have been intentional at some point to make Computer and Recording share the header state, but a) it's not birectional and b) it doesn't make sense IMO. Computer may be sorted by Artist, Title, BPM or whatever while Recording may be sorted by date.