### PR TITLE
Added missing include file for PATH_MAX on Windows

### DIFF
--- a/src/controllers/hid/hiddevice.cpp
+++ b/src/controllers/hid/hiddevice.cpp
@@ -5,6 +5,7 @@
 #include <QDebugStateSaver>
 
 #include "controllers/controllermappinginfo.h"
+#include "util/path.h"
 #include "util/string.h"
 
 namespace {


### PR DESCRIPTION
These are the proposed changes defined as option number 2 in #16600 issue.