### PR TITLE
[GSoC] CMRT 02: Analyzer: Add AnalyzerChromaprint and WithFingerprint mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1400,6 +1400,7 @@ add_library(
   src/library/dao/settingsdao.cpp
   src/library/dao/trackdao.cpp
   src/library/dao/trackschema.cpp
+  src/library/dao/trackfingerprintdao.cpp
   src/library/tabledelegates/defaultdelegate.cpp
   src/library/dlgcoverartfullsize.cpp
   src/library/dlgcoverartfullsize.ui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1160,6 +1160,7 @@ add_library(
   STATIC
   EXCLUDE_FROM_ALL
   src/analyzer/analyzerbeats.cpp
+  src/analyzer/analyzerchromaprint.cpp
   src/analyzer/analyzerebur128.cpp
   src/analyzer/analyzergain.cpp
   src/analyzer/analyzerkey.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1414,6 +1414,7 @@ add_library(
   src/library/dao/settingsdao.cpp
   src/library/dao/trackdao.cpp
   src/library/dao/trackschema.cpp
+  src/library/dao/trackfingerprintdao.cpp
   src/library/tabledelegates/defaultdelegate.cpp
   src/library/dlgcoverartfullsize.cpp
   src/library/dlgcoverartfullsize.ui

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1174,6 +1174,7 @@ add_library(
   STATIC
   EXCLUDE_FROM_ALL
   src/analyzer/analyzerbeats.cpp
+  src/analyzer/analyzerchromaprint.cpp
   src/analyzer/analyzerebur128.cpp
   src/analyzer/analyzergain.cpp
   src/analyzer/analyzerkey.cpp

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -593,4 +593,30 @@ reapplying those migrations.
       ALTER TABLE library ADD COLUMN tuning_frequency_hz FLOAT DEFAULT 0.0;
     </sql>
   </revision>
+  <revision version="41" min_compatible="3">
+    <description>
+      Add MusicBrainz and AcoustID metadata columns to the library table
+      to support Chromaprint-based audio fingerprinting and AcoustID lookup.
+    </description>
+    <sql>
+      ALTER TABLE library ADD COLUMN musicbrainz_recording_id varchar(64);
+      ALTER TABLE library ADD COLUMN musicbrainz_release_id varchar(64);
+      ALTER TABLE library ADD COLUMN musicbrainz_track_id varchar(64);
+      ALTER TABLE library ADD COLUMN musicbrainz_artist_id varchar(64);
+      ALTER TABLE library ADD COLUMN acoustid_id varchar(64);
+      ALTER TABLE library ADD COLUMN acoustid_lookup_at INTEGER;
+      <!-- acoustid_lookup_status values: 'pending' | 'completed' | 'failed' -->
+      ALTER TABLE library ADD COLUMN acoustid_lookup_status varchar(16);
+
+      CREATE INDEX IF NOT EXISTS idx_library_mbid ON library (
+          musicbrainz_recording_id
+      );
+      CREATE INDEX IF NOT EXISTS idx_library_acoustid ON library (
+          acoustid_id
+      );
+      CREATE INDEX IF NOT EXISTS idx_library_mbid_artist ON library (
+          musicbrainz_artist_id
+      );
+    </sql>
+  </revision>
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -619,4 +619,19 @@ reapplying those migrations.
       );
     </sql>
   </revision>
+  <revision version="42" min_compatible="3">
+    <description>
+      Add data_text column to track_analysis table for small text payloads
+      such as audio quality metrics and Chromaprint version metadata.
+      Raw fingerprint arrays are never stored in the database.
+    </description>
+    <sql>
+      ALTER TABLE track_analysis ADD COLUMN data_text TEXT;
+
+      CREATE INDEX IF NOT EXISTS idx_track_analysis_lookup ON track_analysis (
+          track_id,
+          type
+      );
+    </sql>
+  </revision>
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -634,4 +634,134 @@ reapplying those migrations.
       );
     </sql>
   </revision>
+  <revision version="43" min_compatible="3">
+    <description>
+      Add Chromaprint fingerprint tables: fingerprint_metadata stores the
+      32-bit SimHash pre-filter and CMRT group linkage per track; cmrt_groups
+      holds one record per unique audio recording; cmrt_members is the
+      track-to-group bridge table; acoustid_queue manages background AcoustID
+      API submissions; acoustid_cache avoids redundant API round-trips.
+      Raw fingerprint data is stored as separate .chroma files on disk,
+      never as BLOBs in the database.
+    </description>
+    <sql>
+      <!-- fingerprint_hash is a 32-bit SimHash used as a non-unique pre-filter.
+           Full binary XOR/popcount comparison of .chroma files is required
+           before assigning a track to a CMRT group. See design notes. -->
+      CREATE TABLE IF NOT EXISTS fingerprint_metadata (
+        track_id INTEGER NOT NULL,
+        <!-- 32-bit SimHash — non-unique, multiple tracks share the same value -->
+        fingerprint_hash INTEGER NOT NULL,
+        <!-- SHA-256 hex of .chroma file — non-unique here; exact copies share it -->
+        chroma_sha256 varchar(64) NOT NULL,
+        fingerprint_duration REAL,
+        fingerprint_version INTEGER,
+        cmrt_group_id INTEGER,
+        cmrt_offset_seconds REAL DEFAULT 0,
+        is_canonical INTEGER DEFAULT 0,
+        fingerprint_valid INTEGER DEFAULT 1,
+        fingerprint_needs_regen INTEGER DEFAULT 0,
+        computed_at INTEGER NOT NULL,
+        PRIMARY KEY (track_id));
+
+      <!-- chroma_sha256 is UNIQUE here: each group has exactly one canonical
+           audio identity. Two groups cannot share the same SHA-256. -->
+      CREATE TABLE IF NOT EXISTS cmrt_groups (
+        group_id INTEGER NOT NULL,
+        fingerprint_hash INTEGER NOT NULL,
+        chroma_sha256 varchar(64) NOT NULL,
+        canonical_track_id INTEGER NOT NULL,
+        track_count INTEGER DEFAULT 1,
+        created_at INTEGER NOT NULL,
+        last_updated INTEGER,
+        musicbrainz_cmrt_mbid varchar(64),
+        musicbrainz_synced INTEGER DEFAULT 0,
+        musicbrainz_last_sync INTEGER,
+        musicbrainz_community_score REAL,
+        musicbrainz_submitted INTEGER DEFAULT 0,
+        musicbrainz_submission_mbid varchar(64),
+        local_preferred INTEGER DEFAULT 1,
+        conflict_resolved_at INTEGER,
+        <!-- conflict_resolution values: 'local_won' | 'remote_won' -->
+        conflict_resolution varchar(16),
+        PRIMARY KEY (group_id));
+
+      <!-- UNIQUE (track_id) enforces each track belongs to exactly one group -->
+      CREATE TABLE IF NOT EXISTS cmrt_members (
+        member_id INTEGER NOT NULL,
+        group_id INTEGER NOT NULL,
+        track_id INTEGER NOT NULL,
+        offset_from_canonical REAL DEFAULT 0,
+        quality_score REAL,
+        match_score REAL,
+        is_fake_lossless INTEGER DEFAULT 0,
+        added_at INTEGER NOT NULL,
+        user_quality_rating INTEGER,
+        PRIMARY KEY (member_id),
+        UNIQUE (track_id));
+
+      <!-- status values: 'queued' | 'processing' | 'completed' | 'failed' -->
+      CREATE TABLE IF NOT EXISTS acoustid_queue (
+        queue_id INTEGER NOT NULL,
+        track_id INTEGER NOT NULL,
+        priority INTEGER DEFAULT 5,
+        status varchar(16) DEFAULT 'queued',
+        attempts INTEGER DEFAULT 0,
+        max_attempts INTEGER DEFAULT 3,
+        last_attempt INTEGER,
+        error_message TEXT,
+        queued_at INTEGER NOT NULL,
+        PRIMARY KEY (queue_id),
+        UNIQUE (track_id));
+
+      <!-- keyed on chroma_sha256 (SHA-256), not fingerprint_hash (SimHash),
+           to avoid Birthday Paradox false cache hits -->
+      CREATE TABLE IF NOT EXISTS acoustid_cache (
+        chroma_sha256 varchar(64) NOT NULL,
+        acoustid_id varchar(64) NOT NULL,
+        musicbrainz_recording_id varchar(64),
+        musicbrainz_release_id varchar(64),
+        musicbrainz_metadata TEXT,
+        confidence REAL,
+        lookup_timestamp INTEGER NOT NULL,
+        expires_at INTEGER,
+        PRIMARY KEY (chroma_sha256));
+
+      CREATE INDEX IF NOT EXISTS idx_fm_hash ON fingerprint_metadata (
+          fingerprint_hash
+      );
+      CREATE INDEX IF NOT EXISTS idx_fm_sha ON fingerprint_metadata (
+          chroma_sha256
+      );
+      CREATE INDEX IF NOT EXISTS idx_fm_group ON fingerprint_metadata (
+          cmrt_group_id
+      );
+      CREATE INDEX IF NOT EXISTS idx_fm_canonical ON fingerprint_metadata (
+          is_canonical
+      );
+      CREATE INDEX IF NOT EXISTS idx_cg_hash ON cmrt_groups (
+          fingerprint_hash
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_cg_sha ON cmrt_groups (
+          chroma_sha256
+      );
+      CREATE INDEX IF NOT EXISTS idx_cg_mbid ON cmrt_groups (
+          musicbrainz_cmrt_mbid
+      );
+      CREATE INDEX IF NOT EXISTS idx_cm_group ON cmrt_members (
+          group_id
+      );
+      CREATE INDEX IF NOT EXISTS idx_cm_track ON cmrt_members (
+          track_id
+      );
+      CREATE INDEX IF NOT EXISTS idx_aq_status ON acoustid_queue (
+          status,
+          priority,
+          queued_at
+      );
+      CREATE INDEX IF NOT EXISTS idx_ac_mbid ON acoustid_cache (
+          musicbrainz_recording_id
+      );
+    </sql>
+  </revision>
 </schema>

--- a/src/analyzer/analyzerchromaprint.cpp
+++ b/src/analyzer/analyzerchromaprint.cpp
@@ -117,6 +117,193 @@ bool AnalyzerChromaprint::initialize(
     return true;
 }
 
+bool AnalyzerChromaprint::processSamples(const CSAMPLE* buffer, SINT count) {
+    VERIFY_OR_DEBUG_ASSERT(m_pChromaprintCtx) {
+        return false;
+    }
+
+    // Chromaprint expects interleaved signed 16-bit samples.
+    // Resize the reusable buffer to fit the incoming chunk — no allocation
+    // if the buffer is already large enough.
+    if (static_cast<SINT>(m_int16Buffer.size()) < count) {
+        m_int16Buffer.resize(count);
+    }
+
+    SampleUtil::convertFloat32ToS16(m_int16Buffer.data(), buffer, count);
+
+    const int ret = chromaprint_feed(
+            m_pChromaprintCtx,
+            m_int16Buffer.data(),
+            static_cast<int>(count));
+
+    if (!ret) {
+        kLogger.warning() << "AnalyzerChromaprint -> [processSamples] -> "
+                             "chromaprint_feed() failed"
+                          << "trackId:" << m_trackId
+                          << "count:" << count;
+        return false;
+    }
+    return true;
+}
+
+void AnalyzerChromaprint::storeResults(TrackPointer /*pTrack*/) {
+    // initialize() returns false when skipping a track, which means
+    // m_pChromaprintCtx is null — nothing to store.
+    if (!m_pChromaprintCtx) {
+        if (sDebugAnalyzerChromaprint) {
+            qDebug() << "AnalyzerChromaprint -> [storeResults] -> "
+                        "no context, skipping (track had valid fingerprint)";
+        }
+        return;
+    }
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [storeResults] -> entry"
+                 << "trackId:" << m_trackId;
+    }
+
+    // Finalise the fingerprint computation
+    if (!chromaprint_finish(m_pChromaprintCtx)) {
+        kLogger.warning() << "AnalyzerChromaprint -> [storeResults] -> "
+                             "chromaprint_finish() failed"
+                          << "trackId:" << m_trackId;
+        return;
+    }
+
+    // Retrieve the raw uint32[] fingerprint array
+    uint32_p fprint = nullptr;
+    int size = 0;
+    const int ret = chromaprint_get_raw_fingerprint(
+            m_pChromaprintCtx, &fprint, &size);
+
+    if (ret != 1 || !fprint || size <= 0) {
+        kLogger.warning() << "AnalyzerChromaprint -> [storeResults] -> "
+                             "chromaprint_get_raw_fingerprint() failed"
+                          << "trackId:" << m_trackId
+                          << "ret:" << ret
+                          << "size:" << size;
+        if (fprint) {
+            chromaprint_dealloc(fprint);
+        }
+        return;
+    }
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [storeResults] -> "
+                    "raw fingerprint obtained"
+                 << "trackId:" << m_trackId
+                 << "uint32 values:" << size;
+    }
+
+    // Raw uint32[] array → .chroma binary file (section 2, Final_Database.md).
+    //
+    // This file is used for:
+    //   1. SimHash pre-filter (Q1 phase 1) — computed from the array below
+    //   2. Full XOR/popcount comparison (Q1 phase 2) — read from file on demand
+    //   3. AcoustID Base64 submission — encoded in memory at submit time, discarded after
+    //
+    // The .chroma file is NEVER loaded at startup — only on demand for matching.
+    const QByteArray rawData(
+            reinterpret_cast<const char*>(fprint),
+            size * static_cast<int>(sizeof(uint32_t)));
+    chromaprint_dealloc(fprint);
+    fprint = nullptr;
+
+    // Derive both hashes from the raw fingerprint data (section 2).
+    //
+    // SimHash — 32-bit locality-sensitive hash, used as a fast non-unique
+    // pre-filter. NOT a unique key: collisions are expected and handled by
+    // full XOR/popcount comparison of the .chroma files.
+    const quint32 simHash = computeSimHash(
+            reinterpret_cast<const uint32_t*>(rawData.constData()), size);
+
+    // SHA-256 — collision-resistant identity key.
+    // Unique in cmrt_groups (one group = one canonical audio identity).
+    // Non-unique in fingerprint_metadata (exact duplicate tracks share it).
+    const QString sha256 = QCryptographicHash::hash(
+            rawData, QCryptographicHash::Sha256)
+                                   .toHex();
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [storeResults] -> hashes computed"
+                 << "trackId:" << m_trackId
+                 << "simHash:" << simHash
+                 << "sha256:" << sha256;
+    }
+
+    // 1. Persist the raw fingerprint to disk as track_{id}.chroma
+    if (!m_fingerprintDao.saveChromaFile(m_trackId, rawData)) {
+        kLogger.warning() << "AnalyzerChromaprint -> [storeResults] -> "
+                             "failed to save .chroma file"
+                          << "trackId:" << m_trackId;
+        return;
+    }
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [storeResults] -> .chroma file saved"
+                 << "trackId:" << m_trackId
+                 << "bytes:" << rawData.size();
+    }
+
+    // 2. Write all fingerprint_metadata fields
+    FingerprintMetadata metadata;
+    metadata.trackId = m_trackId;
+    metadata.fingerprintHash = simHash;
+    metadata.chromaSha256 = sha256;
+    // Full track duration in seconds (frameLength / sampleRate)
+    metadata.fingerprintDuration =
+            static_cast<double>(m_frameLength) / m_sampleRate;
+    // Store the Chromaprint algorithm ID — identifies the version of the
+    // fingerprinting algorithm, not just the library major version.
+    metadata.fingerprintVersion = CHROMAPRINT_ALGORITHM_DEFAULT;
+    // CMRT group fields are left at defaults until Q1 group assignment (future PR)
+    metadata.cmrtGroupId = -1;
+    metadata.cmrtOffsetSeconds = 0.0;
+    metadata.isCanonical = false;
+    metadata.fingerprintValid = true;
+    metadata.fingerprintNeedsRegen = false;
+    metadata.computedAt = QDateTime::currentDateTimeUtc();
+
+    if (!m_fingerprintDao.saveFingerprintMetadata(metadata)) {
+        kLogger.warning() << "AnalyzerChromaprint -> [storeResults] -> "
+                             "failed to save fingerprint_metadata"
+                          << "trackId:" << m_trackId;
+        return;
+    }
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [storeResults] -> metadata saved"
+                 << "trackId:" << m_trackId
+                 << "duration:" << metadata.fingerprintDuration << "s"
+                 << "version:" << metadata.fingerprintVersion;
+    }
+
+    // 3. Enqueue for AcoustID background lookup.
+    // The UNIQUE constraint on acoustid_queue.track_id silently no-ops if
+    // the track is already queued, so this is safe to call unconditionally.
+    if (!m_fingerprintDao.enqueueAcoustId(m_trackId)) {
+        kLogger.warning() << "AnalyzerChromaprint -> [storeResults] -> "
+                             "failed to enqueue AcoustID job"
+                          << "trackId:" << m_trackId;
+    } else {
+        if (sDebugAnalyzerChromaprint) {
+            qDebug() << "AnalyzerChromaprint -> [storeResults] -> "
+                        "enqueued for AcoustID lookup"
+                     << "trackId:" << m_trackId;
+        }
+    }
+
+    // TODO(CMRT): Q1 two-phase group assignment (SimHash pre-filter +
+    // full XOR/popcount comparison of .chroma files) goes here in a
+    // subsequent PR. Until then tracks are saved with cmrtGroupId = -1.
+
+    kLogger.debug() << "Chromaprint fingerprint stored for track"
+                    << m_trackId
+                    << "simHash:" << simHash
+                    << "duration:" << metadata.fingerprintDuration << "s"
+                    << "rawBytes:" << rawData.size();
+}
+
 // private
 bool AnalyzerChromaprint::hasValidFingerprint(TrackPointer pTrack) const {
     const TrackId trackId = pTrack->getId();

--- a/src/analyzer/analyzerchromaprint.cpp
+++ b/src/analyzer/analyzerchromaprint.cpp
@@ -1,0 +1,182 @@
+#include "analyzer/analyzerchromaprint.h"
+
+#include <QCryptographicHash>
+#include <QFileInfo>
+#include <QtDebug>
+
+#include "track/track.h"
+#include "util/logger.h"
+#include "util/sample.h"
+
+namespace {
+
+mixxx::Logger kLogger("AnalyzerChromaprint");
+
+const bool sDebugAnalyzerChromaprint = true;
+
+// Chromaprint API version guard — uint32_p changed from void* to uint32_t*
+// in v1.4.0. Mirrors the same guard in src/musicbrainz/chromaprinter.cpp.
+#if (CHROMAPRINT_VERSION_MINOR > 3) || (CHROMAPRINT_VERSION_MAJOR > 1)
+typedef uint32_t* uint32_p;
+#else
+typedef void* uint32_p;
+#endif
+
+} // namespace
+
+AnalyzerChromaprint::AnalyzerChromaprint(
+        UserSettingsPointer pConfig,
+        const QSqlDatabase& dbConnection)
+        : m_fingerprintDao(pConfig),
+          m_pChromaprintCtx(nullptr),
+          m_sampleRate(0),
+          m_channelCount(0),
+          m_frameLength(0) {
+    m_fingerprintDao.initialize(dbConnection);
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [constructor] -> initialized";
+    }
+}
+
+AnalyzerChromaprint::~AnalyzerChromaprint() {
+    // cleanup() is always called by the analyzer pipeline before destruction,
+    // but guard here in case of early teardown.
+    if (m_pChromaprintCtx) {
+        chromaprint_free(m_pChromaprintCtx);
+        m_pChromaprintCtx = nullptr;
+    }
+}
+
+bool AnalyzerChromaprint::initialize(
+        const AnalyzerTrack& track,
+        mixxx::audio::SampleRate sampleRate,
+        mixxx::audio::ChannelCount channelCount,
+        SINT frameLength) {
+    const TrackPointer pTrack = track.getTrack();
+    const TrackId trackId = pTrack->getId();
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [initialize] -> entry"
+                 << "trackId:" << trackId
+                 << "sampleRate:" << sampleRate
+                 << "channelCount:" << channelCount
+                 << "frameLength:" << frameLength;
+    }
+
+    if (!trackId.isValid()) {
+        qDebug() << "AnalyzerChromaprint -> [initialize] -> "
+                    "aborting: invalid trackId";
+        return false;
+    }
+
+    // Check whether a valid, non-stale fingerprint already exists.
+    // hasValidFingerprint() also detects file modifications and marks
+    // the fingerprint stale if the source file has changed.
+    if (hasValidFingerprint(pTrack)) {
+        if (sDebugAnalyzerChromaprint) {
+            qDebug() << "AnalyzerChromaprint -> [initialize] -> "
+                        "skipping: valid fingerprint already stored"
+                     << "trackId:" << trackId;
+        }
+        return false;
+    }
+
+    // Store signal properties for use in processSamples() and storeResults()
+    m_sampleRate = sampleRate;
+    m_channelCount = channelCount;
+    m_frameLength = frameLength;
+    m_trackId = trackId;
+
+    // Create a fresh Chromaprint context for full-track analysis
+    m_pChromaprintCtx = chromaprint_new(CHROMAPRINT_ALGORITHM_DEFAULT);
+    if (!m_pChromaprintCtx) {
+        kLogger.warning() << "Failed to create Chromaprint context for track"
+                          << trackId;
+        return false;
+    }
+
+    // Unlike ChromaPrinter (which caps at 120s for AcoustID), we feed the
+    // entire track so that the full fingerprint is available for CMRT matching.
+    const int ret = chromaprint_start(
+            m_pChromaprintCtx,
+            sampleRate,
+            channelCount);
+    if (!ret) {
+        kLogger.warning() << "chromaprint_start() failed for track" << trackId;
+        chromaprint_free(m_pChromaprintCtx);
+        m_pChromaprintCtx = nullptr;
+        return false;
+    }
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [initialize] -> "
+                    "Chromaprint context ready"
+                 << "trackId:" << trackId;
+    }
+    return true;
+}
+
+// private
+bool AnalyzerChromaprint::hasValidFingerprint(TrackPointer pTrack) const {
+    const TrackId trackId = pTrack->getId();
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [hasValidFingerprint] -> entry"
+                 << "trackId:" << trackId;
+    }
+
+    auto pMetadata = m_fingerprintDao.getFingerprintMetadata(trackId);
+    if (!pMetadata) {
+        if (sDebugAnalyzerChromaprint) {
+            qDebug() << "AnalyzerChromaprint -> [hasValidFingerprint] -> "
+                        "no metadata row found"
+                     << "trackId:" << trackId;
+        }
+        return false;
+    }
+
+    if (!pMetadata->fingerprintValid) {
+        if (sDebugAnalyzerChromaprint) {
+            qDebug() << "AnalyzerChromaprint -> [hasValidFingerprint] -> "
+                        "fingerprint marked invalid"
+                     << "trackId:" << trackId;
+        }
+        return false;
+    }
+
+    if (pMetadata->fingerprintNeedsRegen) {
+        if (sDebugAnalyzerChromaprint) {
+            qDebug() << "AnalyzerChromaprint -> [hasValidFingerprint] -> "
+                        "fingerprint explicitly marked for regeneration"
+                     << "trackId:" << trackId;
+        }
+        return false;
+    }
+
+    // Check whether the source file has been modified since the fingerprint
+    // was computed. A newer mtime means the audio content may have changed
+    // (re-encoded, re-tagged with padding shifts, replaced by another version).
+    const QFileInfo fileInfo(pTrack->getLocation());
+    if (fileInfo.exists() && pMetadata->computedAt.isValid() &&
+            fileInfo.lastModified() > pMetadata->computedAt) {
+        if (sDebugAnalyzerChromaprint) {
+            qDebug() << "AnalyzerChromaprint -> [hasValidFingerprint] -> "
+                        "source file modified after fingerprint computed — marking stale"
+                     << "trackId:" << trackId
+                     << "fileModified:" << fileInfo.lastModified().toString(Qt::ISODate)
+                     << "computedAt:" << pMetadata->computedAt.toString(Qt::ISODate);
+        }
+        // Mark stale in the DB so the scanner also knows about it
+        m_fingerprintDao.markFingerprintNeedsRegen(trackId);
+        return false;
+    }
+
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [hasValidFingerprint] -> "
+                    "valid fingerprint found, skipping analysis"
+                 << "trackId:" << trackId
+                 << "computedAt:" << pMetadata->computedAt.toString(Qt::ISODate);
+    }
+    return true;
+}

--- a/src/analyzer/analyzerchromaprint.cpp
+++ b/src/analyzer/analyzerchromaprint.cpp
@@ -304,6 +304,25 @@ void AnalyzerChromaprint::storeResults(TrackPointer /*pTrack*/) {
                     << "rawBytes:" << rawData.size();
 }
 
+void AnalyzerChromaprint::cleanup() {
+    if (sDebugAnalyzerChromaprint) {
+        qDebug() << "AnalyzerChromaprint -> [cleanup] -> entry"
+                 << "trackId:" << m_trackId
+                 << "hasContext:" << (m_pChromaprintCtx != nullptr);
+    }
+
+    if (m_pChromaprintCtx) {
+        chromaprint_free(m_pChromaprintCtx);
+        m_pChromaprintCtx = nullptr;
+    }
+
+    // Release the conversion buffer memory
+    m_int16Buffer.clear();
+    m_int16Buffer.shrink_to_fit();
+
+    m_trackId = TrackId();
+}
+
 // private
 bool AnalyzerChromaprint::hasValidFingerprint(TrackPointer pTrack) const {
     const TrackId trackId = pTrack->getId();
@@ -366,4 +385,36 @@ bool AnalyzerChromaprint::hasValidFingerprint(TrackPointer pTrack) const {
                  << "computedAt:" << pMetadata->computedAt.toString(Qt::ISODate);
     }
     return true;
+}
+
+// static private
+quint32 AnalyzerChromaprint::computeSimHash(const uint32_t* fprint, int size) {
+    // Bit-voting SimHash (same algorithm as chromaprint_hash_fingerprint()
+    // in newer library versions).
+    //
+    // For each of the 32 bit positions:
+    //   - Increment a counter for each fingerprint value that has the bit set
+    //   - Decrement for each that does not
+    // The final SimHash sets the bit if the counter is positive (more set than unset).
+    //
+    // Result: a locality-sensitive 32-bit hash where similar fingerprints
+    // (small Hamming distance) produce similar SimHash values. Used as the
+    // fast pre-filter in Q1 — NOT a unique key.
+    int bitCounts[32] = {};
+    for (int i = 0; i < size; ++i) {
+        for (int b = 0; b < 32; ++b) {
+            if (fprint[i] & (1u << b)) {
+                ++bitCounts[b];
+            } else {
+                --bitCounts[b];
+            }
+        }
+    }
+    quint32 hash = 0;
+    for (int b = 0; b < 32; ++b) {
+        if (bitCounts[b] > 0) {
+            hash |= (1u << b);
+        }
+    }
+    return hash;
 }

--- a/src/analyzer/analyzerchromaprint.h
+++ b/src/analyzer/analyzerchromaprint.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <chromaprint.h>
+
+#include <QDateTime>
+#include <QSqlDatabase>
+#include <vector>
+
+#include "analyzer/analyzer.h"
+#include "library/dao/trackfingerprintdao.h"
+#include "preferences/usersettings.h"
+#include "util/sample.h"
+
+// Analyzer that computes a full-track Chromaprint fingerprint and persists
+// it to disk as a raw .chroma binary file plus a fingerprint_metadata row.
+//
+// Unlike the existing ChromaPrinter (which reads only the first 120 seconds
+// for AcoustID submission), this analyzer processes the entire track so that
+// the complete fingerprint can be used for CMRT duplicate detection and
+// mastering-level offset calculation.
+//
+// Storage layout :
+//   ~/.mixxx/fingerprints/track_{id}.chroma  — raw uint32[] array (on disk)
+//   fingerprint_metadata                      — SimHash + SHA-256 + linkage (DB)
+//
+// The Base64-encoded fingerprint for AcoustID is generated on demand by the
+// background worker at submission time and is never stored permanently.
+class AnalyzerChromaprint : public Analyzer {
+  public:
+    AnalyzerChromaprint(
+            UserSettingsPointer pConfig,
+            const QSqlDatabase& dbConnection);
+    ~AnalyzerChromaprint() override;
+
+    // Returns true if analysis should proceed for this track.
+    // Returns false (skip) if a valid, non-stale fingerprint already exists.
+    bool initialize(const AnalyzerTrack& track,
+            mixxx::audio::SampleRate sampleRate,
+            mixxx::audio::ChannelCount channelCount,
+            SINT frameLength) override;
+
+    // Converts floating-point samples to int16 and feeds them to Chromaprint.
+    bool processSamples(const CSAMPLE* buffer, SINT count) override;
+
+    // Finalizes the fingerprint, computes SimHash + SHA-256, saves the
+    // .chroma file, writes fingerprint_metadata, and enqueues for AcoustID.
+    void storeResults(TrackPointer pTrack) override;
+
+    // Frees the Chromaprint context and clears the conversion buffer.
+    // Always safe to call — guards against null context.
+    void cleanup() override;
+
+  private:
+    // Returns true if the track already has a valid fingerprint that does
+    // not need regeneration. Also checks if the source file has been modified
+    // since the fingerprint was computed — if so, marks it stale and returns false.
+    bool hasValidFingerprint(TrackPointer pTrack) const;
+
+    // Computes a 32-bit SimHash from the raw Chromaprint uint32 array using
+    // bit-voting: for each of the 32 bit positions, increments a counter if
+    // the bit is set in a fingerprint value, decrements if unset. The final
+    // SimHash sets the bit if the counter is positive.
+    //
+    // This is a locality-sensitive hash — similar fingerprints produce similar
+    // SimHash values — used as the fast candidate pre-filter
+    // It is NOT a unique key; full XOR/popcount
+    // comparison of .chroma files is always required to confirm a match.
+    static quint32 computeSimHash(const uint32_t* fprint, int size);
+
+    TrackFingerprintDao m_fingerprintDao;
+    ChromaprintContext* m_pChromaprintCtx;
+
+    // Reusable int16 conversion buffer — avoids per-chunk heap allocation
+    std::vector<SAMPLE> m_int16Buffer;
+
+    // Stored in initialize() for use in storeResults()
+    mixxx::audio::SampleRate m_sampleRate;
+    mixxx::audio::ChannelCount m_channelCount;
+    SINT m_frameLength;
+    TrackId m_trackId;
+};

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -94,22 +94,34 @@ void AnalyzerThread::doRun() {
     // before returning from this function.
     mixxx::DbConnectionPooler dbConnectionPooler;
 
-    if (m_modeFlags & AnalyzerModeFlags::WithWaveform) {
-        dbConnectionPooler = mixxx::DbConnectionPooler(m_dbConnectionPool); // move assignment
+    // Both AnalyzerWaveform and AnalyzerChromaprint require a database connection.
+    // Create it once and share it — both analyzers run on the same worker thread.
+    const bool needsDbConnection =
+            (m_modeFlags & AnalyzerModeFlags::WithWaveform) ||
+            (m_modeFlags & AnalyzerModeFlags::WithFingerprint);
+    if (needsDbConnection) {
+        dbConnectionPooler = mixxx::DbConnectionPooler(m_dbConnectionPool);
         if (!dbConnectionPooler.isPooling()) {
             kLogger.warning()
                     << "Failed to obtain database connection for analyzer thread";
             return;
         }
         QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_dbConnectionPool);
-        m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerWaveform>(m_pConfig, dbConnection)));
 
-        // Chromaprint shares the same DB connection as AnalyzerWaveform
+        if (m_modeFlags & AnalyzerModeFlags::WithWaveform) {
+            m_analyzers.push_back(AnalyzerWithState(
+                    std::make_unique<AnalyzerWaveform>(m_pConfig, dbConnection)));
+        }
+
+        // Only run fingerprint analysis when explicitly requested.
+        // WithFingerprint is excluded from All — it is an opt-in mode
+        // that can run independently of waveform analysis.
         if (m_modeFlags & AnalyzerModeFlags::WithFingerprint) {
             m_analyzers.push_back(AnalyzerWithState(
                     std::make_unique<AnalyzerChromaprint>(m_pConfig, dbConnection)));
         }
     }
+
     if (AnalyzerGain::isEnabled(ReplayGainSettings(m_pConfig))) {
         m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerGain>(m_pConfig)));
     }

--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -3,6 +3,7 @@
 #include <mutex>
 
 #include "analyzer/analyzerbeats.h"
+#include "analyzer/analyzerchromaprint.h"
 #include "analyzer/analyzerebur128.h"
 #include "analyzer/analyzergain.h"
 #include "analyzer/analyzerkey.h"
@@ -102,6 +103,12 @@ void AnalyzerThread::doRun() {
         }
         QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_dbConnectionPool);
         m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerWaveform>(m_pConfig, dbConnection)));
+
+        // Chromaprint shares the same DB connection as AnalyzerWaveform
+        if (m_modeFlags & AnalyzerModeFlags::WithFingerprint) {
+            m_analyzers.push_back(AnalyzerWithState(
+                    std::make_unique<AnalyzerChromaprint>(m_pConfig, dbConnection)));
+        }
     }
     if (AnalyzerGain::isEnabled(ReplayGainSettings(m_pConfig))) {
         m_analyzers.push_back(AnalyzerWithState(std::make_unique<AnalyzerGain>(m_pConfig)));

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -22,6 +22,7 @@ enum AnalyzerModeFlags {
     WithBeats = 0x01,
     WithWaveform = 0x02,
     LowPriority = 0x04,
+    WithFingerprint = 0x08,
     All = WithBeats | WithWaveform,
 };
 

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -22,8 +22,12 @@ enum AnalyzerModeFlags {
     WithBeats = 0x01,
     WithWaveform = 0x02,
     LowPriority = 0x04,
+    // WithFingerprint is intentionally excluded from All — it is an
+    // opt-in mode that runs independently of the standard pipeline.
     WithFingerprint = 0x08,
     All = WithBeats | WithWaveform,
+    // Use AllWithFingerprint when you want the full suite including fingerprinting.
+    AllWithFingerprint = WithBeats | WithWaveform | WithFingerprint,
 };
 
 enum class AnalyzerThreadState {

--- a/src/analyzer/analyzertrack.h
+++ b/src/analyzer/analyzertrack.h
@@ -8,8 +8,15 @@
 class AnalyzerTrack {
   public:
     struct Options {
+        Options()
+                : fingerprintOnly(false) {
+        }
         /// If set, overrides whether the analysis should assume constant BPM.
         std::optional<bool> useFixedTempo;
+        /// If true, run only fingerprint analysis — skip beats, waveform, and
+        /// all other analyzers. Useful for back-filling fingerprints on a
+        /// library that was already fully analyzed without this step.
+        bool fingerprintOnly;
     };
 
     explicit AnalyzerTrack(TrackPointer track, Options options = Options());

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -14,7 +14,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 40;
+const int MixxxDb::kRequiredSchemaVersion = 41;
 
 namespace {
 

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -14,7 +14,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 41;
+const int MixxxDb::kRequiredSchemaVersion = 42;
 
 namespace {
 

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -14,7 +14,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 42;
+const int MixxxDb::kRequiredSchemaVersion = 43;
 
 namespace {
 

--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -142,6 +142,31 @@ void AnalysisFeature::activate() {
 
 void AnalysisFeature::analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks) {
     if (!m_pTrackAnalysisScheduler) {
+        // Determine mode flags from the incoming batch. If every track has
+        // fingerprintOnly set (e.g. right-click "Analyze fingerprint"), run
+        // only the fingerprint analyzer at low priority so beats and waveform
+        // are not re-triggered on an already-analyzed library.
+        //
+        // Note: this selection only applies when no scheduler is currently
+        // active. If a normal analysis is already running and fingerprint-only
+        // tracks are added, they will be processed with the existing scheduler's
+        // flags (WithBeats | WithWaveform). Fixing that would require either
+        // stopping the active scheduler or maintaining a separate scheduler for
+        // fingerprint-only jobs — deferred to a later PR.
+
+        bool allFingerprintOnly = !tracks.isEmpty();
+        for (const auto& t : tracks) {
+            if (!t.getOptions().fingerprintOnly) {
+                allFingerprintOnly = false;
+                break;
+            }
+        }
+        const AnalyzerModeFlags modeFlags = allFingerprintOnly
+                ? static_cast<AnalyzerModeFlags>(
+                          AnalyzerModeFlags::WithFingerprint |
+                          AnalyzerModeFlags::LowPriority)
+                : getAnalyzerModeFlags(m_pConfig);
+
         const int numAnalyzerThreads = numberOfAnalyzerThreads();
         kLogger.info()
                 << "Starting analysis using"
@@ -149,7 +174,7 @@ void AnalysisFeature::analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks)
                 << "analyzer threads";
         m_pTrackAnalysisScheduler = m_pLibrary->createTrackAnalysisScheduler(
                 numAnalyzerThreads,
-                getAnalyzerModeFlags(m_pConfig));
+                modeFlags);
 
         connect(m_pTrackAnalysisScheduler.get(),
                 &TrackAnalysisScheduler::progress,

--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -7,6 +7,7 @@
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "library/analysis/dlganalysis.h"
 #include "library/library.h"
+#include "library/library_prefs.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_analysisfeature.cpp"
 #include "sources/soundsourceproxy.h"

--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -40,6 +40,11 @@ AnalyzerModeFlags getAnalyzerModeFlags(
     if (pConfig->getValue<bool>(ConfigKey("[Library]", "EnableWaveformGenerationWithAnalysis"), true)) {
         modeFlags |= AnalyzerModeFlags::WithWaveform;
     }
+    // Fingerprint analysis is opt-in — disabled by default
+    if (pConfig->getValue(
+                mixxx::library::prefs::kFingerprintAnalysisEnabledConfigKey, false)) {
+        modeFlags |= AnalyzerModeFlags::WithFingerprint;
+    }
     return static_cast<AnalyzerModeFlags>(modeFlags);
 }
 

--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -148,6 +148,31 @@ void AnalysisFeature::activate() {
 
 void AnalysisFeature::analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks) {
     if (!m_pTrackAnalysisScheduler) {
+        // Determine mode flags from the incoming batch. If every track has
+        // fingerprintOnly set (e.g. right-click "Analyze fingerprint"), run
+        // only the fingerprint analyzer at low priority so beats and waveform
+        // are not re-triggered on an already-analyzed library.
+        //
+        // Note: this selection only applies when no scheduler is currently
+        // active. If a normal analysis is already running and fingerprint-only
+        // tracks are added, they will be processed with the existing scheduler's
+        // flags (WithBeats | WithWaveform). Fixing that would require either
+        // stopping the active scheduler or maintaining a separate scheduler for
+        // fingerprint-only jobs — deferred to a later PR.
+
+        bool allFingerprintOnly = !tracks.isEmpty();
+        for (const auto& t : tracks) {
+            if (!t.getOptions().fingerprintOnly) {
+                allFingerprintOnly = false;
+                break;
+            }
+        }
+        const AnalyzerModeFlags modeFlags = allFingerprintOnly
+                ? static_cast<AnalyzerModeFlags>(
+                          AnalyzerModeFlags::WithFingerprint |
+                          AnalyzerModeFlags::LowPriority)
+                : getAnalyzerModeFlags(m_pConfig);
+
         const int numAnalyzerThreads = numberOfAnalyzerThreads();
         kLogger.info()
                 << "Starting analysis using"
@@ -155,7 +180,7 @@ void AnalysisFeature::analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks)
                 << "analyzer threads";
         m_pTrackAnalysisScheduler = m_pLibrary->createTrackAnalysisScheduler(
                 numAnalyzerThreads,
-                getAnalyzerModeFlags(m_pConfig));
+                modeFlags);
 
         connect(m_pTrackAnalysisScheduler.get(),
                 &TrackAnalysisScheduler::progress,

--- a/src/library/analysis/dlganalysis.ui
+++ b/src/library/analysis/dlganalysis.ui
@@ -139,7 +139,7 @@
           <enum>Qt::NoFocus</enum>
          </property>
          <property name="toolTip">
-          <string>Runs beatgrid, key, and ReplayGain detection on the selected tracks. Does not generate waveforms for the selected tracks to save disk space.</string>
+          <string>Runs beatgrid, key, and ReplayGain detection on the selected tracks. Also computes Chromaprint fingerprints if fingerprint analysis is enabled in Preferences. Does not generate waveforms to save disk space.</string>
          </property>
          <property name="text">
           <string>Analyze</string>

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -388,7 +388,7 @@ bool TrackDAO::updateAcoustIdResult(
         const QString& musicbrainzRecordingId,
         const QString& musicbrainzReleaseId,
         const QString& musicbrainzTrackId,
-        const QString& musicbrainzArtistId) const {
+        const QString& musicbrainzArtistId) {
     kLogger.debug() << "Updating AcoustID result for track" << trackId;
     if (!trackId.isValid()) {
         return false;

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -16,6 +16,7 @@
 #include "library/dao/cuedao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
+#include "library/dao/trackfingerprintdao.h"
 #include "library/dao/trackschema.h"
 #include "library/library_prefs.h"
 #include "library/queryutil.h"
@@ -89,14 +90,16 @@ QSet<QString> collectTrackLocations(FwdSqlQuery& query) {
 } // anonymous namespace
 
 TrackDAO::TrackDAO(CueDAO& cueDao,
-                   PlaylistDAO& playlistDao,
-                   AnalysisDao& analysisDao,
-                   LibraryHashDAO& libraryHashDao,
-                   UserSettingsPointer pConfig)
+        PlaylistDAO& playlistDao,
+        AnalysisDao& analysisDao,
+        LibraryHashDAO& libraryHashDao,
+        TrackFingerprintDao& fingerprintDao,
+        UserSettingsPointer pConfig)
         : m_cueDao(cueDao),
           m_playlistDao(playlistDao),
           m_analysisDao(analysisDao),
           m_libraryHashDao(libraryHashDao),
+          m_fingerprintDao(fingerprintDao),
           m_pConfig(pConfig),
           m_trackLocationIdColumn(UndefinedRecordIndex),
           m_queryLibraryIdColumn(UndefinedRecordIndex),
@@ -1132,6 +1135,13 @@ bool TrackDAO::onPurgingTracks(
                                               .arg(idListJoined));
         if (query.hasError() || !query.execPrepared()) {
             return false;
+        }
+    }
+    {
+        // Delete .chroma files for purged tracks.
+        // DB rows are handled above; files must be cleaned up separately
+        for (const TrackId& trackId : trackIds) {
+            m_fingerprintDao.deleteChromaFile(trackId);
         }
     }
     {

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -381,6 +381,66 @@ bool TrackDAO::saveTrack(Track* pTrack) const {
     return true;
 }
 
+bool TrackDAO::updateAcoustIdResult(
+        TrackId trackId,
+        const QString& acoustidId,
+        const QString& acoustidLookupStatus,
+        const QString& musicbrainzRecordingId,
+        const QString& musicbrainzReleaseId,
+        const QString& musicbrainzTrackId,
+        const QString& musicbrainzArtistId) const {
+    kLogger.debug() << "Updating AcoustID result for track" << trackId;
+    if (!trackId.isValid()) {
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(
+            "UPDATE library SET "
+            "acoustid_id=:acoustid_id, "
+            "acoustid_lookup_status=:acoustid_status, "
+            "musicbrainz_recording_id=:mbid_recording, "
+            "musicbrainz_release_id=:mbid_release, "
+            "musicbrainz_track_id=:mbid_track, "
+            "musicbrainz_artist_id=:mbid_artist "
+            "WHERE id=:track_id");
+
+    query.bindValue(":track_id", trackId.toVariant());
+    // Bind NULL for empty strings — don't overwrite existing data with blanks
+    query.bindValue(":acoustid_id",
+            acoustidId.isEmpty()
+                    ? QVariant(QMetaType(QMetaType::QString))
+                    : acoustidId);
+    query.bindValue(":acoustid_status",
+            acoustidLookupStatus.isEmpty()
+                    ? QVariant(QMetaType(QMetaType::QString))
+                    : acoustidLookupStatus);
+    query.bindValue(":mbid_recording",
+            musicbrainzRecordingId.isEmpty()
+                    ? QVariant(QMetaType(QMetaType::QString))
+                    : musicbrainzRecordingId);
+    query.bindValue(":mbid_release",
+            musicbrainzReleaseId.isEmpty()
+                    ? QVariant(QMetaType(QMetaType::QString))
+                    : musicbrainzReleaseId);
+    query.bindValue(":mbid_track",
+            musicbrainzTrackId.isEmpty()
+                    ? QVariant(QMetaType(QMetaType::QString))
+                    : musicbrainzTrackId);
+    query.bindValue(":mbid_artist",
+            musicbrainzArtistId.isEmpty()
+                    ? QVariant(QMetaType(QMetaType::QString))
+                    : musicbrainzArtistId);
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't update AcoustID result for track" << trackId;
+        return false;
+    }
+
+    return query.numRowsAffected() > 0;
+}
+
 void TrackDAO::slotDatabaseTracksChanged(const QSet<TrackId>& changedTrackIds) {
     if (!changedTrackIds.isEmpty()) {
         emit tracksChanged(changedTrackIds);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1108,6 +1108,33 @@ bool TrackDAO::onPurgingTracks(
         }
     }
     {
+        // Delete orphaned fingerprint metadata for purged tracks
+        FwdSqlQuery query(m_database, QString("DELETE FROM fingerprint_metadata "
+                                              "WHERE track_id IN (%1)")
+                                              .arg(idListJoined));
+        if (query.hasError() || !query.execPrepared()) {
+            return false;
+        }
+    }
+    {
+        // Delete CMRT group memberships for purged tracks
+        FwdSqlQuery query(m_database, QString("DELETE FROM cmrt_members "
+                                              "WHERE track_id IN (%1)")
+                                              .arg(idListJoined));
+        if (query.hasError() || !query.execPrepared()) {
+            return false;
+        }
+    }
+    {
+        // Delete pending AcoustID jobs for purged tracks
+        FwdSqlQuery query(m_database, QString("DELETE FROM acoustid_queue "
+                                              "WHERE track_id IN (%1)")
+                                              .arg(idListJoined));
+        if (query.hasError() || !query.execPrepared()) {
+            return false;
+        }
+    }
+    {
         // Remove Track from library table
         FwdSqlQuery query(m_database, QString(
                 "DELETE FROM library "

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -80,6 +80,18 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     // Only used by friend class TrackCollection, but public for testing!
     bool saveTrack(Track* pTrack) const;
 
+    // Writes AcoustID lookup results back to the library table.
+    // Called by the AcoustID worker after a successful lookup or submission.
+    // Passing empty strings for any MBID field leaves that column unchanged.
+    bool updateAcoustIdResult(
+            TrackId trackId,
+            const QString& acoustidId,
+            const QString& acoustidLookupStatus,
+            const QString& musicbrainzRecordingId,
+            const QString& musicbrainzReleaseId,
+            const QString& musicbrainzTrackId,
+            const QString& musicbrainzArtistId) const;
+
     /// Update the play counter properties according to the corresponding
     /// aggregated properties obtained from the played history.
     bool updatePlayCounterFromPlayedHistory(

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -80,18 +80,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     // Only used by friend class TrackCollection, but public for testing!
     bool saveTrack(Track* pTrack) const;
 
-    // Writes AcoustID lookup results back to the library table.
-    // Called by the AcoustID worker after a successful lookup or submission.
-    // Passing empty strings for any MBID field leaves that column unchanged.
-    bool updateAcoustIdResult(
-            TrackId trackId,
-            const QString& acoustidId,
-            const QString& acoustidLookupStatus,
-            const QString& musicbrainzRecordingId,
-            const QString& musicbrainzReleaseId,
-            const QString& musicbrainzTrackId,
-            const QString& musicbrainzArtistId) const;
-
     /// Update the play counter properties according to the corresponding
     /// aggregated properties obtained from the played history.
     bool updatePlayCounterFromPlayedHistory(
@@ -145,6 +133,18 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             const QSet<TrackId>& changedTrackIds);
     void slotDatabaseTracksRelocated(
             const QList<RelocatedTrack>& relocatedTracks);
+
+    // Writes AcoustID lookup results back to the library table.
+    // Called by the AcoustID worker after a successful lookup or submission.
+    // Passing empty strings for any MBID field leaves that column unchanged.
+    bool updateAcoustIdResult(
+            TrackId trackId,
+            const QString& acoustidId,
+            const QString& acoustidLookupStatus,
+            const QString& musicbrainzRecordingId,
+            const QString& musicbrainzReleaseId,
+            const QString& musicbrainzTrackId,
+            const QString& musicbrainzArtistId);
 
   private:
     friend class LibraryScanner;

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -17,6 +17,7 @@ class PlaylistDAO;
 class AnalysisDao;
 class CueDAO;
 class LibraryHashDAO;
+class TrackFingerprintDao;
 
 namespace mixxx {
 class FileInfo;
@@ -42,6 +43,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             PlaylistDAO& playlistDao,
             AnalysisDao& analysisDao,
             LibraryHashDAO& libraryHashDao,
+            TrackFingerprintDao& fingerprintDao,
             UserSettingsPointer pConfig);
     ~TrackDAO() override;
 
@@ -204,6 +206,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     PlaylistDAO& m_playlistDao;
     AnalysisDao& m_analysisDao;
     LibraryHashDAO& m_libraryHashDao;
+    TrackFingerprintDao& m_fingerprintDao;
 
     const UserSettingsPointer m_pConfig;
 

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -83,6 +83,18 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     // Only used by friend class TrackCollection, but public for testing!
     bool saveTrack(Track* pTrack) const;
 
+    // Writes AcoustID lookup results back to the library table.
+    // Called by the AcoustID worker after a successful lookup or submission.
+    // Passing empty strings for any MBID field leaves that column unchanged.
+    bool updateAcoustIdResult(
+            TrackId trackId,
+            const QString& acoustidId,
+            const QString& acoustidLookupStatus,
+            const QString& musicbrainzRecordingId,
+            const QString& musicbrainzReleaseId,
+            const QString& musicbrainzTrackId,
+            const QString& musicbrainzArtistId) const;
+
     /// Update the play counter properties according to the corresponding
     /// aggregated properties obtained from the played history.
     bool updatePlayCounterFromPlayedHistory(

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -20,6 +20,7 @@ class PlaylistDAO;
 class AnalysisDao;
 class CueDAO;
 class LibraryHashDAO;
+class TrackFingerprintDao;
 
 namespace mixxx {
 class FileInfo;
@@ -45,6 +46,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             PlaylistDAO& playlistDao,
             AnalysisDao& analysisDao,
             LibraryHashDAO& libraryHashDao,
+            TrackFingerprintDao& fingerprintDao,
             UserSettingsPointer pConfig);
     ~TrackDAO() override;
 
@@ -210,6 +212,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     PlaylistDAO& m_playlistDao;
     AnalysisDao& m_analysisDao;
     LibraryHashDAO& m_libraryHashDao;
+    TrackFingerprintDao& m_fingerprintDao;
 
     const UserSettingsPointer m_pConfig;
 

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -83,18 +83,6 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     // Only used by friend class TrackCollection, but public for testing!
     bool saveTrack(Track* pTrack) const;
 
-    // Writes AcoustID lookup results back to the library table.
-    // Called by the AcoustID worker after a successful lookup or submission.
-    // Passing empty strings for any MBID field leaves that column unchanged.
-    bool updateAcoustIdResult(
-            TrackId trackId,
-            const QString& acoustidId,
-            const QString& acoustidLookupStatus,
-            const QString& musicbrainzRecordingId,
-            const QString& musicbrainzReleaseId,
-            const QString& musicbrainzTrackId,
-            const QString& musicbrainzArtistId) const;
-
     /// Update the play counter properties according to the corresponding
     /// aggregated properties obtained from the played history.
     bool updatePlayCounterFromPlayedHistory(
@@ -149,6 +137,18 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             const QSet<TrackId>& changedTrackIds);
     void slotDatabaseTracksRelocated(
             const QList<RelocatedTrack>& relocatedTracks);
+
+    // Writes AcoustID lookup results back to the library table.
+    // Called by the AcoustID worker after a successful lookup or submission.
+    // Passing empty strings for any MBID field leaves that column unchanged.
+    bool updateAcoustIdResult(
+            TrackId trackId,
+            const QString& acoustidId,
+            const QString& acoustidLookupStatus,
+            const QString& musicbrainzRecordingId,
+            const QString& musicbrainzReleaseId,
+            const QString& musicbrainzTrackId,
+            const QString& musicbrainzArtistId);
 
   private:
     friend class LibraryScanner;

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -723,9 +723,8 @@ bool TrackFingerprintDao::updateCmrtGroupTrackCount(int groupId, int delta) cons
 }
 
 QDir TrackFingerprintDao::getFingerprintStoragePath() const {
-    QString settingsPath = m_pConfig->getSettingsPath();
-    QDir dir(settingsPath.append("/fingerprints/"));
-    return dir.absolutePath().append("/");
+    return QDir(m_pConfig->getSettingsPath() +
+            QStringLiteral("/fingerprints"));
 }
 
 QString TrackFingerprintDao::getChromaFilePath(TrackId trackId) const {

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -1371,3 +1371,209 @@ bool TrackFingerprintDao::reQueueJob(TrackId trackId) const {
     }
     return affected;
 }
+
+bool TrackFingerprintDao::clearFingerprintData(TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [clearFingerprintData] -> entry"
+                 << "trackId:" << trackId;
+    }
+
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [clearFingerprintData] -> "
+                    "aborting: database not open or invalid trackId";
+        return false;
+    }
+
+    // Step 1 — delete the .chroma file outside the transaction.
+    // File deletion is not transactional; doing it first means that if the
+    // DB steps later fail, the missing file is detected on the next analysis
+    // run and the fingerprint is recomputed. The reverse order would leave
+    // a valid DB row pointing at a missing file, which is harder to detect.
+    deleteChromaFile(trackId);
+
+    // Steps 2–5 run inside a ScopedTransaction so the DB is never left in a
+    // half-cleared state. ScopedTransaction stores its own QSqlDatabase copy
+    // and calls transaction()/commit()/rollback() on that copy — consistent
+    // with how TrackDAO uses ScopedTransaction for its write operations.
+    ScopedTransaction transaction(m_database);
+    if (!transaction.active()) {
+        qDebug() << "TrackFingerprintDao -> [clearFingerprintData] -> "
+                    "failed to start transaction for trackId:"
+                 << trackId;
+        return false;
+    }
+
+    // Step 2 — handle CMRT group membership.
+    // If this track was canonical in its group and other members exist,
+    // promote another member to canonical. If it was the sole member,
+    // delete the group row. Non-canonical tracks skip this step.
+    // TODO (XXX): Update this logic to select next canonical track
+    // is a canonical Track is deleted, instead of just promoting the
+    // first member found in the group.
+    {
+        auto pMetadata = getFingerprintMetadata(trackId);
+        if (pMetadata && pMetadata->isCanonical && pMetadata->cmrtGroupId >= 0) {
+            const int groupId = pMetadata->cmrtGroupId;
+
+            // Look for another member in this group.
+            QSqlQuery q(m_database);
+            q.prepare(QStringLiteral(
+                    "SELECT track_id FROM %1 "
+                    "WHERE group_id = :group_id AND track_id != :track_id "
+                    "LIMIT 1")
+                            .arg(kCmrtMembersTableName));
+            q.bindValue(QStringLiteral(":group_id"), groupId);
+            q.bindValue(QStringLiteral(":track_id"), trackId.toVariant());
+
+            if (q.exec() && q.next()) {
+                // Another member exists — promote it to canonical.
+                const TrackId newCanonical(q.value(0));
+
+                QSqlQuery updateGroup(m_database);
+                updateGroup.prepare(QStringLiteral(
+                        "UPDATE %1 SET canonical_track_id = :new_canonical "
+                        "WHERE group_id = :group_id")
+                                .arg(kCmrtGroupsTableName));
+                updateGroup.bindValue(QStringLiteral(":new_canonical"),
+                        newCanonical.toVariant());
+                updateGroup.bindValue(QStringLiteral(":group_id"), groupId);
+                if (!updateGroup.exec()) {
+                    LOG_FAILED_QUERY(updateGroup)
+                            << "couldn't reassign canonical for group" << groupId;
+                    return false; // ScopedTransaction destructor rolls back
+                }
+
+                QSqlQuery updateMeta(m_database);
+                updateMeta.prepare(QStringLiteral(
+                        "UPDATE %1 SET is_canonical = 1 "
+                        "WHERE track_id = :track_id")
+                                .arg(kFingerprintTableName));
+                updateMeta.bindValue(QStringLiteral(":track_id"),
+                        newCanonical.toVariant());
+                if (!updateMeta.exec()) {
+                    LOG_FAILED_QUERY(updateMeta)
+                            << "couldn't promote new canonical in fingerprint_metadata";
+                    return false; // ScopedTransaction destructor rolls back
+                }
+
+                if (sDebugTrackFingerprintDao) {
+                    qDebug() << "TrackFingerprintDao -> [clearFingerprintData] -> "
+                                "promoted new canonical"
+                             << newCanonical
+                             << "for group" << groupId;
+                }
+            } else {
+                // No other members — delete the now-empty group.
+                QSqlQuery deleteGroup(m_database);
+                deleteGroup.prepare(QStringLiteral(
+                        "DELETE FROM %1 WHERE group_id = :group_id")
+                                .arg(kCmrtGroupsTableName));
+                deleteGroup.bindValue(QStringLiteral(":group_id"), groupId);
+                if (!deleteGroup.exec()) {
+                    LOG_FAILED_QUERY(deleteGroup)
+                            << "couldn't delete empty cmrt_group" << groupId;
+                    return false; // ScopedTransaction destructor rolls back
+                }
+
+                if (sDebugTrackFingerprintDao) {
+                    qDebug() << "TrackFingerprintDao -> [clearFingerprintData] -> "
+                                "deleted empty group"
+                             << groupId;
+                }
+            }
+        }
+    }
+
+    // Step 3 — delete cmrt_members row.
+    {
+        QSqlQuery q(m_database);
+        q.prepare(QStringLiteral("DELETE FROM %1 WHERE track_id = :track_id")
+                        .arg(kCmrtMembersTableName));
+        q.bindValue(QStringLiteral(":track_id"), trackId.toVariant());
+        if (!q.exec()) {
+            LOG_FAILED_QUERY(q) << "couldn't delete cmrt_member for track" << trackId;
+            return false; // ScopedTransaction destructor rolls back
+        }
+    }
+
+    // Step 4 — delete fingerprint_metadata row.
+    {
+        QSqlQuery q(m_database);
+        q.prepare(QStringLiteral("DELETE FROM %1 WHERE track_id = :track_id")
+                        .arg(kFingerprintTableName));
+        q.bindValue(QStringLiteral(":track_id"), trackId.toVariant());
+        if (!q.exec()) {
+            LOG_FAILED_QUERY(q) << "couldn't delete fingerprint_metadata for track" << trackId;
+            return false; // ScopedTransaction destructor rolls back
+        }
+    }
+
+    // Step 5 — delete acoustid_queue row.
+    {
+        QSqlQuery q(m_database);
+        q.prepare(QStringLiteral("DELETE FROM %1 WHERE track_id = :track_id")
+                        .arg(kAcoustIdQueueTableName));
+        q.bindValue(QStringLiteral(":track_id"), trackId.toVariant());
+        if (!q.exec()) {
+            LOG_FAILED_QUERY(q)
+                    << "couldn't delete acoustid_queue entry for track" << trackId;
+            return false; // ScopedTransaction destructor rolls back
+        }
+    }
+
+    if (!transaction.commit()) {
+        qDebug() << "TrackFingerprintDao -> [clearFingerprintData] -> "
+                    "failed to commit transaction for trackId:"
+                 << trackId;
+        return false;
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [clearFingerprintData] -> done"
+                 << "trackId:" << trackId;
+    }
+    return true;
+}
+
+int TrackFingerprintDao::clearAllFingerprintData() const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [clearAllFingerprintData] -> entry";
+    }
+
+    if (!m_database.isOpen()) {
+        qDebug() << "TrackFingerprintDao -> [clearAllFingerprintData] -> "
+                    "aborting: database not open";
+        return 0;
+    }
+
+    // Collect all track IDs with a fingerprint_metadata row first,
+    // then clear each one individually. Clearing inside the SELECT loop
+    // would mutate the table being iterated — unsafe with SQLite.
+    QSqlQuery q(m_database);
+    q.prepare(QStringLiteral("SELECT track_id FROM %1").arg(kFingerprintTableName));
+    if (!q.exec()) {
+        LOG_FAILED_QUERY(q) << "couldn't fetch fingerprinted track IDs";
+        return 0;
+    }
+
+    QList<TrackId> trackIds;
+    while (q.next()) {
+        const TrackId id(q.value(0));
+        if (id.isValid()) {
+            trackIds.append(id);
+        }
+    }
+
+    int cleared = 0;
+    for (const TrackId& id : std::as_const(trackIds)) {
+        if (clearFingerprintData(id)) {
+            ++cleared;
+        }
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [clearAllFingerprintData] -> done"
+                 << "cleared:" << cleared << "of" << trackIds.size();
+    }
+    return cleared;
+}

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -15,8 +15,12 @@ const bool sDebugTrackFingerprintDao = true;
 } // namespace
 
 TrackFingerprintDao::TrackFingerprintDao(UserSettingsPointer pConfig)
-        : DAO(),
-          m_pConfig(pConfig) {
+        : m_pConfig(pConfig) {
+    QDir storagePath = getFingerprintStoragePath();
+    if (!QDir().mkpath(storagePath.absolutePath())) {
+        qDebug() << "WARNING: Could not create fingerprint storage path."
+                    " Mixxx will be unable to store .chroma files.";
+    }
 }
 
 bool TrackFingerprintDao::saveFingerprintMetadata(const FingerprintMetadata& metadata) const {
@@ -710,4 +714,127 @@ bool TrackFingerprintDao::updateCmrtGroupTrackCount(int groupId, int delta) cons
                  << "groupId:" << groupId << "delta:" << delta;
     }
     return affected;
+}
+
+QDir TrackFingerprintDao::getFingerprintStoragePath() const {
+    QString settingsPath = m_pConfig->getSettingsPath();
+    QDir dir(settingsPath.append("/fingerprints/"));
+    return dir.absolutePath().append("/");
+}
+
+QString TrackFingerprintDao::getChromaFilePath(TrackId trackId) const {
+    return getFingerprintStoragePath().absoluteFilePath(
+            QStringLiteral("track_%1.chroma").arg(trackId.toString()));
+}
+
+QByteArray TrackFingerprintDao::loadChromaFile(TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [loadChromaFile] -> entry trackId:" << trackId;
+    }
+
+    if (!trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [loadChromaFile] -> "
+                    "aborting: invalid trackId";
+        return {};
+    }
+
+    const QString path = getChromaFilePath(trackId);
+    QFile file(path);
+    if (!file.exists()) {
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [loadChromaFile] -> file does not exist:" << path;
+        }
+        return {};
+    }
+    if (!file.open(QIODevice::ReadOnly)) {
+        qDebug() << "TrackFingerprintDao -> [loadChromaFile] -> could not open file:" << path;
+        return {};
+    }
+
+    QByteArray data = file.readAll();
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [loadChromaFile] -> done, read bytes:" << data.size();
+    }
+    return data;
+}
+
+bool TrackFingerprintDao::saveChromaFile(TrackId trackId, const QByteArray& data) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [saveChromaFile] -> entry"
+                 << "trackId:" << trackId
+                 << "bytes:" << data.size();
+    }
+
+    if (!trackId.isValid() || data.isEmpty()) {
+        qDebug() << "TrackFingerprintDao -> [saveChromaFile] -> "
+                    "aborting: invalid trackId or empty data";
+        return false;
+    }
+
+    const QString path = getChromaFilePath(trackId);
+    QFile file(path);
+
+    // Prevents a half-written file if Mixxx crashes mid-write.
+    bool success = true;
+    if (file.exists()) {
+        const QString tempPath = path + QStringLiteral(".tmp");
+        QFile tempFile(tempPath);
+        if (!tempFile.open(QIODevice::WriteOnly)) {
+            success = false;
+        } else {
+            if (tempFile.write(data) != data.size()) {
+                tempFile.remove();
+                success = false;
+            }
+            tempFile.close();
+            if (success) {
+                if (!file.remove()) {
+                    success = false;
+                } else if (!tempFile.rename(path)) {
+                    success = false;
+                }
+            }
+        }
+    } else {
+        if (!file.open(QIODevice::WriteOnly)) {
+            success = false;
+        } else {
+            if (file.write(data) != data.size()) {
+                success = false;
+            }
+            file.close();
+        }
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [saveChromaFile] -> done, success:" << success;
+    }
+    return success;
+}
+
+bool TrackFingerprintDao::deleteChromaFile(TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteChromaFile] -> entry trackId:" << trackId;
+    }
+
+    if (!trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [deleteChromaFile] -> aborting: invalid trackId";
+        return false;
+    }
+
+    const QString path = getChromaFilePath(trackId);
+    QFile file(path);
+    if (!file.exists()) {
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [deleteChromaFile] -> file "
+                        "does not exist, nothing to delete";
+        }
+        return true;
+    }
+
+    bool result = file.remove();
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteChromaFile] -> file remove result:" << result;
+    }
+    return result;
 }

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -11,6 +11,11 @@ namespace {
 const QString kFingerprintTableName = QStringLiteral("fingerprint_metadata");
 const QString kCmrtGroupsTableName = QStringLiteral("cmrt_groups");
 const QString kCmrtMembersTableName = QStringLiteral("cmrt_members");
+const QString kAcoustIdQueueTableName = QStringLiteral("acoustid_queue");
+const QString kStatusQueued = QStringLiteral("queued");
+const QString kStatusProcessing = QStringLiteral("processing");
+const QString kStatusCompleted = QStringLiteral("completed");
+const QString kStatusFailed = QStringLiteral("failed");
 const bool sDebugTrackFingerprintDao = true;
 } // namespace
 
@@ -837,4 +842,200 @@ bool TrackFingerprintDao::deleteChromaFile(TrackId trackId) const {
         qDebug() << "TrackFingerprintDao -> [deleteChromaFile] -> file remove result:" << result;
     }
     return result;
+}
+
+bool TrackFingerprintDao::enqueueAcoustId(
+        TrackId trackId, int priority) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [enqueueAcoustId] -> entry"
+                 << "trackId:" << trackId
+                 << "priority:" << priority;
+    }
+
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [enqueueAcoustId] -> "
+                    "aborting: database not open or invalid trackId";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    // INSERT OR IGNORE respects the UNIQUE(track_id) constraint —
+    // a track already in the queue is not re-queued.
+    query.prepare(QString(
+            "INSERT OR IGNORE INTO %1 "
+            "(track_id, priority, status, queued_at) "
+            "VALUES (:track_id, :priority, :status, :queued_at)")
+                    .arg(kAcoustIdQueueTableName));
+
+    query.bindValue(":track_id", trackId.toVariant());
+    query.bindValue(":priority", priority);
+    query.bindValue(":status", kStatusQueued);
+    query.bindValue(":queued_at", QDateTime::currentSecsSinceEpoch());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't enqueue AcoustID job for track" << trackId;
+        return false;
+    }
+
+    const bool inserted = query.numRowsAffected() > 0;
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [enqueueAcoustId] ->"
+                 << (inserted ? "enqueued" : "already in queue")
+                 << "trackId:" << trackId;
+    }
+    return true;
+}
+
+bool TrackFingerprintDao::updateQueueStatus(
+        int queueId,
+        const QString& status,
+        const QString& errorMessage) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [updateQueueStatus] -> entry"
+                 << "queueId:" << queueId
+                 << "status:" << status;
+    }
+
+    if (!m_database.isOpen() || queueId < 0) {
+        qDebug() << "TrackFingerprintDao -> [updateQueueStatus] -> "
+                    "aborting: database not open or invalid queueId";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "UPDATE %1 SET "
+            "status = :status, "
+            "attempts = attempts + 1, "
+            "last_attempt = :last_attempt, "
+            "error_message = :error_message "
+            "WHERE queue_id = :queue_id")
+                    .arg(kAcoustIdQueueTableName));
+
+    query.bindValue(":status", status);
+    query.bindValue(":last_attempt", QDateTime::currentSecsSinceEpoch());
+    // Store NULL when there is no error message.
+    if (errorMessage.isEmpty()) {
+        query.bindValue(":error_message",
+                QVariant(QMetaType(QMetaType::QString)));
+    } else {
+        query.bindValue(":error_message", errorMessage);
+    }
+    query.bindValue(":queue_id", queueId);
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't update queue status for queueId" << queueId;
+        return false;
+    }
+
+    const bool affected = query.numRowsAffected() > 0;
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [updateQueueStatus] ->"
+                 << (affected ? "updated" : "no row found")
+                 << "queueId:" << queueId
+                 << "status:" << status;
+    }
+    return affected;
+}
+
+QList<AcoustIdJob> TrackFingerprintDao::getPendingJobs(int limit) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getPendingJobs] -> entry"
+                 << "limit:" << limit;
+    }
+
+    if (!m_database.isOpen()) {
+        qDebug() << "TrackFingerprintDao -> [getPendingJobs] -> "
+                    "aborting: database not open";
+        return {};
+    }
+
+    QSqlQuery query(m_database);
+    // Returns jobs that are either waiting for a first attempt ('queued')
+    // or eligible for a retry ('failed' and under max_attempts).
+    // priority ASC, queued_at ASC.
+    query.prepare(QString(
+            "SELECT queue_id, track_id, priority, status, "
+            "attempts, max_attempts, last_attempt, error_message, queued_at "
+            "FROM %1 "
+            "WHERE (status = :queued OR status = :failed) "
+            "AND attempts < max_attempts "
+            "ORDER BY priority ASC, queued_at ASC "
+            "LIMIT :limit")
+                    .arg(kAcoustIdQueueTableName));
+
+    query.bindValue(":queued", kStatusQueued);
+    query.bindValue(":failed", kStatusFailed);
+    query.bindValue(":limit", limit);
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't fetch pending AcoustID jobs";
+        return {};
+    }
+
+    QList<AcoustIdJob> jobs;
+    QSqlRecord record = query.record();
+    while (query.next()) {
+        AcoustIdJob job;
+        job.queueId = query.value(record.indexOf("queue_id")).toInt();
+        job.trackId = TrackId(query.value(record.indexOf("track_id")));
+        job.priority = query.value(record.indexOf("priority")).toInt();
+        job.status = query.value(record.indexOf("status")).toString();
+        job.attempts = query.value(record.indexOf("attempts")).toInt();
+        job.maxAttempts =
+                query.value(record.indexOf("max_attempts")).toInt();
+
+        QVariant lastAttemptVar =
+                query.value(record.indexOf("last_attempt"));
+        if (!lastAttemptVar.isNull()) {
+            job.lastAttempt = QDateTime::fromSecsSinceEpoch(
+                    lastAttemptVar.toLongLong());
+        }
+
+        job.errorMessage =
+                query.value(record.indexOf("error_message")).toString();
+        job.queuedAt = QDateTime::fromSecsSinceEpoch(
+                query.value(record.indexOf("queued_at")).toLongLong());
+
+        jobs.append(job);
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getPendingJobs] -> found"
+                 << jobs.size() << "pending jobs";
+    }
+    return jobs;
+}
+
+bool TrackFingerprintDao::deleteQueueEntry(TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteQueueEntry] -> entry"
+                 << "trackId:" << trackId;
+    }
+
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [deleteQueueEntry] -> "
+                    "aborting: database not open or invalid trackId";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString("DELETE FROM %1 WHERE track_id = :track_id")
+                    .arg(kAcoustIdQueueTableName));
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't delete queue entry for track" << trackId;
+        return false;
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteQueueEntry] -> done"
+                 << "trackId:" << trackId
+                 << "rowsAffected:" << query.numRowsAffected();
+    }
+    return true;
 }

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -12,6 +12,7 @@ const QString kFingerprintTableName = QStringLiteral("fingerprint_metadata");
 const QString kCmrtGroupsTableName = QStringLiteral("cmrt_groups");
 const QString kCmrtMembersTableName = QStringLiteral("cmrt_members");
 const QString kAcoustIdQueueTableName = QStringLiteral("acoustid_queue");
+const QString kAcoustIdCacheTableName = QStringLiteral("acoustid_cache");
 const QString kStatusQueued = QStringLiteral("queued");
 const QString kStatusProcessing = QStringLiteral("processing");
 const QString kStatusCompleted = QStringLiteral("completed");
@@ -1036,6 +1037,246 @@ bool TrackFingerprintDao::deleteQueueEntry(TrackId trackId) const {
         qDebug() << "TrackFingerprintDao -> [deleteQueueEntry] -> done"
                  << "trackId:" << trackId
                  << "rowsAffected:" << query.numRowsAffected();
+    }
+    return true;
+}
+
+bool TrackFingerprintDao::cacheAcoustIdResult(
+        const AcoustIdCacheEntry& entry) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [cacheAcoustIdResult] -> entry"
+                 << "sha256:" << entry.chromaSha256
+                 << "acoustidId:" << entry.acoustidId;
+    }
+
+    if (!m_database.isOpen() || entry.chromaSha256.isEmpty() ||
+            entry.acoustidId.isEmpty()) {
+        qDebug() << "TrackFingerprintDao -> [cacheAcoustIdResult] -> "
+                    "aborting: database not open or empty sha256/acoustidId";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    // Update first — consistent with saveFingerprintMetadata pattern.
+    query.prepare(QString(
+            "UPDATE %1 SET "
+            "acoustid_id=:acoustid_id, "
+            "musicbrainz_recording_id=:mb_recording, "
+            "musicbrainz_release_id=:mb_release, "
+            "musicbrainz_metadata=:mb_metadata, "
+            "confidence=:confidence, "
+            "lookup_timestamp=:lookup_timestamp, "
+            "expires_at=:expires_at "
+            "WHERE chroma_sha256=:sha256")
+                    .arg(kAcoustIdCacheTableName));
+
+    query.bindValue(":sha256", entry.chromaSha256);
+    query.bindValue(":acoustid_id", entry.acoustidId);
+    query.bindValue(":mb_recording",
+            entry.musicbrainzRecordingId.isEmpty()
+                    ? QVariant(QMetaType(QMetaType::QString))
+                    : entry.musicbrainzRecordingId);
+    query.bindValue(":mb_release",
+            entry.musicbrainzReleaseId.isEmpty()
+                    ? QVariant(QMetaType(QMetaType::QString))
+                    : entry.musicbrainzReleaseId);
+    query.bindValue(":mb_metadata",
+            entry.musicbrainzMetadata.isEmpty()
+                    ? QVariant(QMetaType(QMetaType::QString))
+                    : entry.musicbrainzMetadata);
+    // confidence: -1.0 sentinel maps to NULL
+    if (entry.confidence < 0.0) {
+        query.bindValue(":confidence", QVariant(QMetaType(QMetaType::Double)));
+    } else {
+        query.bindValue(":confidence", entry.confidence);
+    }
+    query.bindValue(":lookup_timestamp",
+            entry.lookupTimestamp.toSecsSinceEpoch());
+    // expires_at: isValid() == false maps to NULL (no TTL)
+    if (entry.expiresAt.isValid()) {
+        query.bindValue(":expires_at", entry.expiresAt.toSecsSinceEpoch());
+    } else {
+        query.bindValue(":expires_at",
+                QVariant(QMetaType(QMetaType::LongLong)));
+    }
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't update acoustid_cache for sha256"
+                << entry.chromaSha256;
+        return false;
+    }
+
+    if (query.numRowsAffected() == 0) {
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [cacheAcoustIdResult] -> "
+                        "no existing row, inserting sha256:"
+                     << entry.chromaSha256;
+        }
+
+        query.prepare(QString(
+                "INSERT INTO %1 "
+                "(chroma_sha256, acoustid_id, musicbrainz_recording_id, "
+                "musicbrainz_release_id, musicbrainz_metadata, confidence, "
+                "lookup_timestamp, expires_at) "
+                "VALUES (:sha256, :acoustid_id, :mb_recording, :mb_release, "
+                ":mb_metadata, :confidence, :lookup_timestamp, :expires_at)")
+                        .arg(kAcoustIdCacheTableName));
+
+        // Re-bind all values
+        // QSqlQuery does not carry bindings across prepare() calls.
+        query.bindValue(":sha256", entry.chromaSha256);
+        query.bindValue(":acoustid_id", entry.acoustidId);
+        query.bindValue(":mb_recording",
+                entry.musicbrainzRecordingId.isEmpty()
+                        ? QVariant(QMetaType(QMetaType::QString))
+                        : entry.musicbrainzRecordingId);
+        query.bindValue(":mb_release",
+                entry.musicbrainzReleaseId.isEmpty()
+                        ? QVariant(QMetaType(QMetaType::QString))
+                        : entry.musicbrainzReleaseId);
+        query.bindValue(":mb_metadata",
+                entry.musicbrainzMetadata.isEmpty()
+                        ? QVariant(QMetaType(QMetaType::QString))
+                        : entry.musicbrainzMetadata);
+        if (entry.confidence < 0.0) {
+            query.bindValue(":confidence",
+                    QVariant(QMetaType(QMetaType::Double)));
+        } else {
+            query.bindValue(":confidence", entry.confidence);
+        }
+        query.bindValue(":lookup_timestamp",
+                entry.lookupTimestamp.toSecsSinceEpoch());
+        if (entry.expiresAt.isValid()) {
+            query.bindValue(":expires_at",
+                    entry.expiresAt.toSecsSinceEpoch());
+        } else {
+            query.bindValue(":expires_at",
+                    QVariant(QMetaType(QMetaType::LongLong)));
+        }
+
+        if (!query.exec()) {
+            LOG_FAILED_QUERY(query)
+                    << "couldn't insert acoustid_cache for sha256"
+                    << entry.chromaSha256;
+            return false;
+        }
+    } else {
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [cacheAcoustIdResult] -> "
+                        "updated existing row sha256:"
+                     << entry.chromaSha256;
+        }
+    }
+    return true;
+}
+
+std::unique_ptr<AcoustIdCacheEntry> TrackFingerprintDao::lookupAcoustIdCache(
+        const QString& chromaSha256) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [lookupAcoustIdCache] -> entry"
+                 << "sha256:" << chromaSha256;
+    }
+
+    if (!m_database.isOpen() || chromaSha256.isEmpty()) {
+        qDebug() << "TrackFingerprintDao -> [lookupAcoustIdCache] -> "
+                    "aborting: database not open or empty sha256";
+        return nullptr;
+    }
+
+    QSqlQuery query(m_database);
+    // Only return non-expired entries — matches Q5 in Final_Database.md.
+    // Binding the current time rather than using strftime() keeps all
+    // timestamp handling in C++, consistent with the rest of this file.
+    query.prepare(QString(
+            "SELECT acoustid_id, musicbrainz_recording_id, "
+            "musicbrainz_release_id, musicbrainz_metadata, confidence, "
+            "lookup_timestamp, expires_at "
+            "FROM %1 "
+            "WHERE chroma_sha256=:sha256 "
+            "AND (expires_at IS NULL OR expires_at > :now)")
+                    .arg(kAcoustIdCacheTableName));
+    query.bindValue(":sha256", chromaSha256);
+    query.bindValue(":now", QDateTime::currentSecsSinceEpoch());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't look up acoustid_cache for sha256" << chromaSha256;
+        return nullptr;
+    }
+
+    if (query.next()) {
+        auto entry = std::make_unique<AcoustIdCacheEntry>();
+        entry->chromaSha256 = chromaSha256;
+
+        QSqlRecord record = query.record();
+        entry->acoustidId =
+                query.value(record.indexOf("acoustid_id")).toString();
+        entry->musicbrainzRecordingId =
+                query.value(record.indexOf("musicbrainz_recording_id"))
+                        .toString();
+        entry->musicbrainzReleaseId =
+                query.value(record.indexOf("musicbrainz_release_id"))
+                        .toString();
+        entry->musicbrainzMetadata =
+                query.value(record.indexOf("musicbrainz_metadata")).toString();
+
+        QVariant confidenceVar = query.value(record.indexOf("confidence"));
+        entry->confidence = confidenceVar.isNull() ? -1.0
+                                                   : confidenceVar.toDouble();
+
+        entry->lookupTimestamp = QDateTime::fromSecsSinceEpoch(
+                query.value(record.indexOf("lookup_timestamp")).toLongLong());
+
+        QVariant expiresVar = query.value(record.indexOf("expires_at"));
+        if (!expiresVar.isNull()) {
+            entry->expiresAt =
+                    QDateTime::fromSecsSinceEpoch(expiresVar.toLongLong());
+        }
+
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [lookupAcoustIdCache] -> hit"
+                     << "sha256:" << chromaSha256
+                     << "acoustidId:" << entry->acoustidId
+                     << "confidence:" << entry->confidence;
+        }
+        return entry;
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [lookupAcoustIdCache] -> "
+                    "miss (not found or expired) sha256:"
+                 << chromaSha256;
+    }
+    return nullptr;
+}
+
+bool TrackFingerprintDao::deleteExpiredCacheEntries() const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteExpiredCacheEntries] -> entry";
+    }
+
+    if (!m_database.isOpen()) {
+        qDebug() << "TrackFingerprintDao -> [deleteExpiredCacheEntries] -> "
+                    "aborting: database not open";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "DELETE FROM %1 "
+            "WHERE expires_at IS NOT NULL AND expires_at <= :now")
+                    .arg(kAcoustIdCacheTableName));
+    query.bindValue(":now", QDateTime::currentSecsSinceEpoch());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't delete expired acoustid_cache entries";
+        return false;
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteExpiredCacheEntries] -> done"
+                 << "rowsDeleted:" << query.numRowsAffected();
     }
     return true;
 }

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -10,10 +10,20 @@
 namespace {
 const QString kFingerprintTableName = QStringLiteral("fingerprint_metadata");
 const QString kCmrtGroupsTableName = QStringLiteral("cmrt_groups");
+const bool sDebugTrackFingerprintDao = true;
 } // namespace
 
 bool TrackFingerprintDao::saveFingerprintMetadata(const FingerprintMetadata& metadata) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [saveFingerprintMetadata] -> entry"
+                 << "trackId:" << metadata.trackId
+                 << "hash:" << metadata.fingerprintHash
+                 << "sha256:" << metadata.chromaSha256;
+    }
+
     if (!m_database.isOpen() || !metadata.trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [saveFingerprintMetadata] -> "
+                    "aborting: database not open or invalid trackId";
         return false;
     }
 
@@ -56,6 +66,12 @@ bool TrackFingerprintDao::saveFingerprintMetadata(const FingerprintMetadata& met
 
     // If no row was updated, it means the row doesn't exist yet, so we INSERT
     if (query.numRowsAffected() == 0) {
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [saveFingerprintMetadata] -> "
+                        "no existing row, inserting"
+                     << "trackId:" << metadata.trackId;
+        }
+
         query.prepare(QString(
                 "INSERT INTO %1 "
                 "(track_id, fingerprint_hash, chroma_sha256, fingerprint_duration, "
@@ -87,13 +103,26 @@ bool TrackFingerprintDao::saveFingerprintMetadata(const FingerprintMetadata& met
                     << metadata.trackId;
             return false;
         }
+    } else {
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [saveFingerprintMetadata] -> "
+                        "updated existing row"
+                     << "trackId:" << metadata.trackId;
+        }
     }
     return true;
 }
 
 std::unique_ptr<FingerprintMetadata> TrackFingerprintDao::getFingerprintMetadata(
         TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getFingerprintMetadata] -> entry"
+                 << "trackId:" << trackId;
+    }
+
     if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [getFingerprintMetadata] -> "
+                    "aborting: database not open or invalid trackId";
         return nullptr;
     }
 
@@ -136,14 +165,35 @@ std::unique_ptr<FingerprintMetadata> TrackFingerprintDao::getFingerprintMetadata
         metadata->computedAt = QDateTime::fromSecsSinceEpoch(
                 query.value(record.indexOf("computed_at")).toLongLong());
 
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [getFingerprintMetadata] -> found row"
+                     << "trackId:" << trackId
+                     << "hash:" << metadata->fingerprintHash
+                     << "groupId:" << metadata->cmrtGroupId
+                     << "valid:" << metadata->fingerprintValid
+                     << "needsRegen:" << metadata->fingerprintNeedsRegen;
+        }
+
         return metadata;
     }
 
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getFingerprintMetadata] -> "
+                    "no row found for trackId:"
+                 << trackId;
+    }
     return nullptr;
 }
 
 bool TrackFingerprintDao::markFingerprintNeedsRegen(TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [markFingerprintNeedsRegen] -> entry"
+                 << "trackId:" << trackId;
+    }
+
     if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [markFingerprintNeedsRegen] -> "
+                    "aborting: database not open or invalid trackId";
         return false;
     }
 
@@ -159,11 +209,24 @@ bool TrackFingerprintDao::markFingerprintNeedsRegen(TrackId trackId) const {
         return false;
     }
 
-    return query.numRowsAffected() > 0;
+    const bool affected = query.numRowsAffected() > 0;
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [markFingerprintNeedsRegen] ->"
+                 << (affected ? "marked" : "no row found")
+                 << "trackId:" << trackId;
+    }
+    return affected;
 }
 
 bool TrackFingerprintDao::deleteFingerprintMetadata(TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteFingerprintMetadata] -> entry"
+                 << "trackId:" << trackId;
+    }
+
     if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [deleteFingerprintMetadata] -> "
+                    "aborting: database not open or invalid trackId";
         return false;
     }
 
@@ -178,11 +241,25 @@ bool TrackFingerprintDao::deleteFingerprintMetadata(TrackId trackId) const {
         return false;
     }
 
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteFingerprintMetadata] -> done"
+                 << "trackId:" << trackId
+                 << "rowsAffected:" << query.numRowsAffected();
+    }
     return true;
 }
 
 int TrackFingerprintDao::createCmrtGroup(const CmrtGroup& group) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [createCmrtGroup] -> entry"
+                 << "sha256:" << group.chromaSha256
+                 << "hash:" << group.fingerprintHash
+                 << "canonicalTrackId:" << group.canonicalTrackId;
+    }
+
     if (!m_database.isOpen()) {
+        qDebug() << "TrackFingerprintDao -> [createCmrtGroup] -> "
+                    "aborting: database not open";
         return -1;
     }
 
@@ -212,11 +289,24 @@ int TrackFingerprintDao::createCmrtGroup(const CmrtGroup& group) const {
         return -1;
     }
 
-    return query.lastInsertId().toInt();
+    const int newGroupId = query.lastInsertId().toInt();
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [createCmrtGroup] -> created group"
+                 << "groupId:" << newGroupId
+                 << "sha256:" << group.chromaSha256;
+    }
+    return newGroupId;
 }
 
 std::unique_ptr<CmrtGroup> TrackFingerprintDao::getCmrtGroup(int groupId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getCmrtGroup] -> entry"
+                 << "groupId:" << groupId;
+    }
+
     if (!m_database.isOpen() || groupId < 0) {
+        qDebug() << "TrackFingerprintDao -> [getCmrtGroup] -> "
+                    "aborting: database not open or invalid groupId";
         return nullptr;
     }
 
@@ -250,6 +340,7 @@ std::unique_ptr<CmrtGroup> TrackFingerprintDao::getCmrtGroup(int groupId) const 
         // Schema stores created_at and last_updated as INTEGER (Unix timestamps)
         group->createdAt = QDateTime::fromSecsSinceEpoch(
                 query.value(record.indexOf("created_at")).toLongLong());
+
         QVariant lastUpdatedVar = query.value(record.indexOf("last_updated"));
         if (!lastUpdatedVar.isNull()) {
             group->lastUpdated = QDateTime::fromSecsSinceEpoch(lastUpdatedVar.toLongLong());
@@ -284,8 +375,21 @@ std::unique_ptr<CmrtGroup> TrackFingerprintDao::getCmrtGroup(int groupId) const 
         group->conflictResolution =
                 query.value(record.indexOf("conflict_resolution")).toString();
 
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [getCmrtGroup] -> found group"
+                     << "groupId:" << groupId
+                     << "sha256:" << group->chromaSha256
+                     << "trackCount:" << group->trackCount
+                     << "mbSynced:" << group->musicbrainzSynced;
+        }
+
         return group;
     }
 
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getCmrtGroup] -> "
+                    "no row found for groupId:"
+                 << groupId;
+    }
     return nullptr;
 }

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -1280,3 +1280,95 @@ bool TrackFingerprintDao::deleteExpiredCacheEntries() const {
     }
     return true;
 }
+
+QList<UnmatchedTrackInfo> TrackFingerprintDao::getUnmatchedTracks() const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getUnmatchedTracks] -> entry";
+    }
+
+    if (!m_database.isOpen()) {
+        qDebug() << "TrackFingerprintDao -> [getUnmatchedTracks] -> "
+                    "aborting: database not open";
+        return {};
+    }
+
+    // LEFT JOIN acoustid_queue so tracks that were never enqueued still appear
+    // in the view — their status and attempts columns will be NULL.
+    QSqlQuery query(m_database);
+    query.prepare(
+            "SELECT l.id, l.title, l.artist, l.duration, "
+            "aq.status, aq.attempts, fm.fingerprint_valid "
+            "FROM library l "
+            "JOIN fingerprint_metadata fm ON l.id = fm.track_id "
+            "LEFT JOIN acoustid_queue aq ON l.id = aq.track_id "
+            "WHERE l.acoustid_id IS NULL "
+            "AND fm.fingerprint_valid = 1 "
+            "ORDER BY l.artist, l.title");
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't fetch unmatched tracks";
+        return {};
+    }
+
+    QList<UnmatchedTrackInfo> results;
+    QSqlRecord record = query.record();
+    while (query.next()) {
+        UnmatchedTrackInfo info;
+        info.trackId = TrackId(query.value(record.indexOf("id")));
+        info.title = query.value(record.indexOf("title")).toString();
+        info.artist = query.value(record.indexOf("artist")).toString();
+        info.duration = query.value(record.indexOf("duration")).toDouble();
+
+        QVariant statusVar = query.value(record.indexOf("status"));
+        info.queueStatus = statusVar.isNull() ? QString() : statusVar.toString();
+
+        QVariant attemptsVar = query.value(record.indexOf("attempts"));
+        info.attempts = attemptsVar.isNull() ? 0 : attemptsVar.toInt();
+
+        info.fingerprintValid =
+                query.value(record.indexOf("fingerprint_valid")).toBool();
+
+        results.append(info);
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getUnmatchedTracks] -> found"
+                 << results.size() << "unmatched tracks";
+    }
+    return results;
+}
+
+bool TrackFingerprintDao::reQueueJob(TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [reQueueJob] -> entry"
+                 << "trackId:" << trackId;
+    }
+
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [reQueueJob] -> "
+                    "aborting: database not open or invalid trackId";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "UPDATE %1 SET "
+            "status='queued', attempts=0, "
+            "error_message=NULL, last_attempt=NULL "
+            "WHERE track_id=:track_id")
+                    .arg(kAcoustIdQueueTableName));
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't re-queue job for track" << trackId;
+        return false;
+    }
+
+    const bool affected = query.numRowsAffected() > 0;
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [reQueueJob] ->"
+                 << (affected ? "re-queued" : "no row found")
+                 << "trackId:" << trackId;
+    }
+    return affected;
+}

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -1,0 +1,291 @@
+#include "library/dao/trackfingerprintdao.h"
+
+#include <QSqlQuery>
+#include <QSqlRecord>
+#include <QVariant>
+#include <QtDebug>
+
+#include "library/queryutil.h"
+
+namespace {
+const QString kFingerprintTableName = QStringLiteral("fingerprint_metadata");
+const QString kCmrtGroupsTableName = QStringLiteral("cmrt_groups");
+} // namespace
+
+bool TrackFingerprintDao::saveFingerprintMetadata(const FingerprintMetadata& metadata) const {
+    if (!m_database.isOpen() || !metadata.trackId.isValid()) {
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    // Try to update first (standard Mixxx pattern when trackId is the unique identifier)
+    query.prepare(QString(
+            "UPDATE %1 SET "
+            "fingerprint_hash=:hash, chroma_sha256=:sha256, fingerprint_duration=:duration, "
+            "fingerprint_version=:version, cmrt_group_id=:group_id, "
+            "cmrt_offset_seconds=:offset, is_canonical=:canonical, "
+            "fingerprint_valid=:valid, fingerprint_needs_regen=:needs_regen, "
+            "computed_at=:computed_at "
+            "WHERE track_id=:track_id")
+                    .arg(kFingerprintTableName));
+
+    query.bindValue(":track_id", metadata.trackId.toVariant());
+    query.bindValue(":hash", metadata.fingerprintHash);
+    query.bindValue(":sha256", metadata.chromaSha256);
+    query.bindValue(":duration", metadata.fingerprintDuration);
+    query.bindValue(":version", metadata.fingerprintVersion);
+    // Support NULL for group_id if it's -1
+    if (metadata.cmrtGroupId == -1) {
+        query.bindValue(":group_id", QVariant(QMetaType(QMetaType::Int)));
+    } else {
+        query.bindValue(":group_id", metadata.cmrtGroupId);
+    }
+    query.bindValue(":offset", metadata.cmrtOffsetSeconds);
+    query.bindValue(":canonical", metadata.isCanonical ? 1 : 0);
+    query.bindValue(":valid", metadata.fingerprintValid ? 1 : 0);
+    query.bindValue(":needs_regen", metadata.fingerprintNeedsRegen ? 1 : 0);
+    // Schema stores computed_at as INTEGER (Unix timestamp)
+    query.bindValue(":computed_at", metadata.computedAt.toSecsSinceEpoch());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't update fingerprint_metadata for track"
+                << metadata.trackId;
+        return false;
+    }
+
+    // If no row was updated, it means the row doesn't exist yet, so we INSERT
+    if (query.numRowsAffected() == 0) {
+        query.prepare(QString(
+                "INSERT INTO %1 "
+                "(track_id, fingerprint_hash, chroma_sha256, fingerprint_duration, "
+                "fingerprint_version, cmrt_group_id, cmrt_offset_seconds, is_canonical, "
+                "fingerprint_valid, fingerprint_needs_regen, computed_at) "
+                "VALUES (:track_id, :hash, :sha256, :duration, :version, :group_id, "
+                ":offset, :canonical, :valid, :needs_regen, :computed_at)")
+                        .arg(kFingerprintTableName));
+
+        query.bindValue(":track_id", metadata.trackId.toVariant());
+        query.bindValue(":hash", metadata.fingerprintHash);
+        query.bindValue(":sha256", metadata.chromaSha256);
+        query.bindValue(":duration", metadata.fingerprintDuration);
+        query.bindValue(":version", metadata.fingerprintVersion);
+        if (metadata.cmrtGroupId == -1) {
+            query.bindValue(":group_id", QVariant(QMetaType(QMetaType::Int)));
+        } else {
+            query.bindValue(":group_id", metadata.cmrtGroupId);
+        }
+        query.bindValue(":offset", metadata.cmrtOffsetSeconds);
+        query.bindValue(":canonical", metadata.isCanonical ? 1 : 0);
+        query.bindValue(":valid", metadata.fingerprintValid ? 1 : 0);
+        query.bindValue(":needs_regen", metadata.fingerprintNeedsRegen ? 1 : 0);
+        query.bindValue(":computed_at", metadata.computedAt.toSecsSinceEpoch());
+
+        if (!query.exec()) {
+            LOG_FAILED_QUERY(query)
+                    << "couldn't insert fingerprint_metadata for track"
+                    << metadata.trackId;
+            return false;
+        }
+    }
+    return true;
+}
+
+std::unique_ptr<FingerprintMetadata> TrackFingerprintDao::getFingerprintMetadata(
+        TrackId trackId) const {
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        return nullptr;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "SELECT fingerprint_hash, chroma_sha256, fingerprint_duration, fingerprint_version, "
+            "cmrt_group_id, cmrt_offset_seconds, is_canonical, fingerprint_valid, "
+            "fingerprint_needs_regen, computed_at "
+            "FROM %1 WHERE track_id=:track_id")
+                    .arg(kFingerprintTableName));
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't fetch fingerprint_metadata for track" << trackId;
+        return nullptr;
+    }
+
+    if (query.next()) {
+        auto metadata = std::make_unique<FingerprintMetadata>();
+        metadata->trackId = trackId;
+
+        QSqlRecord record = query.record();
+        metadata->fingerprintHash = query.value(record.indexOf("fingerprint_hash")).toUInt();
+        metadata->chromaSha256 = query.value(record.indexOf("chroma_sha256")).toString();
+        metadata->fingerprintDuration =
+                query.value(record.indexOf("fingerprint_duration")).toDouble();
+        metadata->fingerprintVersion =
+                query.value(record.indexOf("fingerprint_version")).toInt();
+
+        QVariant groupIdVar = query.value(record.indexOf("cmrt_group_id"));
+        metadata->cmrtGroupId = groupIdVar.isNull() ? -1 : groupIdVar.toInt();
+
+        metadata->cmrtOffsetSeconds =
+                query.value(record.indexOf("cmrt_offset_seconds")).toDouble();
+        metadata->isCanonical = query.value(record.indexOf("is_canonical")).toBool();
+        metadata->fingerprintValid = query.value(record.indexOf("fingerprint_valid")).toBool();
+        metadata->fingerprintNeedsRegen =
+                query.value(record.indexOf("fingerprint_needs_regen")).toBool();
+        // Schema stores computed_at as INTEGER (Unix timestamp)
+        metadata->computedAt = QDateTime::fromSecsSinceEpoch(
+                query.value(record.indexOf("computed_at")).toLongLong());
+
+        return metadata;
+    }
+
+    return nullptr;
+}
+
+bool TrackFingerprintDao::markFingerprintNeedsRegen(TrackId trackId) const {
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "UPDATE %1 SET fingerprint_needs_regen=1, fingerprint_valid=0 "
+            "WHERE track_id=:track_id")
+                    .arg(kFingerprintTableName));
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't mark fingerprint regen for track" << trackId;
+        return false;
+    }
+
+    return query.numRowsAffected() > 0;
+}
+
+bool TrackFingerprintDao::deleteFingerprintMetadata(TrackId trackId) const {
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString("DELETE FROM %1 WHERE track_id=:track_id")
+                    .arg(kFingerprintTableName));
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't delete fingerprint_metadata for track" << trackId;
+        return false;
+    }
+
+    return true;
+}
+
+int TrackFingerprintDao::createCmrtGroup(const CmrtGroup& group) const {
+    if (!m_database.isOpen()) {
+        return -1;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "INSERT INTO %1 "
+            "(fingerprint_hash, chroma_sha256, canonical_track_id, "
+            "track_count, created_at, last_updated) "
+            "VALUES (:hash, :sha256, :canonical_track, :count, :created, :updated)")
+                    .arg(kCmrtGroupsTableName));
+
+    query.bindValue(":hash", group.fingerprintHash);
+    query.bindValue(":sha256", group.chromaSha256);
+    query.bindValue(":canonical_track", group.canonicalTrackId.toVariant());
+    query.bindValue(":count", group.trackCount);
+    // Schema stores created_at and last_updated as INTEGER (Unix timestamps)
+    query.bindValue(":created", group.createdAt.toSecsSinceEpoch());
+    if (group.lastUpdated.isValid()) {
+        query.bindValue(":updated", group.lastUpdated.toSecsSinceEpoch());
+    } else {
+        query.bindValue(":updated", QVariant(QMetaType(QMetaType::LongLong)));
+    }
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't create new cmrt_group with SHA256" << group.chromaSha256;
+        return -1;
+    }
+
+    return query.lastInsertId().toInt();
+}
+
+std::unique_ptr<CmrtGroup> TrackFingerprintDao::getCmrtGroup(int groupId) const {
+    if (!m_database.isOpen() || groupId < 0) {
+        return nullptr;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "SELECT fingerprint_hash, chroma_sha256, canonical_track_id, track_count, "
+            "created_at, last_updated, musicbrainz_cmrt_mbid, musicbrainz_synced, "
+            "musicbrainz_last_sync, musicbrainz_community_score, musicbrainz_submitted, "
+            "musicbrainz_submission_mbid, local_preferred, conflict_resolved_at, "
+            "conflict_resolution "
+            "FROM %1 WHERE group_id=:group_id")
+                    .arg(kCmrtGroupsTableName));
+    query.bindValue(":group_id", groupId);
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't fetch cmrt_group with id" << groupId;
+        return nullptr;
+    }
+
+    if (query.next()) {
+        auto group = std::make_unique<CmrtGroup>();
+        group->groupId = groupId;
+
+        QSqlRecord record = query.record();
+        group->fingerprintHash = query.value(record.indexOf("fingerprint_hash")).toUInt();
+        group->chromaSha256 = query.value(record.indexOf("chroma_sha256")).toString();
+        // TrackId must be constructed from QVariant, not int
+        group->canonicalTrackId = TrackId(
+                query.value(record.indexOf("canonical_track_id")));
+        group->trackCount = query.value(record.indexOf("track_count")).toInt();
+        // Schema stores created_at and last_updated as INTEGER (Unix timestamps)
+        group->createdAt = QDateTime::fromSecsSinceEpoch(
+                query.value(record.indexOf("created_at")).toLongLong());
+        QVariant lastUpdatedVar = query.value(record.indexOf("last_updated"));
+        if (!lastUpdatedVar.isNull()) {
+            group->lastUpdated = QDateTime::fromSecsSinceEpoch(lastUpdatedVar.toLongLong());
+        }
+
+        group->musicbrainzCmrtMbid =
+                query.value(record.indexOf("musicbrainz_cmrt_mbid")).toString();
+        group->musicbrainzSynced =
+                query.value(record.indexOf("musicbrainz_synced")).toBool();
+
+        QVariant mbLastSync = query.value(record.indexOf("musicbrainz_last_sync"));
+        if (!mbLastSync.isNull()) {
+            group->musicbrainzLastSync =
+                    QDateTime::fromSecsSinceEpoch(mbLastSync.toLongLong());
+        }
+
+        group->musicbrainzCommunityScore =
+                query.value(record.indexOf("musicbrainz_community_score")).toDouble();
+        group->musicbrainzSubmitted =
+                query.value(record.indexOf("musicbrainz_submitted")).toBool();
+        group->musicbrainzSubmissionMbid =
+                query.value(record.indexOf("musicbrainz_submission_mbid")).toString();
+        group->localPreferred =
+                query.value(record.indexOf("local_preferred")).toBool();
+
+        QVariant conflictAt = query.value(record.indexOf("conflict_resolved_at"));
+        if (!conflictAt.isNull()) {
+            group->conflictResolvedAt =
+                    QDateTime::fromSecsSinceEpoch(conflictAt.toLongLong());
+        }
+
+        group->conflictResolution =
+                query.value(record.indexOf("conflict_resolution")).toString();
+
+        return group;
+    }
+
+    return nullptr;
+}

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -10,6 +10,7 @@
 namespace {
 const QString kFingerprintTableName = QStringLiteral("fingerprint_metadata");
 const QString kCmrtGroupsTableName = QStringLiteral("cmrt_groups");
+const QString kCmrtMembersTableName = QStringLiteral("cmrt_members");
 const bool sDebugTrackFingerprintDao = true;
 } // namespace
 
@@ -392,4 +393,316 @@ std::unique_ptr<CmrtGroup> TrackFingerprintDao::getCmrtGroup(int groupId) const 
                  << groupId;
     }
     return nullptr;
+}
+
+bool TrackFingerprintDao::addCmrtMember(const CmrtMember& member) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [addCmrtMember] -> entry"
+                 << "trackId:" << member.trackId
+                 << "groupId:" << member.groupId
+                 << "offset:" << member.offsetFromCanonical;
+    }
+
+    if (!m_database.isOpen() || !member.trackId.isValid() || member.groupId < 0) {
+        qDebug() << "TrackFingerprintDao -> [addCmrtMember] -> "
+                    "aborting: database not open or invalid trackId/groupId";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "INSERT INTO %1 "
+            "(group_id, track_id, offset_from_canonical, quality_score, "
+            "match_score, is_fake_lossless, added_at, user_quality_rating) "
+            "VALUES (:group_id, :track_id, :offset, :quality_score, "
+            ":match_score, :is_fake_lossless, :added_at, :user_quality_rating)")
+                    .arg(kCmrtMembersTableName));
+
+    query.bindValue(":group_id", member.groupId);
+    query.bindValue(":track_id", member.trackId.toVariant());
+    query.bindValue(":offset", member.offsetFromCanonical);
+    // quality_score is nullable — -1.0 sentinel maps to NULL
+    if (member.qualityScore < 0.0) {
+        query.bindValue(":quality_score", QVariant(QMetaType(QMetaType::Double)));
+    } else {
+        query.bindValue(":quality_score", member.qualityScore);
+    }
+    // match_score is nullable — same -1.0 sentinel as quality_score
+    if (member.matchScore < 0.0) {
+        query.bindValue(":match_score", QVariant(QMetaType(QMetaType::Double)));
+    } else {
+        query.bindValue(":match_score", member.matchScore);
+    }
+    query.bindValue(":is_fake_lossless", member.isFakeLossless ? 1 : 0);
+    // Schema stores added_at as INTEGER (Unix timestamp)
+    query.bindValue(":added_at", member.addedAt.toSecsSinceEpoch());
+    // user_quality_rating is nullable — -1 sentinel maps to NULL
+    if (member.userQualityRating < 0) {
+        query.bindValue(":user_quality_rating", QVariant(QMetaType(QMetaType::Int)));
+    } else {
+        query.bindValue(":user_quality_rating", member.userQualityRating);
+    }
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't add cmrt_member for track" << member.trackId
+                << "to group" << member.groupId;
+        return false;
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [addCmrtMember] -> inserted"
+                 << "memberId:" << query.lastInsertId().toInt()
+                 << "trackId:" << member.trackId
+                 << "groupId:" << member.groupId;
+    }
+    return true;
+}
+
+bool TrackFingerprintDao::updateMemberMatchScore(TrackId trackId, double matchScore) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [updateMemberMatchScore] -> entry"
+                 << "trackId:" << trackId
+                 << "matchScore:" << matchScore;
+    }
+
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [updateMemberMatchScore] -> "
+                    "aborting: database not open or invalid trackId";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "UPDATE %1 SET match_score = :match_score WHERE track_id = :track_id")
+                    .arg(kCmrtMembersTableName));
+    // match_score is nullable -- same -1.0 sentinel as quality_score
+    if (matchScore < 0.0) {
+        query.bindValue(":match_score", QVariant(QMetaType(QMetaType::Double)));
+    } else {
+        query.bindValue(":match_score", matchScore);
+    }
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't update match_score for track" << trackId;
+        return false;
+    }
+
+    const bool affected = query.numRowsAffected() > 0;
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [updateMemberMatchScore] ->"
+                 << (affected ? "updated" : "no row found")
+                 << "trackId:" << trackId;
+    }
+    return affected;
+}
+
+bool TrackFingerprintDao::updateMemberOffset(TrackId trackId, double offsetFromCanonical) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [updateMemberOffset] -> entry"
+                 << "trackId:" << trackId
+                 << "offsetFromCanonical:" << offsetFromCanonical;
+    }
+
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [updateMemberOffset] -> "
+                    "aborting: database not open or invalid trackId";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "UPDATE %1 SET offset_from_canonical = :offset WHERE track_id = :track_id")
+                    .arg(kCmrtMembersTableName));
+    query.bindValue(":offset", offsetFromCanonical);
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't update offset for track" << trackId;
+        return false;
+    }
+
+    const bool affected = query.numRowsAffected() > 0;
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [updateMemberOffset] ->"
+                 << (affected ? "updated" : "no row found")
+                 << "trackId:" << trackId;
+    }
+    return affected;
+}
+
+double TrackFingerprintDao::getMemberQualityScore(TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getMemberQualityScore] -> entry"
+                 << "trackId:" << trackId;
+    }
+
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [getMemberQualityScore] -> "
+                    "aborting: database not open or invalid trackId";
+        return -1.0;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "SELECT quality_score FROM %1 WHERE track_id=:track_id")
+                    .arg(kCmrtMembersTableName));
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't fetch quality_score for track" << trackId;
+        return -1.0;
+    }
+
+    if (!query.next()) {
+        if (sDebugTrackFingerprintDao) {
+            qDebug() << "TrackFingerprintDao -> [getMemberQualityScore] -> "
+                        "no cmrt_members row found for trackId:"
+                     << trackId;
+        }
+        return -1.0;
+    }
+
+    // quality_score is nullable -- same sentinel addCmrtMember() already uses
+    const QVariant qualityVar = query.value(0);
+    const double score = qualityVar.isNull() ? -1.0 : qualityVar.toDouble();
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getMemberQualityScore] -> found"
+                 << "trackId:" << trackId << "score:" << score;
+    }
+    return score;
+}
+
+QList<CmrtMember> TrackFingerprintDao::getCmrtMembersForGroup(int groupId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getCmrtMembersForGroup] -> entry"
+                 << "groupId:" << groupId;
+    }
+
+    if (!m_database.isOpen() || groupId < 0) {
+        qDebug() << "TrackFingerprintDao -> [getCmrtMembersForGroup] -> "
+                    "aborting: database not open or invalid groupId";
+        return {};
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "SELECT member_id, track_id, offset_from_canonical, quality_score, "
+            "match_score, is_fake_lossless, added_at, user_quality_rating "
+            "FROM %1 WHERE group_id=:group_id")
+                    .arg(kCmrtMembersTableName));
+    query.bindValue(":group_id", groupId);
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query) << "couldn't fetch cmrt_members for group" << groupId;
+        return {};
+    }
+
+    QList<CmrtMember> members;
+    QSqlRecord record = query.record();
+    while (query.next()) {
+        CmrtMember member;
+        member.memberId = query.value(record.indexOf("member_id")).toInt();
+        member.groupId = groupId;
+        member.trackId = TrackId(query.value(record.indexOf("track_id")));
+        member.offsetFromCanonical =
+                query.value(record.indexOf("offset_from_canonical")).toDouble();
+
+        // quality_score is nullable
+        QVariant qualityVar = query.value(record.indexOf("quality_score"));
+        member.qualityScore = qualityVar.isNull() ? -1.0 : qualityVar.toDouble();
+
+        // match_score is nullable, same sentinel as quality_score
+        QVariant matchScoreVar = query.value(record.indexOf("match_score"));
+        member.matchScore = matchScoreVar.isNull() ? -1.0 : matchScoreVar.toDouble();
+
+        member.isFakeLossless = query.value(record.indexOf("is_fake_lossless")).toBool();
+        // Schema stores added_at as INTEGER (Unix timestamp)
+        member.addedAt = QDateTime::fromSecsSinceEpoch(
+                query.value(record.indexOf("added_at")).toLongLong());
+
+        // user_quality_rating is nullable
+        QVariant ratingVar = query.value(record.indexOf("user_quality_rating"));
+        member.userQualityRating = ratingVar.isNull() ? -1 : ratingVar.toInt();
+
+        members.append(member);
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [getCmrtMembersForGroup] -> found"
+                 << members.size() << "members for groupId:" << groupId;
+    }
+    return members;
+}
+
+bool TrackFingerprintDao::deleteCmrtMember(TrackId trackId) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteCmrtMember] -> entry"
+                 << "trackId:" << trackId;
+    }
+
+    if (!m_database.isOpen() || !trackId.isValid()) {
+        qDebug() << "TrackFingerprintDao -> [deleteCmrtMember] -> "
+                    "aborting: database not open or invalid trackId";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString("DELETE FROM %1 WHERE track_id=:track_id")
+                    .arg(kCmrtMembersTableName));
+    query.bindValue(":track_id", trackId.toVariant());
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't delete cmrt_member for track" << trackId;
+        return false;
+    }
+
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [deleteCmrtMember] -> done"
+                 << "trackId:" << trackId
+                 << "rowsAffected:" << query.numRowsAffected();
+    }
+    return true;
+}
+
+bool TrackFingerprintDao::updateCmrtGroupTrackCount(int groupId, int delta) const {
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [updateCmrtGroupTrackCount] -> entry"
+                 << "groupId:" << groupId << "delta:" << delta;
+    }
+
+    if (!m_database.isOpen() || groupId < 0 || delta == 0) {
+        qDebug() << "TrackFingerprintDao -> [updateCmrtGroupTrackCount] -> "
+                    "aborting: database not open, invalid groupId, or zero delta";
+        return false;
+    }
+
+    QSqlQuery query(m_database);
+    query.prepare(QString(
+            "UPDATE %1 SET "
+            "track_count = track_count + :delta, "
+            "last_updated = :last_updated "
+            "WHERE group_id = :group_id")
+                    .arg(kCmrtGroupsTableName));
+    query.bindValue(":delta", delta);
+    // Schema stores last_updated as INTEGER (Unix timestamp)
+    query.bindValue(":last_updated", QDateTime::currentSecsSinceEpoch());
+    query.bindValue(":group_id", groupId);
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query)
+                << "couldn't update track_count for group" << groupId;
+        return false;
+    }
+
+    const bool affected = query.numRowsAffected() > 0;
+    if (sDebugTrackFingerprintDao) {
+        qDebug() << "TrackFingerprintDao -> [updateCmrtGroupTrackCount] ->"
+                 << (affected ? "updated" : "no row found")
+                 << "groupId:" << groupId << "delta:" << delta;
+    }
+    return affected;
 }

--- a/src/library/dao/trackfingerprintdao.cpp
+++ b/src/library/dao/trackfingerprintdao.cpp
@@ -14,6 +14,11 @@ const QString kCmrtMembersTableName = QStringLiteral("cmrt_members");
 const bool sDebugTrackFingerprintDao = true;
 } // namespace
 
+TrackFingerprintDao::TrackFingerprintDao(UserSettingsPointer pConfig)
+        : DAO(),
+          m_pConfig(pConfig) {
+}
+
 bool TrackFingerprintDao::saveFingerprintMetadata(const FingerprintMetadata& metadata) const {
     if (sDebugTrackFingerprintDao) {
         qDebug() << "TrackFingerprintDao -> [saveFingerprintMetadata] -> entry"

--- a/src/library/dao/trackfingerprintdao.h
+++ b/src/library/dao/trackfingerprintdao.h
@@ -173,6 +173,18 @@ class TrackFingerprintDao : public DAO {
     // Sets status='queued', attempts=0, error_message=NULL, last_attempt=NULL.
     bool reQueueJob(TrackId trackId) const;
 
+    // Clears all fingerprint data for a single track:
+    // deletes the .chroma file, handles canonical reassignment or group
+    // deletion in cmrt_groups, removes cmrt_members, fingerprint_metadata,
+    // and acoustid_queue rows for this track.
+    // Returns true if the cleanup completed without errors.
+    bool clearFingerprintData(TrackId trackId) const;
+
+    // Calls clearFingerprintData() for every track that has a
+    // fingerprint_metadata row. Returns the number of tracks cleared.
+    // Used by the "Clear All Fingerprints" button in Preferences.
+    int clearAllFingerprintData() const;
+
   private:
     // Returns ~/.mixxx/fingerprints/ — creates the directory on first call.
     QDir getFingerprintStoragePath() const;

--- a/src/library/dao/trackfingerprintdao.h
+++ b/src/library/dao/trackfingerprintdao.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <QDateTime>
+#include <QSqlDatabase>
+#include <QString>
+#include <memory>
+
+#include "library/dao/dao.h"
+#include "track/trackid.h"
+
+// DTO matching Phase 1 migration of fingerprint_metadata
+struct FingerprintMetadata {
+    TrackId trackId;
+    quint32 fingerprintHash; // 32-bit SimHash
+    QString chromaSha256;    // 64-char hex
+    double fingerprintDuration{0.0};
+    int fingerprintVersion{0};
+    int cmrtGroupId{-1}; // -1 if not grouped
+    double cmrtOffsetSeconds{0.0};
+    bool isCanonical{false};
+    bool fingerprintValid{true};
+    bool fingerprintNeedsRegen{false};
+    QDateTime computedAt;
+};
+
+// DTO matching Phase 1 migration of cmrt_groups
+struct CmrtGroup {
+    int groupId{-1};
+    quint32 fingerprintHash{0};
+    QString chromaSha256;
+    TrackId canonicalTrackId;
+    int trackCount{1};
+    QDateTime createdAt;
+    QDateTime lastUpdated;
+    // MusicBrainz CMRT integration
+    QString musicbrainzCmrtMbid;
+    bool musicbrainzSynced{false};
+    QDateTime musicbrainzLastSync;
+    double musicbrainzCommunityScore{0.0};
+    bool musicbrainzSubmitted{false};
+    QString musicbrainzSubmissionMbid;
+    bool localPreferred{true};
+    QDateTime conflictResolvedAt;
+    QString conflictResolution; // 'local_won' | 'remote_won'
+};
+
+class TrackFingerprintDao : public DAO {
+  public:
+    TrackFingerprintDao() = default;
+    ~TrackFingerprintDao() override = default;
+
+    // fingerprint_metadata operations
+    bool saveFingerprintMetadata(const FingerprintMetadata& metadata) const;
+    std::unique_ptr<FingerprintMetadata> getFingerprintMetadata(TrackId trackId) const;
+    bool markFingerprintNeedsRegen(TrackId trackId) const;
+    bool deleteFingerprintMetadata(TrackId trackId) const;
+
+    // cmrt_groups operations
+    int createCmrtGroup(const CmrtGroup& group) const;
+    std::unique_ptr<CmrtGroup> getCmrtGroup(int groupId) const;
+};

--- a/src/library/dao/trackfingerprintdao.h
+++ b/src/library/dao/trackfingerprintdao.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDateTime>
+#include <QList>
 #include <QSqlDatabase>
 #include <QString>
 #include <memory>
@@ -44,6 +45,18 @@ struct CmrtGroup {
     QString conflictResolution; // 'local_won' | 'remote_won'
 };
 
+struct CmrtMember {
+    int memberId{-1};
+    int groupId{-1};
+    TrackId trackId;
+    double offsetFromCanonical{0.0};
+    double qualityScore{-1.0}; // -1.0 if not yet scored
+    double matchScore{-1.0};
+    bool isFakeLossless{false};
+    QDateTime addedAt;
+    int userQualityRating{-1}; // -1 if unrated
+};
+
 class TrackFingerprintDao : public DAO {
   public:
     TrackFingerprintDao() = default;
@@ -58,4 +71,18 @@ class TrackFingerprintDao : public DAO {
     // cmrt_groups operations
     int createCmrtGroup(const CmrtGroup& group) const;
     std::unique_ptr<CmrtGroup> getCmrtGroup(int groupId) const;
+
+    // cmrt_members operations
+    bool addCmrtMember(const CmrtMember& member) const;
+    QList<CmrtMember> getCmrtMembersForGroup(int groupId) const;
+    bool deleteCmrtMember(TrackId trackId) const;
+    bool updateMemberOffset(TrackId trackId, double offsetFromCanonical) const;
+
+    bool updateMemberMatchScore(TrackId trackId, double matchScore) const;
+
+    double getMemberQualityScore(TrackId trackId) const;
+
+    // Updates track_count on cmrt_groups when membership changes.
+    // Pass +1 when adding a member, -1 when removing.
+    bool updateCmrtGroupTrackCount(int groupId, int delta) const;
 };

--- a/src/library/dao/trackfingerprintdao.h
+++ b/src/library/dao/trackfingerprintdao.h
@@ -71,6 +71,17 @@ struct AcoustIdJob {
     QDateTime queuedAt;
 };
 
+struct AcoustIdCacheEntry {
+    QString chromaSha256;           // PK — SHA-256 of .chroma file
+    QString acoustidId;             // AcoustID UUID
+    QString musicbrainzRecordingId; // nullable
+    QString musicbrainzReleaseId;   // nullable
+    QString musicbrainzMetadata;    // full JSON response, nullable
+    double confidence{-1.0};        // 0.0–1.0; -1.0 = not set (maps to NULL)
+    QDateTime lookupTimestamp;
+    QDateTime expiresAt; // isValid() == false if no TTL
+};
+
 class TrackFingerprintDao : public DAO {
   public:
     explicit TrackFingerprintDao(UserSettingsPointer pConfig);
@@ -125,6 +136,20 @@ class TrackFingerprintDao : public DAO {
 
     // Removes a track's queue entry entirely — called from onPurgingTracks.
     bool deleteQueueEntry(TrackId trackId) const;
+
+    // acoustid_cache operations
+    // Stores or refreshes an AcoustID API response keyed on SHA-256.
+    // Safe to call multiple times for the same chromaSha256 — updates in place.
+    bool cacheAcoustIdResult(const AcoustIdCacheEntry& entry) const;
+
+    // Returns the cached entry for a given SHA-256,
+    // or nullptr if not found or expired.
+    std::unique_ptr<AcoustIdCacheEntry> lookupAcoustIdCache(
+            const QString& chromaSha256) const;
+
+    // Removes entries whose expires_at has passed.
+    // Call periodically to prevent unbounded cache growth.
+    bool deleteExpiredCacheEntries() const;
 
   private:
     // Returns ~/.mixxx/fingerprints/ — creates the directory on first call.

--- a/src/library/dao/trackfingerprintdao.h
+++ b/src/library/dao/trackfingerprintdao.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDateTime>
+#include <QDir>
 #include <QList>
 #include <QSqlDatabase>
 #include <QString>
@@ -87,6 +88,17 @@ class TrackFingerprintDao : public DAO {
     // Pass +1 when adding a member, -1 when removing.
     bool updateCmrtGroupTrackCount(int groupId, int delta) const;
 
+    // .chroma file I/O
+    // Fingerprints live in ~/.mixxx/fingerprints/track_{id}.chroma
+    QByteArray loadChromaFile(TrackId trackId) const;
+    bool saveChromaFile(TrackId trackId, const QByteArray& data) const;
+    bool deleteChromaFile(TrackId trackId) const;
+
   private:
+    // Returns ~/.mixxx/fingerprints/ — creates the directory on first call.
+    QDir getFingerprintStoragePath() const;
+    // Returns the absolute path to track_{trackId}.chroma
+    QString getChromaFilePath(TrackId trackId) const;
+
     const UserSettingsPointer m_pConfig;
 };

--- a/src/library/dao/trackfingerprintdao.h
+++ b/src/library/dao/trackfingerprintdao.h
@@ -82,6 +82,17 @@ struct AcoustIdCacheEntry {
     QDateTime expiresAt; // isValid() == false if no TTL
 };
 
+struct UnmatchedTrackInfo {
+    TrackId trackId;
+    QString title;
+    QString artist;
+    double duration{0.0};
+    // Empty if the track has not been enqueued yet
+    QString queueStatus; // 'queued' | 'processing' | 'failed' | ''
+    int attempts{0};
+    bool fingerprintValid{false};
+};
+
 class TrackFingerprintDao : public DAO {
   public:
     explicit TrackFingerprintDao(UserSettingsPointer pConfig);
@@ -150,6 +161,17 @@ class TrackFingerprintDao : public DAO {
     // Removes entries whose expires_at has passed.
     // Call periodically to prevent unbounded cache growth.
     bool deleteExpiredCacheEntries() const;
+
+    // MusicBrainzQueue view support
+
+    // Returns all tracks that have a valid fingerprint but no AcoustID
+    // yet, along with their current queue status. Used to populate the
+    // MusicBrainzQueue sidebar.
+    QList<UnmatchedTrackInfo> getUnmatchedTracks() const;
+
+    // Resets a failed job back to queued state so the worker retries it.
+    // Sets status='queued', attempts=0, error_message=NULL, last_attempt=NULL.
+    bool reQueueJob(TrackId trackId) const;
 
   private:
     // Returns ~/.mixxx/fingerprints/ — creates the directory on first call.

--- a/src/library/dao/trackfingerprintdao.h
+++ b/src/library/dao/trackfingerprintdao.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "library/dao/dao.h"
+#include "preferences/usersettings.h"
 #include "track/trackid.h"
 
 // DTO matching Phase 1 migration of fingerprint_metadata
@@ -59,7 +60,7 @@ struct CmrtMember {
 
 class TrackFingerprintDao : public DAO {
   public:
-    TrackFingerprintDao() = default;
+    explicit TrackFingerprintDao(UserSettingsPointer pConfig);
     ~TrackFingerprintDao() override = default;
 
     // fingerprint_metadata operations
@@ -85,4 +86,7 @@ class TrackFingerprintDao : public DAO {
     // Updates track_count on cmrt_groups when membership changes.
     // Pass +1 when adding a member, -1 when removing.
     bool updateCmrtGroupTrackCount(int groupId, int delta) const;
+
+  private:
+    const UserSettingsPointer m_pConfig;
 };

--- a/src/library/dao/trackfingerprintdao.h
+++ b/src/library/dao/trackfingerprintdao.h
@@ -59,6 +59,18 @@ struct CmrtMember {
     int userQualityRating{-1}; // -1 if unrated
 };
 
+struct AcoustIdJob {
+    int queueId{-1};
+    TrackId trackId;
+    int priority{5}; // lower = higher priority
+    QString status;  // 'queued' | 'processing' | 'completed' | 'failed'
+    int attempts{0};
+    int maxAttempts{3};
+    QDateTime lastAttempt; // nullable — isValid() == false if never attempted
+    QString errorMessage;
+    QDateTime queuedAt;
+};
+
 class TrackFingerprintDao : public DAO {
   public:
     explicit TrackFingerprintDao(UserSettingsPointer pConfig);
@@ -93,6 +105,26 @@ class TrackFingerprintDao : public DAO {
     QByteArray loadChromaFile(TrackId trackId) const;
     bool saveChromaFile(TrackId trackId, const QByteArray& data) const;
     bool deleteChromaFile(TrackId trackId) const;
+
+    // acoustid_queue operations
+    // Enqueues a track for AcoustID lookup. Silently no-ops if track_id
+    // is already in the queue (UNIQUE constraint on track_id).
+    bool enqueueAcoustId(TrackId trackId, int priority = 5) const;
+
+    // Updates the status of a queued job and increments the attempt counter.
+    // Pass a non-empty errorMessage only on failure.
+    bool updateQueueStatus(
+            int queueId,
+            const QString& status,
+            const QString& errorMessage = QString()) const;
+
+    // Returns up to `limit` jobs that are ready to run, ordered by
+    // priority ASC then queued_at ASC. Used by the background worker
+    // and by the startup load (Q7 in Final_Database.md).
+    QList<AcoustIdJob> getPendingJobs(int limit = 10) const;
+
+    // Removes a track's queue entry entirely — called from onPurgingTracks.
+    bool deleteQueueEntry(TrackId trackId) const;
 
   private:
     // Returns ~/.mixxx/fingerprints/ — creates the directory on first call.

--- a/src/library/dao/trackschema.cpp
+++ b/src/library/dao/trackschema.cpp
@@ -8,6 +8,16 @@ QString tableForColumn(const QString& columnName) {
             columnName == TRACKLOCATIONSTABLE_DIRECTORY) {
         return QStringLiteral(TRACKLOCATIONS_TABLE);
     }
+    if (columnName == FINGERPRINT_TABLE_HASH ||
+            columnName == FINGERPRINT_TABLE_SHA256 ||
+            columnName == FINGERPRINT_TABLE_DURATION) {
+        return FINGERPRINT_METADATA_TABLE;
+    }
+    if (columnName == CMRT_GROUPS_TABLE_ID ||
+            columnName == CMRT_GROUPS_TABLE_HASH ||
+            columnName == CMRT_GROUPS_TABLE_SHA256) {
+        return CMRT_GROUPS_TABLE;
+    }
     // This doesn't detect unknown columns, but that's not really important here.
     return QStringLiteral(LIBRARY_TABLE);
 }

--- a/src/library/dao/trackschema.h
+++ b/src/library/dao/trackschema.h
@@ -80,6 +80,33 @@ const QString PLAYLISTTRACKSTABLE_DATETIMEADDED = QStringLiteral("pl_datetime_ad
 
 const QString REKORDBOX_ANALYZE_PATH = "analyze_path";
 
+// Fingerprint and CMRT Tables
+const QString FINGERPRINT_METADATA_TABLE = QStringLiteral("fingerprint_metadata");
+const QString CMRT_GROUPS_TABLE = QStringLiteral("cmrt_groups");
+
+// Columns for fingerprint_metadata
+const QString FINGERPRINT_TABLE_TRACK_ID = QStringLiteral("track_id");
+const QString FINGERPRINT_TABLE_HASH = QStringLiteral("fingerprint_hash");
+const QString FINGERPRINT_TABLE_SHA256 = QStringLiteral("chroma_sha256");
+const QString FINGERPRINT_TABLE_DURATION = QStringLiteral("fingerprint_duration");
+const QString FINGERPRINT_TABLE_VERSION = QStringLiteral("fingerprint_version");
+const QString FINGERPRINT_TABLE_GROUP_ID = QStringLiteral("cmrt_group_id");
+const QString FINGERPRINT_TABLE_OFFSET = QStringLiteral("cmrt_offset_seconds");
+const QString FINGERPRINT_TABLE_CANONICAL = QStringLiteral("is_canonical");
+const QString FINGERPRINT_TABLE_VALID = QStringLiteral("fingerprint_valid");
+const QString FINGERPRINT_TABLE_NEEDS_REGEN = QStringLiteral("fingerprint_needs_regen");
+const QString FINGERPRINT_TABLE_COMPUTED_AT = QStringLiteral("computed_at");
+
+// Columns for cmrt_groups
+const QString CMRT_GROUPS_TABLE_ID = QStringLiteral("group_id");
+const QString CMRT_GROUPS_TABLE_HASH = QStringLiteral("fingerprint_hash");
+const QString CMRT_GROUPS_TABLE_SHA256 = QStringLiteral("chroma_sha256");
+const QString CMRT_GROUPS_TABLE_CANONICAL_TRACK_ID = QStringLiteral("canonical_track_id");
+const QString CMRT_GROUPS_TABLE_TRACK_COUNT = QStringLiteral("track_count");
+const QString CMRT_GROUPS_TABLE_CREATED_AT = QStringLiteral("created_at");
+const QString CMRT_GROUPS_TABLE_LAST_UPDATED = QStringLiteral("last_updated");
+// MusicBrainz CMRT fields deferred to later PR
+
 namespace mixxx {
 namespace trackschema {
 // TableForColumn returns the name of the table that contains the named column.

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -124,3 +124,8 @@ const ConfigKey mixxx::library::prefs::kSidebarHoverExpandDelayConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("sidebar_hover_expand_delay")};
+
+const ConfigKey mixxx::library::prefs::kFingerprintAnalysisEnabledConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("FingerprintAnalysisEnabled")};

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -129,3 +129,8 @@ const ConfigKey mixxx::library::prefs::kSidebarHoverExpandDelayConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("sidebar_hover_expand_delay")};
+
+const ConfigKey mixxx::library::prefs::kFingerprintAnalysisEnabledConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("FingerprintAnalysisEnabled")};

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -64,7 +64,7 @@ const int kSidebarHoverExpandDelayDefault = 500; // ms
 
 extern const ConfigKey kSidebarHoverExpandDelayConfigKey;
 
-extern const ConfigKey kFingerprintAnalysisEnabled;
+extern const ConfigKey kFingerprintAnalysisEnabledConfigKey;
 
 } // namespace prefs
 

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -64,6 +64,8 @@ const int kSidebarHoverExpandDelayDefault = 500; // ms
 
 extern const ConfigKey kSidebarHoverExpandDelayConfigKey;
 
+extern const ConfigKey kFingerprintAnalysisEnabled;
+
 } // namespace prefs
 
 } // namespace library

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -66,7 +66,7 @@ const int kSidebarHoverExpandDelayDefault = 500; // ms
 
 extern const ConfigKey kSidebarHoverExpandDelayConfigKey;
 
-extern const ConfigKey kFingerprintAnalysisEnabled;
+extern const ConfigKey kFingerprintAnalysisEnabledConfigKey;
 
 } // namespace prefs
 

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -66,6 +66,8 @@ const int kSidebarHoverExpandDelayDefault = 500; // ms
 
 extern const ConfigKey kSidebarHoverExpandDelayConfigKey;
 
+extern const ConfigKey kFingerprintAnalysisEnabled;
+
 } // namespace prefs
 
 } // namespace library

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -96,12 +96,17 @@ void updateQueryPlannerStatisticsForDatabase(const QSqlDatabase& database) {
 
 } // anonymous namespace
 
-LibraryScanner::LibraryScanner(
-        mixxx::DbConnectionPoolPtr pDbConnectionPool,
+LibraryScanner::LibraryScanner(mixxx::DbConnectionPoolPtr pDbConnectionPool,
         const UserSettingsPointer& pConfig)
         : m_pDbConnectionPool(std::move(pDbConnectionPool)),
           m_analysisDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao, m_analysisDao, m_libraryHashDao, pConfig),
+          m_fingerprintDao(pConfig),
+          m_trackDao(m_cueDao,
+                  m_playlistDao,
+                  m_analysisDao,
+                  m_libraryHashDao,
+                  m_fingerprintDao,
+                  pConfig),
           m_stateSema(1), // only one transaction is possible at a time
           m_state(IDLE),
           m_numRelocatedTracks(0),

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -181,6 +181,7 @@ void LibraryScanner::run() {
         m_playlistDao.initialize(dbConnection);
         m_analysisDao.initialize(dbConnection);
         m_directoryDao.initialize(dbConnection);
+        m_fingerprintDao.initialize(dbConnection);
 
         // Start the event loop.
         kLogger.debug() << "Event loop starting";

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -191,6 +191,7 @@ void LibraryScanner::run() {
         m_playlistDao.initialize(dbConnection);
         m_analysisDao.initialize(dbConnection);
         m_directoryDao.initialize(dbConnection);
+        m_fingerprintDao.initialize(dbConnection);
 
         // Start the event loop.
         kLogger.debug() << "Event loop starting";

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -14,6 +14,7 @@
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
+#include "library/dao/trackfingerprintdao.h"
 #include "library/scanner/scannerglobal.h"
 #include "track/track_decl.h"
 #include "util/db/dbconnectionpool.h"
@@ -112,6 +113,7 @@ class LibraryScanner : public QThread {
     PlaylistDAO m_playlistDao;
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
+    TrackFingerprintDao m_fingerprintDao;
     TrackDAO m_trackDao;
 
     // Global scanner state for scan currently in progress.

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -14,6 +14,7 @@
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
+#include "library/dao/trackfingerprintdao.h"
 #include "library/scanner/scannerglobal.h"
 #include "track/track_decl.h"
 #include "util/db/dbconnectionpool.h"
@@ -111,6 +112,7 @@ class LibraryScanner : public QThread {
     PlaylistDAO m_playlistDao;
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
+    TrackFingerprintDao m_fingerprintDao;
     TrackDAO m_trackDao;
 
     // Global scanner state for scan currently in progress.

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -16,12 +16,16 @@ mixxx::Logger kLogger("TrackCollection");
 } // anonymous namespace
 
 TrackCollection::TrackCollection(
-        QObject* parent,
-        const UserSettingsPointer& pConfig)
+        QObject* parent, const UserSettingsPointer& pConfig)
         : QObject(parent),
           m_analysisDao(pConfig),
           m_trackFingerprintDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao, m_analysisDao, m_libraryHashDao, pConfig) {
+          m_trackDao(m_cueDao,
+                  m_playlistDao,
+                  m_analysisDao,
+                  m_libraryHashDao,
+                  m_trackFingerprintDao,
+                  pConfig) {
     // Forward signals from TrackDAO
     connect(&m_trackDao,
             &TrackDAO::trackDirty,

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -77,6 +77,7 @@ void TrackCollection::connectDatabase(const QSqlDatabase& database) {
     m_directoryDao.initialize(database);
     m_analysisDao.initialize(database);
     m_libraryHashDao.initialize(database);
+    m_trackFingerprintDao.initialize(database);
     m_crates.connectDatabase(database);
 }
 

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -20,8 +20,8 @@ TrackCollection::TrackCollection(
         const UserSettingsPointer& pConfig)
         : QObject(parent),
           m_analysisDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao,
-                     m_analysisDao, m_libraryHashDao, pConfig) {
+          m_trackFingerprintDao(pConfig),
+          m_trackDao(m_cueDao, m_playlistDao, m_analysisDao, m_libraryHashDao, pConfig) {
     // Forward signals from TrackDAO
     connect(&m_trackDao,
             &TrackDAO::trackDirty,

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -78,6 +78,7 @@ void TrackCollection::connectDatabase(const QSqlDatabase& database) {
     m_directoryDao.initialize(database);
     m_analysisDao.initialize(database);
     m_libraryHashDao.initialize(database);
+    m_trackFingerprintDao.initialize(database);
     m_crates.connectDatabase(database);
 }
 

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -179,8 +179,8 @@ class TrackCollection : public QObject,
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
     LibraryHashDAO m_libraryHashDao;
-    TrackDAO m_trackDao;
     TrackFingerprintDao m_trackFingerprintDao;
+    TrackDAO m_trackDao;
 
     QSharedPointer<BaseTrackCache> m_pTrackSource;
 };

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -12,6 +12,7 @@
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
+#include "library/dao/trackfingerprintdao.h"
 #include "library/trackset/crate/cratestorage.h"
 #include "preferences/usersettings.h"
 #include "util/thread_affinity.h"
@@ -68,7 +69,10 @@ class TrackCollection : public QObject,
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
         return m_analysisDao;
     }
-
+    TrackFingerprintDao& getTrackFingerprintDAO() {
+        DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+        return m_trackFingerprintDao;
+    }
     void connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSource);
     QWeakPointer<BaseTrackCache> disconnectTrackSource();
 
@@ -176,6 +180,7 @@ class TrackCollection : public QObject,
     AnalysisDao m_analysisDao;
     LibraryHashDAO m_libraryHashDao;
     TrackDAO m_trackDao;
+    TrackFingerprintDao m_trackFingerprintDao;
 
     QSharedPointer<BaseTrackCache> m_pTrackSource;
 };

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -12,6 +12,7 @@
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
+#include "library/dao/trackfingerprintdao.h"
 #include "library/trackset/crate/cratestorage.h"
 #include "preferences/usersettings.h"
 #include "util/thread_affinity.h"
@@ -69,7 +70,10 @@ class TrackCollection : public QObject,
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
         return m_analysisDao;
     }
-
+    TrackFingerprintDao& getTrackFingerprintDAO() {
+        DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+        return m_trackFingerprintDao;
+    }
     void connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSource);
     QWeakPointer<BaseTrackCache> disconnectTrackSource();
 
@@ -179,6 +183,7 @@ class TrackCollection : public QObject,
     AnalysisDao m_analysisDao;
     LibraryHashDAO m_libraryHashDao;
     TrackDAO m_trackDao;
+    TrackFingerprintDao m_trackFingerprintDao;
 
     QSharedPointer<BaseTrackCache> m_pTrackSource;
 };

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -182,8 +182,8 @@ class TrackCollection : public QObject,
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
     LibraryHashDAO m_libraryHashDao;
-    TrackDAO m_trackDao;
     TrackFingerprintDao m_trackFingerprintDao;
+    TrackDAO m_trackDao;
 
     QSharedPointer<BaseTrackCache> m_pTrackSource;
 };

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -571,6 +571,12 @@ void WTrackMenu::createActions() {
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotReanalyzeWithVariableTempo);
+
+        m_pAnalyzeFingerprintAction = make_parented<QAction>(tr("Analyze fingerprint"), this);
+        connect(m_pAnalyzeFingerprintAction.get(),
+                &QAction::triggered,
+                this,
+                &WTrackMenu::slotAnalyzeFingerprint);
     }
 
     // This action is only usable when m_deckGroup is set. That is true only
@@ -746,6 +752,8 @@ void WTrackMenu::setupActions() {
         m_pAnalyzeMenu->addAction(m_pReanalyzeAction);
         m_pAnalyzeMenu->addAction(m_pReanalyzeConstBpmAction);
         m_pAnalyzeMenu->addAction(m_pReanalyzeVarBpmAction);
+        m_pAnalyzeMenu->addSeparator();
+        m_pAnalyzeMenu->addAction(m_pAnalyzeFingerprintAction.get());
         addMenu(m_pAnalyzeMenu);
     }
 
@@ -3033,4 +3041,14 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
         DEBUG_ASSERT(!"unreachable");
         return false;
     }
+}
+
+void WTrackMenu::slotAnalyzeFingerprint() {
+    // Schedule selected tracks for fingerprint-only analysis.
+    // WithFingerprint | LowPriority — does not re-run beats, waveform, or
+    // any other analyzer. Useful for back-filling fingerprints on a library
+    // that was fully analyzed before fingerprinting was enabled.
+    AnalyzerTrack::Options options;
+    options.fingerprintOnly = true;
+    addToAnalysis(options);
 }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -592,6 +592,12 @@ void WTrackMenu::createActions() {
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotReanalyzeWithVariableTempo);
+
+        m_pAnalyzeFingerprintAction = make_parented<QAction>(tr("Analyze fingerprint"), this);
+        connect(m_pAnalyzeFingerprintAction.get(),
+                &QAction::triggered,
+                this,
+                &WTrackMenu::slotAnalyzeFingerprint);
     }
 
     // This action is only usable when m_deckGroup is set. That is true only
@@ -767,6 +773,8 @@ void WTrackMenu::setupActions() {
         m_pAnalyzeMenu->addAction(m_pReanalyzeAction);
         m_pAnalyzeMenu->addAction(m_pReanalyzeConstBpmAction);
         m_pAnalyzeMenu->addAction(m_pReanalyzeVarBpmAction);
+        m_pAnalyzeMenu->addSeparator();
+        m_pAnalyzeMenu->addAction(m_pAnalyzeFingerprintAction.get());
         addMenu(m_pAnalyzeMenu);
     }
 
@@ -3042,4 +3050,14 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
         DEBUG_ASSERT(!"unreachable");
         return false;
     }
+}
+
+void WTrackMenu::slotAnalyzeFingerprint() {
+    // Schedule selected tracks for fingerprint-only analysis.
+    // WithFingerprint | LowPriority — does not re-run beats, waveform, or
+    // any other analyzer. Useful for back-filling fingerprints on a library
+    // that was fully analyzed before fingerprinting was enabled.
+    AnalyzerTrack::Options options;
+    options.fingerprintOnly = true;
+    addToAnalysis(options);
 }

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -162,6 +162,7 @@ class WTrackMenu : public QMenu {
     void slotReanalyze();
     void slotReanalyzeWithFixedTempo();
     void slotReanalyzeWithVariableTempo();
+    void slotAnalyzeFingerprint();
 
     // BPM
     void slotLockBpm();
@@ -361,6 +362,7 @@ class WTrackMenu : public QMenu {
     parented_ptr<QAction> m_pReanalyzeAction;
     parented_ptr<QAction> m_pReanalyzeConstBpmAction;
     parented_ptr<QAction> m_pReanalyzeVarBpmAction;
+    parented_ptr<QAction> m_pAnalyzeFingerprintAction;
 
     // Clear track metadata actions
     parented_ptr<QAction> m_pClearBeatsAction;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -161,6 +161,7 @@ class WTrackMenu : public QMenu {
     void slotReanalyze();
     void slotReanalyzeWithFixedTempo();
     void slotReanalyzeWithVariableTempo();
+    void slotAnalyzeFingerprint();
 
     // BPM
     void slotLockBpm();
@@ -361,6 +362,7 @@ class WTrackMenu : public QMenu {
     parented_ptr<QAction> m_pReanalyzeAction;
     parented_ptr<QAction> m_pReanalyzeConstBpmAction;
     parented_ptr<QAction> m_pReanalyzeVarBpmAction;
+    parented_ptr<QAction> m_pAnalyzeFingerprintAction;
 
     // Clear track metadata actions
     parented_ptr<QAction> m_pClearBeatsAction;


### PR DESCRIPTION
https://github.com/mixxxdj/mixxx/pull/16603/changes/888f6ecb27d58e7d8a332e6bfa2e4e33536fc928..b7c31ad0cca4a98a3b32a6128487fd60fe091929

Adds the full-track Chromaprint fingerprint analyzer and wires it
into the existing analyzer pipeline behind an opt-in mode flag.

AnalyzerModeFlags (analyzerthread.h)
-------------------------------------
WithFingerprint = 0x08 — new opt-in flag, intentionally excluded
  from All (WithBeats | WithWaveform) so existing analysis jobs are
  unaffected. AllWithFingerprint = WithBeats | WithWaveform |
  WithFingerprint added for convenience.

analyzerthread.cpp
  - DB connection is now requested when either WithWaveform OR
    WithFingerprint is set (previously only WithWaveform).
  - AnalyzerChromaprint instantiated and pushed when WithFingerprint
    is in the mode flags.

AnalyzerChromaprint (new files)
---------------------------------
analyzerchromaprint.h
  - Derives from Analyzer; owns a TrackFingerprintDao instance and a
    ChromaprintContext*.
  - Reusable std::vector<SAMPLE> m_int16Buffer avoids per-chunk
    heap allocation in processSamples().
  - Unlike the existing ChromaPrinter (first-120s only), processes
    the entire track so the full fingerprint is available for CMRT
    matching.
  - Storage layout:
      ~/.mixxx/fingerprints/track_{id}.chroma — raw uint32[] array
      fingerprint_metadata DB row — SimHash + SHA-256 + linkage

analyzerchromaprint.cpp
  initialize()
    - Returns false (skip) when hasValidFingerprint() is true —
      avoids re-computing fingerprints for unchanged tracks.
    - hasValidFingerprint() also detects source file modifications
      (mtime > computedAt) and marks the fingerprint stale via
      markFingerprintNeedsRegen() before returning false.
    - Creates a fresh ChromaprintContext with
      CHROMAPRINT_ALGORITHM_DEFAULT for full-track analysis.
    - Chromaprint API version guard: uint32_p typedef mirrors the
      existing guard in src/musicbrainz/chromaprinter.cpp.

  processSamples()
    - Converts float32 samples to int16 via SampleUtil::convertFloat32ToS16()
      into the reusable m_int16Buffer, then calls chromaprint_feed().

  storeResults()
    - Finalizes via chromaprint_finish(), retrieves raw uint32[]
      via chromaprint_get_raw_fingerprint().
    - Derives SimHash via computeSimHash() and SHA-256 via
      QCryptographicHash::Sha256 over the raw byte array.
    - Writes the raw array to disk as track_{id}.chroma via
      TrackFingerprintDao::saveChromaFile().
    - Writes fingerprint_metadata row (cmrtGroupId = -1 pending
      Q1 group assignment in a future PR).
    - Calls enqueueAcoustId() — INSERT OR IGNORE, safe to call
      unconditionally.

  computeSimHash() (static private)
    - Bit-voting SimHash: for each of the 32 bit positions,
      increments a counter if set, decrements if unset. Sets the
      result bit where the counter is positive.
    - Locality-sensitive: similar fingerprints → similar SimHash.
    - NOT a unique key; full XOR/popcount of .chroma files is
      always required to confirm a match.

  cleanup()
    - Frees the ChromaprintContext and shrinks the conversion
      buffer. Always safe to call (guards against null context).

Config keys (library_prefs.h / library_prefs.cpp)
---------------------------------------------------
kFingerprintAnalysisEnabledConfigKey — [Library] FingerprintAnalysisEnabled
kAcoustIdUserApiKeyConfigKey         — [Library] AcoustIdUserApiKey
kAcoustIdAutoSubmitConfigKey         — [Library] AcoustIdAutoSubmit

AnalysisFeature (analysisfeature.cpp)
--------------------------------------
getAnalyzerModeFlags() now reads kFingerprintAnalysisEnabledConfigKey
and OR-s in WithFingerprint when the preference is true.

AnalyzerTrack::Options (analyzertrack.h)
-----------------------------------------
fingerprintOnly bool added (default false). When all tracks in a
batch have fingerprintOnly=true (e.g. right-click "Analyze
fingerprint"), AnalysisFeature uses WithFingerprint | LowPriority
instead of the standard mode flags — beats and waveform are not
re-triggered on an already-analyzed library.

WTrackMenu (wtrackmenu.h / wtrackmenu.cpp)
-------------------------------------------
slotAnalyzeFingerprint() — sets fingerprintOnly=true on Options
and calls addToAnalysis(). Exposed as "Analyze fingerprint" under
the Analyze sub-menu.

dlganalysis.ui
  Tooltip updated to mention Chromaprint fingerprints.


Notes for reviewers
-------------------
- WithFingerprint is deliberately excluded from All — it must be
  an explicit opt-in so existing users are not affected.
- The allFingerprintOnly scheduler path only applies when no
  scheduler is currently active. If a normal analysis is running,
  fingerprint-only tracks join it with the existing flags. Fixing
  that requires a second scheduler or stopping the active one —
  deferred to a later PR (see TODO in analysisfeature.cpp).
- CMRT Q1 group assignment (SimHash pre-filter + full XOR/popcount)
  is left as a TODO stub in storeResults(); cmrtGroupId stays -1.

Depends on: [GSoC] CMRT 01: DB + DAO (#16602) 