### PR TITLE
EngineVuMeter: add selectable DJ peak / VU-RMS metering modes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2904,6 +2904,7 @@ if(BUILD_TESTING)
     src/test/enginemixertest.cpp
     src/test/enginemicrophonetest.cpp
     src/test/enginesynctest.cpp
+    src/test/enginevumetertest.cpp
     src/test/fileinfo_test.cpp
     src/test/frametest.cpp
     src/test/globaltrackcache_test.cpp

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -93,6 +93,17 @@ EngineMixer::EngineMixer(UserSettingsPointer pConfig,
                   ConfigKey(group, "boothDelay"))),
           m_pLatencyCompensationDelay(std::make_unique<EngineDelay>(
                   ConfigKey(group, "microphoneLatencyCompensation"))),
+          // The shared VuMeterMode control must be created before any
+          // EngineVuMeter (the main meter below as well as the per-channel and
+          // per-stem meters built later by PlayerManager), because each meter
+          // connects a PollingControlProxy to this key at construction time and
+          // will not retroactively connect if the control does not yet exist.
+          m_pVuMeterMode(std::make_unique<ControlObject>(
+                  EngineVuMeter::modeConfigKey(),
+                  true,
+                  false,
+                  true,
+                  EngineVuMeter::modeToValue(EngineVuMeter::MeterMode::DjPeak))),
           m_pVumeter(std::make_unique<EngineVuMeter>(kMainGroup, kLegacyGroup)),
           // Starts a thread for recording and broadcast
           m_pEngineSideChain(bEnableSidechain

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -312,6 +312,10 @@ class EngineMixer : public QObject, public AudioSource {
     std::unique_ptr<EngineDelay> m_pBoothDelay;
     std::unique_ptr<EngineDelay> m_pLatencyCompensationDelay;
 
+    // Must precede m_pVumeter (and be created before any per-channel meter) so
+    // each EngineVuMeter's mode proxy can connect to this control. See the
+    // initializer list in the constructor.
+    std::unique_ptr<ControlObject> m_pVuMeterMode;
     std::unique_ptr<EngineVuMeter> m_pVumeter;
     std::unique_ptr<EngineSideChain> m_pEngineSideChain;
 

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -1,21 +1,90 @@
 #include "engine/enginevumeter.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include "audio/types.h"
 #include "moc_enginevumeter.cpp"
-#include "util/sample.h"
 
 namespace {
 
-// Rate at which the vumeter is updated (using a sample rate of 44100 Hz):
-constexpr unsigned int kVuUpdateRate = 30; // in Hz (1/s), fits to display frame rate
-constexpr int kPeakDuration = 500;         // in ms
+// Rate at which the vumeter is updated. The audio envelope itself is sampled
+// continuously and only the ControlObjects are throttled to this rate.
+constexpr std::size_t kVuUpdateRate = 30; // in Hz (1/s), fits to display frame rate
+constexpr std::size_t kPeakDuration = 500; // in ms
 
-// Smoothing Factors
-// Must be from 0-1 the lower the factor, the more smoothing that is applied
-constexpr CSAMPLE kAttackSmoothing = 1.0f; // .85
-constexpr CSAMPLE kDecaySmoothing = 0.1f;  //.16//.4
+// Mixer-style peak meter ballistics. The level meter uses fast attack and a
+// constant dB/s release so transient spacing does not get folded into the
+// measured level before the display smoothing is applied.
+constexpr double kDjAttackTimeSeconds = 0.005;
+constexpr double kDjReleaseDbPerSecond = 30.0;
+
+// VU/RMS mode uses true RMS values with a one-pole VU-style 300 ms rise time.
+// The time constant below makes a step input reach 99% after 300 ms.
+constexpr double kVuIntegrationTimeConstantSeconds = 0.06514476;
+
+constexpr double kMinDb = -60.0;
+constexpr double kMaxDb = 0.0;
+constexpr double kDbRange = kMaxDb - kMinDb;
+
+CSAMPLE levelFromAmplitude(double amplitude) {
+    if (amplitude <= 0.0) {
+        return CSAMPLE_ZERO;
+    }
+    const double clampedAmplitude = std::min<double>(amplitude, CSAMPLE_PEAK);
+    const double db = 20.0 * std::log10(clampedAmplitude);
+    return static_cast<CSAMPLE>(
+            std::clamp((db - kMinDb) / kDbRange, 0.0, 1.0));
+}
+
+void smoothDjLevel(
+        CSAMPLE& currentVolume,
+        CSAMPLE newVolume,
+        double secondsElapsed) {
+    if (currentVolume <= newVolume) {
+        const double attack = 1.0 - std::exp(-secondsElapsed / kDjAttackTimeSeconds);
+        currentVolume += static_cast<CSAMPLE>(attack * (newVolume - currentVolume));
+    } else {
+        const double release = kDjReleaseDbPerSecond * secondsElapsed / kDbRange;
+        currentVolume = static_cast<CSAMPLE>(
+                std::max<double>(newVolume, currentVolume - release));
+    }
+    currentVolume = static_cast<CSAMPLE>(
+            std::clamp<double>(currentVolume, 0.0, 1.0));
+}
+
+void smoothVuLevel(
+        CSAMPLE& currentVolume,
+        CSAMPLE newVolume,
+        double secondsElapsed) {
+    const double coefficient = 1.0 -
+            std::exp(-secondsElapsed / kVuIntegrationTimeConstantSeconds);
+    currentVolume += static_cast<CSAMPLE>(coefficient * (newVolume - currentVolume));
+    currentVolume = static_cast<CSAMPLE>(
+            std::clamp<double>(currentVolume, 0.0, 1.0));
+}
 
 } // namespace
+
+const ConfigKey& EngineVuMeter::modeConfigKey() {
+    static const ConfigKey kModeConfigKey(
+            QStringLiteral("[Mixer Profile]"), QStringLiteral("VuMeterMode"));
+    return kModeConfigKey;
+}
+
+EngineVuMeter::MeterMode EngineVuMeter::modeFromValue(double value) {
+    switch (static_cast<int>(std::lround(value))) {
+    case static_cast<int>(MeterMode::VuRms):
+        return MeterMode::VuRms;
+    case static_cast<int>(MeterMode::DjPeak):
+    default:
+        return MeterMode::DjPeak;
+    }
+}
+
+double EngineVuMeter::modeToValue(MeterMode mode) {
+    return static_cast<double>(static_cast<int>(mode));
+}
 
 EngineVuMeter::EngineVuMeter(const QString& group,
         const QString& legacyGroup,
@@ -28,7 +97,8 @@ EngineVuMeter::EngineVuMeter(const QString& group,
                   ConfigKey(group, QStringLiteral("peak_indicator_left"))),
           m_peakIndicatorRight(
                   ConfigKey(group, QStringLiteral("peak_indicator_right"))),
-          m_sampleRate(QStringLiteral("[App]"), QStringLiteral("samplerate")) {
+          m_sampleRate(QStringLiteral("[App]"), QStringLiteral("samplerate")),
+          m_meterMode(modeConfigKey(), ControlFlag::NoWarnIfMissing) {
     if (createLegacyAliases) {
         const QString& aliasGroup = legacyGroup.isEmpty() ? group : legacyGroup;
         m_vuMeter.addAlias(ConfigKey(aliasGroup, QStringLiteral("VuMeter")));
@@ -43,86 +113,186 @@ EngineVuMeter::EngineVuMeter(const QString& group,
 }
 
 void EngineVuMeter::process(CSAMPLE* pIn, const std::size_t bufferSize) {
-    CSAMPLE fVolSumL, fVolSumR;
+    updateMeterMode();
 
     const auto sampleRate = mixxx::audio::SampleRate::fromDouble(m_sampleRate.get());
-
-    SampleUtil::CLIP_STATUS clipped = SampleUtil::sumAbsPerChannel(&fVolSumL,
-            &fVolSumR,
-            pIn,
-            bufferSize);
-    m_fRMSvolumeSumL += fVolSumL;
-    m_fRMSvolumeSumR += fVolSumR;
-
-    m_samplesCalculated += static_cast<unsigned int>(bufferSize / 2);
-
-    // Are we ready to update the VU meter?:
-    if (m_samplesCalculated > (sampleRate / kVuUpdateRate)) {
-        doSmooth(m_fRMSvolumeL,
-                std::log10(SHRT_MAX * m_fRMSvolumeSumL / (m_samplesCalculated * 1000) + 1));
-        doSmooth(m_fRMSvolumeR,
-                std::log10(SHRT_MAX * m_fRMSvolumeSumR / (m_samplesCalculated * 1000) + 1));
-
-        const double epsilon = .0001;
-
-        // Since VU meters are a rolling sum of audio, the no-op checks in
-        // ControlObject will not prevent us from causing tons of extra
-        // work. Because of this, we use an epsilon here to be gentle on the GUI
-        // and MIDI controllers.
-        if (fabs(m_fRMSvolumeL - m_vuMeterLeft.get()) > epsilon) {
-            m_vuMeterLeft.set(m_fRMSvolumeL);
-        }
-        if (fabs(m_fRMSvolumeR - m_vuMeterRight.get()) > epsilon) {
-            m_vuMeterRight.set(m_fRMSvolumeR);
-        }
-
-        double fRMSvolume = (m_fRMSvolumeL + m_fRMSvolumeR) / 2.0;
-        if (fabs(fRMSvolume - m_vuMeter.get()) > epsilon) {
-            m_vuMeter.set(fRMSvolume);
-        }
-
-        // Reset calculation:
-        m_samplesCalculated = 0;
-        m_fRMSvolumeSumL = 0;
-        m_fRMSvolumeSumR = 0;
+    const auto sampleRateValue = static_cast<std::size_t>(sampleRate.value());
+    const std::size_t frameCount = bufferSize / 2;
+    if (!sampleRate.isValid() || frameCount == 0) {
+        return;
     }
 
-    if (clipped & SampleUtil::CLIPPING_LEFT) {
+    CSAMPLE peakL = CSAMPLE_ZERO;
+    CSAMPLE peakR = CSAMPLE_ZERO;
+    CSAMPLE squareSumL = CSAMPLE_ZERO;
+    CSAMPLE squareSumR = CSAMPLE_ZERO;
+    bool clippedL = false;
+    bool clippedR = false;
+    for (std::size_t i = 0; i < frameCount; ++i) {
+        const CSAMPLE sampleL = pIn[i * 2];
+        const CSAMPLE absL = std::abs(sampleL);
+        peakL = std::max(peakL, absL);
+        squareSumL += sampleL * sampleL;
+        clippedL = clippedL || absL > CSAMPLE_PEAK;
+
+        const CSAMPLE sampleR = pIn[i * 2 + 1];
+        const CSAMPLE absR = std::abs(sampleR);
+        peakR = std::max(peakR, absR);
+        squareSumR += sampleR * sampleR;
+        clippedR = clippedR || absR > CSAMPLE_PEAK;
+    }
+
+    m_peakVolumeL = std::max(m_peakVolumeL, peakL);
+    m_peakVolumeR = std::max(m_peakVolumeR, peakR);
+    m_squareSumL += squareSumL;
+    m_squareSumR += squareSumR;
+    m_framesCalculated += frameCount;
+
+    const auto updateFrameCount = std::max<std::size_t>(1, sampleRateValue / kVuUpdateRate);
+    if (m_framesCalculated >= updateFrameCount) {
+        const double secondsElapsed = static_cast<double>(m_framesCalculated) /
+                static_cast<double>(sampleRateValue);
+        setMeterControls(m_meterCalculator.process({m_peakVolumeL,
+                m_peakVolumeR,
+                m_squareSumL,
+                m_squareSumR,
+                m_framesCalculated,
+                secondsElapsed}));
+
+        m_framesCalculated = 0;
+        m_peakVolumeL = CSAMPLE_ZERO;
+        m_peakVolumeR = CSAMPLE_ZERO;
+        m_squareSumL = CSAMPLE_ZERO;
+        m_squareSumR = CSAMPLE_ZERO;
+    }
+
+    if (clippedL) {
         m_peakIndicatorLeft.set(1.0);
-        m_peakDurationL = static_cast<int>(kPeakDuration * sampleRate / bufferSize / 2000);
-    } else if (m_peakDurationL <= 0) {
+        m_peakDurationFramesL = kPeakDuration * sampleRateValue / 1000;
+    } else if (m_peakDurationFramesL <= frameCount) {
         m_peakIndicatorLeft.set(0.0);
+        m_peakDurationFramesL = 0;
     } else {
-        --m_peakDurationL;
+        m_peakDurationFramesL -= frameCount;
     }
 
-    if (clipped & SampleUtil::CLIPPING_RIGHT) {
+    if (clippedR) {
         m_peakIndicatorRight.set(1.0);
-        m_peakDurationR = static_cast<int>(kPeakDuration * sampleRate / bufferSize / 2000);
-    } else if (m_peakDurationR <= 0) {
+        m_peakDurationFramesR = kPeakDuration * sampleRateValue / 1000;
+    } else if (m_peakDurationFramesR <= frameCount) {
         m_peakIndicatorRight.set(0.0);
+        m_peakDurationFramesR = 0;
     } else {
-        --m_peakDurationR;
+        m_peakDurationFramesR -= frameCount;
     }
 
+    setPeakIndicatorControls();
+}
+
+EngineVuMeter::StereoLevel EngineVuMeter::MeterCalculatorBase::process(
+        const MeterInput& input) {
+    // No samples in this window: keep the displayed level unchanged. This also
+    // guards the RMS division against a zero frame count.
+    if (input.frameCount == 0) {
+        return {m_volumeLeft, m_volumeRight};
+    }
+    smooth(m_volumeLeft,
+            targetLevel(input.peakLeft, input.squareSumLeft, input.frameCount),
+            input.secondsElapsed);
+    smooth(m_volumeRight,
+            targetLevel(input.peakRight, input.squareSumRight, input.frameCount),
+            input.secondsElapsed);
+    return {m_volumeLeft, m_volumeRight};
+}
+
+void EngineVuMeter::MeterCalculatorBase::reset() {
+    m_volumeLeft = 0;
+    m_volumeRight = 0;
+}
+
+CSAMPLE EngineVuMeter::DjPeakMeterCalculator::targetLevel(
+        CSAMPLE peak, CSAMPLE /*squareSum*/, std::size_t /*frameCount*/) const {
+    return levelFromAmplitude(peak);
+}
+
+void EngineVuMeter::DjPeakMeterCalculator::smooth(
+        CSAMPLE& currentVolume, CSAMPLE targetLevel, double secondsElapsed) const {
+    smoothDjLevel(currentVolume, targetLevel, secondsElapsed);
+}
+
+CSAMPLE EngineVuMeter::VuRmsMeterCalculator::targetLevel(
+        CSAMPLE /*peak*/, CSAMPLE squareSum, std::size_t frameCount) const {
+    // frameCount is guaranteed non-zero by MeterCalculatorBase::process().
+    const double rms = std::sqrt(
+            static_cast<double>(squareSum) / static_cast<double>(frameCount));
+    return levelFromAmplitude(rms);
+}
+
+void EngineVuMeter::VuRmsMeterCalculator::smooth(
+        CSAMPLE& currentVolume, CSAMPLE targetLevel, double secondsElapsed) const {
+    smoothVuLevel(currentVolume, targetLevel, secondsElapsed);
+}
+
+void EngineVuMeter::MeterCalculator::setMode(MeterMode mode) {
+    m_mode = mode;
+    reset();
+}
+
+EngineVuMeter::MeterCalculatorBase& EngineVuMeter::MeterCalculator::activeCalculator() {
+    switch (m_mode) {
+    case MeterMode::VuRms:
+        return m_vuRmsMeter;
+    case MeterMode::DjPeak:
+    default:
+        return m_djPeakMeter;
+    }
+}
+
+EngineVuMeter::StereoLevel EngineVuMeter::MeterCalculator::process(
+        const MeterInput& input) {
+    return activeCalculator().process(input);
+}
+
+void EngineVuMeter::MeterCalculator::reset() {
+    m_djPeakMeter.reset();
+    m_vuRmsMeter.reset();
+}
+
+void EngineVuMeter::updateMeterMode() {
+    const MeterMode mode = modeFromValue(m_meterMode.get());
+    if (mode == m_meterCalculator.mode()) {
+        return;
+    }
+    m_meterCalculator.setMode(mode);
+    m_framesCalculated = 0;
+    m_peakVolumeL = CSAMPLE_ZERO;
+    m_peakVolumeR = CSAMPLE_ZERO;
+    m_squareSumL = CSAMPLE_ZERO;
+    m_squareSumR = CSAMPLE_ZERO;
+    setMeterControls({0, 0});
+}
+
+void EngineVuMeter::setMeterControls(StereoLevel level) {
+    constexpr double kEpsilon = 0.0001;
+
+    if (std::abs(level.left - m_vuMeterLeft.get()) > kEpsilon) {
+        m_vuMeterLeft.set(level.left);
+    }
+    if (std::abs(level.right - m_vuMeterRight.get()) > kEpsilon) {
+        m_vuMeterRight.set(level.right);
+    }
+
+    const double volume = (level.left + level.right) / 2.0;
+    if (std::abs(volume - m_vuMeter.get()) > kEpsilon) {
+        m_vuMeter.set(volume);
+    }
+}
+
+void EngineVuMeter::setPeakIndicatorControls() {
     m_peakIndicator.set(
             (m_peakIndicatorRight.toBool() || m_peakIndicatorLeft.toBool())
                     ? 1.0
                     : 0.0);
-}
-
-void EngineVuMeter::doSmooth(CSAMPLE& currentVolume, CSAMPLE newVolume) {
-    if (currentVolume > newVolume) {
-        currentVolume -= kDecaySmoothing * (currentVolume - newVolume);
-    } else {
-        currentVolume += kAttackSmoothing * (newVolume - currentVolume);
-    }
-    if (currentVolume < 0) {
-        currentVolume = 0;
-    }
-    if (currentVolume > 1.0) {
-        currentVolume = 1.0;
-    }
 }
 
 void EngineVuMeter::reset() {
@@ -133,11 +303,12 @@ void EngineVuMeter::reset() {
     m_peakIndicatorLeft.set(0);
     m_peakIndicatorRight.set(0);
 
-    m_samplesCalculated = 0;
-    m_fRMSvolumeL = 0;
-    m_fRMSvolumeSumL = 0;
-    m_fRMSvolumeR = 0;
-    m_fRMSvolumeSumR = 0;
-    m_peakDurationL = 0;
-    m_peakDurationR = 0;
+    m_meterCalculator.setMode(modeFromValue(m_meterMode.get()));
+    m_framesCalculated = 0;
+    m_peakVolumeL = 0;
+    m_peakVolumeR = 0;
+    m_squareSumL = 0;
+    m_squareSumR = 0;
+    m_peakDurationFramesL = 0;
+    m_peakDurationFramesR = 0;
 }

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "control/controlobject.h"
 #include "control/pollingcontrolproxy.h"
 #include "engine/engineobject.h"
@@ -7,6 +9,11 @@
 class EngineVuMeter : public EngineObject {
     Q_OBJECT
   public:
+    enum class MeterMode {
+        DjPeak = 0,
+        VuRms = 1,
+    };
+
     EngineVuMeter(const QString& group,
             const QString& legacyGroup = QString(),
             bool createLegacyAliases = true);
@@ -15,23 +22,110 @@ class EngineVuMeter : public EngineObject {
 
     void reset();
 
+    static const ConfigKey& modeConfigKey();
+    static MeterMode modeFromValue(double value);
+    static double modeToValue(MeterMode mode);
+
   private:
-    void doSmooth(CSAMPLE& currentVolume, CSAMPLE newVolume);
+    struct MeterInput {
+        CSAMPLE peakLeft;
+        CSAMPLE peakRight;
+        CSAMPLE squareSumLeft;
+        CSAMPLE squareSumRight;
+        std::size_t frameCount;
+        double secondsElapsed;
+    };
+
+    struct StereoLevel {
+        CSAMPLE left;
+        CSAMPLE right;
+    };
+
+    // Shared per-channel level state and smoothing structure for the level
+    // calculators. Each concrete calculator only defines how a raw window
+    // measurement maps to a target level and which ballistics smooth the
+    // displayed value toward that target.
+    class MeterCalculatorBase {
+      public:
+        virtual ~MeterCalculatorBase() = default;
+
+        StereoLevel process(const MeterInput& input);
+        void reset();
+
+      protected:
+        // Maps the raw per-channel window measurements to a normalized 0..1
+        // level. Which inputs are relevant depends on the meter mode
+        // (peak amplitude vs. RMS over the window).
+        virtual CSAMPLE targetLevel(
+                CSAMPLE peak, CSAMPLE squareSum, std::size_t frameCount) const = 0;
+        // Moves currentVolume toward targetLevel using the mode-specific
+        // attack/release ballistics.
+        virtual void smooth(CSAMPLE& currentVolume,
+                CSAMPLE targetLevel,
+                double secondsElapsed) const = 0;
+
+      private:
+        CSAMPLE m_volumeLeft = 0;
+        CSAMPLE m_volumeRight = 0;
+    };
+
+    class DjPeakMeterCalculator : public MeterCalculatorBase {
+      protected:
+        CSAMPLE targetLevel(CSAMPLE peak,
+                CSAMPLE squareSum,
+                std::size_t frameCount) const override;
+        void smooth(CSAMPLE& currentVolume,
+                CSAMPLE targetLevel,
+                double secondsElapsed) const override;
+    };
+
+    class VuRmsMeterCalculator : public MeterCalculatorBase {
+      protected:
+        CSAMPLE targetLevel(CSAMPLE peak,
+                CSAMPLE squareSum,
+                std::size_t frameCount) const override;
+        void smooth(CSAMPLE& currentVolume,
+                CSAMPLE targetLevel,
+                double secondsElapsed) const override;
+    };
+
+    class MeterCalculator {
+      public:
+        MeterMode mode() const {
+            return m_mode;
+        }
+        void setMode(MeterMode mode);
+        StereoLevel process(const MeterInput& input);
+        void reset();
+
+      private:
+        MeterCalculatorBase& activeCalculator();
+
+        MeterMode m_mode = MeterMode::DjPeak;
+        DjPeakMeterCalculator m_djPeakMeter;
+        VuRmsMeterCalculator m_vuRmsMeter;
+    };
+
+    void updateMeterMode();
+    void setMeterControls(StereoLevel level);
+    void setPeakIndicatorControls();
 
     ControlObject m_vuMeter;
     ControlObject m_vuMeterLeft;
     ControlObject m_vuMeterRight;
-    CSAMPLE m_fRMSvolumeL;
-    CSAMPLE m_fRMSvolumeSumL;
-    CSAMPLE m_fRMSvolumeR;
-    CSAMPLE m_fRMSvolumeSumR;
-    unsigned int m_samplesCalculated;
+    CSAMPLE m_peakVolumeL;
+    CSAMPLE m_peakVolumeR;
+    CSAMPLE m_squareSumL;
+    CSAMPLE m_squareSumR;
+    std::size_t m_framesCalculated;
+    MeterCalculator m_meterCalculator;
 
     ControlObject m_peakIndicator;
     ControlObject m_peakIndicatorLeft;
     ControlObject m_peakIndicatorRight;
-    int m_peakDurationL;
-    int m_peakDurationR;
+    std::size_t m_peakDurationFramesL;
+    std::size_t m_peakDurationFramesR;
 
     PollingControlProxy m_sampleRate;
+    PollingControlProxy m_meterMode;
 };

--- a/src/library/dao/analysisdao.cpp
+++ b/src/library/dao/analysisdao.cpp
@@ -350,7 +350,7 @@ void AnalysisDao::saveTrackAnalyses(
                  << "waveform analysis for trackId" << trackId
                  << "analysisId" << analysis.analysisId;
 
-    // Clear analysisId since we are re-using the AnalysisInfo
+    // Clear analysisId since we are reusing the AnalysisInfo
     analysis.analysisId = -1;
     analysis.type = AnalysisDao::TYPE_WAVESUMMARY;
     analysis.description = pWaveSummary->getDescription();

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -13,6 +13,7 @@
 #include "effects/effectslot.h"
 #include "effects/effectsmanager.h"
 #include "effects/presets/effectchainpreset.h"
+#include "engine/enginevumeter.h"
 #include "engine/enginexfader.h"
 #include "mixer/playermanager.h"
 #include "moc_dlgprefmixer.cpp"
@@ -78,6 +79,7 @@ DlgPrefMixer::DlgPrefMixer(
           m_xfCurveCO(make_parented<ControlProxy>(kXfaderCurveKey, this)),
           m_xfReverseCO(make_parented<ControlProxy>(kXfaderReverseKey, this)),
           m_xfCalibrationCO(make_parented<ControlProxy>(kXfaderCalibrationKey, this)),
+          m_vuMeterModeCO(make_parented<ControlProxy>(EngineVuMeter::modeConfigKey(), this)),
           m_crossfader(QStringLiteral("[Master]"), QStringLiteral("crossfader")),
           m_xFaderReverse(false),
           m_COLoFreq(kLowEqFreqKey),
@@ -95,6 +97,7 @@ DlgPrefMixer::DlgPrefMixer(
           m_eqEffectsOnly(true),
           m_eqAutoReset(false),
           m_gainAutoReset(false),
+          m_vuMeterMode(static_cast<int>(EngineVuMeter::MeterMode::DjPeak)),
 #ifdef __STEM__
           m_stemAutoReset(true),
 #endif
@@ -104,6 +107,11 @@ DlgPrefMixer::DlgPrefMixer(
           m_applyingDeckEQs(false),
           m_applyingQuickEffects(false) {
     setupUi(this);
+
+    ComboBoxVuMeterMode->addItem(tr("DJ peak meter"),
+            static_cast<int>(EngineVuMeter::MeterMode::DjPeak));
+    ComboBoxVuMeterMode->addItem(tr("VU/RMS meter"),
+            static_cast<int>(EngineVuMeter::MeterMode::VuRms));
 
     // Update the crossfader curve graph and other settings when the
     // crossfader mode is changed or the slider is moved.
@@ -163,6 +171,10 @@ DlgPrefMixer::DlgPrefMixer(
 #endif
             this,
             &DlgPrefMixer::slotGainAutoResetToggled);
+    connect(ComboBoxVuMeterMode,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &DlgPrefMixer::slotVuMeterModeChanged);
 #ifdef __STEM__
     connect(CheckBoxStemAutoReset,
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
@@ -224,6 +236,7 @@ DlgPrefMixer::DlgPrefMixer(
     setScrollSafeGuard(SliderHiEQ);
     setScrollSafeGuard(SliderLoEQ);
     setScrollSafeGuard(comboBoxMainEq);
+    setScrollSafeGuard(ComboBoxVuMeterMode);
 
     // This applies the Main EQ and saves default values of previously missing
     // ConfigKeys. EQ/QuickEffects are already applied by slotNumDecksChanged().
@@ -521,6 +534,8 @@ void DlgPrefMixer::slotResetToDefaults() {
     CheckBoxSingleEqEffect->setChecked(true);
     CheckBoxEqAutoReset->setChecked(false);
     CheckBoxGainAutoReset->setChecked(false);
+    ComboBoxVuMeterMode->setCurrentIndex(ComboBoxVuMeterMode->findData(
+            static_cast<int>(EngineVuMeter::MeterMode::DjPeak)));
 #ifdef __STEM__
     CheckBoxStemAutoReset->setChecked(true);
 #endif
@@ -735,6 +750,8 @@ void DlgPrefMixer::slotApply() {
     m_pConfig->set(kEqsOnlyKey, ConfigValue(m_eqEffectsOnly ? 1 : 0));
     m_pConfig->set(kEqAutoResetKey, ConfigValue(m_eqAutoReset ? 1 : 0));
     m_pConfig->set(kGainAutoResetKey, ConfigValue(m_gainAutoReset ? 1 : 0));
+    m_pConfig->set(EngineVuMeter::modeConfigKey(), ConfigValue(m_vuMeterMode));
+    m_vuMeterModeCO->set(m_vuMeterMode);
 #ifdef __STEM__
     m_pConfig->set(kStemAutoResetKey, ConfigValue(m_stemAutoReset ? 1 : 0));
 #endif
@@ -792,6 +809,13 @@ void DlgPrefMixer::slotUpdate() {
 
     m_gainAutoReset = m_pConfig->getValue<bool>(kGainAutoResetKey, false);
     CheckBoxGainAutoReset->setChecked(m_gainAutoReset);
+
+    m_vuMeterMode = static_cast<int>(EngineVuMeter::modeFromValue(
+            m_pConfig->getValue<int>(EngineVuMeter::modeConfigKey(),
+                    static_cast<int>(EngineVuMeter::MeterMode::DjPeak))));
+    const int vuMeterModeIndex = ComboBoxVuMeterMode->findData(m_vuMeterMode);
+    ComboBoxVuMeterMode->setCurrentIndex(
+            vuMeterModeIndex >= 0 ? vuMeterModeIndex : 0);
 
 #ifdef __STEM__
     m_stemAutoReset = m_pConfig->getValue(kStemAutoResetKey, true);
@@ -1052,6 +1076,15 @@ void DlgPrefMixer::slotEqAutoResetToggled(bool checked) {
 
 void DlgPrefMixer::slotGainAutoResetToggled(bool checked) {
     m_gainAutoReset = checked;
+}
+
+void DlgPrefMixer::slotVuMeterModeChanged(int index) {
+    if (index < 0) {
+        return;
+    }
+    m_vuMeterMode = static_cast<int>(
+            EngineVuMeter::modeFromValue(
+                    ComboBoxVuMeterMode->itemData(index).toInt()));
 }
 
 #ifdef __STEM__

--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -39,6 +39,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     void slotSingleEqToggled(bool checked);
     void slotEqAutoResetToggled(bool checked);
     void slotGainAutoResetToggled(bool checked);
+    void slotVuMeterModeChanged(int index);
 #ifdef __STEM__
     void slotStemAutoResetToggled(bool checked);
 #endif
@@ -100,6 +101,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     parented_ptr<ControlProxy> m_xfCurveCO;
     parented_ptr<ControlProxy> m_xfReverseCO;
     parented_ptr<ControlProxy> m_xfCalibrationCO;
+    parented_ptr<ControlProxy> m_vuMeterModeCO;
     PollingControlProxy m_crossfader;
 
     bool m_xFaderReverse;
@@ -128,6 +130,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     bool m_eqEffectsOnly;
     bool m_eqAutoReset;
     bool m_gainAutoReset;
+    int m_vuMeterMode;
 #ifdef __STEM__
     bool m_stemAutoReset;
 #endif

--- a/src/preferences/dialog/dlgprefmixerdlg.ui
+++ b/src/preferences/dialog/dlgprefmixerdlg.ui
@@ -191,6 +191,33 @@
    </item>
 
    <item>
+    <widget class="QGroupBox" name="LevelMeterOptions">
+     <property name="title">
+      <string>Level Meters</string>
+     </property>
+     <layout class="QFormLayout" name="formLayoutLevelMeters">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelVuMeterMode">
+        <property name="text">
+         <string>Meter type</string>
+        </property>
+        <property name="buddy">
+         <cstring>ComboBoxVuMeterMode</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="ComboBoxVuMeterMode">
+        <property name="toolTip">
+         <string>Choose how Mixxx calculates the level meter. DJ peak meter reacts like common mixer LED meters; VU/RMS meter uses RMS with VU-style integration.</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+
+   <item>
     <widget class="QGroupBox" name="DeckEqualizerOptions">
      <property name="title">
       <string>Deck Equalizers</string>

--- a/src/test/enginevumetertest.cpp
+++ b/src/test/enginevumetertest.cpp
@@ -1,0 +1,223 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <QString>
+#include <vector>
+
+#include "control/controlobject.h"
+#include "control/controlproxy.h"
+#include "engine/enginevumeter.h"
+#include "test/mixxxtest.h"
+#include "util/sample.h"
+
+namespace {
+
+constexpr int kSampleRate = 44100;
+constexpr int kVuUpdateFrames = kSampleRate / 30;
+constexpr int kBufferFrames = 512;
+constexpr double kMinDb = -60.0;
+constexpr double kDbRange = 60.0;
+constexpr double kDjReleaseDbPerSecond = 30.0;
+
+QString makeGroup() {
+    static int groupIndex = 0;
+    return QStringLiteral("[EngineVuMeterTest%1]").arg(++groupIndex);
+}
+
+void setSampleRate() {
+    ControlProxy sampleRate(QStringLiteral("[App]"), QStringLiteral("samplerate"));
+    sampleRate.set(kSampleRate);
+}
+
+std::vector<CSAMPLE> makeStereoBuffer(int frames, CSAMPLE left, CSAMPLE right) {
+    std::vector<CSAMPLE> buffer(frames * 2);
+    for (int i = 0; i < frames; ++i) {
+        buffer[i * 2] = left;
+        buffer[i * 2 + 1] = right;
+    }
+    return buffer;
+}
+
+void processSilence(EngineVuMeter* pMeter, int buffers) {
+    auto silence = makeStereoBuffer(kBufferFrames, 0.0f, 0.0f);
+    for (int i = 0; i < buffers; ++i) {
+        pMeter->process(silence.data(), silence.size());
+    }
+}
+
+double levelFromAmplitude(double amplitude) {
+    if (amplitude <= 0.0) {
+        return 0.0;
+    }
+    const double db = 20.0 * std::log10(
+            std::min<double>(amplitude, CSAMPLE_PEAK));
+    return std::clamp((db - kMinDb) / kDbRange, 0.0, 1.0);
+}
+
+class EngineVuMeterTest : public MixxxTest {
+  protected:
+    EngineVuMeterTest()
+            : m_vuMeterMode(EngineVuMeter::modeConfigKey(),
+                      true,
+                      false,
+                      false,
+                      EngineVuMeter::modeToValue(EngineVuMeter::MeterMode::DjPeak)) {
+    }
+
+    void setMeterMode(EngineVuMeter::MeterMode mode) {
+        m_vuMeterMode.set(EngineVuMeter::modeToValue(mode));
+    }
+
+  private:
+    ControlObject m_vuMeterMode;
+};
+
+TEST_F(EngineVuMeterTest, ShortTransientUsesPeakLevel) {
+    setSampleRate();
+
+    const QString group = makeGroup();
+    EngineVuMeter meter(group, QString(), false);
+    ControlProxy vuMeter(group, QStringLiteral("vu_meter"));
+    ControlProxy vuMeterLeft(group, QStringLiteral("vu_meter_left"));
+    ControlProxy vuMeterRight(group, QStringLiteral("vu_meter_right"));
+
+    auto buffer = makeStereoBuffer(kVuUpdateFrames, 0.0f, 0.0f);
+    buffer[0] = CSAMPLE_PEAK;
+    buffer[1] = CSAMPLE_PEAK;
+
+    meter.process(buffer.data(), buffer.size());
+
+    EXPECT_GT(vuMeter.get(), 0.99);
+    EXPECT_GT(vuMeterLeft.get(), 0.99);
+    EXPECT_GT(vuMeterRight.get(), 0.99);
+}
+
+TEST_F(EngineVuMeterTest, DjPeakModeReleasesAtConstantDbPerSecond) {
+    setSampleRate();
+    setMeterMode(EngineVuMeter::MeterMode::DjPeak);
+
+    const QString group = makeGroup();
+    EngineVuMeter meter(group, QString(), false);
+    ControlProxy vuMeter(group, QStringLiteral("vu_meter"));
+
+    // Saturate the meter to full scale (0 dBFS).
+    auto fullScale = makeStereoBuffer(kVuUpdateFrames, CSAMPLE_PEAK, CSAMPLE_PEAK);
+    for (int i = 0; i < 5; ++i) {
+        meter.process(fullScale.data(), fullScale.size());
+    }
+    const double levelBefore = vuMeter.get();
+    ASSERT_GT(levelBefore, 0.99);
+
+    // Release for a known duration of silence and check the level dropped by
+    // the expected dB amount (constant dB/s release mapped onto the meter
+    // range). Each buffer holds exactly one update window so the elapsed time
+    // per fire is well defined.
+    constexpr int kReleaseWindows = 10;
+    auto silence = makeStereoBuffer(kVuUpdateFrames, 0.0f, 0.0f);
+    for (int i = 0; i < kReleaseWindows; ++i) {
+        meter.process(silence.data(), silence.size());
+    }
+
+    const double secondsElapsed = static_cast<double>(
+            kReleaseWindows * kVuUpdateFrames) / kSampleRate;
+    const double expectedDrop = kDjReleaseDbPerSecond * secondsElapsed / kDbRange;
+    EXPECT_NEAR(vuMeter.get(), levelBefore - expectedDrop, 0.02);
+}
+
+TEST_F(EngineVuMeterTest, VuRmsModeDoesNotTreatSingleSampleTransientAsFullScale) {
+    setSampleRate();
+    setMeterMode(EngineVuMeter::MeterMode::VuRms);
+
+    const QString group = makeGroup();
+    EngineVuMeter meter(group, QString(), false);
+    ControlProxy vuMeter(group, QStringLiteral("vu_meter"));
+
+    auto buffer = makeStereoBuffer(kVuUpdateFrames, 0.0f, 0.0f);
+    buffer[0] = CSAMPLE_PEAK;
+    buffer[1] = CSAMPLE_PEAK;
+
+    meter.process(buffer.data(), buffer.size());
+
+    EXPECT_LT(vuMeter.get(), 0.25);
+}
+
+TEST_F(EngineVuMeterTest, VuRmsModeUsesSteadyRmsLevel) {
+    setSampleRate();
+    setMeterMode(EngineVuMeter::MeterMode::VuRms);
+
+    const QString group = makeGroup();
+    EngineVuMeter meter(group, QString(), false);
+    ControlProxy vuMeter(group, QStringLiteral("vu_meter"));
+
+    auto buffer = makeStereoBuffer(kVuUpdateFrames, 0.5f, 0.5f);
+    for (int i = 0; i < 20; ++i) {
+        meter.process(buffer.data(), buffer.size());
+    }
+
+    EXPECT_NEAR(vuMeter.get(), levelFromAmplitude(0.5), 0.02);
+}
+
+TEST_F(EngineVuMeterTest, SwitchingModeResetsMeterState) {
+    setSampleRate();
+
+    const QString group = makeGroup();
+    EngineVuMeter meter(group, QString(), false);
+    ControlProxy vuMeter(group, QStringLiteral("vu_meter"));
+
+    auto buffer = makeStereoBuffer(kVuUpdateFrames, 0.0f, 0.0f);
+    buffer[0] = CSAMPLE_PEAK;
+    buffer[1] = CSAMPLE_PEAK;
+
+    meter.process(buffer.data(), buffer.size());
+    ASSERT_GT(vuMeter.get(), 0.99);
+
+    setMeterMode(EngineVuMeter::MeterMode::VuRms);
+    meter.process(buffer.data(), buffer.size());
+
+    EXPECT_LT(vuMeter.get(), 0.25);
+}
+
+TEST_F(EngineVuMeterTest, ClipIndicatorHoldUsesElapsedFrames) {
+    setSampleRate();
+
+    const QString group = makeGroup();
+    EngineVuMeter meter(group, QString(), false);
+    ControlProxy peakIndicator(group, QStringLiteral("peak_indicator"));
+    ControlProxy peakIndicatorLeft(group, QStringLiteral("peak_indicator_left"));
+
+    auto clipped = makeStereoBuffer(kBufferFrames, 0.0f, 0.0f);
+    clipped[0] = CSAMPLE_PEAK + 0.1f;
+    meter.process(clipped.data(), clipped.size());
+
+    EXPECT_DOUBLE_EQ(peakIndicatorLeft.get(), 1.0);
+    EXPECT_DOUBLE_EQ(peakIndicator.get(), 1.0);
+
+    processSilence(&meter, 20);
+    EXPECT_DOUBLE_EQ(peakIndicatorLeft.get(), 1.0);
+    EXPECT_DOUBLE_EQ(peakIndicator.get(), 1.0);
+
+    processSilence(&meter, 24);
+    EXPECT_DOUBLE_EQ(peakIndicatorLeft.get(), 0.0);
+    EXPECT_DOUBLE_EQ(peakIndicator.get(), 0.0);
+}
+
+TEST(EngineVuMeterModeTest, ModeValueRoundTripAndClamping) {
+    // modeToValue/modeFromValue round-trip for every defined mode.
+    EXPECT_EQ(EngineVuMeter::modeFromValue(
+                      EngineVuMeter::modeToValue(EngineVuMeter::MeterMode::DjPeak)),
+            EngineVuMeter::MeterMode::DjPeak);
+    EXPECT_EQ(EngineVuMeter::modeFromValue(
+                      EngineVuMeter::modeToValue(EngineVuMeter::MeterMode::VuRms)),
+            EngineVuMeter::MeterMode::VuRms);
+
+    // Out-of-range or unknown values fall back to the default DjPeak mode.
+    EXPECT_EQ(EngineVuMeter::modeFromValue(-1.0), EngineVuMeter::MeterMode::DjPeak);
+    EXPECT_EQ(EngineVuMeter::modeFromValue(99.0), EngineVuMeter::MeterMode::DjPeak);
+
+    // Non-integer values round to the nearest mode.
+    EXPECT_EQ(EngineVuMeter::modeFromValue(0.4), EngineVuMeter::MeterMode::DjPeak);
+    EXPECT_EQ(EngineVuMeter::modeFromValue(1.4), EngineVuMeter::MeterMode::VuRms);
+}
+
+} // namespace


### PR DESCRIPTION
Rework EngineVuMeter to support two metering algorithms, selectable from the new "Level Meters" section of the Mixer preferences:

- DjPeak (default): per-sample peak detection with a fast attack and a constant 30 dB/s release, mapped onto a -60..0 dB scale.
- VuRms: true RMS with a one-pole ~300 ms VU-style integration.

New DjPeak looks like a real DJ mixer and should stop the problem that mixxx is hard to get same loudness.

The mode is held in a new persistent control [Mixer Profile],VuMeterMode created by EngineMixer and read by every meter (main, per-channel and per-stem) through a PollingControlProxy, so the choice applies live to all meters at once.

Smoothing is now time-based (elapsed seconds instead of buffer counts) and the clip-indicator hold is tracked in frames, removing the previous dependence on audio buffer size and sample rate.

The two level calculators share a MeterCalculatorBase using the template method pattern: subclasses only provide the target-level mapping and the smoothing ballistics. Add enginevumetertest.cpp covering peak/RMS behavior, mode switching, clip-hold timing, the DJ release rate and mode-value conversion.

Developed-By: Opencode ChatGPT 5.5 xHigh
Reviewed-By: Claude Opus 4.8