### PR TITLE
(fix) Scanner summary dialog: revert to pointer, set Qt::WA_DeleteOnClos attribute to clean up after use

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1297,7 +1297,8 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
         if (result.numNewMissingTracks != 0) {
             summary += tr("%n track(s) missing (%1 total)",
                     nullptr,
-                    result.numNewMissingTracks);
+                    result.numNewMissingTracks)
+                               .arg(result.numMissingTracks);
         }
         if (result.numRediscoveredTracks != 0) {
             summary += QStringLiteral("<br>") +

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1262,15 +1262,16 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
         return;
     }
 
-    QMessageBox msgBox;
-    msgBox.setTextFormat(Qt::RichText); // required to get bold text with <b> tags
-    msgBox.setWindowTitle(tr("Library scan finished"));
+    QMessageBox* pMsg = new QMessageBox();
+    pMsg->setAttribute(Qt::WA_DeleteOnClose);
+    pMsg->setTextFormat(Qt::RichText); // required to get bold text with <b> tags
+    pMsg->setWindowTitle(tr("Library scan finished"));
 
     if (result.noDirectoriesConfigured) {
-        msgBox.setText(tr("No music directories configured for scanning.") +
+        pMsg->setText(tr("No music directories configured for scanning.") +
                 QStringLiteral("<br>") +
                 tr("Add directories in the library preferences."));
-        msgBox.show();
+        pMsg->show();
         return;
     }
 
@@ -1309,8 +1310,8 @@ void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& 
                 QStringLiteral("</b>");
     }
 
-    msgBox.setText(summary);
-    msgBox.show();
+    pMsg->setText(summary);
+    pMsg->show();
 }
 
 void MixxxMainWindow::slotShowKeywheel(bool toggle) {


### PR DESCRIPTION
Fixes #16647 by reverting #16639 and setting the proper window attribute to avoid the memory leak.

Creating QMessageBox on the stack and showing it with `show()` (not `exec()` which makes it modal) will delete it when the function finishes -> it never shows up

Sorry I didn't test this manually!

