### PR TITLE
Fix translation formatting for playlist types (vi) 2.5

### DIFF
--- a/res/translations/mixxx_vi.ts
+++ b/res/translations/mixxx_vi.ts
@@ -288,7 +288,7 @@
     <message>
         <location filename="../../src/library/trackset/baseplaylistfeature.cpp" line="561"/>
         <source>M3U Playlist (*.m3u);;M3U8 Playlist (*.m3u8);;PLS Playlist (*.pls);;Text CSV (*.csv);;Readable Text (*.txt)</source>
-        <translation>M3U danh sách bài hát (*.m3u); M3U8 danh sách bài hát (*.m3u8); PLS danh sách bài hát (* .pls); Văn bản CSV (*.csv); Có thể đọc được văn bản (*.txt)</translation>
+        <translation>M3U danh sách bài hát (*.m3u);;M3U8 danh sách bài hát (*.m3u8);;PLS danh sách bài hát (* .pls);;Văn bản CSV (*.csv);;Có thể đọc được văn bản (*.txt)</translation>
     </message>
 </context>
 <context>
@@ -3736,7 +3736,7 @@ trace    - Above + Profiling messages</source>
     <message>
         <location filename="../../src/library/trackset/crate/cratefeature.cpp" line="791"/>
         <source>M3U Playlist (*.m3u);;M3U8 Playlist (*.m3u8);;PLS Playlist (*.pls);;Text CSV (*.csv);;Readable Text (*.txt)</source>
-        <translation>M3U danh sách bài hát (*.m3u); M3U8 danh sách bài hát (*.m3u8); PLS danh sách bài hát (* .pls); Văn bản CSV (*.csv); Có thể đọc được văn bản (*.txt)</translation>
+        <translation>M3U danh sách bài hát (*.m3u);;M3U8 danh sách bài hát (*.m3u8);;PLS danh sách bài hát (* .pls);;Văn bản CSV (*.csv);;Có thể đọc được văn bản (*.txt)</translation>
     </message>
     <message>
         <location filename="../../src/library/trackset/crate/cratefeature.cpp" line="793"/>


### PR DESCRIPTION
translation replaced double semicolon with single ones which breaks the list