### PR TITLE
Only ignore tailing ~ when packing the tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5074,7 +5074,7 @@ set(CPACK_GIT_COMMIT_DATE ${GIT_COMMIT_DATE})
 # Detailed version information, git info and package file name are set from
 # CPackConfig.cmake, not here.
 
-set(CPACK_SOURCE_IGNORE_FILES "\\\\.#;/#;.*~;\\\\.o$")
+set(CPACK_SOURCE_IGNORE_FILES "\\\\.#;/#;.*~$;\\\\.o$")
 list(APPEND CPACK_SOURCE_IGNORE_FILES "/\\\\.git/")
 list(APPEND CPACK_SOURCE_IGNORE_FILES "/\\\\.github/")
 list(APPEND CPACK_SOURCE_IGNORE_FILES "/build/")


### PR DESCRIPTION
This fixes #16615, building on Launchpad. 

This a perfect example how measuring lines of code is not significant for the work we put in PRs :-) 
I am glad it is fixed now. 