### PR TITLE
Pref Colors: fix reset to defaults, Hotcue & Loop Cue color

### DIFF
--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -202,9 +202,9 @@ void DlgPrefColors::slotResetToDefaults() {
             qPrintable(mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette
                                .getName())));
     comboBoxHotcueDefaultColor->setCurrentIndex(
-            mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size());
+            mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette.size());
     comboBoxLoopDefaultColor->setCurrentIndex(
-            mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size() - 1);
+            mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette.size() - 1);
     checkboxKeyColorsEnabled->setChecked(BaseTrackTableModel::kKeyColorsEnabledDefault);
 }
 


### PR DESCRIPTION
Currently pressing "Reset to defaults" clears the Hotcue and Loop Cue color comboboxes.
Fixed by using the correct color palette.