### PR TITLE
[GSoC] LateNightQML: Fix library column header click assertion crash in QML skin

### DIFF
--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -2,6 +2,7 @@
 
 #include <QCheckBox>
 #include <QContextMenuEvent>
+#include <QLabel>
 #include <QPainter>
 #include <QStyleOptionHeader>
 #include <QTextOption>
@@ -451,6 +452,13 @@ void WTrackTableViewHeader::leaveEvent(QEvent* pEvent) {
     }
 
     QHeaderView::leaveEvent(pEvent);
+}
+
+void WTrackTableViewHeader::mousePressEvent(QMouseEvent* pEvent) {
+    QHeaderView::mousePressEvent(pEvent);
+    if (QLabel* pIndicator = viewport()->findChild<QLabel*>()) {
+        pIndicator->hide();
+    }
 }
 
 void WTrackTableViewHeader::mouseMoveEvent(QMouseEvent* pEvent) {

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -78,6 +78,7 @@ class WTrackTableViewHeader : public QHeaderView {
 
     // These two track the hovered section which is considered in paintSection().
     // This essentially restores the qss `hover` style.
+    void mousePressEvent(QMouseEvent* pEvent) override;
     void mouseMoveEvent(QMouseEvent* pEvent) override;
     void leaveEvent(QEvent* pEvent) override;
 


### PR DESCRIPTION
## Description
This PR fixes a SIGABRT assertion crash `ASSERT: "to != -1"` that occurs under `--developer` builds when clicking on library column headers in QML-based skins (like LateNightQML) without first dragging or resizing any columns, on a fresh build.

### The Bug
1. In the QML-to-QWidget offscreen bridge (`QmlLegacyLibraryItem`), native mouse events are forwarded to the underlying table view.
2. On the first header press after startup, `QHeaderView::mousePressEvent` instantiates its private `sectionIndicator` label via `new QLabel(viewport)`.
3. In this offscreen rendering environment, the newly constructed child widget's visibility state can be uninitialized or set to visible (meaning `isHidden()` returns `false` instead of `true`).
4. On the subsequent mouse release event, `QHeaderView::mouseReleaseEvent` checks `!d->sectionIndicator->isHidden()`. Since it evaluates to `true`, the code enters the section-moving branch thinking a drag-and-drop was in progress.
5. Because no actual drag occurred, `d->target` remains `-1`. Translating this to a visual index via `visualIndex(d->target)` returns `-1`, triggering `Q_ASSERT(to != -1)` and crashing the application.

### The Fix
In `WTrackTableViewHeader::mousePressEvent`, after delegating to the base class, we look up the newly created indicator widget inside the header's `viewport()` and explicitly call `hide()` on it. This ensures that the indicator correctly registers as hidden on the first press. When an actual drag operation begins, `mouseMoveEvent` will call `updateSectionIndicator()` which shows the label as expected, preserving column reordering.

## Tracking
GSoC: LateNightQML PR-3