### PR TITLE
Fix Clazy 1.17 warnings in 2.5

### DIFF
--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -364,7 +364,7 @@ void BrowseTableModel::slotClear(BrowseTableModel* caller_object) {
     }
 }
 
-void BrowseTableModel::slotInsert(const QList<QList<QStandardItem*>>& rows,
+void BrowseTableModel::slotInsert(const BrowseTableItems& rows,
         BrowseTableModel* caller_object) {
     // There exists more than one BrowseTableModel in Mixxx and we only want to
     // receive items this object has 'ordered' from the BrowseThread (singleton)

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -108,7 +108,7 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
 
   public slots:
     void slotClear(BrowseTableModel*);
-    void slotInsert(const QList<QList<QStandardItem*>>&, BrowseTableModel*);
+    void slotInsert(const BrowseTableItems&, BrowseTableModel*);
     void trackChanged(const QString& group, TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   private:

--- a/src/library/browse/browsethread.h
+++ b/src/library/browse/browsethread.h
@@ -24,6 +24,8 @@ class BrowseTableModel;
 class BrowseThread;
 class QStandardItem;
 
+using BrowseTableItems = QList<QList<QStandardItem*>>;
+
 typedef QSharedPointer<BrowseThread> BrowseThreadPointer;
 
 class BrowseThread : public QThread {
@@ -35,7 +37,7 @@ class BrowseThread : public QThread {
     static BrowseThreadPointer getInstanceRef();
 
   signals:
-    void rowsAppended(const QList<QList<QStandardItem*>>&, BrowseTableModel*);
+    void rowsAppended(const BrowseTableItems&, BrowseTableModel*);
     void clearModel(BrowseTableModel*);
 
   private:

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -441,7 +441,7 @@ void buildPlaylistTree(
 
 QString parseDeviceDB(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* deviceItem) {
     QString device = deviceItem->getLabel();
-    QString devicePath = deviceItem->getData().toList()[0].toString();
+    QString devicePath = deviceItem->getData().toList().at(0).toString();
 
     qDebug() << "parseDeviceDB device: " << device << " devicePath: " << devicePath;
 

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -431,7 +431,7 @@ QString parseCrate(
 
 QString parseDatabase(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* databaseItem) {
     QString databaseName = databaseItem->getLabel();
-    QString databaseFilePath = databaseItem->getData().toList()[0].toString();
+    QString databaseFilePath = databaseItem->getData().toList().at(0).toString();
     QDir databaseDir = QFileInfo(databaseFilePath).dir();
 
     QDir databaseRootDir = QDir(databaseDir);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -364,7 +364,7 @@ void MixxxMainWindow::initialize() {
     // that says "mixxx will barely work with no outs".
     // In case of persisting errors, the user has already received a message
     // above. So we can just check the output count here.
-    while (m_pCoreServices->getSoundManager()->getConfig().getOutputs().count() == 0) {
+    while (m_pCoreServices->getSoundManager()->getConfig().getOutputs().isEmpty()) {
         // Exit when we press the Exit button in the noSoundDlg dialog
         // only call it if result != OK
         bool continueClicked = false;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1587,7 +1587,7 @@ void WTrackTableView::moveSelection(int delta) {
 
     while (delta != 0) {
         QItemSelectionModel* currentSelection = selectionModel();
-        if (currentSelection->selectedRows().length() > 0) {
+        if (!currentSelection->selectedRows().isEmpty()) {
             if (delta > 0) {
                 // i is positive, so we want to move the highlight down
                 int row = currentSelection->selectedRows().last().row();


### PR DESCRIPTION
- Signal arguments need to be fully-qualified [-Wclazy-fully-qualified-moc-types] resulting at some places in [-Wclazy-qproperty-type-mismatch] 
- Wclazy-isempty-vs-count
- Wclazy-function-args-by-ref