### PR TITLE
Fix: color column sorting for dirty tracks

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -686,8 +686,8 @@ int BaseTrackCache::compareColumnValues(int sortColumn,
             sortColumn == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_CHANNELS) ||
             sortColumn == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED) ||
             sortColumn == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING) ||
-            sortColumn == fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION)
-    ) {
+            sortColumn == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COLOR) ||
+            sortColumn == fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION)) {
         // Sort as floats.
         double delta = val1.toDouble() - val2.toDouble();
 


### PR DESCRIPTION
### Problem
When we have a track that is already playing/played (dirty) and we try to sort by color, mixxx compares strings and puts the track in a wrong position after sorting.

### How to reproduce
- you will need to have some tracks with a color property on them, enough to make blocks of colored tracks.
- sort by color when track is not played
- sort by color when track is playing



https://github.com/user-attachments/assets/5e314f37-5b63-4490-8f41-f66edcacfc46

Adding color to be compared as float solves the issue.