### PR TITLE
Moving the main thread check to a separate function & updating for Qt =>6.8

### DIFF
--- a/src/errordialoghandler.cpp
+++ b/src/errordialoghandler.cpp
@@ -10,6 +10,7 @@
 #include "moc_errordialoghandler.cpp"
 #include "util/assert.h"
 #include "util/compatibility/qmutex.h"
+#include "util/thread_check.h"
 #include "util/versionstore.h"
 #include "util/widgethelper.h"
 
@@ -146,8 +147,7 @@ void ErrorDialogHandler::errorDialog(ErrorDialogProperties* pProps) {
         return;
     }
 
-    // Check we are in the main thread.
-    if (QThread::currentThread()->objectName() != "Main") {
+    if (!inMainThread()) {
         qWarning() << "WARNING: errorDialog not called in the main thread. Not showing error dialog.";
         return;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -255,8 +255,10 @@ int main(int argc, char * argv[]) {
         return kParseCmdlineArgsErrorExitCode;
     }
 
-    // If you change this here, you also need to change it in
-    // ErrorDialogHandler::errorDialog(). TODO(XXX): Remove this hack.
+    // Set a unique thread object name
+    //
+    // This is used for a check within ErrorDialogHandler::errorDialog()
+    // for earlier Qt versions
     QThread::currentThread()->setObjectName("Main");
 
     // Create the ErrorDialogHandler in the main thread, otherwise it will be

--- a/src/util/thread_check.h
+++ b/src/util/thread_check.h
@@ -9,6 +9,7 @@ inline bool inMainThread() noexcept {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     return QThread::isMainThread();
 #else
-    return QCoreApplication::instance()->thread() == QThread::currentThread();
+    return QCoreApplication::instance()->thread()->objectName() ==
+            QThread::currentThread()->objectName();
 #endif
 }

--- a/src/util/thread_check.h
+++ b/src/util/thread_check.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <QThread>
+#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+#include <QCoreApplication>
+#endif
+
+inline bool inMainThread() noexcept {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    return QThread::isMainThread();
+#else
+    return QCoreApplication::instance()->thread() == QThread::currentThread();
+#endif
+}


### PR DESCRIPTION
These changesets would introduce QThread::isMainThread() in Qt versions where this is available. In those Qt versions, this would replace the earlier check for the thread's object name, when testing for whether the function call is in the main thread. The earlier check is retained, for earlier Qt versions.

In the interest of portability, the main thread check is moved to a separate function.
