### PR TITLE
Highlight harmonically/tempo compatible tracks in the library (Key/BPM columns)

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -6,6 +6,9 @@
 #include <QScreen>
 #include <QtGlobal>
 
+#include <cmath>
+#include <utility>
+
 #include "base/Pitch.h"
 #include "library/coverartcache.h"
 #include "library/dao/trackschema.h"
@@ -46,6 +49,46 @@ constexpr double kRelativeHeightOfCoverartToolTip =
         0.165; // Height of the image for the cover art tooltip (Relative to the available screen size)
 
 constexpr int kReplayGainPrecision = 2;
+
+// Tracks within this relative BPM tolerance (also checked at half/double
+// tempo) are considered an easy tempo match with a loaded deck track.
+constexpr double kMixBpmToleranceRatio = 0.06;
+
+// Subtle translucent highlight for Key/BPM cells that are compatible with a
+// track currently loaded on a deck. Kept translucent so it composes with the
+// regular row/track colors and selection highlighting.
+const QColor kMixCompatibleHighlightColor = QColor(76, 175, 80, 50);
+
+// Recomputes the harmonic-key and BPM reference values from the tracks that
+// are currently loaded on decks (using PlayerInfo, which is updated whenever
+// a deck loads/unloads a track) and publishes them to BaseTrackTableModel so
+// every visible library table can highlight compatible Key/BPM cells.
+void recomputeMixCompatibilityReference() {
+    QSet<int> compatibleKeyValues;
+    QList<double> referenceBpmValues;
+    const QMap<QString, TrackPointer> loadedTracks = PlayerInfo::instance().getLoadedTracks();
+    for (auto it = loadedTracks.constBegin(); it != loadedTracks.constEnd(); ++it) {
+        if (!PlayerManager::isDeckGroup(it.key())) {
+            continue;
+        }
+        const TrackPointer& pTrack = it.value();
+        if (!pTrack) {
+            continue;
+        }
+        const auto key = pTrack->getKey();
+        if (key != mixxx::track::io::key::INVALID) {
+            const auto compatibleKeys = KeyUtils::getCompatibleKeys(key);
+            for (const auto compatibleKey : compatibleKeys) {
+                compatibleKeyValues.insert(static_cast<int>(compatibleKey));
+            }
+        }
+        const double bpmValue = pTrack->getBpm();
+        if (bpmValue > 0) {
+            referenceBpmValues.append(bpmValue);
+        }
+    }
+    BaseTrackTableModel::setMixCompatibilityReference(compatibleKeyValues, referenceBpmValues);
+}
 
 inline QSqlDatabase cloneDatabase(
         const QSqlDatabase& prototype) {
@@ -120,6 +163,47 @@ QString BaseTrackTableModel::s_dateFormat = BaseTrackTableModel::kDateFormatDefa
 
 void BaseTrackTableModel::setDateFormat(const QString& format) {
     s_dateFormat = format;
+}
+
+QSet<int> BaseTrackTableModel::s_mixCompatibleKeyValues;
+QList<double> BaseTrackTableModel::s_mixReferenceBpmValues;
+
+// static
+void BaseTrackTableModel::setMixCompatibilityReference(
+        const QSet<int>& compatibleKeyValues,
+        const QList<double>& referenceBpmValues) {
+    s_mixCompatibleKeyValues = compatibleKeyValues;
+    s_mixReferenceBpmValues = referenceBpmValues;
+}
+
+// static
+bool BaseTrackTableModel::isKeyCompatibleWithLoadedDecks(int keyValue) {
+    if (keyValue == static_cast<int>(mixxx::track::io::key::INVALID)) {
+        return false;
+    }
+    return s_mixCompatibleKeyValues.contains(keyValue);
+}
+
+// static
+bool BaseTrackTableModel::isBpmCompatibleWithLoadedDecks(double bpmValue) {
+    if (bpmValue <= 0.0) {
+        return false;
+    }
+    for (const double referenceBpm : std::as_const(s_mixReferenceBpmValues)) {
+        if (referenceBpm <= 0.0) {
+            continue;
+        }
+        // Also check half/double tempo, since DJs commonly mix tracks at
+        // double or half the tempo of the reference track.
+        for (const double scale : {0.5, 1.0, 2.0}) {
+            const double scaledReference = referenceBpm * scale;
+            const double diffRatio = std::fabs(bpmValue - scaledReference) / scaledReference;
+            if (diffRatio <= kMixBpmToleranceRatio) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 BaseTrackTableModel::BaseTrackTableModel(
@@ -419,15 +503,39 @@ QVariant BaseTrackTableModel::data(
                 index,
                 ColumnCache::COLUMN_LIBRARYTABLE_COLOR);
         const auto rgbColor = mixxx::RgbColor::fromQVariant(rgbColorValue);
-        if (!rgbColor) {
-            return QVariant();
+        if (rgbColor) {
+            auto bgColor = mixxx::RgbColor::toQColor(rgbColor);
+            DEBUG_ASSERT(bgColor.isValid());
+            DEBUG_ASSERT(m_backgroundColorOpacity >= 0.0);
+            DEBUG_ASSERT(m_backgroundColorOpacity <= 1.0);
+            bgColor.setAlphaF(static_cast<float>(m_backgroundColorOpacity));
+            return QBrush(bgColor);
         }
-        auto bgColor = mixxx::RgbColor::toQColor(rgbColor);
-        DEBUG_ASSERT(bgColor.isValid());
-        DEBUG_ASSERT(m_backgroundColorOpacity >= 0.0);
-        DEBUG_ASSERT(m_backgroundColorOpacity <= 1.0);
-        bgColor.setAlphaF(static_cast<float>(m_backgroundColorOpacity));
-        return QBrush(bgColor);
+        // No manually assigned track color: highlight the Key/BPM cell if
+        // this track is an easy harmonic/tempo match for a track currently
+        // loaded on a deck.
+        const auto field = mapColumn(index.column());
+        if (field == ColumnCache::COLUMN_LIBRARYTABLE_KEY) {
+            const QVariant keyCodeValue = rawSiblingValue(
+                    index, ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID);
+            bool ok = false;
+            const int keyValue = keyCodeValue.toInt(&ok);
+            if (ok && isKeyCompatibleWithLoadedDecks(keyValue)) {
+                return QBrush(kMixCompatibleHighlightColor);
+            }
+        } else if (field == ColumnCache::COLUMN_LIBRARYTABLE_BPM) {
+            const QVariant bpmRawValue = rawValue(index);
+            double bpmValue = -1.0;
+            if (bpmRawValue.canConvert<mixxx::Bpm>()) {
+                bpmValue = bpmRawValue.value<mixxx::Bpm>().valueOr(-1.0);
+            } else if (bpmRawValue.canConvert<double>()) {
+                bpmValue = bpmRawValue.toDouble();
+            }
+            if (bpmValue > 0 && isBpmCompatibleWithLoadedDecks(bpmValue)) {
+                return QBrush(kMixCompatibleHighlightColor);
+            }
+        }
+        return QVariant();
     } else if (role == Qt::ForegroundRole) {
         // Custom text color for missing tracks
         // Visible in playlists, crates and Missing feature.
@@ -1117,6 +1225,22 @@ void BaseTrackTableModel::slotTrackChanged(
             }
         }
         m_previewDeckTrackId = doGetTrackId(pNewTrack);
+    }
+    if (PlayerManager::isDeckGroup(group)) {
+        recomputeMixCompatibilityReference();
+        // Repaint the Key/BPM columns of all rows so the highlight for
+        // mix-compatible tracks reflects the newly loaded/unloaded track.
+        const int keyColumn = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY);
+        const int bpmColumn = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM);
+        const int lastRow = rowCount() - 1;
+        if (lastRow >= 0) {
+            if (keyColumn >= 0) {
+                emit dataChanged(index(0, keyColumn), index(lastRow, keyColumn));
+            }
+            if (bpmColumn >= 0) {
+                emit dataChanged(index(0, bpmColumn), index(lastRow, bpmColumn));
+            }
+        }
     }
 }
 

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -3,6 +3,7 @@
 #include <QAbstractTableModel>
 #include <QList>
 #include <QPointer>
+#include <QSet>
 #include <optional>
 
 #include "library/columncache.h"
@@ -144,6 +145,14 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     static const QString kDateFormatDefault;
     static void setDateFormat(const QString& format);
+
+    /// Updates the reference set of harmonically compatible musical keys
+    /// (as numeric `mixxx::track::io::key::ChromaticKey` values) and the
+    /// reference BPM values used to highlight Key/BPM cells of tracks that
+    /// mix well with the tracks currently loaded on decks.
+    static void setMixCompatibilityReference(
+            const QSet<int>& compatibleKeyValues,
+            const QList<double>& referenceBpmValues);
 
   protected:
     // Build a map from the column names to their indices
@@ -297,6 +306,9 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     QList<QUrl> collectUrls(
             const QModelIndexList& indexes) const;
 
+    static bool isKeyCompatibleWithLoadedDecks(int keyValue);
+    static bool isBpmCompatibleWithLoadedDecks(double bpmValue);
+
     const QString m_previewDeckGroup;
 
     double m_backgroundColorOpacity;
@@ -323,4 +335,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     static bool s_bApplyPlayedTrackColor;
     static QString s_dateFormat;
+
+    static QSet<int> s_mixCompatibleKeyValues;
+    static QList<double> s_mixReferenceBpmValues;
 };


### PR DESCRIPTION
## Summary

Adds a passive visual indicator to the library track table that highlights the **Key** and **BPM** cells of tracks that are an easy mix with whatever is currently loaded on a deck — no new columns, delegates, or preferences required.

- **Key compatibility** reuses the existing circle-of-fifths logic already in `KeyUtils::getCompatibleKeys()` (same key, relative major/minor, perfect 4th/5th — i.e. the standard ±1 Camelot/Lancelot step).
- **BPM compatibility** checks a 6% relative tolerance, also at half/double tempo (since DJs commonly mix tracks at double-time).
- The reference set (compatible keys + BPMs) is recomputed from `PlayerInfo` whenever a deck loads/unloads a track, and surfaces through the `Qt::BackgroundRole` already painted by `KeyDelegate`/`BPMDelegate` — so the highlight "just works" in every library table view (Tracks, Playlists, Crates, search results, etc.) with zero UI/preference changes.
- A manually assigned track color still takes priority over the highlight, so it never fights with the existing track-coloring feature.

This closes the long-requested "traffic light" highlighting feature, and is a building block toward the broader "suggest compatible tracks" requests.

<img width="1914" height="1042" alt="image" src="https://github.com/user-attachments/assets/6d7b801a-e8b9-4be9-a76b-cc5fe41a8cfd" />


Closes #14823
Closes #7599
Related to #5655, #9896, #6106

## Implementation notes

All changes are contained to `src/library/basetracktablemodel.{h,cpp}`:
- `BaseTrackTableModel::setMixCompatibilityReference()` (static) stores the current compatible-key set and reference BPM list.
- `slotTrackChanged()` (already wired to `PlayerInfo::trackChanged` for preview-deck handling) now also recomputes the reference set on any deck load/unload and repaints the Key/BPM columns.
- `isKeyCompatibleWithLoadedDecks()` / `isBpmCompatibleWithLoadedDecks()` do the actual matching, called from the existing `Qt::BackgroundRole` handler in `data()`.

## Test plan

- [x] CI build matrix passing on this branch: Windows x64 (MSVC+vcpkg+Qt6), Windows ARM64, macOS x64/arm64, Android arm64, `clazy`, `clang-tidy`, `coverage`, `pre-commit` — see [run](https://github.com/qwertyuu/mixxx/actions/runs/27863487208).
- [ ] Manual verification in a running Mixxx session (load tracks with known compatible/incompatible keys+BPMs onto two decks, confirm the library highlight appears/disappears correctly) — screenshots to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)