### PR TITLE
Fix crash when a track without beats hits the bpm:const search filter

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -717,7 +717,9 @@ bool BpmFilterNode::match(const TrackPointer& pTrack) const {
     }
 
     if (m_matchMode == MatchMode::Constant) {
-        return pTrack->getBeats()->hasConstantTempo();
+        const mixxx::BeatsPointer pBeats = pTrack->getBeats();
+        // Note: a track without a beatgrid cannot have a constant tempo.
+        return pBeats && pBeats->hasConstantTempo();
     }
 
     double value = pTrack->getBpm();


### PR DESCRIPTION
This was a collateral finding I stumbled upon while investigating something else . But it's an actual bug. Steps to reproduce:

1. Load a track into a deck.
2. Clear the beatgrid of the track (contextual menu in the library).
3. Click BPM-lock.
4. Write `bpm:const` into the filter field.
5. mixxx segfaults (null pointer dereference).