### PR TITLE
[feat] allow to "pin" a track to simplify lookup in track sets

### DIFF
--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -107,14 +107,114 @@
               </WidgetGroup><!-- LibSidebarContainer -->
 
               <!-- Library Table-->
-              <Library>
-                <ShowButtonText>false</ShowButtonText>
-                <TrackTableBackgroundColorOpacity>0.175</TrackTableBackgroundColorOpacity>
-                <!-- Colors for the render modes of the Overview column -->
-                <!-- For the overview column we only set the signal color,
-                     other colors are the defaults. -->
-                <SignalColor><Variable name="SignalColor_12"/></SignalColor>
-              </Library>
+              <WidgetGroup>
+                <Layout>vertical</Layout>
+                <Children>
+                  <!-- 'Pinned Track' controls -->
+                  <WidgetGroup>
+                    <ObjectName>PinnedTrackControls</ObjectName>
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <PushButton>
+                        <ObjectName>PinnedTrackToggle</ObjectName>
+                        <Size>22f,22f</Size>
+                        <NumberStates>2</NumberStates>
+                        <State>
+                          <Number>0</Number>
+                          <Text>L</Text>
+                        </State>
+                        <State>
+                          <Number>1</Number>
+                          <Text>L</Text>
+                        </State>
+                        <Connection>
+                          <ConfigKey>[Library],pin_selected_track</ConfigKey>
+                        </Connection>
+                      </PushButton>
+                      <PushButton>
+                        <ObjectName>PinnedTrackToggle</ObjectName>
+                        <Size>22f,22f</Size>
+                        <NumberStates>2</NumberStates>
+                        <State>
+                          <Number>0</Number>
+                          <Text>1</Text>
+                        </State>
+                        <State>
+                          <Number>1</Number>
+                          <Text>1</Text>
+                        </State>
+                        <Connection>
+                          <ConfigKey>[Channel1],pin_loaded_track</ConfigKey>
+                        </Connection>
+                      </PushButton>
+                      <PushButton>
+                        <ObjectName>PinnedTrackToggle</ObjectName>
+                        <Size>22f,22f</Size>
+                        <NumberStates>2</NumberStates>
+                        <State>
+                          <Number>0</Number>
+                          <Text>2</Text>
+                        </State>
+                        <State>
+                          <Number>1</Number>
+                          <Text>2</Text>
+                        </State>
+                        <Connection>
+                          <ConfigKey>[Channel2],pin_loaded_track</ConfigKey>
+                        </Connection>
+                      </PushButton>
+
+                      <WidgetGroup>
+                        <Layout>horizontal</Layout>
+                        <SizePolicy>me,min</SizePolicy>
+                        <MaximumSize>500,</MaximumSize>
+                        <Children>
+                          <TrackProperty>
+                            <ObjectName>TitleTextSmall</ObjectName>
+                            <Size>50min,25f</Size>
+                            <TooltipId>track_title</TooltipId>
+                            <Property>titleInfo</Property>
+                            <Alignment>Left</Alignment>
+                            <Elide>right</Elide>
+                            <Group>[Library]</Group>
+                          </TrackProperty>
+
+                          <Label>
+                            <ObjectName>MicAuxLabelUnconfigured</ObjectName>
+                            <Size>10f,21f</Size>
+                            <Text> - </Text>
+                            <Alignment>center</Alignment>
+                          </Label>
+
+                          <TrackProperty>
+                            <ObjectName>TitleTextSmall</ObjectName>
+                            <Size>0me,25f</Size>
+                            <TooltipId>track_artist</TooltipId>
+                            <Property>artist</Property>
+                            <Alignment>Left</Alignment>
+                            <Elide>right</Elide>
+                            <Group>[Library]</Group>
+                          </TrackProperty>
+                        </Children>
+                      </WidgetGroup>
+                      <WidgetGroup><SizePolicy>i,min</SizePolicy></WidgetGroup>
+                    </Children>
+                    <Connection>
+                      <ConfigKey>[Library],has_pinned_track</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                    </Connection>
+                  </WidgetGroup>
+
+                  <Library>
+                    <ShowButtonText>false</ShowButtonText>
+                    <TrackTableBackgroundColorOpacity>0.175</TrackTableBackgroundColorOpacity>
+                    <!-- Colors for the render modes of the Overview column -->
+                    <!-- For the overview column we only set the signal color,
+                         other colors are the defaults. -->
+                    <SignalColor><Variable name="SignalColor_12"/></SignalColor>
+                  </Library>
+                </Children>
+              </WidgetGroup>
 
             </Children>
           </Splitter><!-- LibrarySplitter -->

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -28,6 +28,7 @@ WEffectChainPresetSelector QAbstractScrollArea,
 #LibraryFeatureControls QPushButton,
 #LibraryFeatureControls QLabel,
 #LibraryFeatureControls QRadioButton,
+WPushButton#PinnedTrackToggle,
 WTrackTableViewHeader,
 WTrackTableViewHeader::section {
   /* On Linux all weight variants of Open Sans are identified
@@ -51,6 +52,7 @@ WPushButton#GuiToggleButton,
 WLabel#RecFeedback, WLabel#RecDuration,
 WPushButton#BroadcastButton,
 WPushButton#SkinSettingsToggle,
+WPushButton#PinnedTrackToggle,
 #LibraryFeatureControls QPushButton,
 /* Passthrough label on overview waveform */
 WPushButton#EQKillButton,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -79,6 +79,7 @@
 #SidebarCoverSplitter:handle,
 #LibrarySplitter::handle,
 #LibraryFeatureControls,
+#PinnedTrackControls,
 QAbstractScrollArea::corner {
   border-top: 1px solid #212123;
   border-right: 1px solid #111;
@@ -141,7 +142,8 @@ QAbstractScrollArea::corner {
         max-height: 3px;
       }
   /* Controls row in AutoDJ, Recording and other library features */
-  #LibraryFeatureControls {
+  #LibraryFeatureControls,
+  #PinnedTrackControls {
     border-width: 1px 0px 0px 0px;
     border-radius: 0px;
     margin-top: 1px;
@@ -1293,6 +1295,7 @@ WEffectChainPresetSelector,
   #DeckMini2 #ArtistTextSmall,
   #DeckMini2 #BpmTextSmall,
   #DeckMini2 #KeyTextSmall,
+#PinnedTrackControls WTrackProperty,
 #MicAuxLabel,
 #SamplerTitle, #SamplerTitleMini,
 #MainMenu QMenu,
@@ -1306,6 +1309,8 @@ WTrackTableView,
 #LibraryPlayedCheckbox::item,
 WLibraryTextBrowser,
 WLibrarySidebar,
+#PinnedTrackControls WPushButton,
+WPushButton#PinnedTrackToggle,
 #LibraryFeatureControls QLabel,
 #LibraryFeatureControls QPushButton,
 #LibraryFeatureControls QRadioButton,
@@ -1503,6 +1508,7 @@ WPushButton#VinylStatus[displayValue="3"], /* needle skip detected (pink bg) */
 #BroadcastButton[displayValue="4"], /* warning */
 #RecDuration[highlight="1"],  /* initializing */
 #RecDuration[highlight="2"],  /* recording */
+WPushButton#PinnedTrackToggle[displayValue="1"],
 #SkinSettingsToggle[displayValue="1"],
 QPushButton#pushButtonAutoDJ:checked,
 QPushButton#pushButtonRepeatPlaylist:checked,
@@ -1569,6 +1575,8 @@ WPushButton#FxAssignButton1[displayValue="0"],
 WEffectSelector:!editable,
 #fadeModeCombobox:!editable,
 #LibraryFeatureControls QPushButton:enabled,
+#PinnedTrackControls WPushButton,
+WPushButton#PinnedTrackToggle,
 #CueDeleteButton,
 #CueStandardButton,
 #CueSavedLoopButton,
@@ -1592,6 +1600,7 @@ WEffectSelector:!editable,
   #BroadcastButton[displayValue="3"],
   #BroadcastButton[displayValue="4"],
   #SkinSettingsToggle[displayValue="1"],
+  WPushButton#PinnedTrackToggle[displayValue="1"],
   #LibraryFeatureControls QPushButton:pressed
   QPushButton#pushButtonAutoDJ:checked,
   QPushButton#pushButtonRepeatPlaylist:checked,
@@ -1751,6 +1760,8 @@ WBpmEditor QDoubleSpinBox {
   #spinBoxRecentDays::up-button,
   #spinBoxRecentDays::down-button,
   QPushButton#pushButtonAutoDJ:enabled:!checked,
+  #PinnedTrackControls WPushButton,
+  WPushButton#PinnedTrackToggle,
   #LibraryFeatureControls QPushButton:enabled {
     background-color: #222;
   }
@@ -1766,6 +1777,7 @@ WPushButton#PlayDeckMini[displayValue="1"],
 WPushButton#PlaySampler[displayValue="1"],
 WPushButton#PlayPreview[displayValue="1"],
 WPushButton#PlayIndicator[displayValue="1"],
+WPushButton#PinnedTrackToggle[displayValue="1"],
 #LibraryPreviewButton:checked,
 #CueDeck[displayValue="1"],
 WPushButton#Reverse[pressed="true"],

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -573,6 +573,7 @@ void Library::slotShowTrackModel(QAbstractItemModel* model) {
     emit switchToView(m_sTrackViewName);
 
     if (m_pLibraryControl->hasPinnedTrack()) {
+        qDebug() << "Library::slotShowTrackModel -> try to select pinned track";
         // TODO try to make sure the pinned track is visible
         // Ie. clear the current search if it's not.
         // Currently the user has to take care of that, then click sidebar item

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -267,6 +267,17 @@ Library::Library(
     m_editMetadataSelectedClick = m_pConfig->getValue(
             kEditMetadataSelectedClickConfigKey,
             kEditMetadataSelectedClickDefault);
+
+    // Forward the 'pinned track' signal so eg. WTrackProperty can be notified
+    connect(m_pLibraryControl,
+            &LibraryControl::pinnedTrackChanged,
+            this,
+            &Library::pinnedTrackChanged);
+    // and a wrapper when LibraryControl only has the TrackId
+    connect(m_pLibraryControl,
+            &LibraryControl::pinnedTrackIdChanged,
+            this,
+            &Library::slotPinnedTrackIdChanged);
 }
 
 Library::~Library() = default;
@@ -613,6 +624,14 @@ void Library::slotLoadTrackToPlayer(
     emit loadTrackToPlayer(pTrack, group, play);
 }
 #endif
+
+void Library::slotPinnedTrackIdChanged(const TrackId& id) {
+    TrackPointer pTrack;
+    if (id.isValid()) {
+        pTrack = trackCollectionManager()->getTrackById(id);
+    }
+    emit pinnedTrackChanged(pTrack);
+}
 
 void Library::slotRefreshLibraryModels() {
     m_pMixxxLibraryFeature->refreshLibraryModels();

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -560,7 +560,23 @@ void Library::slotShowTrackModel(QAbstractItemModel* model) {
     }
     emit showTrackModel(model);
     emit switchToView(m_sTrackViewName);
-    emit restoreSearch(trackModel->currentSearch());
+
+    if (m_pLibraryControl->hasPinnedTrack()) {
+        // TODO try to make sure the pinned track is visible
+        // Ie. clear the current search if it's not.
+        // Currently the user has to take care of that, then click sidebar item
+        // again in order to select the track(s)
+        // isTrackIdInCurrentLibraryView(pinnedTrack) doesn't fit since the
+        // TrackModel also only holds the filtered tracks.
+        // emit restoreSearch(QString()) clears searchbox for all features,
+        // but doesn't clear the model filter
+        //
+        // Try to select pinned track
+        m_pLibraryControl->selectedPinnedTrack();
+    } else {
+        // No pinned track, restore search
+        emit restoreSearch(trackModel->currentSearch());
+    }
 }
 
 void Library::slotSwitchToView(const QString& view) {

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -131,6 +131,9 @@ class Library: public QObject {
     void slotLoadTrackToPlayer(TrackPointer pTrack, const QString& group, bool play);
 #endif
     void slotLoadLocationToPlayer(const QString& location, const QString& group, bool play);
+
+    void slotPinnedTrackIdChanged(const TrackId& id);
+
     void slotRefreshLibraryModels();
     void slotCreatePlaylist();
     void slotCreateCrate();
@@ -178,6 +181,8 @@ class Library: public QObject {
     void setSidebarHoverExpandDelay(int delay);
 
     void onTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
+
+    void pinnedTrackChanged(TrackPointer pTrack);
 
   private slots:
       void onPlayerManagerTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -785,11 +785,13 @@ void LibraryControl::updateHasPinnedTrackControl() {
 };
 
 void LibraryControl::selectedPinnedTrack() {
+    qDebug() << "LibraryControl::selectedPinnedTrack()";
     if (!m_pLibraryWidget) {
         return;
     }
 
     if (!m_pinnedTrackId.isValid()) {
+        qDebug() << "-> pinned id invalid, return";
         return;
     }
 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -12,8 +12,11 @@
 #include "control/controlpushbutton.h"
 #include "library/library.h"
 #include "library/libraryview.h"
+#include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
 #include "moc_librarycontrol.cpp"
+#include "track/track.h"
+#include "track/track_decl.h"
 #include "util/cmdlineargs.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
@@ -87,6 +90,28 @@ void LoadToGroupController::slotLoadToGroupAndPlay(double v) {
     }
 }
 
+PinLoadedTrackController::PinLoadedTrackController(
+        LibraryControl* pLibraryControl, const QString& group)
+        : QObject(pLibraryControl) {
+    m_pPinLoadedTrackControl =
+            std::make_unique<ControlPushButton>(ConfigKey(group, "pin_loaded_track"));
+    m_pPinLoadedTrackControl->setButtonMode(mixxx::control::ButtonMode::Toggle);
+    connect(m_pPinLoadedTrackControl.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this, group](double v) {
+                emit pinLoadedTrack(group, v);
+            });
+    connect(this,
+            &PinLoadedTrackController::pinLoadedTrack,
+            pLibraryControl,
+            &LibraryControl::slotPinLoadedTrack);
+}
+
+void PinLoadedTrackController::reset() {
+    m_pPinLoadedTrackControl->set(0);
+}
+
 LibraryControl::LibraryControl(Library* pLibrary)
         : QObject(pLibrary),
           m_pLibrary(pLibrary),
@@ -95,6 +120,7 @@ LibraryControl::LibraryControl(Library* pLibrary)
           m_pLibraryWidget(nullptr),
           m_pSidebarWidget(nullptr),
           m_pSearchbox(nullptr),
+          m_pinnedTrackId(TrackId()),
           m_numDecks(kAppGroup, QStringLiteral("num_decks"), this),
           m_numSamplers(kAppGroup, QStringLiteral("num_samplers"), this),
           m_numPreviewDecks(kAppGroup, QStringLiteral("num_preview_decks"), this) {
@@ -524,6 +550,14 @@ LibraryControl::LibraryControl(Library* pLibrary)
             this,
             &LibraryControl::slotLoadSelectedIntoFirstStopped);
 
+    m_pPinSelectedTrack = std::make_unique<ControlPushButton>(
+            ConfigKey("[Library]", "pin_selected_track"), false);
+    m_pPinSelectedTrack->setButtonMode(mixxx::control::ButtonMode::Toggle);
+    connect(m_pPinSelectedTrack.get(),
+            &ControlObject::valueChanged,
+            this,
+            &LibraryControl::slotPinSelectedTrack);
+
 #ifdef MIXXX_USE_QML
     if (!CmdlineArgs::Instance().isQml())
 #endif
@@ -552,6 +586,12 @@ LibraryControl::~LibraryControl() = default;
 void LibraryControl::maybeCreateGroupController(const QString& group) {
     if (m_loadToGroupControllers.find(group) == m_loadToGroupControllers.end()) {
         m_loadToGroupControllers.emplace(group, std::make_unique<LoadToGroupController>(this, group));
+    }
+    if (PlayerManager::isDeckGroup(group)) {
+        if (m_pinLoadedTrackControllers.find(group) == m_pinLoadedTrackControllers.end()) {
+            m_pinLoadedTrackControllers.emplace(group,
+                    std::make_unique<PinLoadedTrackController>(this, group));
+        }
     }
 }
 
@@ -670,6 +710,83 @@ void LibraryControl::slotLoadSelectedIntoFirstStopped(double v) {
     if (pTrackTableView) {
         pTrackTableView->activateSelectedTrack();
     }
+}
+
+void LibraryControl::slotPinSelectedTrack(double v) {
+    if (!m_pLibraryWidget) {
+        return;
+    }
+
+    TrackId newId;
+    if (v > 0) {
+        WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+        if (!pTrackTableView) {
+            return;
+        }
+        TrackId id = pTrackTableView->getCurrentTrackId();
+        if (!id.isValid()) {
+            m_pPinSelectedTrack->setAndConfirm(0);
+        }
+        newId = id;
+    }
+
+    // Reset all players' pin controls
+    for (const auto& pinController : m_pinLoadedTrackControllers) {
+        PinLoadedTrackController* controller = pinController.second.get();
+        controller->reset();
+    }
+
+    m_pinnedTrackId = newId;
+}
+
+/// Pin or unpin a track (unpin with invalid id)
+void LibraryControl::slotPinLoadedTrack(const QString& group, double v) {
+    TrackId newId;
+    TrackPointer pNewTrack;
+    if (v > 0) {
+        const auto groupsAndLoadedTracks = PlayerInfo::instance().getLoadedTracks();
+        auto it = groupsAndLoadedTracks.constFind(group);
+        if (it == groupsAndLoadedTracks.constEnd()) {
+            return;
+        }
+        TrackPointer loadedTrack = it.value();
+        if (loadedTrack) {
+            pNewTrack = loadedTrack;
+            newId = loadedTrack->getId();
+        }
+    }
+
+    // Reset the library pin control
+    m_pPinSelectedTrack->setAndConfirm(0);
+    // as well as all other players' pin controls
+    for (const auto& pinController : m_pinLoadedTrackControllers) {
+        if (newId.isValid() && pinController.first == group) {
+            continue;
+        }
+        PinLoadedTrackController* controller = pinController.second.get();
+        controller->reset();
+    }
+    m_pinnedTrackId = newId;
+    // Emit trackSelected() to update the playlist/crate/history item decoration
+    // so we don't need to select the deck track in the library
+    emit m_pLibrary->trackSelected(pNewTrack);
+}
+
+void LibraryControl::selectedPinnedTrack() {
+    if (!m_pLibraryWidget) {
+        return;
+    }
+
+    if (!m_pinnedTrackId.isValid()) {
+        return;
+    }
+
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (!pTrackTableView) {
+        return;
+    }
+
+    pTrackTableView->selectPinnedTrack(m_pinnedTrackId);
 }
 
 void LibraryControl::slotAutoDjAddTop(double v) {

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -558,6 +558,9 @@ LibraryControl::LibraryControl(Library* pLibrary)
             this,
             &LibraryControl::slotPinSelectedTrack);
 
+    m_pHasPinnedTrack = std::make_unique<ControlObject>(ConfigKey("[Library]", "has_pinned_track"));
+    m_pHasPinnedTrack->setReadOnly();
+
 #ifdef MIXXX_USE_QML
     if (!CmdlineArgs::Instance().isQml())
 #endif
@@ -737,6 +740,8 @@ void LibraryControl::slotPinSelectedTrack(double v) {
     }
 
     m_pinnedTrackId = newId;
+    updateHasPinnedTrackControl();
+    emit pinnedTrackIdChanged(newId);
 }
 
 /// Pin or unpin a track (unpin with invalid id)
@@ -770,7 +775,14 @@ void LibraryControl::slotPinLoadedTrack(const QString& group, double v) {
     // Emit trackSelected() to update the playlist/crate/history item decoration
     // so we don't need to select the deck track in the library
     emit m_pLibrary->trackSelected(pNewTrack);
+
+    updateHasPinnedTrackControl();
+    emit pinnedTrackChanged(pNewTrack);
 }
+
+void LibraryControl::updateHasPinnedTrackControl() {
+    m_pHasPinnedTrack->setAndConfirm(m_pinnedTrackId.isValid() ? 1 : 0);
+};
 
 void LibraryControl::selectedPinnedTrack() {
     if (!m_pLibraryWidget) {

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -8,6 +8,8 @@
 #ifdef __STEM__
 #include "engine/engine.h"
 #endif
+#include "track/track_decl.h"
+#include "track/trackid.h"
 
 class ControlEncoder;
 class ControlObject;
@@ -49,6 +51,20 @@ class LoadToGroupController : public QObject {
 #endif
 };
 
+class PinLoadedTrackController : public QObject {
+    Q_OBJECT
+  public:
+    PinLoadedTrackController(LibraryControl* pParent, const QString& group);
+
+    void reset();
+
+  signals:
+    void pinLoadedTrack(const QString& group, double v);
+
+  private:
+    std::unique_ptr<ControlPushButton> m_pPinLoadedTrackControl;
+};
+
 class LibraryControl : public QObject {
     Q_OBJECT
   public:
@@ -62,6 +78,10 @@ class LibraryControl : public QObject {
     void setLibraryFocus(FocusWidget newFocusWidget,
             Qt::FocusReason focusReason = Qt::OtherFocusReason);
     FocusWidget getFocusedWidget();
+    bool hasPinnedTrack() const {
+        return m_pinnedTrackId.isValid();
+    }
+    void selectedPinnedTrack();
 
   signals:
     void clearSearchIfClearButtonHasFocus();
@@ -76,6 +96,10 @@ class LibraryControl : public QObject {
 #else
     void slotLoadSelectedTrackToGroup(const QString& group, bool play);
 #endif
+
+    void slotPinSelectedTrack(double v);
+    void slotPinLoadedTrack(const QString& group, double v);
+
     void slotUpdateTrackMenuControl(bool visible);
 
   private slots:
@@ -140,6 +164,9 @@ class LibraryControl : public QObject {
 
     // Simulate pressing a key on the keyboard
     void emitKeyEvent(QKeyEvent&& event);
+
+    void pinTrack(const TrackId& id);
+    void pinTrack(TrackPointer pTrack);
 
     // Controls to navigate vertically within currently focused widget (up/down buttons)
     std::unique_ptr<ControlPushButton> m_pMoveUp;
@@ -215,15 +242,19 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlObject> m_pSelectNextSidebarItem;
     std::unique_ptr<ControlObject> m_pToggleSidebarItem;
     std::unique_ptr<ControlObject> m_pLoadSelectedIntoFirstStopped;
+    std::unique_ptr<ControlPushButton> m_pPinSelectedTrack;
 
     // Library widgets
     WLibrary* m_pLibraryWidget;
     WLibrarySidebar* m_pSidebarWidget;
     WSearchLineEdit* m_pSearchbox;
 
+    TrackId m_pinnedTrackId;
+
     // Other variables
     ControlProxy m_numDecks;
     ControlProxy m_numSamplers;
     ControlProxy m_numPreviewDecks;
     std::map<QString, std::unique_ptr<LoadToGroupController>> m_loadToGroupControllers;
+    std::map<QString, std::unique_ptr<PinLoadedTrackController>> m_pinLoadedTrackControllers;
 };

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -87,6 +87,9 @@ class LibraryControl : public QObject {
     void clearSearchIfClearButtonHasFocus();
     void showHideTrackMenu(bool show);
 
+    void pinnedTrackIdChanged(const TrackId& id);
+    void pinnedTrackChanged(TrackPointer pTrack);
+
   public slots:
     // Deprecated navigation slots
 #ifdef __STEM__
@@ -167,6 +170,7 @@ class LibraryControl : public QObject {
 
     void pinTrack(const TrackId& id);
     void pinTrack(TrackPointer pTrack);
+    void updateHasPinnedTrackControl();
 
     // Controls to navigate vertically within currently focused widget (up/down buttons)
     std::unique_ptr<ControlPushButton> m_pMoveUp;
@@ -243,6 +247,7 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlObject> m_pToggleSidebarItem;
     std::unique_ptr<ControlObject> m_pLoadSelectedIntoFirstStopped;
     std::unique_ptr<ControlPushButton> m_pPinSelectedTrack;
+    std::unique_ptr<ControlObject> m_pHasPinnedTrack;
 
     // Library widgets
     WLibrary* m_pLibraryWidget;

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -282,6 +282,19 @@ QVariant SidebarModel::data(const QModelIndex& index, int role) const {
             return m_sFeatures[index.row()]->icon();
         case SidebarModel::IconNameRole:
             return m_sFeatures[index.row()]->iconName();
+        case Qt::FontRole: {
+            auto* pFeature = m_sFeatures[index.row()];
+            TreeItem* pTreeItem = nullptr;
+            auto* pChildModel = pFeature->sidebarModel();
+            if (pChildModel) {
+                pTreeItem = pChildModel->getRootItem();
+            }
+            QFont font;
+            if (pTreeItem) {
+                font.setBold(pTreeItem->isBold());
+            }
+            return font;
+        }
         default:
             return QVariant();
         }
@@ -509,6 +522,16 @@ QModelIndex SidebarModel::translateIndex(
     QModelIndex translatedIndex;
 
     if (index.isValid()) {
+        if (!index.parent().isValid()) {
+            // This is the top-level root item of the child model.
+            // Find the feature it belongs to
+            for (int i = 0; i < m_sFeatures.size(); ++i) {
+                if (m_sFeatures[i]->sidebarModel() == pModel) {
+                    return createIndex(i, index.column(), this);
+                }
+            }
+        }
+
         TreeItem* pItem = static_cast<TreeItem*>(index.internalPointer());
         translatedIndex = createIndex(index.row(), index.column(), pItem);
     } else {

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -49,6 +49,7 @@ class SidebarModel : public QAbstractItemModel {
 
     void clear(const QModelIndex& index);
     void paste(const QModelIndex& index);
+
   public slots:
     void pressed(const QModelIndex& index);
     void clicked(const QModelIndex& index);

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -889,37 +889,44 @@ void BasePlaylistFeature::slotTrackSelected(TrackId trackId) {
     m_selectedTrackId = trackId;
     m_playlistDao.getPlaylistsTrackIsIn(m_selectedTrackId, &m_playlistIdsOfSelectedTrack);
 
+    bool shouldRootBeBold = false;
+
     for (int row = 0; row < m_pSidebarModel->rowCount(); ++row) {
         QModelIndex index = m_pSidebarModel->index(row, 0);
         TreeItem* pTreeItem = m_pSidebarModel->getItem(index);
         DEBUG_ASSERT(pTreeItem != nullptr);
-        markTreeItem(pTreeItem);
+
+        // If any child item is marked bold, the root item must be, too
+        if (markTreeItem(pTreeItem)) {
+            shouldRootBeBold = true;
+        }
     }
+
+    m_pSidebarModel->getRootItem()->setBold(shouldRootBeBold);
 
     m_pSidebarModel->triggerRepaint();
 }
 
-void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
+bool BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
     bool ok;
+    bool isBold = false;
     int playlistId = pTreeItem->getData().toInt(&ok);
     if (ok) {
-        bool shouldBold = m_playlistIdsOfSelectedTrack.contains(playlistId);
-        pTreeItem->setBold(shouldBold);
-        if (shouldBold && pTreeItem->hasParent()) {
-            TreeItem* item = pTreeItem;
-            // extra parents, because -Werror=parentheses
-            while ((item = item->parent())) {
-                item->setBold(true);
+        isBold = m_playlistIdsOfSelectedTrack.contains(playlistId);
+    }
+
+    if (pTreeItem->hasChildren()) {
+        QList<TreeItem*> children = pTreeItem->children();
+        for (int i = 0; i < children.size(); i++) {
+            if (markTreeItem(children.at(i))) {
+                isBold = true;
             }
         }
     }
-    if (pTreeItem->hasChildren()) {
-        QList<TreeItem*> children = pTreeItem->children();
 
-        for (int i = 0; i < children.size(); i++) {
-            markTreeItem(children.at(i));
-        }
-    }
+    pTreeItem->setBold(isBold);
+
+    return isBold;
 }
 
 QString BasePlaylistFeature::createPlaylistLabel(const QString& name,

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -139,7 +139,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void initActions();
     void connectPlaylistDAO();
     virtual QString getRootViewHtml() const = 0;
-    void markTreeItem(TreeItem* pTreeItem);
+    bool markTreeItem(TreeItem* pTreeItem);
     QString fetchPlaylistLabel(int playlistId);
 
 

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -950,6 +950,8 @@ void CrateFeature::slotTrackSelected(TrackId trackId) {
         pTreeItem->setBold(crateContainsSelectedTrack);
     }
 
+    pRootItem->setBold(m_selectedTrackId.isValid() && sortedTrackCrates.size() > 0);
+
     m_pSidebarModel->triggerRepaint();
 }
 

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -217,4 +217,9 @@ void TreeItemModel::triggerRepaint() {
     QModelIndex left = index(0, 0);
     QModelIndex right = index(rowCount() - 1, columnCount() - 1);
     emit dataChanged(left, right);
+
+    // Also include the root item in case this has been called in order to
+    // enforce FontRole updates via TreeItem::isBold()
+    QModelIndex rootIdx = getRootIndex();
+    emit dataChanged(rootIdx, rootIdx);
 }

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1178,10 +1178,15 @@ QWidget* LegacySkinParser::parseText(const QDomElement& node) {
 
 QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
-    BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
-    if (!pPlayer) {
-        SKIN_WARNING(node, *m_pContext, QStringLiteral("No player found for group: %1").arg(group));
-        return nullptr;
+    BaseTrackPlayer* pPlayer = nullptr;
+    if (group != QStringLiteral("[Library]")) {
+        pPlayer = m_pPlayerManager->getPlayer(group);
+        if (!pPlayer) {
+            SKIN_WARNING(node,
+                    *m_pContext,
+                    QStringLiteral("No player found for group: %1").arg(group));
+            return nullptr;
+        }
     }
 
     bool isMainDeck = PlayerManager::isDeckGroup(group);
@@ -1226,26 +1231,33 @@ QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
             &Library::slotRestoreCurrentViewState,
             Qt::DirectConnection);
 
-    connect(pPlayer,
-            &BaseTrackPlayer::newTrackLoaded,
-            pTrackProperty,
-            &WTrackProperty::slotTrackLoaded);
-    connect(pPlayer,
-            &BaseTrackPlayer::loadingTrack,
-            pTrackProperty,
-            &WTrackProperty::slotLoadingTrack);
-    connect(pTrackProperty,
-            &WTrackProperty::trackDropped,
-            m_pPlayerManager,
-            &PlayerManager::slotLoadLocationToPlayerMaybePlay);
-    connect(pTrackProperty,
-            &WTrackProperty::cloneDeck,
-            m_pPlayerManager,
-            &PlayerManager::slotCloneDeck);
+    if (pPlayer) { // widget in decks, smaplers etc.
+        connect(pPlayer,
+                &BaseTrackPlayer::newTrackLoaded,
+                pTrackProperty,
+                &WTrackProperty::slotTrackLoaded);
+        connect(pPlayer,
+                &BaseTrackPlayer::loadingTrack,
+                pTrackProperty,
+                &WTrackProperty::slotLoadingTrack);
+        connect(pTrackProperty,
+                &WTrackProperty::trackDropped,
+                m_pPlayerManager,
+                &PlayerManager::slotLoadLocationToPlayerMaybePlay);
+        connect(pTrackProperty,
+                &WTrackProperty::cloneDeck,
+                m_pPlayerManager,
+                &PlayerManager::slotCloneDeck);
 
-    TrackPointer pTrack = pPlayer->getLoadedTrack();
-    if (pTrack) {
-        pTrackProperty->slotTrackLoaded(pTrack);
+        TrackPointer pTrack = pPlayer->getLoadedTrack();
+        if (pTrack) {
+            pTrackProperty->slotTrackLoaded(pTrack);
+        }
+    } else { // Pinned track widget in/near the library
+        connect(m_pLibrary,
+                &Library::pinnedTrackChanged,
+                pTrackProperty,
+                &WTrackProperty::slotPinnedTrackChanged);
     }
 
     return pTrackProperty;

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -99,6 +99,11 @@ void WTrackProperty::slotTrackChanged(TrackId trackId) {
     updateLabel();
 }
 
+void WTrackProperty::slotPinnedTrackChanged(TrackPointer pTrack) {
+    slotLoadingTrack(TrackPointer(), TrackPointer());
+    slotTrackLoaded(pTrack);
+}
+
 void WTrackProperty::updateLabel() {
     if (m_pCurrentTrack) {
         setText(getPropertyStringFromTrack(m_displayProperty));

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -67,6 +67,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
   public slots:
     void slotTrackLoaded(TrackPointer pTrack);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
+    void slotPinnedTrackChanged(TrackPointer pTrack);
     void slotShowTrackMenuChangeRequest(bool show);
 
   protected:

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1309,6 +1309,23 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
     QTableView::keyPressEvent(event);
 }
 
+void WTrackTableView::selectPinnedTrack(const TrackId& id) {
+    if (!isVisible()) {
+        return;
+    }
+    if (!id.isValid()) {
+        return;
+    }
+    selectTrack(id);
+    // emit trackSelected() in order to keep/restore the sidebar item decoration
+    // (bold) that allows to identify playlists/crates that also hold the track
+    TrackPointer pTrack = m_pLibrary->trackCollectionManager()->getTrackById(id);
+    if (!pTrack) {
+        return;
+    }
+    emit trackSelected(pTrack);
+}
+
 void WTrackTableView::resizeEvent(QResizeEvent* event) {
     // When the tracks view shrinks in height, e.g. when other skin regions expand,
     // and if the row was visible before resizing, scroll to it afterwards.
@@ -1832,6 +1849,10 @@ void WTrackTableView::selectTracksById(const QList<TrackId>& trackIds, int prevC
     // Refocus the cell in the column that was focused before sorting.
     // With this, any Up/Down key press moves the selection and keeps the
     // horizontal scrollbar position we will restore below.
+    // Use our prevColumn if the argument is invalid.
+    if (prevColum == -1) {
+        prevColum = m_prevColumn;
+    }
     QModelIndex restoreIndex = pItemModel->index(currentIndex().row(), prevColum);
     if (restoreIndex.isValid()) {
         setCurrentIndex(restoreIndex);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1310,10 +1310,13 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
 }
 
 void WTrackTableView::selectPinnedTrack(const TrackId& id) {
+    qWarning() << "WTrackTableView::selectPinnedTrack" << id;
     if (!isVisible()) {
+        qWarning() << "-> not visible, return";
         return;
     }
     if (!id.isValid()) {
+        qWarning() << "-> id invalid, return";
         return;
     }
     selectTrack(id);
@@ -1321,7 +1324,7 @@ void WTrackTableView::selectPinnedTrack(const TrackId& id) {
     // (bold) that allows to identify playlists/crates that also hold the track
     TrackPointer pTrack = m_pLibrary->trackCollectionManager()->getTrackById(id);
     if (!pTrack) {
-        return;
+        qWarning() << "-> no track for id" << id;
     }
     emit trackSelected(pTrack);
 }

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -61,6 +61,7 @@ class WTrackTableView : public WLibraryTableView {
     void setSelectedTracks(const QList<TrackId>& tracks);
     TrackId getCurrentTrackId() const;
     bool setCurrentTrackId(const TrackId& trackId, int column = 0, bool scrollToTrack = false);
+    void selectPinnedTrack(const TrackId& id);
 
     void addToAutoDJBottom();
     void addToAutoDJTop();


### PR DESCRIPTION
This allows to "pin" a track (selected in library, loaded in deck) in order to easily look it in tracksets that contain it.

### My use case
Every now & then I want look up a track in my setlogs to check what I played before/after.
However, the bold sidebar highlight is lost as soon as we click a playlist or crate, which makes this a rather annoyingly cumbersome endavour.
(I'm pretty sure I filed a bug for this, just don't find it..)

### Now I can
* pin a track in the library with `[Library],pin_selected_track`
  -> all containing playlist, crates or track logs are highlighted in the sidebar
* and go through all of them without "losing" losing the track I want to look up
* check the "context" and let it inspire me what to play next

I think I'll map it to keyboard shortcuts for now, eg. `Alt`+`P`(in).

There is also `[ChannelN],pin_loaded_track`, but for the bold sidebar highlight you also need to "Select track in library".
-> I might couple that to `pin_loaded_track` to save some clicks and allow mapping script automation, but for now it's an okay-ish solution.

The pin controls are exclusive, meaning setting one of them (library or deck) resets all others.

### For UI feedack
I added `[Library],has_pinned_track`. This allows to show a artist + title above the library if there is a pinned track, as well as Pin toggles.

This is admittedly still it a bit clunky, but it does the trick and I'm looking forward testing it in real sessions.
<img width="759" height="175" alt="image" src="https://github.com/user-attachments/assets/4cf7542c-f401-45ea-a5c8-6d3177c74d0b" />

Let me know if you like see that in Mixxx. If there's no feedback I'll close this and keep it in my private branch.
Any ideas for how to improve UI/UX are welcome!