### PR TITLE
Fix translation formatting for playlist types (AR) 2.5

### DIFF
--- a/res/translations/mixxx_ar.ts
+++ b/res/translations/mixxx_ar.ts
@@ -288,7 +288,7 @@
     <message>
         <location filename="../../src/library/trackset/baseplaylistfeature.cpp" line="561"/>
         <source>M3U Playlist (*.m3u);;M3U8 Playlist (*.m3u8);;PLS Playlist (*.pls);;Text CSV (*.csv);;Readable Text (*.txt)</source>
-        <translation>M3U قائمة التشغيل (* .m3u ) ؛؛ M3U8 قائمة التشغيل (* .m3u8) ؛؛ PLS التشغيل (* .pls) ؛؛ CSV نص (* CSV.) ؛؛ نص مقروء (* txt)</translation>
+        <translation>M3U قائمة التشغيل (*.m3u);;M3U8 قائمة التشغيل (*.m3u8);;PLS قائمة التشغيل (*.pls);;نص CSV (*.csv);;نص مقروء (*.txt)</translation>
     </message>
 </context>
 <context>
@@ -3736,7 +3736,7 @@ trace    - Above + Profiling messages</source>
     <message>
         <location filename="../../src/library/trackset/crate/cratefeature.cpp" line="791"/>
         <source>M3U Playlist (*.m3u);;M3U8 Playlist (*.m3u8);;PLS Playlist (*.pls);;Text CSV (*.csv);;Readable Text (*.txt)</source>
-        <translation>M3U قائمة التشغيل (* .m3u ) ؛؛ M3U8 قائمة التشغيل (* .m3u8) ؛؛ PLS التشغيل (* .pls) ؛؛ CSV نص (* CSV.) ؛؛ نص مقروء (* txt)</translation>
+        <translation>M3U قائمة التشغيل (*.m3u);;M3U8 قائمة التشغيل (*.m3u8);;PLS قائمة التشغيل (*.pls);;نص CSV (*.csv);;نص مقروء (*.txt)</translation>
     </message>
     <message>
         <location filename="../../src/library/trackset/crate/cratefeature.cpp" line="793"/>


### PR DESCRIPTION
translation replaced double semicolon with arabic semicolons which breaks the list