### PR TITLE
Revert "EngineBuffer::isTrackLoaded() returns only true if fully loaded"

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1226,7 +1226,8 @@ void EngineBuffer::process(CSAMPLE* pOutput, const std::size_t bufferSize) {
     m_pScaleRB->setSignal(m_sampleRate, m_channelCount);
 #endif
 
-    if (isTrackLoaded() && m_pause.tryLock()) {
+    bool hasStableTrack = m_pTrackLoaded->toBool() && m_iTrackLoading.loadAcquire() == 0;
+    if (hasStableTrack && m_pause.tryLock()) {
         processTrackLocked(pOutput, bufferSize, m_sampleRate);
         // release the pauselock
         m_pause.unlock();
@@ -1601,7 +1602,10 @@ void EngineBuffer::addControl(EngineControl* pControl) {
 }
 
 bool EngineBuffer::isTrackLoaded() const {
-    return (m_pCurrentTrack && m_iTrackLoading.loadAcquire() == 0);
+    if (m_pCurrentTrack) {
+        return true;
+    }
+    return false;
 }
 
 TrackPointer EngineBuffer::getLoadedTrack() const {

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -172,6 +172,9 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
 
     void loadTrack(Deck* pDeck, TrackPointer pTrack) {
         EngineDeck* pEngineDeck = pDeck->getEngineDeck();
+        if (pEngineDeck->getEngineBuffer()->isTrackLoaded()) {
+            pEngineDeck->getEngineBuffer()->ejectTrack();
+        }
         pDeck->slotLoadTrack(pTrack,
 #ifdef __STEM__
                 mixxx::StemChannelSelection(),


### PR DESCRIPTION
This reverts commit 816244d076d814b3b84694c62cba693cf895ce9e.

Might be the reason SteCount tests fail, see https://github.com/mixxxdj/mixxx/pull/16621#issuecomment-4759400113