### PR TITLE
Use latest Windows runner images with Visual Studio 2026

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,8 +117,8 @@ jobs:
             artifacts_name: macOS ARM DMG
             artifacts_path: build/*.dmg
             artifacts_slug: macos-macosarm
-          - name: Windows 2022 x64
-            os: windows-2022
+          - name: Windows Server 2025 VS2026 x64
+            os: windows-2025-vs2026
             # Attention: If you change the cmake_args for the Windows CI build,
             #            also adjust the for the local Windows build setup in
             #            ./tools/windows_buildenv.bat
@@ -144,8 +144,8 @@ jobs:
             artifacts_path: build/*.msi
             artifacts_slug: windows-win64
             arch: x64
-          - name: Windows 11 ARM64
-            os: windows-11-arm
+          - name: Windows 11 VS2026 ARM64
+            os: windows-11-vs2026-arm
             # Attention: If you change the cmake_args for the Windows CI build,
             #            also adjust the for the local Windows build setup in
             #            ./tools/windows_buildenv.bat


### PR DESCRIPTION
These will all the usage of modern C++ features, as the MSVC Build Tools in VisualStudio 2022 are lagging behind gcc and clang on our other patforms.

For details see:
https://devblogs.microsoft.com/cppblog/c23-support-in-msvc-build-tools-14-51/

Updating mixxxdj/mixxx before mixxxdj/VCPKG is the right order to ensure backward compatibility.