### PR TITLE
Add shared QML deck button, cycle, and overview marker behaviors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3930,6 +3930,7 @@ if(QML)
       res/qml/Mixxx/Controls/Spinny.qml
       res/qml/Mixxx/Controls/WaveformOverviewHotcueMarker.qml
       res/qml/Mixxx/Controls/WaveformOverviewMarker.qml
+      res/qml/Mixxx/Controls/WaveformOverviewMarkerLayer.qml
       res/qml/Mixxx/Controls/WaveformOverview.qml
       res/qml/Mixxx/Controls/WaveformDisplay.qml
   )

--- a/res/qml/ControlButton.qml
+++ b/res/qml/ControlButton.qml
@@ -1,5 +1,4 @@
 import "." as Skin
-import Mixxx 1.0 as Mixxx
 
 Skin.Button {
     id: root
@@ -9,25 +8,23 @@ Skin.Button {
     property bool toggleable: false
 
     function toggle() {
-        control.value = !control.value;
+        controlBehavior.toggleControl();
     }
 
-    highlight: control.value
+    highlight: controlBehavior.isActive
     onPressed: {
-        if (toggleable)
-            toggle();
-        else
-            control.value = 1;
+        controlBehavior.pressPrimary();
     }
     onReleased: {
-        if (!toggleable)
-            control.value = 0;
+        controlBehavior.releasePrimary();
     }
 
-    Mixxx.ControlProxy {
-        id: control
+    ControlProxyButtonBehavior {
+        id: controlBehavior
 
         group: root.group
         key: root.key
+        toggleable: root.toggleable
+        handlePointerInput: false
     }
 }

--- a/res/qml/ControlCycleButtonBehavior.qml
+++ b/res/qml/ControlCycleButtonBehavior.qml
@@ -1,0 +1,43 @@
+import Mixxx 1.0 as Mixxx
+import QtQuick 2.12
+
+Item {
+    id: root
+
+    required property string group
+    required property string key
+    property int numberStates: 3
+    property var stateLabels: []
+    property bool handlePointerInput: true
+    readonly property int currentState: Math.round(control.value)
+    readonly property real displayValue: control.value
+    readonly property string label: {
+        if (root.stateLabels.length > root.currentState && root.currentState >= 0) {
+            return root.stateLabels[root.currentState];
+        }
+        return root.currentState.toString();
+    }
+
+    signal cycled(int state)
+
+    function cycle() {
+        const newState = (root.currentState + 1) % root.numberStates;
+        control.value = newState;
+        root.cycled(newState);
+    }
+
+    Mixxx.ControlProxy {
+        id: control
+
+        group: root.group
+        key: root.key
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton
+        enabled: root.enabled && root.handlePointerInput
+
+        onClicked: root.cycle()
+    }
+}

--- a/res/qml/ControlProxyButtonBehavior.qml
+++ b/res/qml/ControlProxyButtonBehavior.qml
@@ -1,0 +1,205 @@
+import Mixxx 1.0 as Mixxx
+import QtQuick 2.12
+
+Item {
+    id: root
+
+    required property string group
+    required property string key
+    property string rightClickKey: ""
+    property string pressAndHoldKey: ""
+    property string displayKey: ""
+    property bool toggleable: false
+    property bool activateOnClick: false
+    property bool ignoreActivePresses: false
+    property bool releaseToZero: true
+    property bool longPressLatching: false
+    property bool handlePointerInput: true
+    property int numberStates: 2
+    property int longPressDuration: 300
+    property real activeDisplayThreshold: 0
+    property bool visualActiveState: false
+    property bool pressAndHoldTriggered: false
+    property bool longPressAnimationRunning: false
+    property real longPressProgress: 0
+    property real pressStartValue: 0
+    property real pressTargetValue: 0
+    readonly property real displayValue: displayControl.value
+    readonly property bool isActive: displayControl.value > root.activeDisplayThreshold
+    readonly property bool isVisuallyActive: root.isActive || root.visualActiveState
+    readonly property bool pressed: interactionArea.pressed
+
+    signal primaryPressed(real displayValue)
+    signal secondaryPressed(real displayValue, real mouseX, real mouseY)
+
+    function triggerPrimaryAction() {
+        if (root.ignoreActivePresses && displayControl.value > root.activeDisplayThreshold) {
+            return;
+        }
+        if (root.toggleable) {
+            root.toggleControl();
+        } else {
+            control.value = 1;
+        }
+    }
+
+    function toggleControl() {
+        control.value = !control.value;
+    }
+
+    function triggerPressAndHoldAction() {
+        holdControl.value = !holdControl.value;
+    }
+
+    function nextState(value) {
+        return (Math.floor(value) + 1) % root.numberStates;
+    }
+
+    function startLatchReveal() {
+        longPressTimer.stop();
+        longPressProgressAnimation.stop();
+        root.longPressProgress = 0;
+        root.longPressAnimationRunning = true;
+        longPressProgressAnimation.start();
+        longPressTimer.start();
+    }
+
+    function pressPrimary() {
+        root.pressAndHoldTriggered = false;
+        root.primaryPressed(displayControl.value);
+        if (root.longPressLatching) {
+            root.pressStartValue = displayControl.value;
+            root.pressTargetValue = root.nextState(root.pressStartValue);
+            longPressTimer.stop();
+            longPressProgressAnimation.stop();
+            root.longPressProgress = 0;
+            control.value = root.pressTargetValue;
+            if (root.pressStartValue <= root.activeDisplayThreshold &&
+                    root.pressTargetValue > root.activeDisplayThreshold) {
+                root.startLatchReveal();
+            }
+        } else if (!root.activateOnClick) {
+            root.triggerPrimaryAction();
+        }
+    }
+
+    function clickPrimary() {
+        if (root.activateOnClick && !root.pressAndHoldTriggered) {
+            root.triggerPrimaryAction();
+        }
+    }
+
+    function releasePrimary() {
+        if (root.longPressLatching) {
+            if (longPressTimer.running &&
+                    root.pressTargetValue > root.activeDisplayThreshold) {
+                control.value = root.pressStartValue;
+            }
+            longPressTimer.stop();
+            longPressProgressAnimation.stop();
+            root.longPressAnimationRunning = false;
+            root.longPressProgress = 0;
+        } else if (!root.toggleable && !root.activateOnClick && root.releaseToZero) {
+            control.value = 0;
+        }
+    }
+
+    function pressSecondary(mouseX, mouseY) {
+        root.secondaryPressed(displayControl.value, mouseX, mouseY);
+        if (root.rightClickKey.length > 0) {
+            rightControl.value = 1;
+        }
+    }
+
+    function releaseSecondary() {
+        if (root.rightClickKey.length > 0) {
+            rightControl.value = 0;
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: control
+
+        group: root.group
+        key: root.key
+    }
+
+    Mixxx.ControlProxy {
+        id: rightControl
+
+        group: root.group
+        key: root.rightClickKey.length > 0 ? root.rightClickKey : root.key
+    }
+
+    Mixxx.ControlProxy {
+        id: holdControl
+
+        group: root.group
+        key: root.pressAndHoldKey.length > 0 ? root.pressAndHoldKey : root.key
+    }
+
+    Mixxx.ControlProxy {
+        id: displayControl
+
+        group: root.group
+        key: root.displayKey.length > 0 ? root.displayKey : root.key
+    }
+
+    MouseArea {
+        id: interactionArea
+
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        enabled: root.enabled && root.handlePointerInput
+
+        onPressed: function(mouse) {
+            if (mouse.button === Qt.LeftButton) {
+                root.pressPrimary();
+            } else if (mouse.button === Qt.RightButton) {
+                root.pressSecondary(mouse.x, mouse.y);
+            }
+        }
+
+        onPressAndHold: {
+            if (root.pressAndHoldKey.length > 0) {
+                root.pressAndHoldTriggered = true;
+                root.triggerPressAndHoldAction();
+            }
+        }
+
+        onClicked: function(mouse) {
+            if (mouse.button === Qt.LeftButton) {
+                root.clickPrimary();
+            }
+        }
+
+        onReleased: function(mouse) {
+            if (mouse.button === Qt.LeftButton) {
+                root.releasePrimary();
+            } else if (mouse.button === Qt.RightButton) {
+                root.releaseSecondary();
+            }
+        }
+    }
+
+    Timer {
+        id: longPressTimer
+
+        interval: root.longPressDuration
+        repeat: false
+        onTriggered: {
+            root.longPressAnimationRunning = false;
+        }
+    }
+
+    NumberAnimation {
+        id: longPressProgressAnimation
+
+        target: root
+        property: "longPressProgress"
+        from: 0
+        to: 1
+        duration: root.longPressDuration
+        running: false
+    }
+}

--- a/res/qml/Mixxx/Controls/WaveformOverviewMarkerLayer.qml
+++ b/res/qml/Mixxx/Controls/WaveformOverviewMarkerLayer.qml
@@ -1,0 +1,336 @@
+pragma ComponentBehavior: Bound
+
+import Mixxx 1.0 as Mixxx
+import QtQuick 2.12
+
+Item {
+    id: root
+
+    required property string group
+    property int hotcueCount: 8
+    property color cueColor: "red"
+    property color loopColor: "green"
+    property color introOutroColor: "blue"
+    property color labelColor: "white"
+    property color fallbackHotcueColor: cueColor
+    property string cueText: "CUE"
+    property string loopStartText: "LOOP"
+    property string introStartText: "IN"
+    property string outroStartText: "OUT"
+    property string introOutroVisibilityGroup: "[Skin]"
+    property string introOutroVisibilityKey: "show_intro_outro_cues"
+    property string fontFamily: ""
+    property int labelPixelSize: 10
+    property bool labelBold: true
+    property bool showHotcueLabels: true
+    property bool showCueLabel: true
+    property bool showLoopLabel: true
+    property bool showIntroOutroLabels: true
+    property real loopRangeOpacity: 0.7
+    property real introOutroRangeOpacity: 0.6
+    property int markerWidth: 1
+    property int labelTopMargin: 2
+    property int labelHorizontalMargin: 2
+
+    function mapX(position) {
+        if (trackSamplesProxy.value <= 0 || position < 0) {
+            return -9999;
+        }
+        return (root.width * position) / trackSamplesProxy.value;
+    }
+
+    function clampedX(position, itemWidth) {
+        return Math.max(0, Math.min(Math.max(0, root.width - itemWidth), position));
+    }
+
+    Mixxx.ControlProxy {
+        id: trackSamplesProxy
+
+        group: root.group
+        key: "track_samples"
+    }
+
+    Mixxx.ControlProxy {
+        id: cuePointProxy
+
+        group: root.group
+        key: "cue_point"
+    }
+
+    Mixxx.ControlProxy {
+        id: loopStartProxy
+
+        group: root.group
+        key: "loop_start_position"
+    }
+
+    Mixxx.ControlProxy {
+        id: loopEndProxy
+
+        group: root.group
+        key: "loop_end_position"
+    }
+
+    Mixxx.ControlProxy {
+        id: loopEnabledProxy
+
+        group: root.group
+        key: "loop_enabled"
+    }
+
+    Mixxx.ControlProxy {
+        id: introStartProxy
+
+        group: root.group
+        key: "intro_start_position"
+    }
+
+    Mixxx.ControlProxy {
+        id: introEndProxy
+
+        group: root.group
+        key: "intro_end_position"
+    }
+
+    Mixxx.ControlProxy {
+        id: outroStartProxy
+
+        group: root.group
+        key: "outro_start_position"
+    }
+
+    Mixxx.ControlProxy {
+        id: outroEndProxy
+
+        group: root.group
+        key: "outro_end_position"
+    }
+
+    Mixxx.ControlProxy {
+        id: showIntroOutroCuesProxy
+
+        group: root.introOutroVisibilityGroup
+        key: root.introOutroVisibilityKey
+    }
+
+    Repeater {
+        model: root.hotcueCount
+
+        delegate: Item {
+            id: hotcueMarker
+
+            required property int index
+            readonly property int hotcueNumber: index + 1
+            readonly property real markerX: root.mapX(positionProxy.value)
+            readonly property color markerColor: colorProxy.value >= 0
+                    ? "#" + Math.round(colorProxy.value).toString(16).padStart(6, "0")
+                    : root.fallbackHotcueColor
+
+            anchors.fill: parent
+            visible: statusProxy.value > 0 && positionProxy.value >= 0
+            z: 1
+
+            Rectangle {
+                x: root.clampedX(hotcueMarker.markerX, width)
+                y: 0
+                width: root.markerWidth
+                height: parent.height
+                color: hotcueMarker.markerColor
+            }
+
+            Text {
+                x: root.clampedX(hotcueMarker.markerX + root.labelHorizontalMargin, width)
+                y: root.labelTopMargin
+                width: 12
+                height: Math.max(root.labelPixelSize + 2, 10)
+                text: hotcueMarker.hotcueNumber
+                color: root.labelColor
+                font.family: root.fontFamily
+                font.pixelSize: root.labelPixelSize
+                font.bold: root.labelBold
+                verticalAlignment: Text.AlignVCenter
+                visible: root.showHotcueLabels
+            }
+
+            Mixxx.ControlProxy {
+                id: statusProxy
+
+                group: root.group
+                key: "hotcue_" + hotcueMarker.hotcueNumber + "_status"
+            }
+
+            Mixxx.ControlProxy {
+                id: positionProxy
+
+                group: root.group
+                key: "hotcue_" + hotcueMarker.hotcueNumber + "_position"
+            }
+
+            Mixxx.ControlProxy {
+                id: colorProxy
+
+                group: root.group
+                key: "hotcue_" + hotcueMarker.hotcueNumber + "_color"
+            }
+        }
+    }
+
+    readonly property real loopStartX: mapX(loopStartProxy.value)
+    readonly property real loopEndX: mapX(loopEndProxy.value)
+    readonly property bool loopValid: loopStartProxy.value >= 0 &&
+            loopEndProxy.value >= 0 &&
+            loopEnabledProxy.value > 0
+    readonly property real cueX: mapX(cuePointProxy.value)
+    readonly property bool showIntroOutroCues: showIntroOutroCuesProxy.value > 0
+    readonly property real introStartX: mapX(introStartProxy.value)
+    readonly property real introEndX: mapX(introEndProxy.value)
+    readonly property bool introValid: introStartProxy.value >= 0 &&
+            introEndProxy.value >= 0 &&
+            showIntroOutroCues
+    readonly property real outroStartX: mapX(outroStartProxy.value)
+    readonly property real outroEndX: mapX(outroEndProxy.value)
+    readonly property bool outroValid: outroStartProxy.value >= 0 &&
+            outroEndProxy.value >= 0 &&
+            showIntroOutroCues
+
+    Rectangle {
+        x: Math.min(root.loopStartX, root.loopEndX)
+        y: 0
+        width: Math.max(root.markerWidth, Math.abs(root.loopEndX - root.loopStartX))
+        height: parent.height
+        color: root.loopColor
+        opacity: root.loopRangeOpacity
+        visible: root.loopValid
+    }
+
+    Rectangle {
+        x: root.loopStartX
+        y: 0
+        width: root.markerWidth
+        height: parent.height
+        color: root.loopColor
+        visible: loopStartProxy.value >= 0
+    }
+
+    Text {
+        x: root.clampedX(root.loopStartX + root.labelHorizontalMargin, width)
+        y: root.labelTopMargin
+        text: root.loopStartText
+        color: root.labelColor
+        font.family: root.fontFamily
+        font.pixelSize: root.labelPixelSize
+        font.bold: root.labelBold
+        visible: root.showLoopLabel && loopStartProxy.value >= 0
+    }
+
+    Rectangle {
+        x: root.loopEndX
+        y: 0
+        width: root.markerWidth
+        height: parent.height
+        color: root.loopColor
+        visible: loopEndProxy.value >= 0
+    }
+
+    Rectangle {
+        x: root.cueX
+        y: 0
+        width: root.markerWidth
+        height: parent.height
+        color: root.cueColor
+        visible: cuePointProxy.value >= 0
+    }
+
+    Text {
+        x: root.clampedX(root.cueX + root.labelHorizontalMargin, width)
+        y: root.labelTopMargin
+        text: root.cueText
+        color: root.labelColor
+        font.family: root.fontFamily
+        font.pixelSize: root.labelPixelSize
+        font.bold: root.labelBold
+        visible: root.showCueLabel && cuePointProxy.value >= 0
+    }
+
+    Rectangle {
+        x: Math.min(root.introStartX, root.introEndX)
+        y: 0
+        width: Math.max(root.markerWidth, Math.abs(root.introEndX - root.introStartX))
+        height: parent.height
+        color: root.introOutroColor
+        opacity: root.introOutroRangeOpacity
+        visible: root.introValid
+    }
+
+    Rectangle {
+        x: root.introStartX
+        y: 0
+        width: root.markerWidth
+        height: parent.height
+        color: root.introOutroColor
+        visible: introStartProxy.value >= 0 && root.showIntroOutroCues
+    }
+
+    Rectangle {
+        x: root.introEndX
+        y: 0
+        width: root.markerWidth
+        height: parent.height
+        color: root.introOutroColor
+        visible: introEndProxy.value >= 0 && root.showIntroOutroCues
+    }
+
+    Text {
+        x: root.clampedX(root.introEndX + root.labelHorizontalMargin, width)
+        y: root.labelTopMargin
+        text: root.introStartText
+        color: root.labelColor
+        font.family: root.fontFamily
+        font.pixelSize: root.labelPixelSize
+        font.bold: root.labelBold
+        visible: root.showIntroOutroLabels &&
+                introEndProxy.value >= 0 &&
+                root.showIntroOutroCues
+    }
+
+    Rectangle {
+        x: Math.min(root.outroStartX, root.outroEndX)
+        y: 0
+        width: Math.max(root.markerWidth, Math.abs(root.outroEndX - root.outroStartX))
+        height: parent.height
+        color: root.introOutroColor
+        opacity: root.introOutroRangeOpacity
+        visible: root.outroValid
+    }
+
+    Rectangle {
+        x: root.outroStartX
+        y: 0
+        width: root.markerWidth
+        height: parent.height
+        color: root.introOutroColor
+        visible: outroStartProxy.value >= 0 && root.showIntroOutroCues
+    }
+
+    Rectangle {
+        x: root.outroEndX
+        y: 0
+        width: root.markerWidth
+        height: parent.height
+        color: root.introOutroColor
+        visible: outroEndProxy.value >= 0 && root.showIntroOutroCues
+    }
+
+    Text {
+        x: root.clampedX(root.outroStartX + root.labelHorizontalMargin, width)
+        y: root.labelTopMargin
+        text: root.outroStartText
+        color: root.labelColor
+        font.family: root.fontFamily
+        font.pixelSize: root.labelPixelSize
+        font.bold: root.labelBold
+        visible: root.showIntroOutroLabels &&
+                outroStartProxy.value >= 0 &&
+                root.showIntroOutroCues
+    }
+}

--- a/res/qml/Mixxx/PlayerDropArea.qml
+++ b/res/qml/Mixxx/PlayerDropArea.qml
@@ -3,6 +3,8 @@ import QtQuick 2.12
 
 // Handles drops on decks and samplers
 DropArea {
+    id: root
+
     required property string group
     property var player: Mixxx.PlayerManager.getPlayer(group)
 
@@ -10,7 +12,7 @@ DropArea {
         if (drop.formats.includes("mixxx/player")) {
             const sourceGroup = drop.getDataAsString("mixxx/player");
             // Prevent dropping a deck onto itself
-            if (sourceGroup != this.group)
+            if (sourceGroup == root.group)
                 return ;
 
             console.log("Drag from group " + sourceGroup);
@@ -18,7 +20,7 @@ DropArea {
             drop.accepted = true;
             return ;
         }
-        if (drop.hasUrls) {
+        if (drop.hasUrls && drop.urls.length > 0) {
             let url = drop.urls[0];
             console.log("Dropped URL '" + url + "' on deck " + group);
             player.loadTrackFromLocationUrl(url);


### PR DESCRIPTION
## Summary

Adds common QML building blocks for deck controls so skins can share behavior without sharing visual styling.

## What changed

- Adds shared ControlProxy button behavior for momentary/toggle controls, alternate right-click controls, press-and-hold controls, display-key state, release-to-zero behavior, and long-press latch progress.
- Adds shared cycle-button behavior for multi-state controls such as vinyl-control mode/cueing selectors.
- Refactors the existing shared ControlButton to use the new behavior while preserving its public toggle helper.
- Adds a reusable waveform overview marker layer for hotcues, cue points, loop ranges, and intro/outro ranges with skin-provided colors and labels.
- Fixes deck drop handling to avoid cloning a deck onto itself and to ignore empty URL drops.

## Follow-up

#16598 depends on this shared QML work. Once this lands, that branch can wrap these behaviors with its LateNight-local SVGs, colors, opacity, and layout instead of carrying duplicate behavior.

This includes richer deck controls like sync/leader-crown buttons and vinyl-control cycle buttons, while skins keep their own icons, colors, sizing, opacity, and latch visuals.

#16654 depends on this as well.