### PR TITLE
[GSoC] LateNightQML: Deck (part 1)

### DIFF
--- a/res/qml/Fader.qml
+++ b/res/qml/Fader.qml
@@ -9,7 +9,7 @@ MixxxControls.Fader {
     property alias bg: backgroundImage.source
     property alias fg: handleImage.source
     property alias handleImage: handleImage
-    property bool defaultHandleVisible: true
+    property bool showDefaultHandle: true
 
     bar: true
     barMargin: 10
@@ -25,9 +25,9 @@ MixxxControls.Fader {
     handle: Item {
         id: handleItem
 
-        height: root.defaultHandleVisible ? handleImage.paintedHeight : 0
-        visible: root.defaultHandleVisible
-        width: root.defaultHandleVisible ? handleImage.paintedWidth : 0
+        height: handleImage.paintedHeight
+        visible: root.showDefaultHandle
+        width: handleImage.paintedWidth
         x: root.horizontal ? (root.visualPosition * (root.width - width)) : ((root.width - width) / 2)
         y: root.vertical ? (root.visualPosition * (root.height - height)) : ((root.height - height) / 2)
 

--- a/res/qml/Fader.qml
+++ b/res/qml/Fader.qml
@@ -9,6 +9,7 @@ MixxxControls.Fader {
     property alias bg: backgroundImage.source
     property alias fg: handleImage.source
     property alias handleImage: handleImage
+    property bool defaultHandleVisible: true
 
     bar: true
     barMargin: 10
@@ -24,8 +25,9 @@ MixxxControls.Fader {
     handle: Item {
         id: handleItem
 
-        height: handleImage.paintedHeight
-        width: handleImage.paintedWidth
+        height: root.defaultHandleVisible ? handleImage.paintedHeight : 0
+        visible: root.defaultHandleVisible
+        width: root.defaultHandleVisible ? handleImage.paintedWidth : 0
         x: root.horizontal ? (root.visualPosition * (root.width - width)) : ((root.width - width) / 2)
         y: root.vertical ? (root.visualPosition * (root.height - height)) : ((root.height - height) / 2)
 

--- a/res/skins/LateNightQML/Controls/Button.qml
+++ b/res/skins/LateNightQML/Controls/Button.qml
@@ -1,0 +1,9 @@
+import "../../../qml" as Shared
+import "../LateNightTheme"
+
+Shared.Button {
+    activeColor: LateNightTheme.buttonActiveColor
+    implicitHeight: LateNightTheme.toolbarButtonHeight
+    normalColor: LateNightTheme.buttonNormalColor
+    pressedColor: LateNightTheme.buttonPressedColor
+}

--- a/res/skins/LateNightQML/Controls/Panel.qml
+++ b/res/skins/LateNightQML/Controls/Panel.qml
@@ -1,0 +1,7 @@
+import QtQuick
+import "../LateNightTheme"
+
+Rectangle {
+    color: LateNightTheme.backgroundColor
+    radius: 1
+}

--- a/res/skins/LateNightQML/Controls/Panel.qml
+++ b/res/skins/LateNightQML/Controls/Panel.qml
@@ -2,6 +2,54 @@ import QtQuick
 import "../LateNightTheme"
 
 Rectangle {
+    id: root
+
+    property bool borderVisible: true
+    property color topBorderColor: LateNightTheme.deckPanelBorderLight
+    property color leftBorderColor: LateNightTheme.deckPanelBorderLeft
+    property color bottomBorderColor: LateNightTheme.deckPanelBorderDark
+    property color rightBorderColor: LateNightTheme.deckPanelBorderRight
+
     color: LateNightTheme.backgroundColor
     radius: 1
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: 1
+        color: root.topBorderColor
+        visible: root.borderVisible
+        z: 1000
+    }
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: 1
+        color: root.leftBorderColor
+        visible: root.borderVisible
+        z: 1000
+    }
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        height: 1
+        color: root.bottomBorderColor
+        visible: root.borderVisible
+        z: 1000
+    }
+
+    Rectangle {
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: 1
+        color: root.rightBorderColor
+        visible: root.borderVisible
+        z: 1000
+    }
 }

--- a/res/skins/LateNightQML/Controls/TextLabel.qml
+++ b/res/skins/LateNightQML/Controls/TextLabel.qml
@@ -1,0 +1,7 @@
+import QtQuick
+import "../LateNightTheme"
+
+Text {
+    color: LateNightTheme.textColor
+    font.family: "Open Sans"
+}

--- a/res/skins/LateNightQML/Controls/ToggleButton.qml
+++ b/res/skins/LateNightQML/Controls/ToggleButton.qml
@@ -1,0 +1,5 @@
+import "." as Controls
+
+Controls.Button {
+    checkable: true
+}

--- a/res/skins/LateNightQML/Deck/BeatSpinBoxPlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/BeatSpinBoxPlaceholder.qml
@@ -1,0 +1,92 @@
+import QtQuick
+import QtQuick.Layouts
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    property string valueText: "4"
+    property int preferredWidth: 78
+
+    implicitWidth: preferredWidth
+    implicitHeight: 26
+
+    Rectangle {
+        anchors.fill: parent
+        anchors.margins: 2
+        color: "#0f0f0f"
+    }
+
+    BorderImage {
+        anchors.fill: parent
+        source: LateNightTheme.assetDeckBeatSpinBoxBorder
+        border {
+            top: 2
+            left: 2
+            right: 19
+            bottom: 2
+        }
+        opacity: 1.0
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 3
+        anchors.rightMargin: 0
+        anchors.bottomMargin: 2
+        spacing: 0
+
+        Text {
+            Layout.fillWidth: true
+            text: root.valueText
+            font.family: "Open Sans"
+            font.pixelSize: 13
+            font.bold: true
+            color: LateNightTheme.deckBeatSpinBoxTextColor
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        Column {
+            Layout.preferredWidth: 17
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 0
+
+            Image {
+                width: parent.width
+                height: 11
+                source: LateNightTheme.assetDeckBeatSpinBoxUpButton
+                fillMode: Image.PreserveAspectFit
+                visible: source.toString().length > 0
+            }
+
+            Image {
+                width: parent.width
+                height: 11
+                source: LateNightTheme.assetDeckBeatSpinBoxDownButton
+                fillMode: Image.PreserveAspectFit
+                visible: source.toString().length > 0
+            }
+
+            Text {
+                width: parent.width
+                height: 11
+                text: "▲"
+                font.pixelSize: 8
+                color: LateNightTheme.textColorMuted
+                horizontalAlignment: Text.AlignHCenter
+                visible: LateNightTheme.assetDeckBeatSpinBoxUpButton.toString().length <= 0
+            }
+
+            Text {
+                width: parent.width
+                height: 11
+                text: "▼"
+                font.pixelSize: 8
+                color: LateNightTheme.textColorMuted
+                horizontalAlignment: Text.AlignHCenter
+                visible: LateNightTheme.assetDeckBeatSpinBoxDownButton.toString().length <= 0
+            }
+        }
+    }
+}

--- a/res/skins/LateNightQML/Deck/Deck.qml
+++ b/res/skins/LateNightQML/Deck/Deck.qml
@@ -1,0 +1,7 @@
+import QtQuick
+
+FullDeck {
+    id: root
+
+    signal toggleFocus
+}

--- a/res/skins/LateNightQML/Deck/DeckSettingsPlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/DeckSettingsPlaceholder.qml
@@ -139,7 +139,7 @@ Item {
             LateNightControlButton {
                 Layout.preferredWidth: 21
                 Layout.preferredHeight: 18
-                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                backgroundSource: LateNightTheme.lateNightButton("btn__.svg")
                 iconSource: LateNightTheme.assetDeckSlipButton
                 activeIconSuffix: root.activeSuffix
                 stretchIcon: true
@@ -155,7 +155,7 @@ Item {
             LateNightControlButton {
                 Layout.preferredWidth: 21
                 Layout.preferredHeight: 18
-                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                backgroundSource: LateNightTheme.lateNightButton("btn__.svg")
                 iconSource: LateNightTheme.assetDeckQuantizeButton
                 activeIconSuffix: root.activeSuffix
                 stretchIcon: true
@@ -172,7 +172,7 @@ Item {
                 id: curposBtn
                 Layout.preferredWidth: 21
                 Layout.preferredHeight: 18
-                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                backgroundSource: LateNightTheme.lateNightButton("btn__.svg")
                 iconSource: LateNightTheme.assetDeckBeatCurposButton
                 activeIconSuffix: root.activeSuffix
                 stretchIcon: true
@@ -202,7 +202,7 @@ Item {
             LateNightControlButton {
                 Layout.preferredWidth: 21
                 Layout.preferredHeight: 18
-                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                backgroundSource: LateNightTheme.lateNightButton("btn__.svg")
                 iconSource: LateNightTheme.assetDeckEjectButton
                 activeIconSuffix: root.activeSuffix
                 stretchIcon: true
@@ -218,7 +218,7 @@ Item {
             LateNightControlButton {
                 Layout.preferredWidth: 21
                 Layout.preferredHeight: 18
-                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                backgroundSource: LateNightTheme.lateNightButton("btn__.svg")
                 iconSource: LateNightTheme.assetDeckRepeatButton
                 activeIconSuffix: root.activeSuffix
                 stretchIcon: true
@@ -234,7 +234,7 @@ Item {
             LateNightControlButton {
                 Layout.preferredWidth: 21
                 Layout.preferredHeight: 18
-                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                backgroundSource: LateNightTheme.lateNightButton("btn__.svg")
                 iconSource: LateNightTheme.assetDeckKeylockButton
                 activeIconSuffix: root.activeSuffix
                 stretchIcon: true

--- a/res/skins/LateNightQML/Deck/DeckSettingsPlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/DeckSettingsPlaceholder.qml
@@ -1,0 +1,254 @@
+import QtQuick
+import QtQuick.Layouts
+import Mixxx 1.0 as Mixxx
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    required property string group
+
+    readonly property var deckPlayer: Mixxx.PlayerManager.getPlayer(root.group)
+    readonly property var currentTrack: deckPlayer?.currentTrack
+
+    readonly property bool isDeck12: root.group === "[Channel1]" || root.group === "[Channel2]"
+    readonly property color starsColor: isDeck12 ? LateNightTheme.starsColor12 : LateNightTheme.starsColor34
+    readonly property string activeSuffix: isDeck12 ? "active_12" : "active_34"
+
+    implicitWidth: 76
+    implicitHeight: 63
+
+    Mixxx.ControlProxy {
+        id: bpmLockControl
+        group: root.group
+        key: "bpmlock"
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.topMargin: 5
+        spacing: 2
+
+        Item {
+            id: starsContainer
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: 75
+            Layout.preferredHeight: 15
+
+            readonly property int hoveredStarCount: {
+                if (!mouseStars.containsMouse) {
+                    return -1;
+                }
+                var localX = mouseStars.mouseX - starsRow.x;
+                if (localX < 3.75) {
+                    return 0;
+                }
+                if (localX >= 75) {
+                    return -1;
+                }
+                var star = Math.floor(localX / 15) + 1;
+                return star > 5 ? 5 : star;
+            }
+
+            Row {
+                id: starsRow
+                anchors.centerIn: parent
+                spacing: 0
+
+                Repeater {
+                    model: 5
+
+                    delegate: Item {
+                        id: starItem
+                        width: 15
+                        height: 15
+
+                        readonly property bool isFilled: {
+                            if (starsContainer.hoveredStarCount >= 0) {
+                                return index < starsContainer.hoveredStarCount;
+                            }
+                            return root.currentTrack && root.currentTrack.stars > index;
+                        }
+
+                        Canvas {
+                            anchors.fill: parent
+
+                            property bool filled: starItem.isFilled
+                            property color shapeColor: root.starsColor
+
+                            renderStrategy: Canvas.Immediate
+
+                            onFilledChanged: requestPaint()
+                            onShapeColorChanged: requestPaint()
+
+                            onPaint: {
+                                const ctx = getContext("2d");
+                                ctx.clearRect(0, 0, width, height);
+                                ctx.fillStyle = shapeColor;
+                                ctx.beginPath();
+                                if (filled) {
+                                    ctx.moveTo(15.0, 7.5);
+                                    ctx.lineTo(1.4324, 11.9084);
+                                    ctx.lineTo(9.8176, 0.3671);
+                                    ctx.lineTo(9.8176, 14.6329);
+                                    ctx.lineTo(1.4324, 3.0916);
+                                } else {
+                                    ctx.moveTo(6.0, 7.5);
+                                    ctx.lineTo(7.5, 6.0);
+                                    ctx.lineTo(9.0, 7.5);
+                                    ctx.lineTo(7.5, 9.0);
+                                }
+                                ctx.closePath();
+                                ctx.fill();
+                            }
+
+                            Component.onCompleted: requestPaint()
+                        }
+                    }
+                }
+            }
+
+            MouseArea {
+                id: mouseStars
+                anchors.fill: parent
+                hoverEnabled: true
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
+
+                onClicked: function(mouse) {
+                    if (!root.currentTrack) {
+                        return;
+                    }
+                    if (mouse.button === Qt.RightButton) {
+                        root.currentTrack.stars = 0;
+                    } else {
+                        var clickedStar = starsContainer.hoveredStarCount;
+                        if (clickedStar >= 0) {
+                            root.currentTrack.stars = clickedStar;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Row 1: Slip, Quantize, Curpos (lock match)
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            spacing: 4
+
+            // Slip mode toggle
+            LateNightControlButton {
+                Layout.preferredWidth: 21
+                Layout.preferredHeight: 18
+                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                iconSource: LateNightTheme.assetDeckSlipButton
+                activeIconSuffix: root.activeSuffix
+                stretchIcon: true
+                inactiveFillEnabled: false
+                group: root.group
+                key: "slip_enabled"
+                toggleable: true
+                activeOpacity: 1.0
+                inactiveOpacity: 0.72
+            }
+
+            // Quantize toggle
+            LateNightControlButton {
+                Layout.preferredWidth: 21
+                Layout.preferredHeight: 18
+                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                iconSource: LateNightTheme.assetDeckQuantizeButton
+                activeIconSuffix: root.activeSuffix
+                stretchIcon: true
+                inactiveFillEnabled: false
+                group: root.group
+                key: "quantize"
+                toggleable: true
+                activeOpacity: 1.0
+                inactiveOpacity: 0.72
+            }
+
+            // Curpos button
+            LateNightControlButton {
+                id: curposBtn
+                Layout.preferredWidth: 21
+                Layout.preferredHeight: 18
+                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                iconSource: LateNightTheme.assetDeckBeatCurposButton
+                activeIconSuffix: root.activeSuffix
+                stretchIcon: true
+                inactiveFillEnabled: false
+                group: root.group
+                key: "beats_translate_curpos"
+                rightClickKey: "beats_translate_match_alignment"
+                toggleable: false
+                activeOpacity: 1.0
+                inactiveOpacity: 0.72
+
+                // Cover rectangle when BPM lock is active
+                Rectangle {
+                    anchors.fill: parent
+                    color: "#b419191a" // rgba(25, 25, 26, 180) cover
+                    visible: bpmLockControl.value > 0
+                }
+            }
+        }
+
+        // Row 2: Eject, Repeat, Keylock
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            spacing: 4
+
+            // Eject button: momentary push
+            LateNightControlButton {
+                Layout.preferredWidth: 21
+                Layout.preferredHeight: 18
+                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                iconSource: LateNightTheme.assetDeckEjectButton
+                activeIconSuffix: root.activeSuffix
+                stretchIcon: true
+                inactiveFillEnabled: false
+                group: root.group
+                key: "eject"
+                toggleable: false
+                activeOpacity: 0.95
+                inactiveOpacity: 0.72
+            }
+
+            // Repeat toggle
+            LateNightControlButton {
+                Layout.preferredWidth: 21
+                Layout.preferredHeight: 18
+                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                iconSource: LateNightTheme.assetDeckRepeatButton
+                activeIconSuffix: root.activeSuffix
+                stretchIcon: true
+                inactiveFillEnabled: false
+                group: root.group
+                key: "repeat"
+                toggleable: true
+                activeOpacity: 1.0
+                inactiveOpacity: 0.72
+            }
+
+            // Keylock toggle
+            LateNightControlButton {
+                Layout.preferredWidth: 21
+                Layout.preferredHeight: 18
+                backgroundSource: LateNightTheme.legacyButton("btn__.svg")
+                iconSource: LateNightTheme.assetDeckKeylockButton
+                activeIconSuffix: root.activeSuffix
+                stretchIcon: true
+                inactiveFillEnabled: false
+                group: root.group
+                key: "keylock"
+                toggleable: true
+                activeOpacity: 1.0
+                inactiveOpacity: 0.72
+            }
+        }
+
+        Item {
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/res/skins/LateNightQML/Deck/FullDeck.qml
+++ b/res/skins/LateNightQML/Deck/FullDeck.qml
@@ -1,0 +1,362 @@
+import QtQuick
+import QtQuick.Layouts
+import Mixxx 1.0 as Mixxx
+import "../LateNightTheme"
+
+Rectangle {
+    id: root
+
+    implicitHeight: root.minimized ? 80 : 206
+    implicitWidth: 620
+
+    required property string group
+    property bool minimized: false
+    property bool editMode: false
+    property bool honorLegacyVisibilityControls: false
+    readonly property bool showBeatjumpControls: !honorLegacyVisibilityControls || showBeatjumpControlsProxy.value > 0
+    readonly property bool showBigSpinnyOrCover: selectBigSpinnyProxy.value > 0
+    readonly property bool showHotcues: !honorLegacyVisibilityControls || showHotcuesProxy.value > 0
+    readonly property bool show8Hotcues: !honorLegacyVisibilityControls || show8HotcuesProxy.value > 0
+    readonly property bool showIntroOutroCues: !honorLegacyVisibilityControls || showIntroOutroCuesProxy.value > 0
+    readonly property bool showKeyControls: !honorLegacyVisibilityControls || showKeyControlsProxy.value > 0
+    readonly property bool showLoopControls: !honorLegacyVisibilityControls || showLoopControlsProxy.value > 0
+    readonly property bool showRateControlButtons: !honorLegacyVisibilityControls || showRateControlButtonsProxy.value > 0
+    readonly property bool showRateControls: !honorLegacyVisibilityControls || showRateControlsProxy.value > 0
+    readonly property bool showSmallSpinnyOrCover: selectBigSpinnyProxy.value <= 0 && !root.minimized
+    readonly property bool showVinylControls: honorLegacyVisibilityControls && showVinylControlsProxy.value > 0
+
+    color: LateNightTheme.deckPanelColor
+    radius: 1
+
+    Mixxx.ControlProxy {
+        id: selectBigSpinnyProxy
+        group: "[Skin]"
+        key: "select_big_spinny_or_cover"
+    }
+
+    Mixxx.ControlProxy {
+        id: showKeyControlsProxy
+        group: "[Skin]"
+        key: "show_key_controls"
+    }
+
+    Mixxx.ControlProxy {
+        id: showVinylControlsProxy
+        group: "[Skin]"
+        key: "show_vinylcontrol"
+    }
+
+    Mixxx.ControlProxy {
+        id: show4EffectUnitsProxy
+        group: "[Skin]"
+        key: "show_4effectunits"
+    }
+
+    Mixxx.ControlProxy {
+        id: showHotcuesProxy
+        group: "[Skin]"
+        key: "show_hotcues"
+    }
+
+    Mixxx.ControlProxy {
+        id: show8HotcuesProxy
+        group: "[Skin]"
+        key: "show_8_hotcues"
+    }
+
+    Mixxx.ControlProxy {
+        id: showIntroOutroCuesProxy
+        group: "[Skin]"
+        key: "show_intro_outro_cues"
+    }
+
+    Mixxx.ControlProxy {
+        id: showLoopControlsProxy
+        group: "[Skin]"
+        key: "show_loop_controls"
+    }
+
+    Mixxx.ControlProxy {
+        id: showBeatjumpControlsProxy
+        group: "[Skin]"
+        key: "show_beatjump_controls"
+    }
+
+    Mixxx.ControlProxy {
+        id: showRateControlsProxy
+        group: "[Skin]"
+        key: "show_rate_controls"
+    }
+
+    Mixxx.ControlProxy {
+        id: showRateControlButtonsProxy
+        group: "[Skin]"
+        key: "show_rate_control_buttons"
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 1
+        anchors.topMargin: 2
+        anchors.rightMargin: 1
+        anchors.bottomMargin: 2
+        spacing: 2
+
+        // Central main deck column
+        ColumnLayout {
+            id: mainDeckColumn
+            Layout.fillWidth: true
+            Layout.fillHeight: false
+            Layout.alignment: Qt.AlignTop
+            spacing: 1
+
+            // Top row: FX assignment and key controls.
+            RowLayout {
+                id: topPlaceholderRow
+                Layout.fillWidth: true
+                Layout.preferredHeight: 20
+                Layout.minimumHeight: 20
+                Layout.maximumHeight: 20
+                Layout.fillHeight: false
+                visible: !root.minimized
+                spacing: 0
+
+                // FX assignment buttons: toggle effect unit assignment for this deck
+                Row {
+                    spacing: 0
+
+                    Repeater {
+                        model: show4EffectUnitsProxy.value > 0 ? 4 : 2
+
+                        delegate: Item {
+                            id: fxAssignButton
+
+                            required property int index
+
+                            width: show4EffectUnitsProxy.value > 0 && index > 0 ? 20 : 26
+                            height: 20
+                            readonly property bool active: fxAssignProxy.value > 0
+                            readonly property color activeColor: index < 2 ? "#236b00" : "#146674"
+                            readonly property color inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+                            readonly property color fillColor: active ? activeColor : inactiveColor
+
+                            Mixxx.ControlProxy {
+                                id: fxAssignProxy
+                                group: `[EffectRack1_EffectUnit${index + 1}]`
+                                key: `group_${root.group}_enable`
+                            }
+
+                            Rectangle {
+                                anchors.fill: parent
+                                color: fxAssignButton.fillColor
+                            }
+
+                            Image {
+                                anchors.fill: parent
+                                source: {
+                                    if (index === 0) {
+                                        return fxAssignButton.active
+                                            ? LateNightTheme.legacyButton("btn_embedded_library_active.svg")
+                                            : LateNightTheme.legacyButton("btn_embedded_library.svg");
+                                    } else {
+                                        return fxAssignButton.active
+                                            ? LateNightTheme.legacyButton("btn_embedded_grid_active.svg")
+                                            : LateNightTheme.legacyButton("btn_embedded_grid.svg");
+                                    }
+                                }
+                                fillMode: Image.Stretch
+                            }
+
+                            Text {
+                                anchors.centerIn: parent
+                                text: show4EffectUnitsProxy.value > 0 && index > 0 ? (index + 1).toString() : "FX" + (show4EffectUnitsProxy.value > 0 && index === 0 ? "1" : (index + 1).toString())
+                                font.family: "Open Sans"
+                                font.pixelSize: 10
+                                font.bold: true
+                                color: fxAssignButton.active ? "#000000" : "#666666"
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    fxAssignProxy.value = !fxAssignProxy.value;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: 1
+                        color: LateNightTheme.deckPanelBorderDark
+                    }
+                }
+
+                VinylControlsPlaceholder {
+                    Layout.preferredWidth: 158
+                    Layout.preferredHeight: 20
+                    Layout.maximumHeight: 20
+                    group: root.group
+                    visible: root.showVinylControls
+                }
+
+                Item {
+                    Layout.preferredWidth: root.showVinylControls ? 2 : 0
+                    Layout.fillHeight: true
+                    visible: root.showVinylControls
+                }
+
+                KeyControlsPlaceholder {
+                    Layout.preferredWidth: 111
+                    Layout.maximumWidth: 111
+                    Layout.preferredHeight: 20
+                    Layout.maximumHeight: 20
+                    group: root.group
+                    visible: root.showKeyControls
+                }
+            }
+
+            // Middle Row: Big Spinny on the left, Title/Overview on the right
+            RowLayout {
+                id: middleDeckRow
+                Layout.fillWidth: true
+                Layout.fillHeight: false
+                Layout.minimumHeight: root.minimized ? 68 : 122
+                Layout.preferredHeight: root.minimized ? 68 : 122
+                Layout.maximumHeight: root.minimized ? 68 : 122
+                spacing: 8
+
+                // Big Spinny/Cover Slot (Large mode)
+                SpinnyCoverSlot {
+                    id: leftSpinnyBig
+                    Layout.preferredHeight: 114
+                    Layout.preferredWidth: 114
+                    group: root.group
+                    visible: root.showBigSpinnyOrCover && !root.minimized
+                }
+
+                // Column containing Title rows and Overview row
+                ColumnLayout {
+                    id: titleOverviewColumn
+                    Layout.fillWidth: true
+                    Layout.fillHeight: false
+                    Layout.preferredHeight: root.minimized ? 68 : 122
+                    spacing: 2
+
+                    // Title, Time, Artist, Duration Rows
+                    TitleTimeRows {
+                        id: titleTimeRows
+                        Layout.fillWidth: true
+                        Layout.minimumHeight: root.minimized ? 48 : 55
+                        Layout.preferredHeight: root.minimized ? 48 : 55
+                        Layout.maximumHeight: root.minimized ? 48 : 55
+                        group: root.group
+                    }
+
+                    // Row containing Small Spinny (on the left of overview) and the Waveform Overview
+                    RowLayout {
+                        id: overviewAndSpinnyRow
+                        Layout.fillWidth: true
+                        Layout.fillHeight: false
+                        Layout.minimumHeight: root.minimized ? 20 : 63
+                        Layout.preferredHeight: root.minimized ? 20 : 63
+                        Layout.maximumHeight: root.minimized ? 20 : 63
+                        spacing: 1
+
+                        // Small Spinny/Cover Slot (Small mode)
+                        SpinnyCoverSlot {
+                            id: leftSpinnySmall
+                            Layout.preferredHeight: 63
+                            Layout.preferredWidth: 63
+                            group: root.group
+                            visible: root.showSmallSpinnyOrCover
+                        }
+
+                        // Waveform Overview Row
+                        OverviewRow {
+                            id: overviewRow
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            group: root.group
+                        }
+                    }
+                }
+            }
+
+            // Lower Transport, Loop, Beatjump Placeholders
+            TransportLoopBeatjumpPlaceholders {
+                id: transportRow
+                Layout.fillWidth: true
+                Layout.fillHeight: false
+                Layout.minimumHeight: 55
+                Layout.preferredHeight: 55
+                Layout.maximumHeight: 55
+                group: root.group
+                showHotcues: root.showHotcues
+                show8Hotcues: root.show8Hotcues
+                showIntroOutroCues: root.showIntroOutroCues
+                showLoopControls: root.showLoopControls
+                showBeatjumpControls: root.showBeatjumpControls
+                visible: !root.minimized
+            }
+        }
+
+        // Right Rate controls placeholder
+        RatePlaceholder {
+            id: rateControls
+            Layout.preferredWidth: 90
+            Layout.fillHeight: false
+            Layout.minimumHeight: 202
+            Layout.preferredHeight: 202
+            Layout.maximumHeight: 202
+            Layout.alignment: Qt.AlignTop
+            group: root.group
+            showRateControlButtons: root.showRateControlButtons
+            visible: !root.minimized && root.showRateControls
+        }
+    }
+
+    Mixxx.PlayerDropArea {
+        anchors.fill: parent
+        group: root.group
+    }
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: 1
+        color: "#333333"
+    }
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: 1
+        color: "#282828"
+    }
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        height: 1
+        color: "#0c0c0c"
+    }
+
+    Rectangle {
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: 1
+        color: "#181818"
+    }
+}

--- a/res/skins/LateNightQML/Deck/FullDeck.qml
+++ b/res/skins/LateNightQML/Deck/FullDeck.qml
@@ -12,18 +12,18 @@ Rectangle {
     required property string group
     property bool minimized: false
     property bool editMode: false
-    property bool honorLegacyVisibilityControls: false
-    readonly property bool showBeatjumpControls: !honorLegacyVisibilityControls || showBeatjumpControlsProxy.value > 0
+    property bool honorSkinVisibilityControls: false
+    readonly property bool showBeatjumpControls: !honorSkinVisibilityControls || showBeatjumpControlsProxy.value > 0
     readonly property bool showBigSpinnyOrCover: selectBigSpinnyProxy.value > 0
-    readonly property bool showHotcues: !honorLegacyVisibilityControls || showHotcuesProxy.value > 0
-    readonly property bool show8Hotcues: !honorLegacyVisibilityControls || show8HotcuesProxy.value > 0
-    readonly property bool showIntroOutroCues: !honorLegacyVisibilityControls || showIntroOutroCuesProxy.value > 0
-    readonly property bool showKeyControls: !honorLegacyVisibilityControls || showKeyControlsProxy.value > 0
-    readonly property bool showLoopControls: !honorLegacyVisibilityControls || showLoopControlsProxy.value > 0
-    readonly property bool showRateControlButtons: !honorLegacyVisibilityControls || showRateControlButtonsProxy.value > 0
-    readonly property bool showRateControls: !honorLegacyVisibilityControls || showRateControlsProxy.value > 0
+    readonly property bool showHotcues: !honorSkinVisibilityControls || showHotcuesProxy.value > 0
+    readonly property bool show8Hotcues: !honorSkinVisibilityControls || show8HotcuesProxy.value > 0
+    readonly property bool showIntroOutroCues: !honorSkinVisibilityControls || showIntroOutroCuesProxy.value > 0
+    readonly property bool showKeyControls: !honorSkinVisibilityControls || showKeyControlsProxy.value > 0
+    readonly property bool showLoopControls: !honorSkinVisibilityControls || showLoopControlsProxy.value > 0
+    readonly property bool showRateControlButtons: !honorSkinVisibilityControls || showRateControlButtonsProxy.value > 0
+    readonly property bool showRateControls: !honorSkinVisibilityControls || showRateControlsProxy.value > 0
     readonly property bool showSmallSpinnyOrCover: selectBigSpinnyProxy.value <= 0 && !root.minimized
-    readonly property bool showVinylControls: honorLegacyVisibilityControls && showVinylControlsProxy.value > 0
+    readonly property bool showVinylControls: honorSkinVisibilityControls && showVinylControlsProxy.value > 0
 
     color: LateNightTheme.deckPanelColor
     radius: 1
@@ -156,12 +156,12 @@ Rectangle {
                                 source: {
                                     if (index === 0) {
                                         return fxAssignButton.active
-                                            ? LateNightTheme.legacyButton("btn_embedded_library_active.svg")
-                                            : LateNightTheme.legacyButton("btn_embedded_library.svg");
+                                            ? LateNightTheme.lateNightButton("btn_embedded_library_active.svg")
+                                            : LateNightTheme.lateNightButton("btn_embedded_library.svg");
                                     } else {
                                         return fxAssignButton.active
-                                            ? LateNightTheme.legacyButton("btn_embedded_grid_active.svg")
-                                            : LateNightTheme.legacyButton("btn_embedded_grid.svg");
+                                            ? LateNightTheme.lateNightButton("btn_embedded_grid_active.svg")
+                                            : LateNightTheme.lateNightButton("btn_embedded_grid.svg");
                                     }
                                 }
                                 fillMode: Image.Stretch
@@ -357,6 +357,6 @@ Rectangle {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         width: 1
-        color: "#181818"
+        color: LateNightTheme.deckTopRowBackgroundColor
     }
 }

--- a/res/skins/LateNightQML/Deck/FullDeck.qml
+++ b/res/skins/LateNightQML/Deck/FullDeck.qml
@@ -1,9 +1,10 @@
 import QtQuick
 import QtQuick.Layouts
 import Mixxx 1.0 as Mixxx
+import "../Controls" as Controls
 import "../LateNightTheme"
 
-Rectangle {
+Controls.Panel {
     id: root
 
     implicitHeight: root.minimized ? 80 : 206
@@ -26,7 +27,6 @@ Rectangle {
     readonly property bool showVinylControls: honorSkinVisibilityControls && showVinylControlsProxy.value > 0
 
     color: LateNightTheme.deckPanelColor
-    radius: 1
 
     Mixxx.ControlProxy {
         id: selectBigSpinnyProxy
@@ -328,35 +328,4 @@ Rectangle {
         group: root.group
     }
 
-    Rectangle {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.top: parent.top
-        height: 1
-        color: "#333333"
-    }
-
-    Rectangle {
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        width: 1
-        color: "#282828"
-    }
-
-    Rectangle {
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        height: 1
-        color: "#0c0c0c"
-    }
-
-    Rectangle {
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        width: 1
-        color: LateNightTheme.deckTopRowBackgroundColor
-    }
 }

--- a/res/skins/LateNightQML/Deck/KeyControlsPlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/KeyControlsPlaceholder.qml
@@ -117,7 +117,7 @@ Item {
         y: 0
         width: root.width - 50
         height: 20
-        color: "#181818"
+        color: LateNightTheme.deckTopRowBackgroundColor
 
         Rectangle {
             anchors.left: parent.left

--- a/res/skins/LateNightQML/Deck/KeyControlsPlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/KeyControlsPlaceholder.qml
@@ -1,0 +1,231 @@
+import QtQuick
+import Mixxx 1.0 as Mixxx
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    required property string group
+
+    implicitWidth: 111
+    implicitHeight: 20
+
+    Mixxx.ControlProxy {
+        id: keyProxy
+        group: root.group
+        key: "key"
+    }
+
+    Mixxx.ControlProxy {
+        id: keyNotationProxy
+        group: "[Library]"
+        key: "key_notation"
+    }
+
+    Mixxx.ControlProxy {
+        id: visualKeyDistanceProxy
+        group: root.group
+        key: "visual_key_distance"
+    }
+
+    function keyToOpenKeyNumber(key) {
+        return Mixxx.KeyUtils.keyToOpenKeyNumber(key);
+    }
+
+    function scaledKey(key, steps) {
+        return Mixxx.KeyUtils.scaleKeySteps(key, steps);
+    }
+
+    function colorForKey(key) {
+        const openKeyNumber = keyToOpenKeyNumber(key);
+        const palette = Mixxx.Config.keyColorPalette;
+        if (openKeyNumber <= 0 || !palette || palette.length < openKeyNumber) {
+            return LateNightTheme.accentColor;
+        }
+        return palette[openKeyNumber - 1];
+    }
+
+    function keyDisplayText(key, notationRevision) {
+        notationRevision;
+        return Mixxx.KeyUtils.keyToString(key);
+    }
+
+    readonly property real keyDistance: visualKeyDistanceProxy.value
+    readonly property real splitPoint: Math.max(0, Math.min(1, keyDistance < 0 ? keyDistance + 1 : keyDistance))
+    readonly property color stripTopColor: keyDistance < 0 ? colorForKey(keyProxy.value) : colorForKey(scaledKey(keyProxy.value, 1))
+    readonly property color stripBottomColor: keyDistance < 0 ? colorForKey(scaledKey(keyProxy.value, -1)) : colorForKey(keyProxy.value)
+    readonly property string displayKeyText: keyDisplayText(keyProxy.value, keyNotationProxy.value)
+    readonly property bool useSecondaryDeckText: root.group === "[Channel3]" || root.group === "[Channel4]"
+    readonly property color keyTextColor: useSecondaryDeckText ? LateNightTheme.secondaryDeckTextColor : LateNightTheme.primaryDeckTextColor
+
+    // Key match/reset button: left-click = sync_key, right-click = reset_key
+    LateNightControlButton {
+        x: 0
+        y: 0
+        width: 26
+        height: 20
+        backgroundSource: LateNightTheme.assetDeckKeyButtonBackground
+        iconSource: LateNightTheme.assetDeckKeyMatchButton
+        iconLeftPadding: 5
+        iconRightPadding: 5
+        iconTopPadding: 3
+        iconBottomPadding: 3
+        group: root.group
+        key: "sync_key"
+        rightClickKey: "reset_key"
+        activeOpacity: 1.0
+        inactiveOpacity: 0.78
+        inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+        pressedBackgroundSuffix: "active"
+        pressedIconSuffix: LateNightTheme.keyControlsPressedIconSuffix
+        pressedActivatesFill: true
+        activeColor: LateNightTheme.keyControlsPressedColor
+        useBorderImageBackground: true
+        backgroundBorderTop: 2
+        backgroundBorderBottom: 2
+        backgroundBorderLeft: 2
+        backgroundBorderRight: 2
+    }
+
+    // Visual key distance strip
+    Rectangle {
+        x: 26
+        y: 0
+        width: 4
+        height: 20
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            height: parent.height * root.splitPoint
+            color: root.stripTopColor
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: parent.height - parent.height * root.splitPoint
+            color: root.stripBottomColor
+        }
+    }
+
+    // Key text display
+    Rectangle {
+        x: 30
+        y: 0
+        width: root.width - 50
+        height: 20
+        color: "#181818"
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            height: 1
+            color: LateNightTheme.deckPanelBorderLight
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: 1
+            color: LateNightTheme.deckPanelBorderLight
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: 1
+            color: LateNightTheme.deckPanelBorderDark
+        }
+
+        Rectangle {
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: 1
+            color: LateNightTheme.deckPanelBorderDark
+        }
+
+        Text {
+            anchors.fill: parent
+            anchors.leftMargin: 6
+            anchors.rightMargin: 6
+            text: root.displayKeyText.length > 0 ? root.displayKeyText : "--"
+            font.family: "Open Sans"
+            font.pixelSize: 12
+            font.weight: Font.Medium
+            color: root.keyTextColor
+            elide: Text.ElideRight
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+    }
+
+    // Key up/down buttons
+    Column {
+        x: root.width - 20
+        y: 0
+        width: 20
+        height: 20
+        spacing: 0
+
+        // Key Up: left-click = pitch_up, right-click = pitch_up_small
+        LateNightControlButton {
+            width: 20
+            height: 10
+            backgroundSource: LateNightTheme.assetDeckKeyButtonBackground
+            iconSource: LateNightTheme.assetDeckKeyUpButton
+            iconLeftPadding: 4
+            iconRightPadding: 4
+            iconTopPadding: 1
+            iconBottomPadding: 1
+            group: root.group
+            key: "pitch_up"
+            rightClickKey: "pitch_up_small"
+            activeOpacity: 0.95
+            inactiveOpacity: 0.72
+            inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+            pressedBackgroundSuffix: "active"
+            pressedIconSuffix: LateNightTheme.keyControlsPressedIconSuffix
+            pressedActivatesFill: true
+            activeColor: LateNightTheme.keyControlsPressedColor
+            useBorderImageBackground: true
+            backgroundBorderTop: 1
+            backgroundBorderBottom: 12
+            backgroundBorderLeft: 2
+            backgroundBorderRight: 2
+        }
+
+        // Key Down: left-click = pitch_down, right-click = pitch_down_small
+        LateNightControlButton {
+            width: 20
+            height: 10
+            backgroundSource: LateNightTheme.assetDeckKeyButtonBackground
+            iconSource: LateNightTheme.assetDeckKeyDownButton
+            iconLeftPadding: 4
+            iconRightPadding: 4
+            iconTopPadding: 1
+            iconBottomPadding: 1
+            group: root.group
+            key: "pitch_down"
+            rightClickKey: "pitch_down_small"
+            activeOpacity: 0.95
+            inactiveOpacity: 0.72
+            inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+            pressedBackgroundSuffix: "active"
+            pressedIconSuffix: LateNightTheme.keyControlsPressedIconSuffix
+            pressedActivatesFill: true
+            activeColor: LateNightTheme.keyControlsPressedColor
+            useBorderImageBackground: true
+            backgroundBorderTop: 12
+            backgroundBorderBottom: 1
+            backgroundBorderLeft: 2
+            backgroundBorderRight: 2
+        }
+    }
+}

--- a/res/skins/LateNightQML/Deck/KeyControlsPlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/KeyControlsPlaceholder.qml
@@ -17,6 +17,12 @@ Item {
     }
 
     Mixxx.ControlProxy {
+        id: trackLoadedProxy
+        group: root.group
+        key: "track_loaded"
+    }
+
+    Mixxx.ControlProxy {
         id: keyNotationProxy
         group: "[Library]"
         key: "key_notation"
@@ -55,6 +61,8 @@ Item {
     readonly property color stripTopColor: keyDistance < 0 ? colorForKey(keyProxy.value) : colorForKey(scaledKey(keyProxy.value, 1))
     readonly property color stripBottomColor: keyDistance < 0 ? colorForKey(scaledKey(keyProxy.value, -1)) : colorForKey(keyProxy.value)
     readonly property string displayKeyText: keyDisplayText(keyProxy.value, keyNotationProxy.value)
+    readonly property bool showKeyColorStrip: trackLoadedProxy.value > 0 && displayKeyText.length > 0
+    readonly property int keyTextX: showKeyColorStrip ? 30 : 26
     readonly property bool useSecondaryDeckText: root.group === "[Channel3]" || root.group === "[Channel4]"
     readonly property color keyTextColor: useSecondaryDeckText ? LateNightTheme.secondaryDeckTextColor : LateNightTheme.primaryDeckTextColor
 
@@ -93,6 +101,7 @@ Item {
         y: 0
         width: 4
         height: 20
+        visible: root.showKeyColorStrip
 
         Rectangle {
             anchors.left: parent.left
@@ -113,9 +122,9 @@ Item {
 
     // Key text display
     Rectangle {
-        x: 30
+        x: root.keyTextX
         y: 0
-        width: root.width - 50
+        width: root.width - root.keyTextX - 20
         height: 20
         color: LateNightTheme.deckTopRowBackgroundColor
 
@@ -155,7 +164,7 @@ Item {
             anchors.fill: parent
             anchors.leftMargin: 6
             anchors.rightMargin: 6
-            text: root.displayKeyText.length > 0 ? root.displayKeyText : "--"
+            text: root.displayKeyText
             font.family: "Open Sans"
             font.pixelSize: 12
             font.weight: Font.Medium

--- a/res/skins/LateNightQML/Deck/LateNightControlButton.qml
+++ b/res/skins/LateNightQML/Deck/LateNightControlButton.qml
@@ -1,0 +1,111 @@
+import QtQuick
+import "../../../qml" as Skin
+
+// A LateNight-styled button wrapper around shared Mixxx.ControlProxy behavior.
+LegacyIconButton {
+    id: root
+
+    required property string group
+    required property string key
+    property string rightClickKey: ""
+    property string pressAndHoldKey: ""
+    property string displayKey: ""
+    property bool toggleable: false
+    property bool activateOnClick: false
+    property bool ignoreActivePresses: false
+    property bool releaseToZero: true
+    property bool longPressLatching: false
+    property int numberStates: 2
+    property int longPressDuration: 300
+    property color longPressLatchOverlayColor: "transparent"
+    property url longPressLatchOverlayBackgroundSource: ""
+    property url longPressLatchOverlayIconSource: ""
+    property real activeOpacity: 1.0
+    property real inactiveOpacity: 0.72
+    property color activeOverlayColor: "transparent"
+    property real activeDisplayThreshold: 0
+    property bool visualActiveState: false
+
+    signal primaryPressed(real displayValue)
+    signal secondaryPressed(real displayValue, real mouseX, real mouseY)
+
+    readonly property bool isActive: controlBehavior.isActive
+    readonly property bool isVisuallyActive: controlBehavior.isVisuallyActive
+    readonly property bool latchRevealRunning: root.longPressLatching &&
+            controlBehavior.longPressAnimationRunning
+    readonly property url effectiveLatchOverlayBackgroundSource:
+            root.longPressLatchOverlayBackgroundSource.toString().length > 0
+            ? root.longPressLatchOverlayBackgroundSource
+            : root.effectiveBackgroundSource
+    readonly property url effectiveLatchOverlayIconSource:
+            root.longPressLatchOverlayIconSource.toString().length > 0
+            ? root.longPressLatchOverlayIconSource
+            : root.effectiveIconSource
+
+    activeState: root.isVisuallyActive
+    pressedState: controlBehavior.pressed
+    latchOverlayVisible: root.latchRevealRunning
+    latchOverlayProgress: controlBehavior.longPressProgress
+    latchOverlayColor: root.longPressLatchOverlayColor
+    latchOverlayBackgroundSource: root.effectiveLatchOverlayBackgroundSource
+    latchOverlayIconSource: root.effectiveLatchOverlayIconSource
+    contentOpacity: root.isVisuallyActive ? root.activeOpacity : root.inactiveOpacity
+
+    function triggerPrimaryAction() {
+        controlBehavior.triggerPrimaryAction();
+    }
+
+    function triggerPressAndHoldAction() {
+        controlBehavior.triggerPressAndHoldAction();
+    }
+
+    function nextState(value) {
+        return controlBehavior.nextState(value);
+    }
+
+    function startLatchReveal() {
+        controlBehavior.startLatchReveal();
+    }
+
+    Skin.ControlProxyButtonBehavior {
+        id: controlBehavior
+
+        anchors.fill: parent
+        group: root.group
+        key: root.key
+        rightClickKey: root.rightClickKey
+        pressAndHoldKey: root.pressAndHoldKey
+        displayKey: root.displayKey
+        toggleable: root.toggleable
+        activateOnClick: root.activateOnClick
+        ignoreActivePresses: root.ignoreActivePresses
+        releaseToZero: root.releaseToZero
+        longPressLatching: root.longPressLatching
+        numberStates: root.numberStates
+        longPressDuration: root.longPressDuration
+        activeDisplayThreshold: root.activeDisplayThreshold
+        visualActiveState: root.visualActiveState
+
+        onPrimaryPressed: function(displayValue) {
+            root.primaryPressed(displayValue);
+        }
+
+        onSecondaryPressed: function(displayValue, mouseX, mouseY) {
+            root.secondaryPressed(displayValue, mouseX, mouseY);
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: root.activeOverlayColor
+        opacity: root.isActive ? 0.15 : 0
+        radius: 2
+        visible: root.activeOverlayColor !== Qt.rgba(0, 0, 0, 0)
+
+        Behavior on opacity {
+            NumberAnimation {
+                duration: 80
+            }
+        }
+    }
+}

--- a/res/skins/LateNightQML/Deck/LateNightControlButton.qml
+++ b/res/skins/LateNightQML/Deck/LateNightControlButton.qml
@@ -2,7 +2,7 @@ import QtQuick
 import "../../../qml" as Skin
 
 // A LateNight-styled button wrapper around shared Mixxx.ControlProxy behavior.
-LegacyIconButton {
+LateNightIconButton {
     id: root
 
     required property string group

--- a/res/skins/LateNightQML/Deck/LateNightCycleButton.qml
+++ b/res/skins/LateNightQML/Deck/LateNightCycleButton.qml
@@ -1,0 +1,32 @@
+import QtQuick
+import "../../../qml" as Skin
+import "../LateNightTheme"
+
+// A LateNight-styled button that cycles through N states.
+LegacyIconButton {
+    id: root
+
+    required property string group
+    required property string key
+    property int numStates: 3
+    property var stateLabels: []
+    property real activeOpacity: 0.95
+    property real inactiveOpacity: 0.72
+
+    readonly property int currentState: cycleBehavior.currentState
+
+    label: cycleBehavior.label
+    labelPixelSize: 9
+    labelColor: root.currentState > 0 ? LateNightTheme.textColor : LateNightTheme.textColorMuted
+    contentOpacity: root.currentState > 0 ? root.activeOpacity : root.inactiveOpacity
+
+    Skin.ControlCycleButtonBehavior {
+        id: cycleBehavior
+
+        anchors.fill: parent
+        group: root.group
+        key: root.key
+        numberStates: root.numStates
+        stateLabels: root.stateLabels
+    }
+}

--- a/res/skins/LateNightQML/Deck/LateNightCycleButton.qml
+++ b/res/skins/LateNightQML/Deck/LateNightCycleButton.qml
@@ -3,7 +3,7 @@ import "../../../qml" as Skin
 import "../LateNightTheme"
 
 // A LateNight-styled button that cycles through N states.
-LegacyIconButton {
+LateNightIconButton {
     id: root
 
     required property string group

--- a/res/skins/LateNightQML/Deck/LateNightIconButton.qml
+++ b/res/skins/LateNightQML/Deck/LateNightIconButton.qml
@@ -4,7 +4,7 @@ import "../LateNightTheme"
 Item {
     id: root
 
-    property url backgroundSource: LateNightTheme.legacySubRegionButton("square")
+    property url backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
     property url iconSource: ""
     property string label: ""
     property color labelColor: LateNightTheme.textColorMuted

--- a/res/skins/LateNightQML/Deck/LegacyIconButton.qml
+++ b/res/skins/LateNightQML/Deck/LegacyIconButton.qml
@@ -1,0 +1,180 @@
+import QtQuick
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    property url backgroundSource: LateNightTheme.legacySubRegionButton("square")
+    property url iconSource: ""
+    property string label: ""
+    property color labelColor: LateNightTheme.textColorMuted
+    property int labelPixelSize: 11
+    property real contentOpacity: 0.82
+
+    property string activeBackgroundSuffix: ""
+    property string activeIconSuffix: ""
+    property string pressedBackgroundSuffix: ""
+    property string pressedIconSuffix: ""
+    property color activeColor: "transparent"
+    property color inactiveColor: LateNightTheme.deckButtonInactiveColor
+    property bool inactiveFillEnabled: true
+    property bool pressedActivatesFill: false
+    property int fillMargin: 2
+    property bool useBorderImageBackground: false
+    property int backgroundBorderTop: 0
+    property int backgroundBorderBottom: 0
+    property int backgroundBorderLeft: 0
+    property int backgroundBorderRight: 0
+    property bool activeState: false
+    property bool pressedState: false
+    property bool latchOverlayVisible: false
+    property real latchOverlayProgress: 0
+    property color latchOverlayColor: "transparent"
+    property url latchOverlayBackgroundSource: backgroundSource
+    property url latchOverlayIconSource: iconSource
+
+    property bool stretchIcon: false
+    property int iconLeftPadding: 0
+    property int iconRightPadding: 0
+    property int iconTopPadding: 0
+    property int iconBottomPadding: 0
+
+    readonly property url effectiveBackgroundSource: {
+        var src = backgroundSource.toString();
+        if (root.pressedState && pressedBackgroundSuffix.length > 0 && src.endsWith(".svg")) {
+            return src.substring(0, src.length - 4) + "_" + pressedBackgroundSuffix + ".svg";
+        }
+        if (root.activeState && activeBackgroundSuffix.length > 0 && src.endsWith(".svg")) {
+            return src.substring(0, src.length - 4) + "_" + activeBackgroundSuffix + ".svg";
+        }
+        return backgroundSource;
+    }
+
+    readonly property url effectiveIconSource: {
+        var src = iconSource.toString();
+        if (root.pressedState && pressedIconSuffix.length > 0 && src.endsWith(".svg")) {
+            return src.substring(0, src.length - 4) + "_" + pressedIconSuffix + ".svg";
+        }
+        if (root.activeState && activeIconSuffix.length > 0 && src.endsWith(".svg")) {
+            return src.substring(0, src.length - 4) + "_" + activeIconSuffix + ".svg";
+        }
+        return iconSource;
+    }
+    readonly property bool fillActive: root.activeState || (root.pressedState && root.pressedActivatesFill)
+    readonly property color fillColor: root.fillActive && root.activeColor.toString() !== "#00000000" && root.activeColor.toString() !== "transparent"
+            ? root.activeColor
+            : root.inactiveFillEnabled
+                ? root.inactiveColor
+                : "transparent"
+    readonly property real iconAvailableWidth: Math.max(0, width - iconLeftPadding - iconRightPadding)
+    readonly property real iconAvailableHeight: Math.max(0, height - iconTopPadding - iconBottomPadding)
+
+    implicitWidth: 26
+    implicitHeight: 26
+
+    Rectangle {
+        anchors.fill: parent
+        anchors.margins: root.fillMargin
+        radius: 1
+        visible: root.fillColor.toString() !== "#00000000" && root.fillColor.toString() !== "transparent"
+
+        gradient: Gradient {
+            GradientStop {
+                position: 0
+                color: Qt.lighter(root.fillColor, 1.16)
+            }
+
+            GradientStop {
+                position: 0.5
+                color: root.fillColor
+            }
+
+            GradientStop {
+                position: 1
+                color: Qt.darker(root.fillColor, 1.25)
+            }
+        }
+    }
+
+    Image {
+        anchors.fill: parent
+        source: root.effectiveBackgroundSource
+        fillMode: Image.Stretch
+        opacity: 1.0
+        visible: !root.useBorderImageBackground
+    }
+
+    BorderImage {
+        anchors.fill: parent
+        source: root.effectiveBackgroundSource
+        visible: root.useBorderImageBackground
+        border {
+            top: root.backgroundBorderTop
+            bottom: root.backgroundBorderBottom
+            left: root.backgroundBorderLeft
+            right: root.backgroundBorderRight
+        }
+    }
+
+    Image {
+        id: iconImage
+        x: root.stretchIcon ? root.iconLeftPadding : root.iconLeftPadding + (root.iconAvailableWidth - width) / 2
+        y: root.stretchIcon ? root.iconTopPadding : root.iconTopPadding + (root.iconAvailableHeight - height) / 2
+        width: root.stretchIcon ? root.iconAvailableWidth : Math.min(root.iconAvailableWidth, sourceSize.width > 0 ? sourceSize.width / 2 : root.iconAvailableWidth)
+        height: root.stretchIcon ? root.iconAvailableHeight : Math.min(root.iconAvailableHeight, sourceSize.height > 0 ? sourceSize.height / 2 : root.iconAvailableHeight)
+        source: root.effectiveIconSource
+        fillMode: root.stretchIcon ? Image.Stretch : Image.PreserveAspectFit
+        opacity: root.contentOpacity
+        visible: root.effectiveIconSource.toString().length > 0
+    }
+
+    Item {
+        id: latchOverlay
+
+        x: parent.width - width
+        y: 0
+        width: root.latchOverlayVisible ? parent.width * (1.0 - root.latchOverlayProgress) : 0
+        height: parent.height
+        clip: true
+        visible: root.latchOverlayVisible && width > 0
+
+        Rectangle {
+            anchors.fill: parent
+            color: root.latchOverlayColor
+            visible: root.latchOverlayColor.toString() !== "#00000000" && root.latchOverlayColor.toString() !== "transparent"
+        }
+
+        Image {
+            x: -latchOverlay.x
+            y: 0
+            width: root.width
+            height: root.height
+            source: root.latchOverlayBackgroundSource
+            fillMode: Image.Stretch
+            opacity: root.contentOpacity
+        }
+
+        Image {
+            x: root.stretchIcon ? root.iconLeftPadding - latchOverlay.x : root.iconLeftPadding + (root.iconAvailableWidth - width) / 2 - latchOverlay.x
+            y: root.stretchIcon ? root.iconTopPadding : root.iconTopPadding + (root.iconAvailableHeight - height) / 2
+            width: root.stretchIcon ? root.iconAvailableWidth : Math.min(root.iconAvailableWidth, sourceSize.width > 0 ? sourceSize.width / 2 : root.iconAvailableWidth)
+            height: root.stretchIcon ? root.iconAvailableHeight : Math.min(root.iconAvailableHeight, sourceSize.height > 0 ? sourceSize.height / 2 : root.iconAvailableHeight)
+            source: root.latchOverlayIconSource
+            fillMode: root.stretchIcon ? Image.Stretch : Image.PreserveAspectFit
+            opacity: root.contentOpacity
+            visible: root.latchOverlayIconSource.toString().length > 0
+        }
+    }
+
+    Text {
+        anchors.centerIn: parent
+        text: root.label
+        font.family: "Open Sans"
+        font.pixelSize: root.labelPixelSize
+        font.bold: true
+        color: root.labelColor
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        visible: root.label.length > 0
+    }
+}

--- a/res/skins/LateNightQML/Deck/OverviewRow.qml
+++ b/res/skins/LateNightQML/Deck/OverviewRow.qml
@@ -78,7 +78,7 @@ Item {
         Rectangle {
             Layout.preferredWidth: 76
             Layout.fillHeight: true
-            color: "#19191a"
+            color: LateNightTheme.overviewSettingsBackgroundColor
 
             Rectangle {
                 anchors.left: parent.left

--- a/res/skins/LateNightQML/Deck/OverviewRow.qml
+++ b/res/skins/LateNightQML/Deck/OverviewRow.qml
@@ -1,0 +1,121 @@
+import QtQuick
+import QtQuick.Layouts
+import Mixxx 1.0 as Mixxx
+import "../LateNightTheme"
+import "../../../qml/Mixxx/Controls" as MixxxControls
+
+Item {
+    id: root
+
+    required property string group
+    readonly property bool useSecondaryDeckColors: root.group === "[Channel3]" || root.group === "[Channel4]"
+    readonly property color overviewBackgroundColor: useSecondaryDeckColors ? LateNightTheme.secondaryOverviewBackgroundColor : LateNightTheme.primaryOverviewBackgroundColor
+    readonly property color waveformSignalColor: useSecondaryDeckColors ? LateNightTheme.secondaryWaveformSignalColor : LateNightTheme.primaryWaveformSignalColor
+    readonly property int waveformOverviewType: Math.round(waveformOverviewTypeProxy.value)
+    readonly property bool useFilteredOverview: waveformOverviewType === 0
+
+    Mixxx.ControlProxy {
+        id: waveformOverviewTypeProxy
+        group: "[Waveform]"
+        key: "WaveformOverviewType"
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            color: root.overviewBackgroundColor
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                height: 1
+                color: "#0d0d0d"
+            }
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                width: 1
+                color: "#121212"
+            }
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                height: 1
+                color: "#2a2a2a"
+            }
+
+            Rectangle {
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                width: 1
+                color: "#252525"
+            }
+
+            MixxxControls.WaveformOverview {
+                id: waveformOverview
+
+                anchors.fill: parent
+                anchors.margins: 1
+                group: root.group
+                colorLow: root.useFilteredOverview ? root.waveformSignalColor : "#0000ff"
+                colorMid: root.useFilteredOverview ? root.waveformSignalColor : "#00ff00"
+                colorHigh: root.useFilteredOverview ? root.waveformSignalColor : "#ff0000"
+                renderer: root.useFilteredOverview ? Mixxx.WaveformOverview.Renderer.Filtered : Mixxx.WaveformOverview.Renderer.RGB
+            }
+        }
+
+        // Settings panel.
+        Rectangle {
+            Layout.preferredWidth: 76
+            Layout.fillHeight: true
+            color: "#19191a"
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                height: 1
+                color: "#0d0d0d"
+            }
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                width: 1
+                color: "#121212"
+            }
+
+            Rectangle {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.bottom: parent.bottom
+                height: 1
+                color: "#2a2a2a"
+            }
+
+            Rectangle {
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                width: 1
+                color: "#252525"
+            }
+
+            DeckSettingsPlaceholder {
+                anchors.fill: parent
+                group: root.group
+            }
+        }
+    }
+}

--- a/res/skins/LateNightQML/Deck/OverviewRow.qml
+++ b/res/skins/LateNightQML/Deck/OverviewRow.qml
@@ -34,7 +34,7 @@ Item {
                 anchors.right: parent.right
                 anchors.top: parent.top
                 height: 1
-                color: "#0d0d0d"
+                color: LateNightTheme.overviewBorderTopColor
             }
 
             Rectangle {
@@ -42,7 +42,7 @@ Item {
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
                 width: 1
-                color: "#121212"
+                color: LateNightTheme.overviewBorderLeftColor
             }
 
             Rectangle {
@@ -50,7 +50,7 @@ Item {
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
                 height: 1
-                color: "#2a2a2a"
+                color: LateNightTheme.overviewBorderBottomColor
             }
 
             Rectangle {
@@ -58,7 +58,7 @@ Item {
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
                 width: 1
-                color: "#252525"
+                color: LateNightTheme.overviewBorderRightColor
             }
 
             MixxxControls.WaveformOverview {
@@ -85,7 +85,7 @@ Item {
                 anchors.right: parent.right
                 anchors.top: parent.top
                 height: 1
-                color: "#0d0d0d"
+                color: LateNightTheme.overviewBorderTopColor
             }
 
             Rectangle {
@@ -93,7 +93,7 @@ Item {
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
                 width: 1
-                color: "#121212"
+                color: LateNightTheme.overviewBorderLeftColor
             }
 
             Rectangle {
@@ -101,7 +101,7 @@ Item {
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
                 height: 1
-                color: "#2a2a2a"
+                color: LateNightTheme.overviewBorderBottomColor
             }
 
             Rectangle {
@@ -109,7 +109,7 @@ Item {
                 anchors.top: parent.top
                 anchors.bottom: parent.bottom
                 width: 1
-                color: "#252525"
+                color: LateNightTheme.overviewBorderRightColor
             }
 
             DeckSettingsPlaceholder {

--- a/res/skins/LateNightQML/Deck/RatePlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/RatePlaceholder.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import Mixxx 1.0 as Mixxx
-import "../../../qml" as Skin
+import Mixxx.Controls 1.0 as MixxxControls
 import "../LateNightTheme"
 
 Item {
@@ -45,6 +45,12 @@ Item {
         id: bpmProxy
         group: root.group
         key: "bpm"
+    }
+
+    Mixxx.ControlProxy {
+        id: rateProxy
+        group: root.group
+        key: "rate"
     }
 
     Mixxx.ControlProxy {
@@ -228,8 +234,9 @@ Item {
             Item {
                 id: sliderContainer
                 Layout.preferredWidth: 54
-                Layout.fillHeight: true
-                Layout.minimumHeight: 118
+                Layout.preferredHeight: 121
+                Layout.minimumHeight: 121
+                Layout.alignment: Qt.AlignVCenter
 
                 // Rate range labels: top = negative direction, center = default, bottom = positive direction
                 Text {
@@ -276,24 +283,50 @@ Item {
                     horizontalAlignment: Text.AlignRight
                 }
 
-                Skin.ControlFader {
+                MixxxControls.Fader {
                     id: rateSlider
-                    anchors.centerIn: parent
+                    x: 5
+                    y: 2
                     width: 40
-                    height: Math.min(119, parent.height - 4)
+                    height: 119
+                    bar: true
                     barColor: "#888888"
-                    barMargin: 0
+                    barMargin: 7
                     barStart: 0.5
-                    bg: LateNightTheme.assetDeckRateSliderBackground
-                    fg: LateNightTheme.assetDeckRateSliderHandle
-                    group: root.group
-                    key: "rate"
+                    from: -1
+                    to: 1
+                    value: rateProxy.value
 
-                    handleImage {
-                        width: 34
-                        height: 18
-                        sourceSize.width: 34
-                        sourceSize.height: 18
+                    onMoved: function(value) {
+                        rateProxy.value = value;
+                    }
+
+                    TapHandler {
+                        onDoubleTapped: {
+                            rateSetDefaultProxy.value = 1;
+                        }
+                    }
+
+                    TapHandler {
+                        acceptedButtons: Qt.RightButton
+                        onTapped: {
+                            rateSetDefaultProxy.value = 1;
+                        }
+                    }
+
+                    background: Image {
+                        anchors.fill: parent
+                        fillMode: Image.PreserveAspectFit
+                        source: LateNightTheme.assetDeckRateSliderBackground
+                    }
+
+                    handle: Image {
+                        width: 40
+                        height: 17
+                        x: (rateSlider.width - width) / 2
+                        y: rateSlider.visualPosition * (rateSlider.height - height)
+                        fillMode: Image.PreserveAspectFit
+                        source: LateNightTheme.assetDeckRateSliderHandle
                     }
                 }
 
@@ -301,8 +334,8 @@ Item {
                     id: rateCenterAsset
                     width: 5
                     height: 5
-                    x: rateSlider.x - 3
-                    y: rateSlider.y + rateSlider.height / 2 - height / 2
+                    x: 2
+                    y: 59
                     z: rateSlider.z + 1
                     source: rateSetDefaultProxy.value > 0 ? LateNightTheme.optionalDeckRateCenterActive : LateNightTheme.optionalDeckRateCenterInactive
                     fillMode: Image.PreserveAspectFit
@@ -312,8 +345,8 @@ Item {
                 Rectangle {
                     width: 5
                     height: 5
-                    x: rateSlider.x - 3
-                    y: rateSlider.y + rateSlider.height / 2 - height / 2
+                    x: 2
+                    y: 59
                     z: rateSlider.z + 1
                     radius: 1
                     color: rateSetDefaultProxy.value > 0 ? "#00ffff" : "#4f4f4f"

--- a/res/skins/LateNightQML/Deck/RatePlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/RatePlaceholder.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import Mixxx 1.0 as Mixxx
+import "../../../qml" as Skin
 import "../LateNightTheme"
 
 Item {
@@ -30,28 +31,12 @@ Item {
         }
     }
 
-    function rateValueToSliderParameter(value) {
-        return Math.max(0, Math.min(1, (value + 1.0) / 2.0));
-    }
-
-    function sliderParameterToRateValue(parameter) {
-        return Math.max(-1, Math.min(1, parameter * 2.0 - 1.0));
-    }
-
-    function sliderHandleCenterY() {
-        return sliderHandle.y + sliderHandle.height / 2;
-    }
-
-    function sliderCenterY() {
-        return sliderTrack.y + sliderTrack.height / 2;
-    }
-
     function rateRangeTopLabelY(labelHeight) {
-        return sliderTrack.y - labelHeight / 2;
+        return rateSlider.y - labelHeight / 2;
     }
 
     function rateRangeBottomLabelY(labelHeight) {
-        return sliderTrack.y + sliderTrack.height - labelHeight / 2;
+        return rateSlider.y + rateSlider.height - labelHeight / 2;
     }
 
     property real previousSyncEnabledValue: syncEnabledProxy.value
@@ -60,12 +45,6 @@ Item {
         id: bpmProxy
         group: root.group
         key: "bpm"
-    }
-
-    Mixxx.ControlProxy {
-        id: rateProxy
-        group: root.group
-        key: "rate"
     }
 
     Mixxx.ControlProxy {
@@ -297,23 +276,34 @@ Item {
                     horizontalAlignment: Text.AlignRight
                 }
 
-                Image {
-                    id: sliderTrack
+                Skin.ControlFader {
+                    id: rateSlider
                     anchors.centerIn: parent
                     width: 40
                     height: Math.min(119, parent.height - 4)
-                    source: LateNightTheme.assetDeckRateSliderBackground
-                    fillMode: Image.PreserveAspectFit
-                    opacity: 0.82
+                    barColor: "#888888"
+                    barMargin: 0
+                    barStart: 0.5
+                    bg: LateNightTheme.assetDeckRateSliderBackground
+                    fg: LateNightTheme.assetDeckRateSliderHandle
+                    group: root.group
+                    key: "rate"
+
+                    handleImage {
+                        width: 34
+                        height: 18
+                        sourceSize.width: 34
+                        sourceSize.height: 18
+                    }
                 }
 
                 Image {
                     id: rateCenterAsset
                     width: 5
                     height: 5
-                    x: sliderTrack.x - 3
-                    y: sliderTrack.y + sliderTrack.height / 2 - height / 2
-                    z: sliderHandle.z + 1
+                    x: rateSlider.x - 3
+                    y: rateSlider.y + rateSlider.height / 2 - height / 2
+                    z: rateSlider.z + 1
                     source: rateSetDefaultProxy.value > 0 ? LateNightTheme.optionalDeckRateCenterActive : LateNightTheme.optionalDeckRateCenterInactive
                     fillMode: Image.PreserveAspectFit
                     visible: root.hasLegacyRateCenterAsset
@@ -322,75 +312,13 @@ Item {
                 Rectangle {
                     width: 5
                     height: 5
-                    x: sliderTrack.x - 3
-                    y: sliderTrack.y + sliderTrack.height / 2 - height / 2
-                    z: sliderHandle.z + 1
+                    x: rateSlider.x - 3
+                    y: rateSlider.y + rateSlider.height / 2 - height / 2
+                    z: rateSlider.z + 1
                     radius: 1
                     color: rateSetDefaultProxy.value > 0 ? "#00ffff" : "#4f4f4f"
                     border.color: "#0c0c0c"
                     visible: !root.hasLegacyRateCenterAsset
-                }
-
-                Rectangle {
-                    id: rateSliderBar
-                    width: 2
-                    x: sliderTrack.x + 20 - width / 2
-                    y: Math.min(root.sliderCenterY(), root.sliderHandleCenterY())
-                    height: Math.abs(root.sliderCenterY() - root.sliderHandleCenterY())
-                    z: 1
-                    color: "#888888"
-                    radius: 1
-                    visible: height > 0.5
-                }
-
-                // Functional rate slider handle
-                Image {
-                    id: sliderHandle
-                    width: 34
-                    height: 18
-                    source: LateNightTheme.assetDeckRateSliderHandle
-                    fillMode: Image.PreserveAspectFit
-                    z: 2
-                    x: (sliderContainer.width - width) / 2
-
-                    // Map [ChannelN],rate directly so short Sync rate updates are reflected.
-                    y: {
-                        var trackTop = sliderTrack.y;
-                        var trackUsable = sliderTrack.height - sliderHandle.height;
-                        var parameter = root.rateValueToSliderParameter(rateProxy.value);
-                        return trackTop + (1.0 - parameter) * trackUsable;
-                    }
-                }
-
-                MouseArea {
-                    anchors.fill: sliderTrack
-                    property bool dragging: false
-
-                    function updateRate(mouseY) {
-                        var trackUsable = sliderTrack.height - sliderHandle.height;
-                        var halfHandle = sliderHandle.height / 2;
-                        var relY = mouseY - halfHandle;
-                        var normalized = 1.0 - Math.max(0, Math.min(1, relY / trackUsable));
-                        rateProxy.value = root.sliderParameterToRateValue(normalized);
-                    }
-
-                    onPressed: function(mouse) {
-                        dragging = true;
-                        updateRate(mouse.y);
-                    }
-                    onPositionChanged: function(mouse) {
-                        if (dragging) {
-                            updateRate(mouse.y);
-                        }
-                    }
-                    onReleased: {
-                        dragging = false;
-                    }
-
-                    // Double-click resets rate to default
-                    onDoubleClicked: {
-                        rateSetDefaultProxy.value = 1;
-                    }
                 }
             }
 

--- a/res/skins/LateNightQML/Deck/RatePlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/RatePlaceholder.qml
@@ -17,7 +17,7 @@ Item {
     implicitHeight: 202
     readonly property bool useSecondaryDeckText: root.group === "[Channel3]" || root.group === "[Channel4]"
     readonly property color bpmTextColor: useSecondaryDeckText ? LateNightTheme.secondaryDeckTextColor : LateNightTheme.primaryDeckTextColor
-    readonly property color rateTextColor: LateNightTheme.deckReadonlyTextColor
+    readonly property color rateTextColor: useSecondaryDeckText ? LateNightTheme.secondaryDeckTextColor : LateNightTheme.primaryDeckTextColor
     readonly property bool hasLegacyRateCenterAsset: LateNightTheme.optionalDeckRateCenterInactive.toString().length > 0
 
     function syncLeaderIconSource() {

--- a/res/skins/LateNightQML/Deck/RatePlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/RatePlaceholder.qml
@@ -287,7 +287,7 @@ Item {
                     barColor: "#888888"
                     barMargin: 7
                     barStart: 0.5
-                    defaultHandleVisible: false
+                    showDefaultHandle: false
                     group: root.group
                     key: "rate"
 

--- a/res/skins/LateNightQML/Deck/RatePlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/RatePlaceholder.qml
@@ -409,7 +409,7 @@ Item {
                 LateNightControlButton {
                     Layout.preferredWidth: 26
                     Layout.preferredHeight: 26
-                    backgroundSource: LateNightTheme.legacyTopRegionButton("square")
+                    backgroundSource: LateNightTheme.lateNightTopRegionButton("square")
                     iconSource: LateNightTheme.assetDeckMinusButton
                     group: root.group
                     key: rateDirProxy.value >= 0 ? "rate_perm_up" : "rate_perm_down"
@@ -422,7 +422,7 @@ Item {
                 LateNightControlButton {
                     Layout.preferredWidth: 26
                     Layout.preferredHeight: 26
-                    backgroundSource: LateNightTheme.legacyTopRegionButton("square")
+                    backgroundSource: LateNightTheme.lateNightTopRegionButton("square")
                     iconSource: LateNightTheme.assetDeckArrowLeftUpButton
                     group: root.group
                     key: rateDirProxy.value >= 0 ? "rate_temp_up" : "rate_temp_down"
@@ -435,7 +435,7 @@ Item {
                 LateNightControlButton {
                     Layout.preferredWidth: 26
                     Layout.preferredHeight: 26
-                    backgroundSource: LateNightTheme.legacyTopRegionButton("square")
+                    backgroundSource: LateNightTheme.lateNightTopRegionButton("square")
                     iconSource: LateNightTheme.assetDeckArrowRightDownButton
                     group: root.group
                     key: rateDirProxy.value >= 0 ? "rate_temp_down" : "rate_temp_up"
@@ -448,7 +448,7 @@ Item {
                 LateNightControlButton {
                     Layout.preferredWidth: 26
                     Layout.preferredHeight: 26
-                    backgroundSource: LateNightTheme.legacyTopRegionButton("square")
+                    backgroundSource: LateNightTheme.lateNightTopRegionButton("square")
                     iconSource: LateNightTheme.assetDeckPlusButton
                     group: root.group
                     key: rateDirProxy.value >= 0 ? "rate_perm_down" : "rate_perm_up"

--- a/res/skins/LateNightQML/Deck/RatePlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/RatePlaceholder.qml
@@ -96,7 +96,7 @@ Item {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: 1
-            color: "#0c0c0c"
+            color: LateNightTheme.deckPanelBorderDark
         }
 
         Rectangle {
@@ -104,7 +104,7 @@ Item {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: 1
-            color: "#333333"
+            color: LateNightTheme.deckPanelBorderLight
         }
     }
 
@@ -317,7 +317,7 @@ Item {
                     z: rateSlider.z + 1
                     radius: 1
                     color: rateSetDefaultProxy.value > 0 ? "#00ffff" : "#4f4f4f"
-                    border.color: "#0c0c0c"
+                    border.color: LateNightTheme.deckPanelBorderDark
                     visible: !root.hasLegacyRateCenterAsset
                 }
             }

--- a/res/skins/LateNightQML/Deck/RatePlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/RatePlaceholder.qml
@@ -1,0 +1,463 @@
+import QtQuick
+import QtQuick.Layouts
+import Mixxx 1.0 as Mixxx
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    required property string group
+    property bool showRateControlButtons: true
+
+    readonly property var deckPlayer: Mixxx.PlayerManager.getPlayer(root.group)
+    readonly property bool isLoaded: deckPlayer?.isLoaded ?? false
+
+    implicitWidth: 90
+    implicitHeight: 202
+    readonly property bool useSecondaryDeckText: root.group === "[Channel3]" || root.group === "[Channel4]"
+    readonly property color bpmTextColor: useSecondaryDeckText ? LateNightTheme.secondaryDeckTextColor : LateNightTheme.primaryDeckTextColor
+    readonly property color rateTextColor: LateNightTheme.deckReadonlyTextColor
+    readonly property bool hasLegacyRateCenterAsset: LateNightTheme.optionalDeckRateCenterInactive.toString().length > 0
+
+    function syncLeaderIconSource() {
+        switch (Math.round(syncLeaderProxy.value)) {
+        case 1:
+            return LateNightTheme.assetDeckLeaderImplicitButton;
+        case 2:
+            return LateNightTheme.assetDeckLeaderExplicitButton;
+        default:
+            return LateNightTheme.assetDeckLeaderButton;
+        }
+    }
+
+    function rateValueToSliderParameter(value) {
+        return Math.max(0, Math.min(1, (value + 1.0) / 2.0));
+    }
+
+    function sliderParameterToRateValue(parameter) {
+        return Math.max(-1, Math.min(1, parameter * 2.0 - 1.0));
+    }
+
+    function sliderHandleCenterY() {
+        return sliderHandle.y + sliderHandle.height / 2;
+    }
+
+    function sliderCenterY() {
+        return sliderTrack.y + sliderTrack.height / 2;
+    }
+
+    function rateRangeTopLabelY(labelHeight) {
+        return sliderTrack.y - labelHeight / 2;
+    }
+
+    function rateRangeBottomLabelY(labelHeight) {
+        return sliderTrack.y + sliderTrack.height - labelHeight / 2;
+    }
+
+    property real previousSyncEnabledValue: syncEnabledProxy.value
+
+    Mixxx.ControlProxy {
+        id: bpmProxy
+        group: root.group
+        key: "bpm"
+    }
+
+    Mixxx.ControlProxy {
+        id: rateProxy
+        group: root.group
+        key: "rate"
+    }
+
+    Mixxx.ControlProxy {
+        id: rateRatioProxy
+        group: root.group
+        key: "rate_ratio"
+    }
+
+    Mixxx.ControlProxy {
+        id: rateDirProxy
+        group: root.group
+        key: "rate_dir"
+    }
+
+    Mixxx.ControlProxy {
+        id: rateRangeProxy
+        group: root.group
+        key: "rateRange"
+    }
+
+    Mixxx.ControlProxy {
+        id: rateSetDefaultProxy
+        group: root.group
+        key: "rate_set_default"
+    }
+
+    Mixxx.ControlProxy {
+        id: syncEnabledProxy
+        group: root.group
+        key: "sync_enabled"
+    }
+
+    Mixxx.ControlProxy {
+        id: syncLeaderProxy
+        group: root.group
+        key: "sync_leader"
+    }
+
+    Item {
+        id: deckRateSeparator
+
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: 2
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: 1
+            color: "#0c0c0c"
+        }
+
+        Rectangle {
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: 1
+            color: "#333333"
+        }
+    }
+
+    ColumnLayout {
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.left: deckRateSeparator.right
+        anchors.leftMargin: 2
+        spacing: 3
+
+        // BPM display
+        Text {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 24
+            text: bpmProxy.value.toFixed(2)
+            font.family: "Open Sans"
+            font.pixelSize: 20
+            font.bold: true
+            color: root.bpmTextColor
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        // Rate percentage display
+        Text {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 17
+            text: ((rateRatioProxy.value - 1) * 100).toFixed(2)
+            font.family: "Open Sans"
+            font.pixelSize: 13
+            color: root.rateTextColor
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        // Sync + Leader buttons
+        RowLayout {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredWidth: 62
+            Layout.preferredHeight: 22
+            spacing: 0
+
+            // Sync button: short click performs momentary sync, hold latches sync, right-click toggles leader.
+            LateNightControlButton {
+                id: syncBtn
+                Layout.preferredWidth: 40
+                Layout.preferredHeight: 22
+                backgroundSource: LateNightTheme.assetDeckSyncBackground
+                activeBackgroundSuffix: "active"
+                iconSource: syncEnabledProxy.value > 0 ? LateNightTheme.assetDeckSyncActiveButton : LateNightTheme.assetDeckSyncButton
+                group: root.group
+                key: "sync_enabled"
+                rightClickKey: "sync_leader"
+                longPressLatching: true
+                numberStates: 2
+                longPressLatchOverlayColor: LateNightTheme.syncInactiveBackgroundColor
+                longPressLatchOverlayBackgroundSource: LateNightTheme.assetDeckSyncBackground
+                longPressLatchOverlayIconSource: LateNightTheme.assetDeckSyncButton
+                activeOpacity: 1.0
+                inactiveOpacity: 1.0
+                activeColor: LateNightTheme.syncExplicitLeaderColor
+                fillMargin: 0
+                iconLeftPadding: LateNightTheme.syncButtonHorizontalPadding
+                iconRightPadding: LateNightTheme.syncButtonHorizontalPadding
+            }
+
+            // Leader button: press = request leader state; display follows sync_leader light.
+            LateNightControlButton {
+                id: leaderBtn
+                Layout.preferredWidth: 22
+                Layout.preferredHeight: 22
+                backgroundSource: LateNightTheme.assetDeckLeaderBackground
+                activeBackgroundSuffix: "active"
+                iconSource: root.syncLeaderIconSource()
+                group: root.group
+                key: "sync_leader"
+                displayKey: "sync_leader"
+                ignoreActivePresses: true
+                releaseToZero: false
+                activeDisplayThreshold: 0.5
+                activeOpacity: 1.0
+                inactiveOpacity: 1.0
+                activeColor: {
+                    // sync_leader: 0=Off, 1=Soft leader, 2=Explicit leader
+                    switch (Math.round(syncLeaderProxy.value)) {
+                    case 1:
+                        return LateNightTheme.syncImplicitLeaderColor;
+                    case 2:
+                        return LateNightTheme.syncExplicitLeaderColor;
+                    default:
+                        return "transparent";
+                    }
+                }
+                fillMargin: 0
+                onPrimaryPressed: function(displayValue) {
+                    if (displayValue <= 0.5) {
+                        syncBtn.startLatchReveal();
+                    }
+                }
+            }
+        }
+
+        Connections {
+            target: syncEnabledProxy
+
+            function onValueChanged(newValue) {
+                if (newValue > 0 && root.previousSyncEnabledValue <= 0) {
+                    syncBtn.startLatchReveal();
+                }
+                root.previousSyncEnabledValue = newValue;
+            }
+        }
+
+        // Rate slider + rate buttons row
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            spacing: 2
+
+            Item {
+                id: sliderContainer
+                Layout.preferredWidth: 54
+                Layout.fillHeight: true
+                Layout.minimumHeight: 118
+
+                // Rate range labels: top = negative direction, center = default, bottom = positive direction
+                Text {
+                    width: 8
+                    x: 1
+                    y: root.rateRangeTopLabelY(height)
+                    text: "-"
+                    font.family: "Open Sans"
+                    font.pixelSize: 12
+                    color: root.rateTextColor
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                Text {
+                    width: 8
+                    x: parent.width - width - 1
+                    y: root.rateRangeTopLabelY(height)
+                    text: (rateRangeProxy.value * 100).toFixed(0)
+                    font.family: "Open Sans"
+                    font.pixelSize: 12
+                    color: root.rateTextColor
+                    horizontalAlignment: Text.AlignRight
+                }
+
+                Text {
+                    width: 8
+                    x: 1
+                    y: root.rateRangeBottomLabelY(height)
+                    text: "+"
+                    font.family: "Open Sans"
+                    font.pixelSize: 12
+                    color: root.rateTextColor
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                Text {
+                    width: 8
+                    x: parent.width - width - 1
+                    y: root.rateRangeBottomLabelY(height)
+                    text: (rateRangeProxy.value * 100).toFixed(0)
+                    font.family: "Open Sans"
+                    font.pixelSize: 12
+                    color: root.rateTextColor
+                    horizontalAlignment: Text.AlignRight
+                }
+
+                Image {
+                    id: sliderTrack
+                    anchors.centerIn: parent
+                    width: 40
+                    height: Math.min(119, parent.height - 4)
+                    source: LateNightTheme.assetDeckRateSliderBackground
+                    fillMode: Image.PreserveAspectFit
+                    opacity: 0.82
+                }
+
+                Image {
+                    id: rateCenterAsset
+                    width: 5
+                    height: 5
+                    x: sliderTrack.x - 3
+                    y: sliderTrack.y + sliderTrack.height / 2 - height / 2
+                    z: sliderHandle.z + 1
+                    source: rateSetDefaultProxy.value > 0 ? LateNightTheme.optionalDeckRateCenterActive : LateNightTheme.optionalDeckRateCenterInactive
+                    fillMode: Image.PreserveAspectFit
+                    visible: root.hasLegacyRateCenterAsset
+                }
+
+                Rectangle {
+                    width: 5
+                    height: 5
+                    x: sliderTrack.x - 3
+                    y: sliderTrack.y + sliderTrack.height / 2 - height / 2
+                    z: sliderHandle.z + 1
+                    radius: 1
+                    color: rateSetDefaultProxy.value > 0 ? "#00ffff" : "#4f4f4f"
+                    border.color: "#0c0c0c"
+                    visible: !root.hasLegacyRateCenterAsset
+                }
+
+                Rectangle {
+                    id: rateSliderBar
+                    width: 2
+                    x: sliderTrack.x + 20 - width / 2
+                    y: Math.min(root.sliderCenterY(), root.sliderHandleCenterY())
+                    height: Math.abs(root.sliderCenterY() - root.sliderHandleCenterY())
+                    z: 1
+                    color: "#888888"
+                    radius: 1
+                    visible: height > 0.5
+                }
+
+                // Functional rate slider handle
+                Image {
+                    id: sliderHandle
+                    width: 34
+                    height: 18
+                    source: LateNightTheme.assetDeckRateSliderHandle
+                    fillMode: Image.PreserveAspectFit
+                    z: 2
+                    x: (sliderContainer.width - width) / 2
+
+                    // Map [ChannelN],rate directly so short Sync rate updates are reflected.
+                    y: {
+                        var trackTop = sliderTrack.y;
+                        var trackUsable = sliderTrack.height - sliderHandle.height;
+                        var parameter = root.rateValueToSliderParameter(rateProxy.value);
+                        return trackTop + (1.0 - parameter) * trackUsable;
+                    }
+                }
+
+                MouseArea {
+                    anchors.fill: sliderTrack
+                    property bool dragging: false
+
+                    function updateRate(mouseY) {
+                        var trackUsable = sliderTrack.height - sliderHandle.height;
+                        var halfHandle = sliderHandle.height / 2;
+                        var relY = mouseY - halfHandle;
+                        var normalized = 1.0 - Math.max(0, Math.min(1, relY / trackUsable));
+                        rateProxy.value = root.sliderParameterToRateValue(normalized);
+                    }
+
+                    onPressed: function(mouse) {
+                        dragging = true;
+                        updateRate(mouse.y);
+                    }
+                    onPositionChanged: function(mouse) {
+                        if (dragging) {
+                            updateRate(mouse.y);
+                        }
+                    }
+                    onReleased: {
+                        dragging = false;
+                    }
+
+                    // Double-click resets rate to default
+                    onDoubleClicked: {
+                        rateSetDefaultProxy.value = 1;
+                    }
+                }
+            }
+
+            // Rate direction buttons
+            ColumnLayout {
+                Layout.preferredWidth: 26
+                Layout.alignment: Qt.AlignVCenter
+                spacing: 2
+                visible: root.showRateControlButtons
+
+                // When rate_dir = 1 (up=faster): perm_up, temp_up, temp_down, perm_down
+                // When rate_dir = -1 (up=slower): perm_down, temp_down, temp_up, perm_up
+                // The icon order stays the same (minus, arrow-up, arrow-down, plus),
+                // but the bound keys swap to match the rate direction.
+
+                LateNightControlButton {
+                    Layout.preferredWidth: 26
+                    Layout.preferredHeight: 26
+                    backgroundSource: LateNightTheme.legacyTopRegionButton("square")
+                    iconSource: LateNightTheme.assetDeckMinusButton
+                    group: root.group
+                    key: rateDirProxy.value >= 0 ? "rate_perm_up" : "rate_perm_down"
+                    rightClickKey: rateDirProxy.value >= 0 ? "rate_perm_up_small" : "rate_perm_down_small"
+                    activeOpacity: 0.95
+                    inactiveOpacity: 0.76
+                    inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+                }
+
+                LateNightControlButton {
+                    Layout.preferredWidth: 26
+                    Layout.preferredHeight: 26
+                    backgroundSource: LateNightTheme.legacyTopRegionButton("square")
+                    iconSource: LateNightTheme.assetDeckArrowLeftUpButton
+                    group: root.group
+                    key: rateDirProxy.value >= 0 ? "rate_temp_up" : "rate_temp_down"
+                    rightClickKey: rateDirProxy.value >= 0 ? "rate_temp_up_small" : "rate_temp_down_small"
+                    activeOpacity: 0.95
+                    inactiveOpacity: 0.76
+                    inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+                }
+
+                LateNightControlButton {
+                    Layout.preferredWidth: 26
+                    Layout.preferredHeight: 26
+                    backgroundSource: LateNightTheme.legacyTopRegionButton("square")
+                    iconSource: LateNightTheme.assetDeckArrowRightDownButton
+                    group: root.group
+                    key: rateDirProxy.value >= 0 ? "rate_temp_down" : "rate_temp_up"
+                    rightClickKey: rateDirProxy.value >= 0 ? "rate_temp_down_small" : "rate_temp_up_small"
+                    activeOpacity: 0.95
+                    inactiveOpacity: 0.76
+                    inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+                }
+
+                LateNightControlButton {
+                    Layout.preferredWidth: 26
+                    Layout.preferredHeight: 26
+                    backgroundSource: LateNightTheme.legacyTopRegionButton("square")
+                    iconSource: LateNightTheme.assetDeckPlusButton
+                    group: root.group
+                    key: rateDirProxy.value >= 0 ? "rate_perm_down" : "rate_perm_up"
+                    rightClickKey: rateDirProxy.value >= 0 ? "rate_perm_down_small" : "rate_perm_up_small"
+                    activeOpacity: 0.95
+                    inactiveOpacity: 0.76
+                    inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+                }
+            }
+        }
+    }
+}

--- a/res/skins/LateNightQML/Deck/RatePlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/RatePlaceholder.qml
@@ -1,7 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import Mixxx 1.0 as Mixxx
-import Mixxx.Controls 1.0 as MixxxControls
+import "../../../qml" as Skin
 import "../LateNightTheme"
 
 Item {
@@ -45,12 +45,6 @@ Item {
         id: bpmProxy
         group: root.group
         key: "bpm"
-    }
-
-    Mixxx.ControlProxy {
-        id: rateProxy
-        group: root.group
-        key: "rate"
     }
 
     Mixxx.ControlProxy {
@@ -283,7 +277,7 @@ Item {
                     horizontalAlignment: Text.AlignRight
                 }
 
-                MixxxControls.Fader {
+                Skin.ControlFader {
                     id: rateSlider
                     x: 5
                     y: 2
@@ -293,26 +287,9 @@ Item {
                     barColor: "#888888"
                     barMargin: 7
                     barStart: 0.5
-                    from: -1
-                    to: 1
-                    value: rateProxy.value
-
-                    onMoved: function(value) {
-                        rateProxy.value = value;
-                    }
-
-                    TapHandler {
-                        onDoubleTapped: {
-                            rateSetDefaultProxy.value = 1;
-                        }
-                    }
-
-                    TapHandler {
-                        acceptedButtons: Qt.RightButton
-                        onTapped: {
-                            rateSetDefaultProxy.value = 1;
-                        }
-                    }
+                    defaultHandleVisible: false
+                    group: root.group
+                    key: "rate"
 
                     background: Image {
                         anchors.fill: parent

--- a/res/skins/LateNightQML/Deck/SpinnyCoverSlot.qml
+++ b/res/skins/LateNightQML/Deck/SpinnyCoverSlot.qml
@@ -1,0 +1,86 @@
+import QtQuick
+import Mixxx 1.0 as Mixxx
+import Mixxx.Controls 1.0 as MixxxControls
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    required property string group
+
+    readonly property var deckPlayer: Mixxx.PlayerManager.getPlayer(root.group)
+    readonly property var currentTrack: deckPlayer?.currentTrack
+    readonly property bool isLoaded: deckPlayer?.isLoaded ?? false
+
+    // Maintain a 1:1 aspect ratio (square)
+    width: height
+
+    Mixxx.ControlProxy {
+        id: showSpinniesProxy
+        group: "[Skin]"
+        key: "show_spinnies"
+    }
+
+    Mixxx.ControlProxy {
+        id: showCoverArtProxy
+        group: "[Skin]"
+        key: "show_coverart"
+    }
+
+    readonly property bool showSpinny: showSpinniesProxy.value > 0 || showCoverArtProxy.value <= 0
+    readonly property bool showCover: !showSpinny && showCoverArtProxy.value > 0
+
+    // Spinny Platter Mode
+    Item {
+        id: spinnyContainer
+        anchors.fill: parent
+        visible: root.showSpinny
+
+        // Platter Background
+        Image {
+            id: spinnyBg
+            anchors.fill: parent
+            source: LateNightTheme.assetDeckSpinnyBackground
+            fillMode: Image.PreserveAspectFit
+        }
+
+        // Rotating Platter Indicator (Active when track is loaded)
+        MixxxControls.Spinny {
+            id: spinnyIndicator
+            anchors.fill: parent
+            group: root.group
+            indicatorVisible: root.isLoaded
+
+            indicator: Image {
+                anchors.fill: parent
+                source: LateNightTheme.assetDeckSpinnyIndicator
+                fillMode: Image.PreserveAspectFit
+            }
+        }
+
+        // Vinyl Grooves Overlay (Mask)
+        Image {
+            id: spinnyMask
+            anchors.fill: parent
+            source: {
+                const isDeck12 = root.group === "[Channel1]" || root.group === "[Channel2]";
+                return isDeck12 ? LateNightTheme.assetDeckSpinnyMask12 : LateNightTheme.assetDeckSpinnyMask34;
+            }
+            fillMode: Image.PreserveAspectFit
+        }
+    }
+
+    // Cover Art Mode
+    Item {
+        id: coverArtContainer
+        anchors.fill: parent
+        visible: !root.showSpinny && root.showCover
+
+        Image {
+            id: coverArtImage
+            anchors.fill: parent
+            source: (root.isLoaded && currentTrack?.coverArtUrl) ? currentTrack.coverArtUrl : LateNightTheme.assetDeckCoverDefault
+            fillMode: Image.PreserveAspectFit
+        }
+    }
+}

--- a/res/skins/LateNightQML/Deck/TitleTimeRows.qml
+++ b/res/skins/LateNightQML/Deck/TitleTimeRows.qml
@@ -1,0 +1,172 @@
+import QtQuick
+import QtQuick.Layouts
+import Mixxx 1.0 as Mixxx
+import "../LateNightTheme"
+import "../../../qml/Deck" as SharedDeck
+
+Item {
+    id: root
+
+    required property string group
+
+    readonly property var deckPlayer: Mixxx.PlayerManager.getPlayer(root.group)
+    readonly property var currentTrack: deckPlayer?.currentTrack
+    readonly property bool isLoaded: deckPlayer?.isLoaded ?? false
+    readonly property bool useSecondaryDeckText: root.group === "[Channel3]" || root.group === "[Channel4]"
+    readonly property color loadedDeckTextColor: useSecondaryDeckText ? LateNightTheme.secondaryDeckTextColor : LateNightTheme.primaryDeckTextColor
+    readonly property var trackColor: currentTrack?.color
+    readonly property string trackColorText: trackColor ? trackColor.toString().toLowerCase() : ""
+    readonly property bool hasVisibleTrackColor: isLoaded && trackColor?.valid &&
+            trackColorText !== "#ffffff" && trackColorText !== "#ffffffff"
+
+    implicitHeight: 55
+
+    function formatDuration(value) {
+        if (!Number.isFinite(value) || value <= 0) {
+            return "";
+        }
+        const totalSeconds = Math.floor(value);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+        if (hours > 0) {
+            return hours.toString() + ":" +
+                    minutes.toString().padStart(2, "0") + ":" +
+                    seconds.toString().padStart(2, "0");
+        }
+        return minutes.toString() + ":" + seconds.toString().padStart(2, "0");
+    }
+
+    function formatTrackTime(value, coarse) {
+        if (!Number.isFinite(value)) {
+            value = 0;
+        }
+
+        const absoluteValue = Math.abs(value);
+        const totalSeconds = Math.floor(absoluteValue);
+        const centiseconds = Math.floor((absoluteValue - totalSeconds) * 100);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+        let text = hours > 0
+                ? hours.toString() + ":" + minutes.toString().padStart(2, "0") + ":" + seconds.toString().padStart(2, "0")
+                : minutes.toString() + ":" + seconds.toString().padStart(2, "0");
+
+        if (!coarse) {
+            text += "." + centiseconds.toString().padStart(2, "0");
+        }
+        return text;
+    }
+
+    function formatPositionTime() {
+        const elapsed = durationProxy.value * playpositionProxy.value;
+        const remaining = durationProxy.value * (1 - playpositionProxy.value);
+        const coarse = Mixxx.Config.controlTimeFormat === SharedDeck.TrackTime.Mode.TraditionalCoarse;
+        switch (Mixxx.Config.controlPositionDisplay) {
+        case SharedDeck.TrackTime.Display.Remaining:
+            return "-" + root.formatTrackTime(remaining, coarse);
+        case SharedDeck.TrackTime.Display.Both:
+            return root.formatTrackTime(elapsed, coarse) + "  -" + root.formatTrackTime(remaining, coarse);
+        case SharedDeck.TrackTime.Display.Elapsed:
+        default:
+            return root.formatTrackTime(elapsed, coarse);
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: durationProxy
+        group: root.group
+        key: "duration"
+    }
+
+    Mixxx.ControlProxy {
+        id: playpositionProxy
+        group: root.group
+        key: "playposition"
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // Row 1: Title and Elapsed/Remaining Time
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 25
+            spacing: 10
+
+            Text {
+                id: titleText
+                Layout.fillWidth: true
+                text: root.isLoaded ? (currentTrack?.title || "Unknown Title") : ""
+                font.family: "Open Sans"
+                font.pixelSize: 18
+                font.weight: Font.Normal
+                color: root.isLoaded ? root.loadedDeckTextColor : LateNightTheme.textColorMuted
+                elide: Text.ElideRight
+                verticalAlignment: Text.AlignVCenter
+            }
+
+            Text {
+                id: trackTimeDisplay
+                Layout.preferredWidth: 180
+                text: root.formatPositionTime()
+                font.family: "Open Sans"
+                font.pixelSize: 16
+                font.weight: Font.Normal
+                color: root.isLoaded ? LateNightTheme.deckTimeTextColor : LateNightTheme.textColorMuted
+                horizontalAlignment: Text.AlignRight
+                verticalAlignment: Text.AlignVCenter
+                visible: root.isLoaded
+            }
+        }
+
+        // Row 2: 2px Track Color Strip
+        Rectangle {
+            id: trackColorStrip
+            Layout.fillWidth: true
+            Layout.preferredHeight: 2
+            color: root.hasVisibleTrackColor ? root.trackColor : "transparent"
+            visible: root.hasVisibleTrackColor
+        }
+
+        // Spacer when color strip is invisible to keep height stable
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 2
+            color: LateNightTheme.deckPanelColor
+            visible: !trackColorStrip.visible
+        }
+
+        // Row 3: Artist and Duration
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 20
+            spacing: 10
+
+            Text {
+                id: artistText
+                Layout.fillWidth: true
+                text: root.isLoaded ? (currentTrack?.artist || "Unknown Artist") : ""
+                font.family: "Open Sans"
+                font.pixelSize: 18
+                font.weight: Font.Normal
+                color: root.isLoaded ? root.loadedDeckTextColor : LateNightTheme.textColorMuted
+                elide: Text.ElideRight
+                verticalAlignment: Text.AlignVCenter
+            }
+
+            Text {
+                id: durationText
+                Layout.preferredWidth: 180
+                text: root.isLoaded ? root.formatDuration(durationProxy.value) : ""
+                font.family: "Open Sans"
+                font.pixelSize: 14
+                font.weight: Font.Normal
+                color: root.isLoaded ? LateNightTheme.deckTimeTextColor : LateNightTheme.textColorMuted
+                horizontalAlignment: Text.AlignRight
+                verticalAlignment: Text.AlignVCenter
+            }
+        }
+    }
+}

--- a/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
+++ b/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
@@ -51,7 +51,7 @@ Item {
             anchors.top: parent.top
             anchors.right: parent.right
             height: 1
-            color: "#0a0a0a"
+            color: LateNightTheme.deckPanelBorderDark
         }
 
         Rectangle {
@@ -59,7 +59,7 @@ Item {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: 1
-            color: "#0a0a0a"
+            color: LateNightTheme.deckPanelBorderDark
         }
 
         Rectangle {

--- a/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
+++ b/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
@@ -100,7 +100,7 @@ Item {
             LateNightControlButton {
                 Layout.preferredWidth: 42
                 Layout.preferredHeight: 26
-                backgroundSource: LateNightTheme.legacySubRegionButton("medium")
+                backgroundSource: LateNightTheme.lateNightSubRegionButton("medium")
                 iconSource: LateNightTheme.assetDeckCueButton
                 group: root.group
                 key: "cue_default"
@@ -120,7 +120,7 @@ Item {
             LateNightControlButton {
                 Layout.preferredWidth: 26
                 Layout.preferredHeight: 26
-                backgroundSource: LateNightTheme.legacySubRegionButton("square")
+                backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
                 activeBackgroundSuffix: "active"
                 iconSource: LateNightTheme.assetDeckReverseButton
                 activeIconSuffix: LateNightTheme.playCueActiveIconSuffix
@@ -140,7 +140,7 @@ Item {
                 Layout.columnSpan: 2
                 Layout.preferredWidth: 68
                 Layout.preferredHeight: 26
-                backgroundSource: LateNightTheme.legacySubRegionButton("play")
+                backgroundSource: LateNightTheme.lateNightSubRegionButton("play")
                 iconSource: LateNightTheme.assetDeckPlayButton
                 group: root.group
                 key: "play"
@@ -172,10 +172,10 @@ Item {
             Repeater {
                 model: root.show8Hotcues ? 8 : 4
 
-                delegate: LegacyIconButton {
+                delegate: LateNightIconButton {
                     Layout.preferredWidth: 26
                     Layout.preferredHeight: 26
-                    iconSource: LateNightTheme.legacyButton("btn__" + (index + 1) + ".svg")
+                    iconSource: LateNightTheme.lateNightButton("btn__" + (index + 1) + ".svg")
                     contentOpacity: 1.0
                     inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
                 }
@@ -204,7 +204,7 @@ Item {
                     LateNightTheme.assetDeckOutroEndButton
                 ]
 
-                delegate: LegacyIconButton {
+                delegate: LateNightIconButton {
                     Layout.preferredWidth: 26
                     Layout.preferredHeight: 26
                     iconSource: modelData
@@ -228,7 +228,7 @@ Item {
             Layout.preferredHeight: 52
             visible: root.showLoopControls
 
-            LegacyIconButton {
+            LateNightIconButton {
                 Layout.preferredWidth: 26
                 Layout.preferredHeight: 26
                 iconSource: LateNightTheme.assetDeckLoopButton
@@ -251,7 +251,7 @@ Item {
                     LateNightTheme.assetDeckLoopAnchorStartButton
                 ]
 
-                delegate: LegacyIconButton {
+                delegate: LateNightIconButton {
                     Layout.preferredWidth: 26
                     Layout.preferredHeight: 26
                     iconSource: modelData
@@ -283,7 +283,7 @@ Item {
                 valueText: root.beatSizeText(beatjumpSizeProxy.value)
             }
 
-            LegacyIconButton {
+            LateNightIconButton {
                 Layout.preferredWidth: 26
                 Layout.preferredHeight: 26
                 iconSource: LateNightTheme.assetDeckBeatjumpLeftButton
@@ -291,7 +291,7 @@ Item {
                 inactiveColor: LateNightTheme.deckDimButtonInactiveColor
             }
 
-            LegacyIconButton {
+            LateNightIconButton {
                 Layout.preferredWidth: 26
                 Layout.preferredHeight: 26
                 iconSource: LateNightTheme.assetDeckBeatjumpRightButton

--- a/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
+++ b/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
@@ -67,7 +67,7 @@ Item {
             anchors.right: parent.right
             anchors.bottom: parent.bottom
             height: 1
-            color: "#333333"
+            color: LateNightTheme.deckPanelBorderLight
         }
 
         Rectangle {
@@ -75,7 +75,7 @@ Item {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: 1
-            color: "#333333"
+            color: LateNightTheme.deckPanelBorderLight
         }
     }
 

--- a/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
+++ b/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
@@ -1,0 +1,307 @@
+import QtQuick
+import QtQuick.Layouts
+import Mixxx 1.0 as Mixxx
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    required property string group
+    property bool show8Hotcues: true
+    property bool showBeatjumpControls: true
+    property bool showHotcues: true
+    property bool showIntroOutroCues: true
+    property bool showLoopControls: true
+
+    height: 55
+    clip: true
+
+    Mixxx.ControlProxy {
+        id: beatloopSizeProxy
+        group: root.group
+        key: "beatloop_size"
+    }
+
+    Mixxx.ControlProxy {
+        id: beatjumpSizeProxy
+        group: root.group
+        key: "beatjump_size"
+    }
+
+    function beatSizeText(value) {
+        if (value >= 1) {
+            return value.toFixed(0);
+        }
+        return value.toString();
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: "#151515"
+        visible: LateNightTheme.optionalDeckControlsBackgroundTile.toString().length > 0
+
+        Image {
+            anchors.fill: parent
+            source: LateNightTheme.optionalDeckControlsBackgroundTile
+            fillMode: Image.Tile
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.right: parent.right
+            height: 1
+            color: "#0a0a0a"
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: 1
+            color: "#0a0a0a"
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            height: 1
+            color: "#333333"
+        }
+
+        Rectangle {
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: 1
+            color: "#333333"
+        }
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: LateNightTheme.optionalDeckControlsBackgroundTile.toString().length > 0 ? 1 : 0
+        anchors.topMargin: LateNightTheme.optionalDeckControlsBackgroundTile.toString().length > 0 ? 1 : 0
+        anchors.rightMargin: LateNightTheme.optionalDeckControlsBackgroundTile.toString().length > 0 ? 1 : 0
+        anchors.bottomMargin: LateNightTheme.optionalDeckControlsBackgroundTile.toString().length > 0 ? 2 : 0
+        spacing: 6
+
+        GridLayout {
+            columns: 2
+            rows: 2
+            rowSpacing: 0
+            columnSpacing: 0
+            Layout.preferredWidth: 68
+            Layout.preferredHeight: 52
+
+            // Cue button: left-click = cue_default, right-click = cue_gotoandstop
+            // Display from cue_indicator
+            LateNightControlButton {
+                Layout.preferredWidth: 42
+                Layout.preferredHeight: 26
+                backgroundSource: LateNightTheme.legacySubRegionButton("medium")
+                iconSource: LateNightTheme.assetDeckCueButton
+                group: root.group
+                key: "cue_default"
+                rightClickKey: "cue_gotoandstop"
+                displayKey: "cue_indicator"
+                activeOpacity: 1.0
+                inactiveOpacity: 0.82
+                activeBackgroundSuffix: "set"
+                pressedBackgroundSuffix: "active"
+                activeIconSuffix: LateNightTheme.playCueActiveIconSuffix
+                pressedIconSuffix: LateNightTheme.playCueActiveIconSuffix
+                activeColor: LateNightTheme.activePlayCueColor
+                pressedActivatesFill: true
+            }
+
+            // Reverse button: left-click = reverse, right-click = reverseroll
+            LateNightControlButton {
+                Layout.preferredWidth: 26
+                Layout.preferredHeight: 26
+                backgroundSource: LateNightTheme.legacySubRegionButton("square")
+                activeBackgroundSuffix: "active"
+                iconSource: LateNightTheme.assetDeckReverseButton
+                activeIconSuffix: LateNightTheme.playCueActiveIconSuffix
+                stretchIcon: true
+                group: root.group
+                key: "reverse"
+                rightClickKey: "reverseroll"
+                activeOpacity: 1.0
+                inactiveOpacity: 0.82
+                activeColor: LateNightTheme.activePlayCueColor
+            }
+
+            // Play button: left-click = play (toggle via play_latched),
+            //              right-click = cue_set
+            //              Display from play_indicator
+            LateNightControlButton {
+                Layout.columnSpan: 2
+                Layout.preferredWidth: 68
+                Layout.preferredHeight: 26
+                backgroundSource: LateNightTheme.legacySubRegionButton("play")
+                iconSource: LateNightTheme.assetDeckPlayButton
+                group: root.group
+                key: "play"
+                rightClickKey: "cue_set"
+                displayKey: "play_indicator"
+                toggleable: true
+                activeOpacity: 1.0
+                inactiveOpacity: 0.82
+                activeBackgroundSuffix: "active"
+                activeIconSuffix: LateNightTheme.playCueActiveIconSuffix
+                activeColor: LateNightTheme.activePlayCueColor
+            }
+        }
+
+        Item {
+            Layout.preferredWidth: 4
+        }
+
+        // Hotcue controls (behavior in progress)
+        GridLayout {
+            columns: root.show8Hotcues ? 4 : 2
+            rows: 2
+            rowSpacing: 0
+            columnSpacing: 0
+            Layout.preferredWidth: root.show8Hotcues ? 104 : 52
+            Layout.preferredHeight: 52
+            visible: root.showHotcues
+
+            Repeater {
+                model: root.show8Hotcues ? 8 : 4
+
+                delegate: LegacyIconButton {
+                    Layout.preferredWidth: 26
+                    Layout.preferredHeight: 26
+                    iconSource: LateNightTheme.legacyButton("btn__" + (index + 1) + ".svg")
+                    contentOpacity: 1.0
+                    inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+                }
+            }
+        }
+
+        Item {
+            Layout.preferredWidth: 4
+        }
+
+        // Intro/Outro controls (behavior in progress)
+        GridLayout {
+            columns: 2
+            rows: 2
+            rowSpacing: 0
+            columnSpacing: 0
+            Layout.preferredWidth: 52
+            Layout.preferredHeight: 52
+            visible: root.showIntroOutroCues
+
+            Repeater {
+                model: [
+                    LateNightTheme.assetDeckIntroStartButton,
+                    LateNightTheme.assetDeckIntroEndButton,
+                    LateNightTheme.assetDeckOutroStartButton,
+                    LateNightTheme.assetDeckOutroEndButton
+                ]
+
+                delegate: LegacyIconButton {
+                    Layout.preferredWidth: 26
+                    Layout.preferredHeight: 26
+                    iconSource: modelData
+                    contentOpacity: 0.72
+                    inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+                }
+            }
+        }
+
+        Item {
+            Layout.preferredWidth: 8
+        }
+
+        // Loop controls (behavior in progress)
+        GridLayout {
+            columns: 4
+            rows: 2
+            rowSpacing: 0
+            columnSpacing: 0
+            Layout.preferredWidth: 104
+            Layout.preferredHeight: 52
+            visible: root.showLoopControls
+
+            LegacyIconButton {
+                Layout.preferredWidth: 26
+                Layout.preferredHeight: 26
+                iconSource: LateNightTheme.assetDeckLoopButton
+                contentOpacity: 0.82
+                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+            }
+
+            BeatSpinBoxPlaceholder {
+                Layout.columnSpan: 3
+                Layout.preferredWidth: 78
+                Layout.preferredHeight: 26
+                valueText: root.beatSizeText(beatloopSizeProxy.value)
+            }
+
+            Repeater {
+                model: [
+                    LateNightTheme.assetDeckReloopButton,
+                    LateNightTheme.assetDeckLoopInButton,
+                    LateNightTheme.assetDeckLoopOutButton,
+                    LateNightTheme.assetDeckLoopAnchorStartButton
+                ]
+
+                delegate: LegacyIconButton {
+                    Layout.preferredWidth: 26
+                    Layout.preferredHeight: 26
+                    iconSource: modelData
+                    contentOpacity: 0.78
+                    inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+                }
+            }
+        }
+
+        Item {
+            Layout.preferredWidth: 8
+        }
+
+        // Beatjump controls (behavior in progress)
+        GridLayout {
+            columns: 2
+            rows: 2
+            rowSpacing: 0
+            columnSpacing: 0
+            Layout.preferredWidth: 60
+            Layout.preferredHeight: 52
+            visible: root.showBeatjumpControls
+
+            BeatSpinBoxPlaceholder {
+                Layout.columnSpan: 2
+                Layout.preferredWidth: 60
+                Layout.preferredHeight: 26
+                preferredWidth: 60
+                valueText: root.beatSizeText(beatjumpSizeProxy.value)
+            }
+
+            LegacyIconButton {
+                Layout.preferredWidth: 26
+                Layout.preferredHeight: 26
+                iconSource: LateNightTheme.assetDeckBeatjumpLeftButton
+                contentOpacity: 0.82
+                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+            }
+
+            LegacyIconButton {
+                Layout.preferredWidth: 26
+                Layout.preferredHeight: 26
+                iconSource: LateNightTheme.assetDeckBeatjumpRightButton
+                contentOpacity: 0.82
+                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+            }
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+    }
+}

--- a/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
+++ b/res/skins/LateNightQML/Deck/TransportLoopBeatjumpPlaceholders.qml
@@ -215,7 +215,12 @@ Item {
         }
 
         Item {
-            Layout.preferredWidth: 8
+            Layout.preferredWidth: 2
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.maximumWidth: 80
         }
 
         // Loop controls (behavior in progress)
@@ -262,7 +267,12 @@ Item {
         }
 
         Item {
-            Layout.preferredWidth: 8
+            Layout.preferredWidth: 2
+        }
+
+        Item {
+            Layout.fillWidth: true
+            Layout.maximumWidth: 80
         }
 
         // Beatjump controls (behavior in progress)

--- a/res/skins/LateNightQML/Deck/VinylControlsPlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/VinylControlsPlaceholder.qml
@@ -36,7 +36,7 @@ Item {
 
             Image {
                 anchors.fill: parent
-                source: LateNightTheme.legacyTopRegionButton("medium")
+                source: LateNightTheme.lateNightTopRegionButton("medium")
                 fillMode: Image.Stretch
                 opacity: vinylEnabledProxy.value > 0 ? 0.95 : 0.72
             }
@@ -74,7 +74,7 @@ Item {
         LateNightCycleButton {
             Layout.preferredWidth: 46
             Layout.preferredHeight: 20
-            backgroundSource: LateNightTheme.legacyTopRegionButton("medium")
+            backgroundSource: LateNightTheme.lateNightTopRegionButton("medium")
             inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
             group: root.group
             key: "vinylcontrol_mode"
@@ -86,7 +86,7 @@ Item {
         LateNightCycleButton {
             Layout.preferredWidth: 32
             Layout.preferredHeight: 20
-            backgroundSource: LateNightTheme.legacyTopRegionButton("medium")
+            backgroundSource: LateNightTheme.lateNightTopRegionButton("medium")
             inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
             group: root.group
             key: "vinylcontrol_cueing"
@@ -98,7 +98,7 @@ Item {
         LateNightControlButton {
             Layout.preferredWidth: 35
             Layout.preferredHeight: 20
-            backgroundSource: LateNightTheme.legacyTopRegionButton("medium")
+            backgroundSource: LateNightTheme.lateNightTopRegionButton("medium")
             label: "PASS"
             labelPixelSize: 9
             inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor

--- a/res/skins/LateNightQML/Deck/VinylControlsPlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/VinylControlsPlaceholder.qml
@@ -1,0 +1,113 @@
+import QtQuick
+import QtQuick.Layouts
+import Mixxx 1.0 as Mixxx
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    required property string group
+
+    implicitWidth: 158
+    implicitHeight: 20
+
+    Mixxx.ControlProxy {
+        id: vinylEnabledProxy
+        group: root.group
+        key: "vinylcontrol_enabled"
+    }
+
+    Mixxx.ControlProxy {
+        id: vinylStatusProxy
+        group: root.group
+        key: "vinylcontrol_status"
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        spacing: 0
+
+        // Vinyl enable/disable toggle with status display.
+        // Left-click toggles vinylcontrol_enabled.
+        // Display shows vinylcontrol_status (0=off, 1=ok, 2=speed, 3=both ok).
+        Item {
+            Layout.preferredWidth: 40
+            Layout.preferredHeight: 20
+
+            Image {
+                anchors.fill: parent
+                source: LateNightTheme.legacyTopRegionButton("medium")
+                fillMode: Image.Stretch
+                opacity: vinylEnabledProxy.value > 0 ? 0.95 : 0.72
+            }
+
+            Image {
+                anchors.centerIn: parent
+                width: Math.min(parent.width, sourceSize.width > 0 ? sourceSize.width / 2 : parent.width)
+                height: Math.min(parent.height, sourceSize.height > 0 ? sourceSize.height / 2 : parent.height)
+                source: {
+                    var status = Math.round(vinylStatusProxy.value);
+                    switch (status) {
+                    case 1:
+                        return LateNightTheme.assetDeckVinylControl1;
+                    case 2:
+                        return LateNightTheme.assetDeckVinylControl2;
+                    case 3:
+                        return LateNightTheme.assetDeckVinylControl3;
+                    default:
+                        return LateNightTheme.assetDeckVinylControl0;
+                    }
+                }
+                fillMode: Image.PreserveAspectFit
+                opacity: vinylEnabledProxy.value > 0 ? 0.95 : 0.72
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    vinylEnabledProxy.value = !vinylEnabledProxy.value;
+                }
+            }
+        }
+
+        // Vinyl mode: cycles ABS(0) → REL(1) → CONST(2) → ABS(0)
+        LateNightCycleButton {
+            Layout.preferredWidth: 46
+            Layout.preferredHeight: 20
+            backgroundSource: LateNightTheme.legacyTopRegionButton("medium")
+            inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+            group: root.group
+            key: "vinylcontrol_mode"
+            numStates: 3
+            stateLabels: ["ABS", "REL", "CONST"]
+        }
+
+        // Vinyl cueing: cycles CUE(0) → CUE(1) → HOT(2) → CUE(0)
+        LateNightCycleButton {
+            Layout.preferredWidth: 32
+            Layout.preferredHeight: 20
+            backgroundSource: LateNightTheme.legacyTopRegionButton("medium")
+            inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+            group: root.group
+            key: "vinylcontrol_cueing"
+            numStates: 3
+            stateLabels: ["CUE", "CUE", "HOT"]
+        }
+
+        // Passthrough toggle
+        LateNightControlButton {
+            Layout.preferredWidth: 35
+            Layout.preferredHeight: 20
+            backgroundSource: LateNightTheme.legacyTopRegionButton("medium")
+            label: "PASS"
+            labelPixelSize: 9
+            inactiveColor: LateNightTheme.deckEmbeddedButtonInactiveColor
+            group: root.group
+            key: "passthrough"
+            toggleable: true
+            activeOpacity: 0.95
+            inactiveOpacity: 0.72
+            activeOverlayColor: LateNightTheme.accentColor
+        }
+    }
+}

--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -35,6 +35,7 @@ QtObject {
     readonly property color textColor: white
     readonly property color textColorMuted: "#696969"
     readonly property color primaryDeckTextColor: isClassic ? "#f0bb2b" : "#c2b3a5"
+    readonly property color overviewSettingsBackgroundColor: isClassic ? "#151515" : "#19191a"
     readonly property color primaryOverviewBackgroundColor: isClassic ? "#0f0f0f" : "#19191a"
     readonly property color primaryWaveformSignalColor: isClassic ? "#e7c413" : "#d9b28c"
     readonly property color secondaryDeckTextColor: isClassic ? "#0bd9d1" : "#85bdbb"

--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -23,6 +23,8 @@ QtObject {
     readonly property color deckPanelColor: "#1e1e20"
     readonly property color deckPanelBorderDark: "#0c0c0c"
     readonly property color deckPanelBorderLight: "#333333"
+    readonly property color deckPanelBorderLeft: "#282828"
+    readonly property color deckPanelBorderRight: deckTopRowBackgroundColor
     readonly property color overviewBorderTopColor: "#0d0d0d"
     readonly property color overviewBorderLeftColor: "#121212"
     readonly property color overviewBorderBottomColor: "#2a2a2a"

--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -19,9 +19,14 @@ QtObject {
     readonly property color deckEmbeddedButtonInactiveColor: isClassic ? "#262626" : "#1e1e20"
     readonly property color deckBeatSpinBoxTextColor: isClassic ? "#888888" : "#a7998b"
     readonly property color deckReadonlyTextColor: isClassic ? "#888888" : "#777777"
+    readonly property color deckTopRowBackgroundColor: "#181818"
     readonly property color deckPanelColor: "#1e1e20"
     readonly property color deckPanelBorderDark: "#0c0c0c"
     readonly property color deckPanelBorderLight: "#333333"
+    readonly property color overviewBorderTopColor: "#0d0d0d"
+    readonly property color overviewBorderLeftColor: "#121212"
+    readonly property color overviewBorderBottomColor: "#2a2a2a"
+    readonly property color overviewBorderRightColor: "#252525"
     readonly property color libraryPanelSplitterBackground: "#1e1e1e"
     readonly property color libraryPanelSplitterHandle: "#5f5f5f"
     readonly property color libraryPanelSplitterHandleActive: "#7a7a7a"
@@ -48,86 +53,86 @@ QtObject {
     readonly property string playCueActiveIconSuffix: isPaleMoon ? "active" : ""
     readonly property color white: "#D9D9D9"
 
-    readonly property url assetDeckArrowLeftUpButton: legacyAsset("buttons", "btn__arrow_left_up.svg")
-    readonly property url assetDeckArrowRightDownButton: legacyAsset("buttons", "btn__arrow_right_down.svg")
-    readonly property url assetDeckBeatjumpLeftButton: legacyAsset("buttons", "btn__beatjump_left.svg")
-    readonly property url assetDeckBeatjumpRightButton: legacyAsset("buttons", "btn__beatjump_right.svg")
-    readonly property url assetDeckBeatSpinBoxBorder: isClassic ? legacyAsset("buttons", "spinbox_elevated_border.svg") : legacySubRegionButton("wide")
-    readonly property url assetDeckBeatSpinBoxDownButton: isClassic ? legacyAsset("buttons", "spinbox_down.svg") : legacyAsset("buttons", "btn__spinbox_down.svg")
-    readonly property url assetDeckBeatSpinBoxUpButton: isClassic ? legacyAsset("buttons", "spinbox_up.svg") : legacyAsset("buttons", "btn__spinbox_up.svg")
-    readonly property url optionalDeckControlsBackgroundTile: isClassic ? legacyAsset("style", "background_tile.png") : ""
-    readonly property url assetDeckCoverDefault: legacyAsset("style", "cover_default.svg")
-    readonly property url assetDeckBeatCurposButton: legacyAsset("buttons", "btn__beat_curpos.svg")
-    readonly property url assetDeckCueButton: legacyAsset("buttons", "btn__cue_deck.svg")
-    readonly property url assetDeckEjectButton: legacyAsset("buttons", "btn__eject.svg")
-    readonly property url assetDeckIntroEndButton: legacyAsset("buttons", "btn__intro_end.svg")
-    readonly property url assetDeckIntroStartButton: legacyAsset("buttons", "btn__intro_start.svg")
-    readonly property url assetDeckKeyDownButton: legacyAsset("buttons", "btn__key_down.svg")
-    readonly property url assetDeckKeylockButton: legacyAsset("buttons", "btn__keylock.svg")
-    readonly property url assetDeckKeyMatchButton: legacyAsset("buttons", "btn__key_match.svg")
-    readonly property url assetDeckKeyUpButton: legacyAsset("buttons", "btn__key_up.svg")
-    readonly property url assetDeckKeyButtonBackground: legacyAsset("buttons", "btn_embedded_library.svg")
-    readonly property url assetDeckLeaderBackground: legacyAsset("buttons", "btn_embedded_grid.svg")
-    readonly property url assetDeckLeaderButton: legacyAsset("buttons", "btn__sync_leader.svg")
-    readonly property url assetDeckLeaderExplicitButton: isPaleMoon ? legacyAsset("buttons", "btn__sync_leader_explicit.svg") : legacyAsset("buttons", "btn__sync_leader_active.svg")
-    readonly property url assetDeckLeaderImplicitButton: isPaleMoon ? legacyAsset("buttons", "btn__sync_leader_implicit.svg") : legacyAsset("buttons", "btn__sync_leader_active.svg")
-    readonly property url assetDeckLoopButton: legacyAsset("buttons", "btn__loop.svg")
-    readonly property url assetDeckLoopAnchorEndButton: legacyAsset("buttons", "btn__loop_anchor_end.svg")
-    readonly property url assetDeckLoopAnchorStartButton: legacyAsset("buttons", "btn__loop_anchor_start.svg")
-    readonly property url assetDeckLoopInButton: legacyAsset("buttons", "btn__loop_in.svg")
-    readonly property url assetDeckLoopOutButton: legacyAsset("buttons", "btn__loop_out.svg")
-    readonly property url assetDeckMinusButton: legacyAsset("buttons", "btn__minus.svg")
-    readonly property url assetDeckOutroEndButton: legacyAsset("buttons", "btn__outro_end.svg")
-    readonly property url assetDeckOutroStartButton: legacyAsset("buttons", "btn__outro_start.svg")
-    readonly property url assetDeckPlayButton: legacyAsset("buttons", "btn__play_deck.svg")
-    readonly property url assetDeckPlusButton: legacyAsset("buttons", "btn__plus.svg")
-    readonly property url assetDeckQuantizeButton: legacyAsset("buttons", "btn__quantize.svg")
-    readonly property url optionalDeckRateCenterActive: isPaleMoon ? legacyAsset("buttons", "btn__rate_center_cyan.svg") : ""
-    readonly property url optionalDeckRateCenterInactive: isPaleMoon ? legacyAsset("buttons", "btn__rate_center_off.svg") : ""
-    readonly property url assetDeckRateSliderBackground: legacyAsset("sliders", "slider_pitch_deck.svg")
-    readonly property url assetDeckRateSliderHandle: legacyAsset("sliders", "knob_pitch_deck.svg")
-    readonly property url assetDeckReloopButton: legacyAsset("buttons", "btn__reloop.svg")
-    readonly property url assetDeckRepeatButton: legacyAsset("buttons", "btn__repeat.svg")
-    readonly property url assetDeckReverseButton: legacyAsset("buttons", "btn__reverse.svg")
-    readonly property url assetDeckSettingsOffButton: legacyAsset("buttons", "btn__settings_off.svg")
-    readonly property url assetDeckSettingsOnButton: legacyAsset("buttons", "btn__settings_on.svg")
-    readonly property url assetDeckSlipButton: legacyAsset("buttons", "btn__slip.svg")
-    readonly property url assetDeckSpinnyBackground: legacyAsset("style", "spinny_bg.svg")
-    readonly property url assetDeckSpinnyGhostIndicator: legacyAsset("style", "spinny_indicator_ghost.svg")
-    readonly property url assetDeckSpinnyIndicator: legacyAsset("style", "spinny_indicator.svg")
-    readonly property url assetDeckSpinnyMask12: legacyAsset("style", "spinny_mask_12.svg")
-    readonly property url assetDeckSpinnyMask34: legacyAsset("style", "spinny_mask_34.svg")
-    readonly property url assetDeckSyncBackground: legacyAsset("buttons", "btn_embedded_library.svg")
-    readonly property url assetDeckSyncButton: legacyAsset("buttons", "btn__sync_deck.svg")
-    readonly property url assetDeckSyncActiveButton: isPaleMoon ? legacyAsset("buttons", "btn__sync_deck_active.svg") : legacyAsset("buttons", "btn__sync_deck.svg")
-    readonly property url assetDeckVolumeSliderBackground: legacyAsset("sliders", "slider_volume_deck.svg")
-    readonly property url assetDeckVolumeSliderHandle: legacyAsset("sliders", "knob_volume_deck.svg")
-    readonly property url assetDeckVinylControl0: legacyAsset("style", "vinyl_control_0.svg")
-    readonly property url assetDeckVinylControl1: legacyAsset("style", "vinyl_control_1.svg")
-    readonly property url assetDeckVinylControl2: legacyAsset("style", "vinyl_control_2.svg")
-    readonly property url assetDeckVinylControl3: legacyAsset("style", "vinyl_control_3.svg")
-    readonly property url assetFxKnobBackground: legacyAsset("knobs", "knob_bg_fx.svg")
-    readonly property url assetMainKnobBackground: legacyAsset("knobs", "knob_bg_main.svg")
-    readonly property url assetRegularKnobBackground: legacyAsset("knobs", "knob_bg_regular.svg")
-    readonly property url assetSmallKnobBackground: legacyAsset("knobs", "knob_bg_small.svg")
+    readonly property url assetDeckArrowLeftUpButton: lateNightAsset("buttons", "btn__arrow_left_up.svg")
+    readonly property url assetDeckArrowRightDownButton: lateNightAsset("buttons", "btn__arrow_right_down.svg")
+    readonly property url assetDeckBeatjumpLeftButton: lateNightAsset("buttons", "btn__beatjump_left.svg")
+    readonly property url assetDeckBeatjumpRightButton: lateNightAsset("buttons", "btn__beatjump_right.svg")
+    readonly property url assetDeckBeatSpinBoxBorder: isClassic ? lateNightAsset("buttons", "spinbox_elevated_border.svg") : lateNightSubRegionButton("wide")
+    readonly property url assetDeckBeatSpinBoxDownButton: isClassic ? lateNightAsset("buttons", "spinbox_down.svg") : lateNightAsset("buttons", "btn__spinbox_down.svg")
+    readonly property url assetDeckBeatSpinBoxUpButton: isClassic ? lateNightAsset("buttons", "spinbox_up.svg") : lateNightAsset("buttons", "btn__spinbox_up.svg")
+    readonly property url optionalDeckControlsBackgroundTile: isClassic ? lateNightAsset("style", "background_tile.png") : ""
+    readonly property url assetDeckCoverDefault: lateNightAsset("style", "cover_default.svg")
+    readonly property url assetDeckBeatCurposButton: lateNightAsset("buttons", "btn__beat_curpos.svg")
+    readonly property url assetDeckCueButton: lateNightAsset("buttons", "btn__cue_deck.svg")
+    readonly property url assetDeckEjectButton: lateNightAsset("buttons", "btn__eject.svg")
+    readonly property url assetDeckIntroEndButton: lateNightAsset("buttons", "btn__intro_end.svg")
+    readonly property url assetDeckIntroStartButton: lateNightAsset("buttons", "btn__intro_start.svg")
+    readonly property url assetDeckKeyDownButton: lateNightAsset("buttons", "btn__key_down.svg")
+    readonly property url assetDeckKeylockButton: lateNightAsset("buttons", "btn__keylock.svg")
+    readonly property url assetDeckKeyMatchButton: lateNightAsset("buttons", "btn__key_match.svg")
+    readonly property url assetDeckKeyUpButton: lateNightAsset("buttons", "btn__key_up.svg")
+    readonly property url assetDeckKeyButtonBackground: lateNightAsset("buttons", "btn_embedded_library.svg")
+    readonly property url assetDeckLeaderBackground: lateNightAsset("buttons", "btn_embedded_grid.svg")
+    readonly property url assetDeckLeaderButton: lateNightAsset("buttons", "btn__sync_leader.svg")
+    readonly property url assetDeckLeaderExplicitButton: isPaleMoon ? lateNightAsset("buttons", "btn__sync_leader_explicit.svg") : lateNightAsset("buttons", "btn__sync_leader_active.svg")
+    readonly property url assetDeckLeaderImplicitButton: isPaleMoon ? lateNightAsset("buttons", "btn__sync_leader_implicit.svg") : lateNightAsset("buttons", "btn__sync_leader_active.svg")
+    readonly property url assetDeckLoopButton: lateNightAsset("buttons", "btn__loop.svg")
+    readonly property url assetDeckLoopAnchorEndButton: lateNightAsset("buttons", "btn__loop_anchor_end.svg")
+    readonly property url assetDeckLoopAnchorStartButton: lateNightAsset("buttons", "btn__loop_anchor_start.svg")
+    readonly property url assetDeckLoopInButton: lateNightAsset("buttons", "btn__loop_in.svg")
+    readonly property url assetDeckLoopOutButton: lateNightAsset("buttons", "btn__loop_out.svg")
+    readonly property url assetDeckMinusButton: lateNightAsset("buttons", "btn__minus.svg")
+    readonly property url assetDeckOutroEndButton: lateNightAsset("buttons", "btn__outro_end.svg")
+    readonly property url assetDeckOutroStartButton: lateNightAsset("buttons", "btn__outro_start.svg")
+    readonly property url assetDeckPlayButton: lateNightAsset("buttons", "btn__play_deck.svg")
+    readonly property url assetDeckPlusButton: lateNightAsset("buttons", "btn__plus.svg")
+    readonly property url assetDeckQuantizeButton: lateNightAsset("buttons", "btn__quantize.svg")
+    readonly property url optionalDeckRateCenterActive: isPaleMoon ? lateNightAsset("buttons", "btn__rate_center_cyan.svg") : ""
+    readonly property url optionalDeckRateCenterInactive: isPaleMoon ? lateNightAsset("buttons", "btn__rate_center_off.svg") : ""
+    readonly property url assetDeckRateSliderBackground: lateNightAsset("sliders", "slider_pitch_deck.svg")
+    readonly property url assetDeckRateSliderHandle: lateNightAsset("sliders", "knob_pitch_deck.svg")
+    readonly property url assetDeckReloopButton: lateNightAsset("buttons", "btn__reloop.svg")
+    readonly property url assetDeckRepeatButton: lateNightAsset("buttons", "btn__repeat.svg")
+    readonly property url assetDeckReverseButton: lateNightAsset("buttons", "btn__reverse.svg")
+    readonly property url assetDeckSettingsOffButton: lateNightAsset("buttons", "btn__settings_off.svg")
+    readonly property url assetDeckSettingsOnButton: lateNightAsset("buttons", "btn__settings_on.svg")
+    readonly property url assetDeckSlipButton: lateNightAsset("buttons", "btn__slip.svg")
+    readonly property url assetDeckSpinnyBackground: lateNightAsset("style", "spinny_bg.svg")
+    readonly property url assetDeckSpinnyGhostIndicator: lateNightAsset("style", "spinny_indicator_ghost.svg")
+    readonly property url assetDeckSpinnyIndicator: lateNightAsset("style", "spinny_indicator.svg")
+    readonly property url assetDeckSpinnyMask12: lateNightAsset("style", "spinny_mask_12.svg")
+    readonly property url assetDeckSpinnyMask34: lateNightAsset("style", "spinny_mask_34.svg")
+    readonly property url assetDeckSyncBackground: lateNightAsset("buttons", "btn_embedded_library.svg")
+    readonly property url assetDeckSyncButton: lateNightAsset("buttons", "btn__sync_deck.svg")
+    readonly property url assetDeckSyncActiveButton: isPaleMoon ? lateNightAsset("buttons", "btn__sync_deck_active.svg") : lateNightAsset("buttons", "btn__sync_deck.svg")
+    readonly property url assetDeckVolumeSliderBackground: lateNightAsset("sliders", "slider_volume_deck.svg")
+    readonly property url assetDeckVolumeSliderHandle: lateNightAsset("sliders", "knob_volume_deck.svg")
+    readonly property url assetDeckVinylControl0: lateNightAsset("style", "vinyl_control_0.svg")
+    readonly property url assetDeckVinylControl1: lateNightAsset("style", "vinyl_control_1.svg")
+    readonly property url assetDeckVinylControl2: lateNightAsset("style", "vinyl_control_2.svg")
+    readonly property url assetDeckVinylControl3: lateNightAsset("style", "vinyl_control_3.svg")
+    readonly property url assetFxKnobBackground: lateNightAsset("knobs", "knob_bg_fx.svg")
+    readonly property url assetMainKnobBackground: lateNightAsset("knobs", "knob_bg_main.svg")
+    readonly property url assetRegularKnobBackground: lateNightAsset("knobs", "knob_bg_regular.svg")
+    readonly property url assetSmallKnobBackground: lateNightAsset("knobs", "knob_bg_small.svg")
 
-    function legacyButton(fileName) {
-        return legacyAsset("buttons", fileName);
+    function lateNightButton(fileName) {
+        return lateNightAsset("buttons", fileName);
     }
 
-    function legacyRegionButton(regionButtonType, buttonSize) {
-        return legacyButton("btn_" + regionButtonType + "_" + buttonSize + ".svg");
+    function lateNightRegionButton(regionButtonType, buttonSize) {
+        return lateNightButton("btn_" + regionButtonType + "_" + buttonSize + ".svg");
     }
 
-    function legacySubRegionButton(buttonSize) {
-        return legacyRegionButton(isClassic ? "elevated" : "embedded", buttonSize);
+    function lateNightSubRegionButton(buttonSize) {
+        return lateNightRegionButton(isClassic ? "elevated" : "embedded", buttonSize);
     }
 
-    function legacyTopRegionButton(buttonSize) {
-        return legacyRegionButton("embedded", buttonSize);
+    function lateNightTopRegionButton(buttonSize) {
+        return lateNightRegionButton("embedded", buttonSize);
     }
 
-    function legacyAsset(directory, fileName) {
+    function lateNightAsset(directory, fileName) {
         return Qt.resolvedUrl("../../LateNight/" + ColorScheme.name + "/" + directory + "/" + fileName);
     }
 

--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -3,44 +3,129 @@ import QtQuick
 import "."
 
 QtObject {
+    readonly property bool isClassic: ColorScheme.name === "classic"
+    readonly property bool isPaleMoon: ColorScheme.name === "palemoon"
+
     readonly property color backgroundColor: "#1e1e1e"
     readonly property color buttonActiveColor: white
     readonly property color buttonNormalColor: "#696969"
     readonly property color buttonPressedColor: white
     readonly property color darkGray: "#0f0f0f"
     readonly property color accentColor: ColorScheme.accentColor
+    readonly property color activePlayCueColor: isClassic ? "#db0000" : "#b24c12"
+    readonly property color deckTimeTextColor: isClassic ? "#f0bb2b" : "#777777"
+    readonly property color deckButtonInactiveColor: isClassic ? "#262626" : "#121213"
+    readonly property color deckDimButtonInactiveColor: isClassic ? "#262626" : "#171719"
+    readonly property color deckEmbeddedButtonInactiveColor: isClassic ? "#262626" : "#1e1e20"
+    readonly property color deckBeatSpinBoxTextColor: isClassic ? "#888888" : "#a7998b"
+    readonly property color deckReadonlyTextColor: isClassic ? "#888888" : "#777777"
+    readonly property color deckPanelColor: "#1e1e20"
+    readonly property color deckPanelBorderDark: "#0c0c0c"
+    readonly property color deckPanelBorderLight: "#333333"
     readonly property color libraryPanelSplitterBackground: "#1e1e1e"
     readonly property color libraryPanelSplitterHandle: "#5f5f5f"
     readonly property color libraryPanelSplitterHandleActive: "#7a7a7a"
     readonly property color textColor: white
+    readonly property color textColorMuted: "#696969"
+    readonly property color primaryDeckTextColor: isClassic ? "#f0bb2b" : "#c2b3a5"
+    readonly property color primaryOverviewBackgroundColor: isClassic ? "#0f0f0f" : "#19191a"
+    readonly property color primaryWaveformSignalColor: isClassic ? "#e7c413" : "#d9b28c"
+    readonly property color secondaryDeckTextColor: isClassic ? "#0bd9d1" : "#85bdbb"
+    readonly property color secondaryOverviewBackgroundColor: "#001b23"
+    readonly property color secondaryWaveformSignalColor: isClassic ? "#09b2ae" : "#7bc6c3"
+    readonly property color starsColor12: isClassic ? "#f0bb2b" : "#988f86"
+    readonly property color starsColor34: isClassic ? "#0bd9d1" : "#559b99"
     readonly property color toolbarActiveColor: white
     readonly property color toolbarBackgroundColor: "#242424"
     readonly property int toolbarButtonHeight: 26
     readonly property int toolbarButtonWidth: 52
+    readonly property color syncExplicitLeaderColor: activePlayCueColor
+    readonly property color syncInactiveBackgroundColor: "#1e1e1e"
+    readonly property color syncImplicitLeaderColor: isPaleMoon ? "#7d350d" : "#db7700"
+    readonly property int syncButtonHorizontalPadding: isClassic ? 3 : 0
+    readonly property color keyControlsPressedColor: isPaleMoon ? "#7d350d" : "#db0000"
+    readonly property string keyControlsPressedIconSuffix: isPaleMoon ? "active" : ""
+    readonly property string playCueActiveIconSuffix: isPaleMoon ? "active" : ""
     readonly property color white: "#D9D9D9"
 
+    readonly property url assetDeckArrowLeftUpButton: legacyAsset("buttons", "btn__arrow_left_up.svg")
+    readonly property url assetDeckArrowRightDownButton: legacyAsset("buttons", "btn__arrow_right_down.svg")
     readonly property url assetDeckBeatjumpLeftButton: legacyAsset("buttons", "btn__beatjump_left.svg")
     readonly property url assetDeckBeatjumpRightButton: legacyAsset("buttons", "btn__beatjump_right.svg")
+    readonly property url assetDeckBeatSpinBoxBorder: isClassic ? legacyAsset("buttons", "spinbox_elevated_border.svg") : legacySubRegionButton("wide")
+    readonly property url assetDeckBeatSpinBoxDownButton: isClassic ? legacyAsset("buttons", "spinbox_down.svg") : legacyAsset("buttons", "btn__spinbox_down.svg")
+    readonly property url assetDeckBeatSpinBoxUpButton: isClassic ? legacyAsset("buttons", "spinbox_up.svg") : legacyAsset("buttons", "btn__spinbox_up.svg")
+    readonly property url optionalDeckControlsBackgroundTile: isClassic ? legacyAsset("style", "background_tile.png") : ""
     readonly property url assetDeckCoverDefault: legacyAsset("style", "cover_default.svg")
+    readonly property url assetDeckBeatCurposButton: legacyAsset("buttons", "btn__beat_curpos.svg")
     readonly property url assetDeckCueButton: legacyAsset("buttons", "btn__cue_deck.svg")
+    readonly property url assetDeckEjectButton: legacyAsset("buttons", "btn__eject.svg")
+    readonly property url assetDeckIntroEndButton: legacyAsset("buttons", "btn__intro_end.svg")
+    readonly property url assetDeckIntroStartButton: legacyAsset("buttons", "btn__intro_start.svg")
+    readonly property url assetDeckKeyDownButton: legacyAsset("buttons", "btn__key_down.svg")
     readonly property url assetDeckKeylockButton: legacyAsset("buttons", "btn__keylock.svg")
+    readonly property url assetDeckKeyMatchButton: legacyAsset("buttons", "btn__key_match.svg")
+    readonly property url assetDeckKeyUpButton: legacyAsset("buttons", "btn__key_up.svg")
+    readonly property url assetDeckKeyButtonBackground: legacyAsset("buttons", "btn_embedded_library.svg")
+    readonly property url assetDeckLeaderBackground: legacyAsset("buttons", "btn_embedded_grid.svg")
+    readonly property url assetDeckLeaderButton: legacyAsset("buttons", "btn__sync_leader.svg")
+    readonly property url assetDeckLeaderExplicitButton: isPaleMoon ? legacyAsset("buttons", "btn__sync_leader_explicit.svg") : legacyAsset("buttons", "btn__sync_leader_active.svg")
+    readonly property url assetDeckLeaderImplicitButton: isPaleMoon ? legacyAsset("buttons", "btn__sync_leader_implicit.svg") : legacyAsset("buttons", "btn__sync_leader_active.svg")
     readonly property url assetDeckLoopButton: legacyAsset("buttons", "btn__loop.svg")
+    readonly property url assetDeckLoopAnchorEndButton: legacyAsset("buttons", "btn__loop_anchor_end.svg")
+    readonly property url assetDeckLoopAnchorStartButton: legacyAsset("buttons", "btn__loop_anchor_start.svg")
+    readonly property url assetDeckLoopInButton: legacyAsset("buttons", "btn__loop_in.svg")
+    readonly property url assetDeckLoopOutButton: legacyAsset("buttons", "btn__loop_out.svg")
+    readonly property url assetDeckMinusButton: legacyAsset("buttons", "btn__minus.svg")
+    readonly property url assetDeckOutroEndButton: legacyAsset("buttons", "btn__outro_end.svg")
+    readonly property url assetDeckOutroStartButton: legacyAsset("buttons", "btn__outro_start.svg")
     readonly property url assetDeckPlayButton: legacyAsset("buttons", "btn__play_deck.svg")
+    readonly property url assetDeckPlusButton: legacyAsset("buttons", "btn__plus.svg")
+    readonly property url assetDeckQuantizeButton: legacyAsset("buttons", "btn__quantize.svg")
+    readonly property url optionalDeckRateCenterActive: isPaleMoon ? legacyAsset("buttons", "btn__rate_center_cyan.svg") : ""
+    readonly property url optionalDeckRateCenterInactive: isPaleMoon ? legacyAsset("buttons", "btn__rate_center_off.svg") : ""
     readonly property url assetDeckRateSliderBackground: legacyAsset("sliders", "slider_pitch_deck.svg")
     readonly property url assetDeckRateSliderHandle: legacyAsset("sliders", "knob_pitch_deck.svg")
+    readonly property url assetDeckReloopButton: legacyAsset("buttons", "btn__reloop.svg")
+    readonly property url assetDeckRepeatButton: legacyAsset("buttons", "btn__repeat.svg")
     readonly property url assetDeckReverseButton: legacyAsset("buttons", "btn__reverse.svg")
+    readonly property url assetDeckSettingsOffButton: legacyAsset("buttons", "btn__settings_off.svg")
+    readonly property url assetDeckSettingsOnButton: legacyAsset("buttons", "btn__settings_on.svg")
+    readonly property url assetDeckSlipButton: legacyAsset("buttons", "btn__slip.svg")
     readonly property url assetDeckSpinnyBackground: legacyAsset("style", "spinny_bg.svg")
     readonly property url assetDeckSpinnyGhostIndicator: legacyAsset("style", "spinny_indicator_ghost.svg")
     readonly property url assetDeckSpinnyIndicator: legacyAsset("style", "spinny_indicator.svg")
     readonly property url assetDeckSpinnyMask12: legacyAsset("style", "spinny_mask_12.svg")
     readonly property url assetDeckSpinnyMask34: legacyAsset("style", "spinny_mask_34.svg")
+    readonly property url assetDeckSyncBackground: legacyAsset("buttons", "btn_embedded_library.svg")
     readonly property url assetDeckSyncButton: legacyAsset("buttons", "btn__sync_deck.svg")
+    readonly property url assetDeckSyncActiveButton: isPaleMoon ? legacyAsset("buttons", "btn__sync_deck_active.svg") : legacyAsset("buttons", "btn__sync_deck.svg")
     readonly property url assetDeckVolumeSliderBackground: legacyAsset("sliders", "slider_volume_deck.svg")
     readonly property url assetDeckVolumeSliderHandle: legacyAsset("sliders", "knob_volume_deck.svg")
+    readonly property url assetDeckVinylControl0: legacyAsset("style", "vinyl_control_0.svg")
+    readonly property url assetDeckVinylControl1: legacyAsset("style", "vinyl_control_1.svg")
+    readonly property url assetDeckVinylControl2: legacyAsset("style", "vinyl_control_2.svg")
+    readonly property url assetDeckVinylControl3: legacyAsset("style", "vinyl_control_3.svg")
     readonly property url assetFxKnobBackground: legacyAsset("knobs", "knob_bg_fx.svg")
     readonly property url assetMainKnobBackground: legacyAsset("knobs", "knob_bg_main.svg")
     readonly property url assetRegularKnobBackground: legacyAsset("knobs", "knob_bg_regular.svg")
     readonly property url assetSmallKnobBackground: legacyAsset("knobs", "knob_bg_small.svg")
+
+    function legacyButton(fileName) {
+        return legacyAsset("buttons", fileName);
+    }
+
+    function legacyRegionButton(regionButtonType, buttonSize) {
+        return legacyButton("btn_" + regionButtonType + "_" + buttonSize + ".svg");
+    }
+
+    function legacySubRegionButton(buttonSize) {
+        return legacyRegionButton(isClassic ? "elevated" : "embedded", buttonSize);
+    }
+
+    function legacyTopRegionButton(buttonSize) {
+        return legacyRegionButton("embedded", buttonSize);
+    }
 
     function legacyAsset(directory, fileName) {
         return Qt.resolvedUrl("../../LateNight/" + ColorScheme.name + "/" + directory + "/" + fileName);

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -1,0 +1,125 @@
+import "../Controls" as Controls
+import "../Theme"
+import "../../../qml" as Shared
+import Mixxx 1.0 as Mixxx
+import QtQuick
+import QtQuick.Layouts
+
+Rectangle {
+    id: root
+
+    property alias editDeck: editDeckButton.checked
+    property alias maximizeLibrary: maximizeLibraryButton.checked
+    readonly property bool show4decks: show4DecksButton.checked && show4DecksButton.visible
+    property bool show4decksAvailable: true
+    property alias showEffects: showEffectsButton.checked
+    property alias showSamplers: showSamplersButton.checked
+    property bool settingsOpened: false
+
+    signal openSettingsRequested
+
+    color: Theme.toolbarBackgroundColor
+    height: 36
+    radius: 1
+
+    RowLayout {
+        anchors.fill: parent
+
+        Controls.ToggleButton {
+            id: show4DecksButton
+
+            activeColor: Theme.toolbarActiveColor
+            text: "4 Decks"
+            visible: root.show4decksAvailable
+        }
+        Controls.ToggleButton {
+            id: maximizeLibraryButton
+
+            activeColor: Theme.toolbarActiveColor
+            text: "Library"
+
+            onCheckedChanged: () => {
+                showMaximizedLibrary.value = checked;
+            }
+
+            Mixxx.ControlProxy {
+                id: showMaximizedLibrary
+
+                group: "[Skin]"
+                key: "show_maximized_library"
+
+                onValueChanged: () => {
+                    maximizeLibraryButton.checked = value;
+                }
+            }
+        }
+        Controls.ToggleButton {
+            id: showEffectsButton
+
+            activeColor: Theme.toolbarActiveColor
+            text: "Effects"
+        }
+        Controls.ToggleButton {
+            id: showAuxButton
+
+            activeColor: Theme.toolbarActiveColor
+            text: "Aux"
+        }
+        Controls.ToggleButton {
+            id: showSamplersButton
+
+            activeColor: Theme.toolbarActiveColor
+            text: "Sampler"
+        }
+        Item {
+            Layout.fillWidth: true
+        }
+        Controls.ToggleButton {
+            id: editDeckButton
+
+            activeColor: Theme.toolbarActiveColor
+            text: "Edit"
+        }
+        Controls.ToggleButton {
+            id: showDevToolsButton
+
+            activeColor: Theme.toolbarActiveColor
+            checked: devToolsWindow.visible
+            text: "Develop"
+
+            onClicked: {
+                if (devToolsWindow.visible) {
+                    devToolsWindow.close();
+                } else {
+                    devToolsWindow.show();
+                }
+            }
+
+            Shared.DeveloperToolsWindow {
+                id: devToolsWindow
+
+                height: 480
+                width: 640
+            }
+        }
+        Controls.Button {
+            id: showPreferencesButton
+
+            activeColor: Theme.toolbarActiveColor
+            checked: root.settingsOpened
+            icon.height: 16
+            icon.source: Theme.sharedImage("gear.svg")
+            icon.width: 16
+            implicitWidth: implicitHeight
+
+            onClicked: {
+                if (!root.settingsOpened) {
+                    root.openSettingsRequested();
+                }
+            }
+            onPressAndHold: {
+                Mixxx.PreferencesDialog.show();
+            }
+        }
+    }
+}

--- a/res/skins/LateNightQML/Waveforms/DeckWaveform.qml
+++ b/res/skins/LateNightQML/Waveforms/DeckWaveform.qml
@@ -1,0 +1,5 @@
+import "../../../qml" as Shared
+
+Shared.WaveformDisplay {
+    id: root
+}

--- a/res/skins/LateNightQML/Waveforms/WaveformStack.qml
+++ b/res/skins/LateNightQML/Waveforms/WaveformStack.qml
@@ -1,0 +1,114 @@
+import "../LateNightTheme"
+import "../../../qml" as Shared
+import QtQuick
+
+Item {
+    id: root
+
+    property string deck1Group: "[Channel1]"
+    property string deck2Group: "[Channel2]"
+    property string deck3Group: "[Channel3]"
+    property string deck4Group: "[Channel4]"
+    property bool show4decks: false
+
+    Loader {
+        id: deck3waveform
+
+        readonly property string group: root.deck3Group
+
+        active: root.show4decks
+        anchors.top: parent.top
+        height: parent.height / 4
+        width: root.width
+
+        sourceComponent: Component {
+            DeckWaveform {
+                group: deck3waveform.group
+
+                Shared.FadeBehavior on visible {
+                    fadeTarget: deck3waveform
+                }
+            }
+        }
+    }
+    DeckWaveform {
+        id: deck1waveform
+
+        anchors.top: root.show4decks ? deck3waveform.bottom : parent.top
+        group: root.deck1Group
+        height: parent.height / (root.show4decks ? 4 : 2)
+        width: root.width
+    }
+    DeckWaveform {
+        id: deck2waveform
+
+        anchors.bottom: root.show4decks ? deck4waveform.top : parent.bottom
+        group: root.deck2Group
+        height: parent.height / (root.show4decks ? 4 : 2)
+        width: root.width
+    }
+    Loader {
+        id: deck4waveform
+
+        readonly property string group: root.deck4Group
+
+        active: root.show4decks
+        anchors.bottom: parent.bottom
+        height: parent.height / 4
+        width: root.width
+
+        sourceComponent: Component {
+            DeckWaveform {
+                group: deck4waveform.group
+
+                Shared.FadeBehavior on visible {
+                    fadeTarget: deck4waveform
+                }
+            }
+        }
+    }
+    Rectangle {
+        width: 125
+
+        gradient: Gradient {
+            orientation: Gradient.Horizontal
+
+            GradientStop {
+                color: LateNightTheme.darkGray
+                position: 0
+            }
+            GradientStop {
+                color: "transparent"
+                position: 1
+            }
+        }
+
+        anchors {
+            bottom: parent.bottom
+            left: parent.left
+            top: parent.top
+        }
+    }
+    Rectangle {
+        width: 125
+
+        gradient: Gradient {
+            orientation: Gradient.Horizontal
+
+            GradientStop {
+                color: "transparent"
+                position: 0
+            }
+            GradientStop {
+                color: LateNightTheme.darkGray
+                position: 1
+            }
+        }
+
+        anchors {
+            bottom: parent.bottom
+            right: parent.right
+            top: parent.top
+        }
+    }
+}

--- a/res/skins/LateNightQML/main.qml
+++ b/res/skins/LateNightQML/main.qml
@@ -23,8 +23,8 @@ ApplicationWindow {
 
     color: LateNightTheme.backgroundColor
     height: 1008
-    minimumHeight: 300
-    minimumWidth: 680
+    minimumHeight: 668
+    minimumWidth: 1280
     visible: true
     width: 1792
 

--- a/res/skins/LateNightQML/main.qml
+++ b/res/skins/LateNightQML/main.qml
@@ -1,5 +1,7 @@
 import "../../qml" as Skin
 import "LateNightTheme"
+import "Deck" as LateNightDeck
+import "Waveforms" as LateNightWaveforms
 import Mixxx 1.0 as Mixxx
 import QtQuick
 import QtQuick.Controls
@@ -11,6 +13,8 @@ ApplicationWindow {
     property alias editDeck: editDeckButton.checked
     property var focusedDeck: null
     property alias maximizeLibrary: maximizeLibraryButton.checked
+    readonly property int fullDeckHeight: 206
+    readonly property int minimizedDeckHeight: 80
     readonly property int numDecks: 4
     readonly property int numSamplers: 16
     readonly property bool show4decks: show4DecksButton.checked && show4DecksButton.visible
@@ -38,6 +42,183 @@ ApplicationWindow {
 
         onInitializedChanged: {
             value = root.numSamplers;
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initDefaultsProxy
+        group: "[LateNightQML]"
+        key: "initialized_defaults"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+        onValueChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initSpinniesProxy
+        group: "[Skin]"
+        key: "show_spinnies"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initCoverartProxy
+        group: "[Skin]"
+        key: "show_coverart"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initSelectBigSpinnyProxy
+        group: "[Skin]"
+        key: "select_big_spinny_or_cover"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initHotcuesProxy
+        group: "[Skin]"
+        key: "show_hotcues"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: init8HotcuesProxy
+        group: "[Skin]"
+        key: "show_8_hotcues"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initIntroOutroCuesProxy
+        group: "[Skin]"
+        key: "show_intro_outro_cues"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initLoopControlsProxy
+        group: "[Skin]"
+        key: "show_loop_controls"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initBeatjumpControlsProxy
+        group: "[Skin]"
+        key: "show_beatjump_controls"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initKeyControlsProxy
+        group: "[Skin]"
+        key: "show_key_controls"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initVinylControlsProxy
+        group: "[Skin]"
+        key: "show_vinylcontrol"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initRateControlsProxy
+        group: "[Skin]"
+        key: "show_rate_controls"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: initRateControlButtonsProxy
+        group: "[Skin]"
+        key: "show_rate_control_buttons"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: init4EffectUnitsProxy
+        group: "[Skin]"
+        key: "show_4effectunits"
+
+        onInitializedChanged: {
+            checkAndInitDefaults();
+        }
+    }
+
+    function checkAndInitDefaults() {
+        if (initDefaultsProxy.initialized &&
+                initSpinniesProxy.initialized &&
+                initCoverartProxy.initialized &&
+                initSelectBigSpinnyProxy.initialized &&
+                initHotcuesProxy.initialized &&
+                init8HotcuesProxy.initialized &&
+                initIntroOutroCuesProxy.initialized &&
+                initLoopControlsProxy.initialized &&
+                initBeatjumpControlsProxy.initialized &&
+                initKeyControlsProxy.initialized &&
+                initVinylControlsProxy.initialized &&
+                initRateControlsProxy.initialized &&
+                initRateControlButtonsProxy.initialized &&
+                init4EffectUnitsProxy.initialized) {
+            if (initDefaultsProxy.value < 2.0) {
+                initSpinniesProxy.value = 1.0;
+                initCoverartProxy.value = 1.0;
+                initSelectBigSpinnyProxy.value = 0.0;
+                initHotcuesProxy.value = 1.0;
+                init8HotcuesProxy.value = 1.0;
+                initIntroOutroCuesProxy.value = 1.0;
+                initLoopControlsProxy.value = 1.0;
+                initBeatjumpControlsProxy.value = 1.0;
+                initKeyControlsProxy.value = 1.0;
+                initVinylControlsProxy.value = 0.0;
+                initRateControlsProxy.value = 1.0;
+                initRateControlButtonsProxy.value = 1.0;
+                init4EffectUnitsProxy.value = 0.0;
+                initDefaultsProxy.value = 2.0;
+            }
         }
     }
     Column {
@@ -207,129 +388,32 @@ ApplicationWindow {
                 }
             }
 
-            Item {
+            LateNightWaveforms.WaveformStack {
                 id: waveforms
 
                 SplitView.fillHeight: !library.active
                 SplitView.preferredHeight: library.active ? 120 : undefined
                 visible: !root.maximizeLibrary
+                show4decks: root.show4decks
 
                 Skin.FadeBehavior on visible {
                     fadeTarget: waveforms
                 }
-
-                Loader {
-                    id: deck3waveform
-
-                    readonly property string group: "[Channel3]"
-
-                    active: root.show4decks
-                    anchors.top: parent.top
-                    height: parent.height / 4
-                    width: root.width
-
-                    sourceComponent: Component {
-                        Skin.WaveformDisplay {
-                            group: deck3waveform.group
-
-                            Skin.FadeBehavior on visible {
-                                fadeTarget: deck3waveform
-                            }
-                        }
-                    }
-                }
-                Skin.WaveformDisplay {
-                    id: deck1waveform
-
-                    anchors.top: root.show4decks ? deck3waveform.bottom : parent.top
-                    group: "[Channel1]"
-                    height: parent.height / (root.show4decks ? 4 : 2)
-                    width: root.width
-                }
-                Skin.WaveformDisplay {
-                    id: deck2waveform
-
-                    anchors.bottom: root.show4decks ? deck4waveform.top : parent.bottom
-                    group: "[Channel2]"
-                    height: parent.height / (root.show4decks ? 4 : 2)
-                    width: root.width
-                }
-                Loader {
-                    id: deck4waveform
-
-                    readonly property string group: "[Channel4]"
-
-                    active: root.show4decks
-                    anchors.bottom: parent.bottom
-                    height: parent.height / 4
-                    width: root.width
-
-                    sourceComponent: Component {
-                        Skin.WaveformDisplay {
-                            group: deck4waveform.group
-
-                            Skin.FadeBehavior on visible {
-                                fadeTarget: deck4waveform
-                            }
-                        }
-                    }
-                }
-                Rectangle {
-                    width: 125
-
-                    gradient: Gradient {
-                        orientation: Gradient.Horizontal
-
-                        GradientStop {
-                            color: LateNightTheme.darkGray
-                            position: 0
-                        }
-                        GradientStop {
-                            color: 'transparent'
-                            position: 1
-                        }
-                    }
-
-                    anchors {
-                        bottom: parent.bottom
-                        left: parent.left
-                        top: parent.top
-                    }
-                }
-                Rectangle {
-                    width: 125
-
-                    gradient: Gradient {
-                        orientation: Gradient.Horizontal
-
-                        GradientStop {
-                            color: 'transparent'
-                            position: 0
-                        }
-                        GradientStop {
-                            color: LateNightTheme.darkGray
-                            position: 1
-                        }
-                    }
-
-                    anchors {
-                        bottom: parent.bottom
-                        right: parent.right
-                        top: parent.top
-                    }
-                }
             }
             Item {
+                id: deckPane
+
                 SplitView.fillHeight: library.active
                 SplitView.maximumHeight: library.active ? undefined : mixer.height
                 SplitView.minimumHeight: mixer.height
+                width: splitView.width
 
-                Skin.Deck {
+                LateNightDeck.Deck {
                     id: deck1
 
                     editMode: root.editDeck
                     group: "[Channel1]"
-                    height: root.maximizeLibrary ? 80 : root.show4decks ? mixer.height / 2 : mixer.height
+                    height: root.maximizeLibrary ? root.minimizedDeckHeight : root.fullDeckHeight
                     minimized: root.maximizeLibrary
 
                     Behavior on height {
@@ -368,6 +452,7 @@ ApplicationWindow {
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.top: parent.top
                     groups: [deck1.group, deck2.group, deck3.group, deck4.group]
+                    width: implicitWidth
                     show4decks: root.show4decks
                     visible: !root.maximizeLibrary
 
@@ -447,12 +532,12 @@ ApplicationWindow {
                         fadeTarget: mixer
                     }
                 }
-                Skin.Deck {
+                LateNightDeck.Deck {
                     id: deck2
 
                     editMode: root.editDeck
                     group: "[Channel2]"
-                    height: root.maximizeLibrary ? 80 : root.show4decks ? mixer.height / 2 : mixer.height
+                    height: root.maximizeLibrary ? root.minimizedDeckHeight : root.fullDeckHeight
                     minimized: root.maximizeLibrary
 
                     Behavior on height {
@@ -491,7 +576,8 @@ ApplicationWindow {
                     readonly property string group: "[Channel3]"
 
                     active: root.show4decks
-                    height: active ? (root.maximizeLibrary ? 80 : mixer.height / 2) : 0
+                    clip: true
+                    height: active ? (root.maximizeLibrary ? root.minimizedDeckHeight : root.fullDeckHeight) : 0
 
                     Behavior on height {
                         SpringAnimation {
@@ -503,7 +589,7 @@ ApplicationWindow {
                         }
                     }
                     sourceComponent: Component {
-                        Skin.Deck {
+                        LateNightDeck.Deck {
                             anchors.bottom: parent.bottom
                             anchors.left: parent.left
                             editMode: root.editDeck
@@ -534,7 +620,8 @@ ApplicationWindow {
                     readonly property string group: "[Channel4]"
 
                     active: root.show4decks
-                    height: active ? (root.maximizeLibrary ? 80 : mixer.height / 2) : 0
+                    clip: true
+                    height: active ? (root.maximizeLibrary ? root.minimizedDeckHeight : root.fullDeckHeight) : 0
 
                     Behavior on height {
                         SpringAnimation {
@@ -546,7 +633,7 @@ ApplicationWindow {
                         }
                     }
                     sourceComponent: Component {
-                        Skin.Deck {
+                        LateNightDeck.Deck {
                             anchors.bottom: parent.bottom
                             anchors.right: parent.right
                             editMode: root.editDeck

--- a/src/qml/qmlskincontrolcreator.cpp
+++ b/src/qml/qmlskincontrolcreator.cpp
@@ -16,6 +16,7 @@ namespace qml {
 QmlSkinControlCreator::QmlSkinControlCreator(QObject* parent)
         : QObject(parent),
           m_persist(false),
+          m_persistConfigured(false),
           m_defaultValue(0.0),
           m_buttonMode(ButtonMode::Toggle),
           m_isComponentComplete(false) {
@@ -23,7 +24,9 @@ QmlSkinControlCreator::QmlSkinControlCreator(QObject* parent)
 
 void QmlSkinControlCreator::componentComplete() {
     m_isComponentComplete = true;
-    createControl();
+    if (!m_pControl) {
+        createControl();
+    }
 }
 
 void QmlSkinControlCreator::setGroup(const QString& group) {
@@ -32,6 +35,7 @@ void QmlSkinControlCreator::setGroup(const QString& group) {
     }
     m_key.group = group;
     emit groupChanged(group);
+    createDefaultControlBeforeComponentComplete();
     createControl();
 }
 
@@ -45,6 +49,7 @@ void QmlSkinControlCreator::setKey(const QString& key) {
     }
     m_key.item = key;
     emit keyChanged(key);
+    createDefaultControlBeforeComponentComplete();
     createControl();
 }
 
@@ -57,7 +62,9 @@ void QmlSkinControlCreator::setPersist(bool persist) {
         return;
     }
     m_persist = persist;
+    m_persistConfigured = true;
     emit persistChanged(persist);
+    createDefaultControlBeforeComponentComplete();
     createControl();
 }
 
@@ -71,6 +78,7 @@ void QmlSkinControlCreator::setDefaultValue(double defaultValue) {
     }
     m_defaultValue = defaultValue;
     emit defaultValueChanged(defaultValue);
+    createDefaultControlBeforeComponentComplete();
     createControl();
 }
 
@@ -111,8 +119,8 @@ mixxx::control::ButtonMode QmlSkinControlCreator::toControlButtonMode(
     return mixxx::control::ButtonMode::Toggle;
 }
 
-void QmlSkinControlCreator::createControl() {
-    if (!m_isComponentComplete) {
+void QmlSkinControlCreator::createControl(bool allowBeforeComponentComplete) {
+    if (!m_isComponentComplete && !allowBeforeComponentComplete) {
         return;
     }
     m_pControl.reset();
@@ -136,6 +144,15 @@ void QmlSkinControlCreator::createControl() {
             m_persist,
             m_defaultValue);
     m_pControl->setButtonMode(toControlButtonMode(m_buttonMode));
+}
+
+void QmlSkinControlCreator::createDefaultControlBeforeComponentComplete() {
+    if (m_isComponentComplete || m_pControl || m_defaultValue == 0.0 ||
+            !m_persistConfigured || !m_key.isValid() || m_key.group != kSkinGroup ||
+            ControlObject::exists(m_key)) {
+        return;
+    }
+    createControl(true);
 }
 
 } // namespace qml

--- a/src/qml/qmlskincontrolcreator.h
+++ b/src/qml/qmlskincontrolcreator.h
@@ -63,10 +63,12 @@ class QmlSkinControlCreator : public QObject, public QQmlParserStatus {
 
   private:
     static mixxx::control::ButtonMode toControlButtonMode(ButtonMode buttonMode);
-    void createControl();
+    void createControl(bool allowBeforeComponentComplete = false);
+    void createDefaultControlBeforeComponentComplete();
 
     ConfigKey m_key;
     bool m_persist;
+    bool m_persistConfigured;
     double m_defaultValue;
     ButtonMode m_buttonMode;
     bool m_isComponentComplete;

--- a/src/test/qmlskincontrolcreatortest.cpp
+++ b/src/test/qmlskincontrolcreatortest.cpp
@@ -41,6 +41,47 @@ TEST_F(QmlSkinControlCreatorTest, CreatesSkinControl) {
     EXPECT_FALSE(ControlObject::exists(key));
 }
 
+TEST_F(QmlSkinControlCreatorTest, AppliesDefaultBeforeComponentComplete) {
+    const ConfigKey key(QStringLiteral("[Skin]"),
+            QStringLiteral("qml_skin_control_creator_precomplete_default_test"));
+
+    auto creator = std::make_unique<QmlSkinControlCreator>();
+    creator->setGroup(key.group);
+    creator->setKey(key.item);
+    creator->setPersist(true);
+    creator->setDefaultValue(1.0);
+
+    EXPECT_TRUE(ControlObject::exists(key));
+    EXPECT_DOUBLE_EQ(1.0, ControlObject::get(key));
+
+    creator->componentComplete();
+
+    EXPECT_TRUE(ControlObject::exists(key));
+    EXPECT_DOUBLE_EQ(1.0, ControlObject::get(key));
+}
+
+TEST_F(QmlSkinControlCreatorTest, AppliesDefaultBeforeComponentCompleteInAnyOrder) {
+    const ConfigKey key(QStringLiteral("[Skin]"),
+            QStringLiteral("qml_skin_control_creator_precomplete_order_test"));
+
+    auto creator = std::make_unique<QmlSkinControlCreator>();
+    creator->setDefaultValue(1.0);
+    creator->setGroup(key.group);
+    creator->setKey(key.item);
+
+    EXPECT_FALSE(ControlObject::exists(key));
+
+    creator->setPersist(true);
+
+    EXPECT_TRUE(ControlObject::exists(key));
+    EXPECT_DOUBLE_EQ(1.0, ControlObject::get(key));
+
+    creator->componentComplete();
+
+    EXPECT_TRUE(ControlObject::exists(key));
+    EXPECT_DOUBLE_EQ(1.0, ControlObject::get(key));
+}
+
 TEST_F(QmlSkinControlCreatorTest, RejectsExistingSkinControl) {
     const ConfigKey key(QStringLiteral("[Skin]"),
             QStringLiteral("qml_skin_control_creator_duplicate_test"));


### PR DESCRIPTION
This PR implements the visual styling, theme integration, and interactive control bindings for the **LateNightQML** deck component, covering both the Classic and PaleMoon color schemes.

## Testing the Experimental Skin

Since this is an early experimental milestone, you must first run Mixxx with the developer flag:

```bash
./build/mixxx --developer
```

Once Mixxx is open, switch to the experimental skin:
**Preferences -> Interface -> LateNight QML (Experimental)**

You can dynamically toggle between the **Classic** and **PaleMoon** color schemes under preferences.

## Previews

### Classic

![LateNightQML Classic Deck Preview](https://raw.githubusercontent.com/xARSENICx/mixxx/LateNightQML/Deck/res/skins/LateNightQML/skin_preview_Classic.png)

### PaleMoon

![LateNightQML PaleMoon Deck Preview](https://raw.githubusercontent.com/xARSENICx/mixxx/LateNightQML/Deck/res/skins/LateNightQML/skin_preview_PaleMoon.png)

## Scope of Changes

### Implemented in this PR:
* **Core Decks & Waveforms:** Full-deck layout shell, title/time rows, overview, spinny/cover slot, transport/loop/beatjump/rate visual layouts, and 2/4 deck waveform switcher integration.
* **Deck Controls:** Play/cue/sync control parity (including explicit/implicit sync leader crown behavior), reverse, key, vinyl, rate controls, deck settings panel (slip, quantize, repeat, eject, keylock, rating stars), and full `[Channel1-4]` ControlProxy bindings.

### To be addressed in later milestones:
* Full interactive hotcue, intro/outro cue actions.
* Interactive loop/beatjump control behaviors.
* Deck FX assignment controls.

## Tracking

GSoC: LateNightQML PR-4
