### PR TITLE
[GSoC] LateNightQML: Toolbar

### DIFF
--- a/res/skins/LateNight/classic/buttons/btn__menu.svg
+++ b/res/skins/LateNight/classic/buttons/btn__menu.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <path d="m6 36h36v-4h-36v4zm0-10h36v-4h-36v4zm0-14v4h36v-4h-36z" fill="#d2d2d1"/>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__menu.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__menu.svg
@@ -1,0 +1,3 @@
+<svg width="48" height="48" version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <path d="m6 36h36v-4h-36v4zm0-10h36v-4h-36v4zm0-14v4h36v-4h-36z" fill="#a89a8c"/>
+</svg>

--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -54,7 +54,7 @@ QtObject {
     readonly property color toolbarClockTextColor: isClassic ? "#f0bb2b" : "#c2b3a5"
     readonly property color toolbarMenuHoverColor: isPaleMoon ? "#2c454f" : "#5e4507"
     readonly property color toolbarMenuHoverTextColor: "#ffffff"
-    readonly property color toolbarMenuTextColor: "#d2d2d2"
+    readonly property color toolbarMenuTextColor: "#c2b3a5"
     readonly property color toolbarMenuDisabledTextColor: "#777777"
     readonly property color toolbarBroadcastOnColor: isClassic ? "#659f08" : "#438225"
     readonly property color toolbarRecordInitColor: "#d09300"

--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -45,8 +45,23 @@ QtObject {
     readonly property color starsColor34: isClassic ? "#0bd9d1" : "#559b99"
     readonly property color toolbarActiveColor: white
     readonly property color toolbarBackgroundColor: "#242424"
+    readonly property color toolbarButtonActiveBackgroundColor: isClassic ? "#d09300" : "#777777"
+    readonly property color toolbarButtonInactiveBackgroundColor: isClassic ? "#262626" : "#151517"
+    readonly property color toolbarButtonActiveTextColor: "#000000"
+    readonly property color toolbarButtonInactiveTextColor: isClassic ? "#d2d2d1" : "#777777"
+    readonly property color toolbarClockTextColor: isClassic ? "#f0bb2b" : "#c2b3a5"
+    readonly property color toolbarBroadcastOnColor: isClassic ? "#659f08" : "#438225"
+    readonly property color toolbarRecordInitColor: "#d09300"
+    readonly property color toolbarRecordOnColor: isClassic ? "#db0000" : "#a80000"
+    readonly property color toolbarStatusErrorColor: "#f856e7"
     readonly property int toolbarButtonHeight: 26
     readonly property int toolbarButtonWidth: 52
+    readonly property url assetToolbarDropdownIcon: legacyAsset("buttons", "btn__fx_selector_down.svg")
+    readonly property color toolbarMeterBackgroundColor: darkGray
+    readonly property color toolbarStatusOkColor: "#54c76a"
+    readonly property color toolbarStatusWarnColor: "#d89124"
+    readonly property color toolbarRecordingColor: "#db0000"
+    readonly property color toolbarRecordingTextColor: "#ff7373"
     readonly property color syncExplicitLeaderColor: activePlayCueColor
     readonly property color syncInactiveBackgroundColor: "#1e1e1e"
     readonly property color syncImplicitLeaderColor: isPaleMoon ? "#7d350d" : "#db7700"

--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -45,19 +45,30 @@ QtObject {
     readonly property color starsColor34: isClassic ? "#0bd9d1" : "#559b99"
     readonly property color toolbarActiveColor: white
     readonly property color toolbarBackgroundColor: "#242424"
+    readonly property color toolbarRootBackgroundColor: "#151517"
+    readonly property color toolbarBottomBorderColor: "#020202"
     readonly property color toolbarButtonActiveBackgroundColor: isClassic ? "#d09300" : "#777777"
     readonly property color toolbarButtonInactiveBackgroundColor: isClassic ? "#262626" : "#151517"
     readonly property color toolbarButtonActiveTextColor: "#000000"
     readonly property color toolbarButtonInactiveTextColor: isClassic ? "#d2d2d1" : "#777777"
     readonly property color toolbarClockTextColor: isClassic ? "#f0bb2b" : "#c2b3a5"
+    readonly property color toolbarMenuHoverColor: isPaleMoon ? "#2c454f" : "#5e4507"
+    readonly property color toolbarMenuHoverTextColor: "#ffffff"
+    readonly property color toolbarMenuTextColor: "#d2d2d2"
+    readonly property color toolbarMenuDisabledTextColor: "#777777"
     readonly property color toolbarBroadcastOnColor: isClassic ? "#659f08" : "#438225"
     readonly property color toolbarRecordInitColor: "#d09300"
     readonly property color toolbarRecordOnColor: isClassic ? "#db0000" : "#a80000"
     readonly property color toolbarStatusErrorColor: "#f856e7"
     readonly property int toolbarButtonHeight: 26
     readonly property int toolbarButtonWidth: 52
-    readonly property url assetToolbarDropdownIcon: legacyAsset("buttons", "btn__fx_selector_down.svg")
+    readonly property url assetToolbarDropdownIcon: lateNightAsset("buttons", "btn__fx_selector_down.svg")
     readonly property color toolbarMeterBackgroundColor: darkGray
+    readonly property color toolbarLatencyBorderColor: "#040404"
+    readonly property color toolbarLatencyOverloadColor: "#ffff00"
+    readonly property color toolbarLatencyLabelColor: "#444444"
+    readonly property color toolbarPopupBorderColor: "#585858"
+    readonly property color toolbarPopupBackgroundColor: "#0f0f0f"
     readonly property color toolbarStatusOkColor: "#54c76a"
     readonly property color toolbarStatusWarnColor: "#d89124"
     readonly property color toolbarRecordingColor: "#db0000"

--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -63,6 +63,7 @@ QtObject {
     readonly property int toolbarButtonHeight: 26
     readonly property int toolbarButtonWidth: 52
     readonly property url assetToolbarDropdownIcon: lateNightAsset("buttons", "btn__fx_selector_down.svg")
+    readonly property url assetToolbarMenuIcon: lateNightAsset("buttons", "btn__menu.svg")
     readonly property color toolbarMeterBackgroundColor: darkGray
     readonly property color toolbarLatencyBorderColor: "#040404"
     readonly property color toolbarLatencyOverloadColor: "#ffff00"

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -969,7 +969,6 @@ Rectangle {
             }
             ToolbarMenuToggle {
                 control: selectBigSpinnyOrCoverControl
-                enabled: showCoverArtControl.value > 0
                 indent: 14
                 text: "Big Spinny/Cover Art"
             }
@@ -1714,6 +1713,8 @@ Rectangle {
         }
     }
     component ToolbarMenuToggle: Item {
+        id: menuToggle
+
         property bool checked: control ? control.value > 0 : false
         required property var control
         property int indent: 0
@@ -1728,8 +1729,8 @@ Rectangle {
             anchors.fill: parent
 
             onClicked: {
-                if (parent.enabled) {
-                    parent.control.value = parent.checked ? 0.0 : 1.0;
+                if (menuToggle.enabled && menuToggle.control && menuToggle.control.initialized) {
+                    menuToggle.control.value = menuToggle.checked ? 0.0 : 1.0;
                 }
             }
         }

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -1,125 +1,1753 @@
-import "../Controls" as Controls
-import "../Theme"
+pragma ComponentBehavior: Bound
+
+import "../LateNightTheme"
 import "../../../qml" as Shared
 import Mixxx 1.0 as Mixxx
 import QtQuick
+import QtQuick.Controls
 import QtQuick.Layouts
 
 Rectangle {
     id: root
 
-    property alias editDeck: editDeckButton.checked
+    property bool editDeck: false
     property alias maximizeLibrary: maximizeLibraryButton.checked
     readonly property bool show4decks: show4DecksButton.checked && show4DecksButton.visible
     property bool show4decksAvailable: true
     property alias showEffects: showEffectsButton.checked
+    property alias showMicAux: showMicAuxButton.checked
+    property alias showMixer: showMixerButton.checked
     property alias showSamplers: showSamplersButton.checked
-    property bool settingsOpened: false
+    property alias showWaveforms: showWaveformsButton.checked
 
-    signal openSettingsRequested
+    function formatTime(date) {
+        const hours = date.getHours();
+        const displayHour = hours % 12 || 12;
+        const suffix = hours >= 12 ? "PM" : "AM";
+        return displayHour.toString() + ":" + date.getMinutes().toString().padStart(2, "0") + " " + suffix;
+    }
+    function initializeToolbarDefaults() {
+        if (!toolbarDefaultsControl.initialized || toolbarDefaultsControl.value >= 1.0) {
+            return;
+        }
+        setControlValueIfInitialized(showMixerControl, 1.0);
+        setControlValueIfInitialized(showWaveformsControl, 1.0);
+        showEffectRackControl.value = 1.0;
+        showMicAuxControl.value = 0.0;
+        showSamplersControl.value = 0.0;
+        setControlValueIfInitialized(show4DecksControl, 0.0);
+        showMaximizedLibraryControl.value = 0.0;
+        maxLibraryDecksControl.value = 1.0;
+        deckSizeControl.value = 1.0;
+        eqKnobsControl.value = 1.0;
+        eqKillsControl.value = 1.0;
+        crossfaderControl.value = 1.0;
+        mainHeadMixerControl.value = 1.0;
+        show4EffectUnitsControl.value = 0.0;
+        showSuperKnobsControl.value = 0.0;
+        showPreviewDecksControl.value = 0.0;
+        showLibraryCoverArtControl.value = 1.0;
+        samplerRowsControl.value = 1.0;
+        showHotcuesControl.value = 1.0;
+        show8HotcuesControl.value = 1.0;
+        showIntroOutroCuesControl.value = 1.0;
+        showLoopControlsControl.value = 1.0;
+        showBeatjumpControlsControl.value = 1.0;
+        showRateControlsControl.value = 1.0;
+        showRateControlButtonsControl.value = 1.0;
+        showKeyControlsControl.value = 1.0;
+        showVinylControlsControl.value = 0.0;
+        showSpinniesControl.value = 1.0;
+        showCoverArtControl.value = 1.0;
+        selectBigSpinnyOrCoverControl.value = 0.0;
+        toolbarDefaultsControl.value = 1.0;
+    }
+    function openPopupForButton(popup, button) {
+        const mapped = button.mapToItem(root, 0, 0);
+        popup.x = Math.max(0, Math.min(root.width - popup.width, mapped.x));
+        popup.y = root.height + 2;
+        popup.open();
+    }
+    function setControlValueIfInitialized(control, value) {
+        if (control.initialized) {
+            control.value = value;
+        }
+    }
+    function setShowWaveforms(enabled) {
+        showWaveformsButton.checked = enabled;
+        setControlValueIfInitialized(showWaveformsControl, enabled ? 1.0 : 0.0);
+    }
+    function syncShow4Decks(enabled) {
+        show4DecksButton.checked = enabled;
+        maximizedShow4DecksButton.checked = enabled;
+    }
+    function setShow4Decks(enabled) {
+        syncShow4Decks(enabled);
+        setControlValueIfInitialized(show4DecksControl, enabled ? 1.0 : 0.0);
+    }
+    function setShowMixer(enabled) {
+        showMixerButton.checked = enabled;
+        setControlValueIfInitialized(showMixerControl, enabled ? 1.0 : 0.0);
+    }
+    function broadcastBackgroundColor(status) {
+        if (status === 1.0) {
+            return LateNightTheme.toolbarRecordInitColor;
+        }
+        if (status === 2.0) {
+            return LateNightTheme.toolbarBroadcastOnColor;
+        }
+        if (status === 3.0 || status === 4.0) {
+            return LateNightTheme.toolbarStatusErrorColor;
+        }
+        return LateNightTheme.toolbarButtonInactiveBackgroundColor;
+    }
+    function recordingBackgroundColor(status) {
+        if (status === 1.0) {
+            return LateNightTheme.toolbarRecordInitColor;
+        }
+        if (status === 2.0 || status === 3.0) {
+            return LateNightTheme.toolbarRecordOnColor;
+        }
+        return LateNightTheme.toolbarButtonInactiveBackgroundColor;
+    }
 
-    color: Theme.toolbarBackgroundColor
-    height: 36
-    radius: 1
+    color: "#151517"
+    height: 26
 
+    Rectangle {
+        anchors.bottom: parent.bottom
+        color: "#020202"
+        height: 1
+        width: parent.width
+    }
+    Mixxx.ControlProxy {
+        id: toolbarDefaultsControl
+
+        group: "[LateNightQML]"
+        key: "initialized_toolbar_defaults"
+
+        onInitializedChanged: {
+            root.initializeToolbarDefaults();
+        }
+        onValueChanged: {
+            root.initializeToolbarDefaults();
+        }
+    }
+    Mixxx.ControlProxy {
+        id: showMixerControl
+
+        group: "[Skin]"
+        key: "show_mixer"
+
+        onValueChanged: {
+            showMixerButton.checked = value > 0;
+        }
+    }
+    Mixxx.ControlProxy {
+        id: showWaveformsControl
+
+        group: "[Skin]"
+        key: "show_waveforms"
+
+        onValueChanged: {
+            showWaveformsButton.checked = value > 0;
+        }
+    }
+    Mixxx.ControlProxy {
+        id: showEffectRackControl
+
+        group: "[Skin]"
+        key: "show_effectrack"
+
+        onValueChanged: {
+            showEffectsButton.checked = value > 0;
+        }
+    }
+    Mixxx.ControlProxy {
+        id: showSamplersControl
+
+        group: "[Skin]"
+        key: "show_samplers"
+
+        onValueChanged: {
+            showSamplersButton.checked = value > 0;
+        }
+    }
+    Mixxx.ControlProxy {
+        id: showMicAuxControl
+
+        group: "[Skin]"
+        key: "show_microphones"
+
+        onValueChanged: {
+            showMicAuxButton.checked = value > 0;
+        }
+    }
+    Mixxx.ControlProxy {
+        id: show4DecksControl
+
+        group: "[Skin]"
+        key: "show_4decks"
+
+        onValueChanged: {
+            root.syncShow4Decks(value > 0);
+        }
+    }
+    Mixxx.ControlProxy {
+        id: showMaximizedLibraryControl
+
+        group: "[Skin]"
+        key: "show_maximized_library"
+
+        onValueChanged: {
+            maximizeLibraryButton.checked = value > 0;
+        }
+    }
+    Mixxx.ControlProxy {
+        id: maxLibraryDecksControl
+
+        group: "[LateNight]"
+        key: "max_lib_show_decks"
+    }
+    Mixxx.ControlProxy {
+        id: deckSizeControl
+
+        group: "[LateNight]"
+        key: "deck_size_without_mixer"
+    }
+    Mixxx.ControlProxy {
+        id: showFullDeckControl
+
+        group: "[LateNight]"
+        key: "show_full_deck"
+    }
+    Mixxx.ControlProxy {
+        id: showCompactDeckControl
+
+        group: "[LateNight]"
+        key: "show_compact_deck"
+    }
+    Mixxx.ControlProxy {
+        id: showMiniDeckControl
+
+        group: "[LateNight]"
+        key: "show_mini_deck"
+    }
+    Mixxx.ControlProxy {
+        id: showHotcuesControl
+
+        group: "[Skin]"
+        key: "show_hotcues"
+    }
+    Mixxx.ControlProxy {
+        id: show8HotcuesControl
+
+        group: "[Skin]"
+        key: "show_8_hotcues"
+    }
+    Mixxx.ControlProxy {
+        id: showIntroOutroCuesControl
+
+        group: "[Skin]"
+        key: "show_intro_outro_cues"
+    }
+    Mixxx.ControlProxy {
+        id: showLoopControlsControl
+
+        group: "[Skin]"
+        key: "show_loop_controls"
+    }
+    Mixxx.ControlProxy {
+        id: showBeatjumpControlsControl
+
+        group: "[Skin]"
+        key: "show_beatjump_controls"
+    }
+    Mixxx.ControlProxy {
+        id: showRateControlsControl
+
+        group: "[Skin]"
+        key: "show_rate_controls"
+    }
+    Mixxx.ControlProxy {
+        id: showRateControlButtonsControl
+
+        group: "[Skin]"
+        key: "show_rate_control_buttons"
+    }
+    Mixxx.ControlProxy {
+        id: showKeyControlsControl
+
+        group: "[Skin]"
+        key: "show_key_controls"
+    }
+    Mixxx.ControlProxy {
+        id: showVinylControlsControl
+
+        group: "[Skin]"
+        key: "show_vinylcontrol"
+    }
+    Mixxx.ControlProxy {
+        id: showSpinniesControl
+
+        group: "[Skin]"
+        key: "show_spinnies"
+    }
+    Mixxx.ControlProxy {
+        id: showCoverArtControl
+
+        group: "[Skin]"
+        key: "show_coverart"
+    }
+    Mixxx.ControlProxy {
+        id: selectBigSpinnyOrCoverControl
+
+        group: "[Skin]"
+        key: "select_big_spinny_or_cover"
+    }
+    Mixxx.ControlProxy {
+        id: eqKnobsControl
+
+        group: "[Skin]"
+        key: "show_eq_knobs"
+    }
+    Mixxx.ControlProxy {
+        id: eqKillsControl
+
+        group: "[Skin]"
+        key: "show_eq_kill_buttons"
+    }
+    Mixxx.ControlProxy {
+        id: crossfaderControl
+
+        group: "[Skin]"
+        key: "show_xfader"
+    }
+    Mixxx.ControlProxy {
+        id: mainHeadMixerControl
+
+        group: "[Skin]"
+        key: "show_main_head_mixer"
+    }
+    Mixxx.ControlProxy {
+        id: equalWaveformHeightsControl
+
+        group: "[Skin]"
+        key: "equal_4deck_waveforms"
+    }
+    Mixxx.ControlProxy {
+        id: hotcueTimingShiftControl
+
+        group: "[Skin]"
+        key: "timing_shift_buttons"
+    }
+    Mixxx.ControlProxy {
+        id: show4EffectUnitsControl
+
+        group: "[Skin]"
+        key: "show_4effectunits"
+    }
+    Mixxx.ControlProxy {
+        id: showSuperKnobsControl
+
+        group: "[Skin]"
+        key: "show_superknobs"
+    }
+    Mixxx.ControlProxy {
+        id: showPreviewDecksControl
+
+        group: "[Skin]"
+        key: "show_preview_decks"
+    }
+    Mixxx.ControlProxy {
+        id: showLibraryCoverArtControl
+
+        group: "[Skin]"
+        key: "show_library_coverart"
+    }
+    Mixxx.ControlProxy {
+        id: samplerRowsControl
+
+        group: "[LateNight]"
+        key: "sampler_rows"
+    }
+    Mixxx.ControlProxy {
+        id: expandSamplers14Control
+
+        group: "[LateNight]"
+        key: "expand_samplers_1-4"
+    }
+    Mixxx.ControlProxy {
+        id: expandSamplers18Control
+
+        group: "[LateNight]"
+        key: "expand_samplers_1-8"
+    }
+    Mixxx.ControlProxy {
+        id: expandSamplers916Control
+
+        group: "[LateNight]"
+        key: "expand_samplers_9-16"
+    }
+    Mixxx.ControlProxy {
+        id: showSamplerFxControl
+
+        group: "[Skin]"
+        key: "show_sampler_fx"
+    }
+    Mixxx.ControlProxy {
+        id: loadSamplerBankControl
+
+        group: "[Sampler]"
+        key: "LoadSamplerBank"
+    }
+    Mixxx.ControlProxy {
+        id: saveSamplerBankControl
+
+        group: "[Sampler]"
+        key: "SaveSamplerBank"
+    }
+    Mixxx.ControlProxy {
+        id: latencyUsageControl
+
+        group: "[App]"
+        key: "audio_latency_usage"
+    }
+    Mixxx.ControlProxy {
+        id: latencyOverloadControl
+
+        group: "[App]"
+        key: "audio_latency_overload"
+    }
+    Mixxx.ControlProxy {
+        id: recordingStatusControl
+
+        group: "[Recording]"
+        key: "status"
+
+    }
+    Mixxx.ControlProxy {
+        id: recordingToggleControl
+
+        group: "[Recording]"
+        key: "toggle_recording"
+    }
+    Mixxx.ControlProxy {
+        id: broadcastEnabledControl
+
+        group: "[Shoutcast]"
+        key: "enabled"
+    }
+    Mixxx.ControlProxy {
+        id: broadcastStatusControl
+
+        group: "[Shoutcast]"
+        key: "status"
+    }
+    Mixxx.ControlProxy {
+        id: autoDjControl
+
+        group: "[AutoDJ]"
+        key: "enabled"
+    }
+    Timer {
+        id: clockTimer
+
+        interval: 1000
+        repeat: true
+        running: true
+        triggeredOnStart: true
+
+        onTriggered: {
+            clockLabel.text = root.formatTime(new Date());
+        }
+    }
+    SequentialAnimation {
+        id: warningPulse
+
+        loops: Animation.Infinite
+        running: latencyOverloadControl.value > 0 || broadcastStatusControl.value === 1.0 || broadcastStatusControl.value === 3.0 || broadcastStatusControl.value === 4.0
+
+        PropertyAnimation {
+            duration: 450
+            property: "opacity"
+            target: pulseDriver
+            to: 0.35
+        }
+        PropertyAnimation {
+            duration: 450
+            property: "opacity"
+            target: pulseDriver
+            to: 1.0
+        }
+    }
+    QtObject {
+        id: pulseDriver
+
+        property real opacity: 1.0
+    }
     RowLayout {
         anchors.fill: parent
+        anchors.leftMargin: 2
+        anchors.rightMargin: 2
+        spacing: 4
 
-        Controls.ToggleButton {
-            id: show4DecksButton
+        RowLayout {
+            Layout.alignment: Qt.AlignVCenter
+            spacing: -2
 
-            activeColor: Theme.toolbarActiveColor
-            text: "4 Decks"
-            visible: root.show4decksAvailable
-        }
-        Controls.ToggleButton {
-            id: maximizeLibraryButton
+            LateNightToolbarButton {
+                id: maximizeLibraryButton
 
-            activeColor: Theme.toolbarActiveColor
-            text: "Library"
+                buttonWidth: 80
+                text: "BIG LIBRARY"
 
-            onCheckedChanged: () => {
-                showMaximizedLibrary.value = checked;
+                onActivated: {
+                    showMaximizedLibraryControl.value = checked ? 1.0 : 0.0;
+                }
             }
+            LateNightToolbarDropButton {
+                popup: librarySettingsPopup
 
-            Mixxx.ControlProxy {
-                id: showMaximizedLibrary
-
-                group: "[Skin]"
-                key: "show_maximized_library"
-
-                onValueChanged: () => {
-                    maximizeLibraryButton.checked = value;
+                onClicked: {
+                    root.openPopupForButton(popup, this);
                 }
             }
         }
-        Controls.ToggleButton {
-            id: showEffectsButton
+        RowLayout {
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 4
+            visible: !maximizeLibraryButton.checked
 
-            activeColor: Theme.toolbarActiveColor
-            text: "Effects"
+            RowLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: -2
+
+                LateNightToolbarButton {
+                    id: showWaveformsButton
+
+                    buttonWidth: 80
+                    text: "WAVEFORMS"
+
+                    onActivated: {
+                        root.setShowWaveforms(checked);
+                    }
+                }
+                LateNightToolbarDropButton {
+                    popup: waveformSettingsPopup
+
+                    onClicked: {
+                        root.openPopupForButton(popup, this);
+                    }
+                }
+            }
+            RowLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: -2
+                visible: root.show4decksAvailable
+
+                LateNightToolbarButton {
+                    id: show4DecksButton
+
+                    buttonWidth: 52
+                    text: "4 DECKS"
+
+                    onActivated: {
+                        root.setShow4Decks(checked);
+                    }
+                }
+                LateNightToolbarDropButton {
+                    popup: deckSettingsPopup
+
+                    onClicked: {
+                        root.openPopupForButton(popup, this);
+                    }
+                }
+            }
+            RowLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: -2
+
+                LateNightToolbarButton {
+                    id: showMixerButton
+
+                    buttonWidth: 48
+                    text: "MIXER"
+
+                    onActivated: {
+                        root.setShowMixer(checked);
+                    }
+                }
+                LateNightToolbarDropButton {
+                    popup: mixerSettingsPopup
+
+                    onClicked: {
+                        root.openPopupForButton(popup, this);
+                    }
+                }
+            }
+            RowLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: -2
+
+                LateNightToolbarButton {
+                    id: showEffectsButton
+
+                    buttonWidth: 59
+                    text: "EFFECTS"
+
+                    onActivated: {
+                        showEffectRackControl.value = checked ? 1.0 : 0.0;
+                    }
+                }
+                LateNightToolbarDropButton {
+                    popup: effectSettingsPopup
+
+                    onClicked: {
+                        root.openPopupForButton(popup, this);
+                    }
+                }
+            }
+            RowLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: -2
+
+                LateNightToolbarButton {
+                    id: showSamplersButton
+
+                    buttonWidth: 71
+                    text: "SAMPLERS"
+
+                    onActivated: {
+                        showSamplersControl.value = checked ? 1.0 : 0.0;
+                    }
+                }
+                LateNightToolbarDropButton {
+                    popup: samplerSettingsPopup
+
+                    onClicked: {
+                        root.openPopupForButton(popup, this);
+                    }
+                }
+            }
+            RowLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: -2
+
+                LateNightToolbarButton {
+                    id: showMicAuxButton
+
+                    buttonWidth: 61
+                    text: "MIC/AUX"
+
+                    onActivated: {
+                        showMicAuxControl.value = checked ? 1.0 : 0.0;
+                    }
+                }
+                LateNightToolbarDropButton {
+                    popup: micAuxSettingsPopup
+
+                    onClicked: {
+                        root.openPopupForButton(popup, this);
+                    }
+                }
+            }
         }
-        Controls.ToggleButton {
-            id: showAuxButton
+        RowLayout {
+            Layout.alignment: Qt.AlignVCenter
+            spacing: 4
+            visible: maximizeLibraryButton.checked
 
-            activeColor: Theme.toolbarActiveColor
-            text: "Aux"
-        }
-        Controls.ToggleButton {
-            id: showSamplersButton
+            RowLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: -2
 
-            activeColor: Theme.toolbarActiveColor
-            text: "Sampler"
+                LateNightToolbarButton {
+                    buttonWidth: 80
+                    checked: maxLibraryDecksControl.value > 0
+                    text: "DECKS"
+
+                    onActivated: {
+                        maxLibraryDecksControl.value = checked ? 1.0 : 0.0;
+                    }
+                }
+                LateNightToolbarDropButton {
+                    popup: deckSettingsPopup
+
+                    onClicked: {
+                        root.openPopupForButton(popup, this);
+                    }
+                }
+            }
+            RowLayout {
+                Layout.alignment: Qt.AlignVCenter
+                spacing: -2
+                visible: root.show4decksAvailable
+
+                LateNightToolbarButton {
+                    id: maximizedShow4DecksButton
+
+                    buttonWidth: 52
+                    checked: show4DecksButton.checked
+                    text: "4 DECKS"
+
+                    onActivated: {
+                        root.setShow4Decks(checked);
+                    }
+                }
+                LateNightToolbarDropButton {
+                    popup: deckSettingsPopup
+
+                    onClicked: {
+                        root.openPopupForButton(popup, this);
+                    }
+                }
+            }
         }
         Item {
             Layout.fillWidth: true
+            Layout.minimumWidth: 0
         }
-        Controls.ToggleButton {
-            id: editDeckButton
-
-            activeColor: Theme.toolbarActiveColor
-            text: "Edit"
+        AutoDjIndicator {
+            active: autoDjControl.value > 0
         }
-        Controls.ToggleButton {
-            id: showDevToolsButton
-
-            activeColor: Theme.toolbarActiveColor
-            checked: devToolsWindow.visible
-            text: "Develop"
+        ClockIndicator {
+            id: clockLabel
+        }
+        Item {
+            Layout.preferredWidth: 7
+        }
+        LatencyIndicator {
+            overload: latencyOverloadControl.value > 0
+            overloadOpacity: pulseDriver.opacity
+            usage: latencyUsageControl.initialized ? latencyUsageControl.value : 0.0
+        }
+        Item {
+            Layout.preferredWidth: 7
+        }
+        BatteryIndicator {
+            visible: Mixxx.Battery.isBatteryAvailable
+        }
+        Item {
+            Layout.preferredWidth: 9
+        }
+        RecordingIndicator {
+            durationText: Mixxx.Recording.durationText
+            pulseOpacity: pulseDriver.opacity
+            status: recordingStatusControl.value
 
             onClicked: {
-                if (devToolsWindow.visible) {
-                    devToolsWindow.close();
-                } else {
-                    devToolsWindow.show();
+                recordingToggleControl.trigger();
+            }
+        }
+        BroadcastIndicator {
+            pulseOpacity: pulseDriver.opacity
+            status: broadcastStatusControl.value
+
+            onClicked: {
+                broadcastEnabledControl.value = broadcastEnabledControl.value > 0 ? 0.0 : 1.0;
+            }
+        }
+        Image {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.preferredHeight: 24
+            Layout.preferredWidth: 74
+            fillMode: Image.PreserveAspectFit
+            source: LateNightTheme.legacyAsset("style", "mixxx_logo_small.svg")
+        }
+    }
+    ToolbarSettingsPopup {
+        id: deckSettingsPopup
+
+        width: 230
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.bottomMargin: 7
+            Layout.leftMargin: 5
+            Layout.rightMargin: 5
+            Layout.topMargin: 2
+            spacing: 0
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 22
+                spacing: 5
+
+                Text {
+                    color: LateNightTheme.primaryDeckTextColor
+                    elide: Text.ElideRight
+                    font.family: "Open Sans"
+                    font.pixelSize: 17
+                    text: "Decks"
+                }
+
+                Item { Layout.fillWidth: true } // spacer
+
+                ToolbarMenuInlineChoice {
+                    checked: !show4DecksButton.checked
+                    text: "2"
+
+                    onClicked: {
+                        root.setShow4Decks(false);
+                    }
+                }
+                ToolbarMenuInlineChoice {
+                    checked: show4DecksButton.checked
+                    text: "4"
+
+                    onClicked: {
+                        root.setShow4Decks(true);
+                    }
+                }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 5
+                visible: showMixerButton.checked
+
+                Text {
+                    color: LateNightTheme.textColor
+                    font.family: "Open Sans"
+                    font.pixelSize: 12
+                    text: "Deck Size:"
+                }
+                Item {
+                    id: hideMixerBtn
+                    Layout.preferredHeight: 18
+                    Layout.fillWidth: true
+
+                    Rectangle {
+                        anchors.fill: parent
+                        color: hideMixerMouseArea.containsMouse ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent"
+                        radius: 1
+                    }
+
+                    Text {
+                        anchors.left: parent.left
+                        anchors.leftMargin: 4
+                        anchors.verticalCenter: parent.verticalCenter
+                        color: hideMixerMouseArea.containsMouse ? "#ffffff" : LateNightTheme.textColor
+                        font.family: "Open Sans"
+                        font.pixelSize: 12
+                        text: "hide mixer to select"
+                    }
+
+                    MouseArea {
+                        id: hideMixerMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            root.setShowMixer(false);
+                        }
+                    }
+                }
+            }
+            ToolbarMenuChoice {
+                checked: deckSizeControl.value === 2.0 || showFullDeckControl.value > 0
+                text: "Full"
+                visible: !showMixerButton.checked
+
+                onClicked: {
+                    deckSizeControl.value = 2.0;
+                    showFullDeckControl.value = 1.0;
+                    showCompactDeckControl.value = 0.0;
+                    showMiniDeckControl.value = 0.0;
+                }
+            }
+            ToolbarMenuChoice {
+                checked: deckSizeControl.value === 1.0 || showCompactDeckControl.value > 0
+                text: "Compact"
+                visible: !showMixerButton.checked
+
+                onClicked: {
+                    deckSizeControl.value = 1.0;
+                    showFullDeckControl.value = 0.0;
+                    showCompactDeckControl.value = 1.0;
+                    showMiniDeckControl.value = 0.0;
+                }
+            }
+            ToolbarMenuChoice {
+                checked: deckSizeControl.value === 0.0 || showMiniDeckControl.value > 0
+                text: "Mini"
+                visible: !showMixerButton.checked
+
+                onClicked: {
+                    deckSizeControl.value = 0.0;
+                    showFullDeckControl.value = 0.0;
+                    showCompactDeckControl.value = 0.0;
+                    showMiniDeckControl.value = 1.0;
+                }
+            }
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 5
+
+                ToolbarMenuToggle {
+                    Layout.fillWidth: false
+                    control: showHotcuesControl
+                    text: "Hotcues"
+                }
+                ToolbarMenuInlineChoice {
+                    checked: showHotcuesControl.value > 0 && show8HotcuesControl.value <= 0
+                    enabled: showHotcuesControl.value > 0
+                    text: "4"
+
+                    onClicked: {
+                        showHotcuesControl.value = 1.0;
+                        show8HotcuesControl.value = 0.0;
+                    }
+                }
+                ToolbarMenuInlineChoice {
+                    checked: showHotcuesControl.value > 0 && show8HotcuesControl.value > 0
+                    enabled: showHotcuesControl.value > 0
+                    text: "8"
+
+                    onClicked: {
+                        showHotcuesControl.value = 1.0;
+                        show8HotcuesControl.value = 1.0;
+                    }
+                }
+            }
+            ToolbarMenuToggle {
+                control: showIntroOutroCuesControl
+                text: "Intro & Outro Cues"
+            }
+            ToolbarMenuToggle {
+                control: showLoopControlsControl
+                text: "Loop Controls"
+            }
+            ToolbarMenuToggle {
+                control: showBeatjumpControlsControl
+                text: "Beatjump Controls"
+            }
+            ToolbarMenuToggle {
+                control: showRateControlsControl
+                text: "Rate Controls"
+            }
+            ToolbarMenuToggle {
+                control: showRateControlButtonsControl
+                enabled: showRateControlsControl.value > 0
+                indent: 14
+                text: "Rate Adjust Buttons"
+            }
+            ToolbarMenuToggle {
+                control: showKeyControlsControl
+                text: "Key Controls"
+            }
+            ToolbarMenuToggle {
+                control: showVinylControlsControl
+                text: "Vinyl Control"
+            }
+            ToolbarMenuToggle {
+                control: showSpinniesControl
+                text: "Spinny"
+            }
+            ToolbarMenuToggle {
+                control: showCoverArtControl
+                text: "Cover Art"
+            }
+            ToolbarMenuToggle {
+                control: selectBigSpinnyOrCoverControl
+                enabled: showCoverArtControl.value > 0
+                indent: 14
+                text: "Big Spinny/Cover Art"
+            }
+        }
+    }
+    ToolbarSettingsPopup {
+        id: mixerSettingsPopup
+
+        ToolbarMenuSectionToggle {
+            title: "Mixer"
+            control: showMixerControl
+
+            ToolbarMenuToggle {
+                control: mainHeadMixerControl
+                enabled: showMixerControl.value > 0
+                text: "Main / Headphone Mixer"
+            }
+            ToolbarMenuToggle {
+                control: eqKnobsControl
+                enabled: showMixerControl.value > 0
+                text: "EQ Knobs"
+            }
+            ToolbarMenuToggle {
+                control: eqKillsControl
+                enabled: showMixerControl.value > 0 && eqKnobsControl.value > 0
+                indent: 14
+                text: "EQ Kill Buttons"
+            }
+            ToolbarMenuToggle {
+                control: crossfaderControl
+                enabled: showMixerControl.value > 0
+                text: "Crossfader"
+            }
+        }
+    }
+    ToolbarSettingsPopup {
+        id: waveformSettingsPopup
+
+        ToolbarMenuSectionToggle {
+            title: "Waveforms"
+            control: showWaveformsControl
+
+            ToolbarMenuToggle {
+                control: hotcueTimingShiftControl
+                enabled: showWaveformsControl.value > 0
+                text: "Hotcue Shift Buttons"
+            }
+            ToolbarMenuToggle {
+                control: equalWaveformHeightsControl
+                enabled: showWaveformsControl.value > 0
+                text: "Enforce equal heights"
+            }
+        }
+    }
+    ToolbarSettingsPopup {
+        id: effectSettingsPopup
+
+        width: 230
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.bottomMargin: 7
+            Layout.leftMargin: 5
+            Layout.rightMargin: 5
+            Layout.topMargin: 2
+            spacing: 0
+
+            Item {
+                id: effectUnitsHeader
+                property bool checked: showEffectRackControl.value > 0
+
+                Layout.fillWidth: true
+                implicitHeight: 22
+
+                MouseArea {
+                    anchors.fill: parent
+
+                    onClicked: {
+                        showEffectRackControl.value = effectUnitsHeader.checked ? 0.0 : 1.0;
+                    }
+                }
+
+                RowLayout {
+                    anchors.fill: parent
+                    spacing: 5
+
+                    Image {
+                        Layout.preferredHeight: 18
+                        Layout.preferredWidth: 18
+                        fillMode: Image.PreserveAspectFit
+                        source: effectUnitsHeader.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+                    }
+
+                    Text {
+                        color: LateNightTheme.primaryDeckTextColor
+                        elide: Text.ElideRight
+                        font.family: "Open Sans"
+                        font.pixelSize: 17
+                        text: "Effect Units"
+                    }
+
+                    Item { Layout.fillWidth: true } // spacer
+
+                    ToolbarMenuInlineChoice {
+                        checked: show4EffectUnitsControl.value === 0.0
+                        enabled: showEffectRackControl.value > 0
+                        text: "2"
+
+                        onClicked: {
+                            show4EffectUnitsControl.value = 0.0;
+                        }
+                    }
+
+                    ToolbarMenuInlineChoice {
+                        checked: show4EffectUnitsControl.value === 1.0
+                        enabled: showEffectRackControl.value > 0
+                        text: "4"
+
+                        onClicked: {
+                            show4EffectUnitsControl.value = 1.0;
+                        }
+                    }
                 }
             }
 
-            Shared.DeveloperToolsWindow {
-                id: devToolsWindow
-
-                height: 480
-                width: 640
+            ToolbarMenuToggle {
+                control: showSuperKnobsControl
+                enabled: showEffectRackControl.value > 0
+                text: "Super Knobs"
             }
         }
-        Controls.Button {
-            id: showPreferencesButton
+    }
+    ToolbarSettingsPopup {
+        id: samplerSettingsPopup
 
-            activeColor: Theme.toolbarActiveColor
-            checked: root.settingsOpened
-            icon.height: 16
-            icon.source: Theme.sharedImage("gear.svg")
-            icon.width: 16
-            implicitWidth: implicitHeight
+        width: 230
 
-            onClicked: {
-                if (!root.settingsOpened) {
-                    root.openSettingsRequested();
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.bottomMargin: 7
+            Layout.leftMargin: 5
+            Layout.rightMargin: 5
+            Layout.topMargin: 2
+            spacing: 0
+
+            Item {
+                id: samplersHeader
+                property bool checked: showSamplersControl.value > 0
+
+                Layout.fillWidth: true
+                implicitHeight: 22
+
+                MouseArea {
+                    anchors.fill: parent
+
+                    onClicked: {
+                        showSamplersControl.value = samplersHeader.checked ? 0.0 : 1.0;
+                    }
+                }
+
+                RowLayout {
+                    anchors.fill: parent
+                    spacing: 5
+
+                    Image {
+                        Layout.preferredHeight: 18
+                        Layout.preferredWidth: 18
+                        fillMode: Image.PreserveAspectFit
+                        source: samplersHeader.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+                    }
+
+                    Text {
+                        color: LateNightTheme.primaryDeckTextColor
+                        elide: Text.ElideRight
+                        font.family: "Open Sans"
+                        font.pixelSize: 17
+                        text: "Samplers"
+                    }
+
+                    Item { Layout.fillWidth: true } // spacer
+
+                    ToolbarMenuInlineChoice {
+                        checked: samplerRowsControl.value === 0.0
+                        enabled: showSamplersControl.value > 0
+                        text: "4"
+
+                        onClicked: {
+                            samplerRowsControl.value = 0.0;
+                        }
+                    }
+
+                    ToolbarMenuInlineChoice {
+                        checked: samplerRowsControl.value === 1.0
+                        enabled: showSamplersControl.value > 0
+                        text: "8"
+
+                        onClicked: {
+                            samplerRowsControl.value = 1.0;
+                        }
+                    }
+
+                    ToolbarMenuInlineChoice {
+                        checked: samplerRowsControl.value === 2.0
+                        enabled: showSamplersControl.value > 0
+                        text: "16"
+
+                        onClicked: {
+                            samplerRowsControl.value = 2.0;
+                        }
+                    }
+
+                    ToolbarMenuInlineChoice {
+                        checked: samplerRowsControl.value === 4.0
+                        enabled: showSamplersControl.value > 0
+                        text: "64"
+
+                        onClicked: {
+                            samplerRowsControl.value = 4.0;
+                        }
+                    }
                 }
             }
-            onPressAndHold: {
-                Mixxx.PreferencesDialog.show();
+
+            ToolbarMenuToggle {
+                control: showSamplerFxControl
+                enabled: showSamplersControl.value > 0
+                text: "Fx controls"
             }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 22
+                Layout.preferredHeight: 18
+                spacing: 3
+                enabled: showSamplersControl.value > 0
+                opacity: enabled ? 1.0 : 0.45
+
+                Item {
+                    id: loadBankBtn
+                    Layout.preferredHeight: 18
+                    Layout.preferredWidth: loadBankText.implicitWidth + 8
+
+                    Rectangle {
+                        anchors.fill: parent
+                        color: loadBankMouseArea.containsMouse ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent"
+                        radius: 1
+                    }
+
+                    Text {
+                        id: loadBankText
+                        anchors.centerIn: parent
+                        color: loadBankMouseArea.containsMouse ? "#ffffff" : LateNightTheme.textColor
+                        font.family: "Open Sans"
+                        font.pixelSize: 12
+                        text: "Load"
+                    }
+
+                    MouseArea {
+                        id: loadBankMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            loadSamplerBankControl.value = 1.0;
+                        }
+                    }
+                }
+
+                Text {
+                    color: LateNightTheme.textColor
+                    font.family: "Open Sans"
+                    font.pixelSize: 12
+                    text: "/"
+                }
+
+                Item {
+                    id: saveBankBtn
+                    Layout.preferredHeight: 18
+                    Layout.preferredWidth: saveBankText.implicitWidth + 8
+
+                    Rectangle {
+                        anchors.fill: parent
+                        color: saveBankMouseArea.containsMouse ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent"
+                        radius: 1
+                    }
+
+                    Text {
+                        id: saveBankText
+                        anchors.centerIn: parent
+                        color: saveBankMouseArea.containsMouse ? "#ffffff" : LateNightTheme.textColor
+                        font.family: "Open Sans"
+                        font.pixelSize: 12
+                        text: "Save"
+                    }
+
+                    MouseArea {
+                        id: saveBankMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            saveSamplerBankControl.value = 1.0;
+                        }
+                    }
+                }
+
+                Text {
+                    color: LateNightTheme.textColor
+                    font.family: "Open Sans"
+                    font.pixelSize: 12
+                    text: "Sampler Bank"
+                    Layout.fillWidth: true
+                }
+            }
+        }
+    }
+    ToolbarSettingsPopup {
+        id: librarySettingsPopup
+
+        width: 140
+
+        ToolbarMenuSection {
+            title: "Library"
+
+            ToolbarMenuToggle {
+                control: showPreviewDecksControl
+                text: "Preview Deck"
+            }
+            ToolbarMenuToggle {
+                control: showLibraryCoverArtControl
+                text: "Cover Art"
+            }
+        }
+    }
+    ToolbarSettingsPopup {
+        id: micAuxSettingsPopup
+
+        width: 140
+
+        ToolbarMenuSection {
+            title: "Mic/Aux"
+
+            ToolbarMenuToggle {
+                control: showMicAuxControl
+                text: "Microphones"
+            }
+        }
+    }
+
+    component AutoDjIndicator: Image {
+        required property bool active
+
+        Layout.alignment: Qt.AlignVCenter
+        Layout.preferredHeight: 22
+        Layout.preferredWidth: active ? 30 : 0
+        fillMode: Image.PreserveAspectFit
+        source: LateNightTheme.legacyAsset("style", "autodj_status.svg")
+        visible: active
+    }
+    component BatteryIndicator: Shared.BatteryIcon {
+        Layout.alignment: Qt.AlignVCenter
+        Layout.preferredHeight: 24
+        Layout.preferredWidth: 24
+        chargedSource: LateNightTheme.legacyAsset("style/batt", "ic_battery_charged.svg")
+        chargingSources: [LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_0.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_1.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_2.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_3.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_4.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_5.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_6.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_7.svg")]
+        dischargingSources: [LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_0.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_1.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_2.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_3.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_4.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_5.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_6.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_7.svg")]
+        fillMode: Image.PreserveAspectFit
+    }
+    component BroadcastIndicator: MouseArea {
+        id: broadcastIndicator
+
+        required property real pulseOpacity
+        required property real status
+
+        Layout.alignment: Qt.AlignVCenter
+        Layout.preferredHeight: 20
+        Layout.preferredWidth: 72
+
+        LateNightToolbarButtonBackground {
+            active: broadcastIndicator.status > 0
+            fillColor: root.broadcastBackgroundColor(broadcastIndicator.status)
+        }
+        Image {
+            anchors.fill: parent
+            fillMode: Image.Stretch
+            source: broadcastIndicator.status > 0 ? LateNightTheme.legacyAsset("buttons", "btn__broadcast_on.svg") : LateNightTheme.legacyAsset("buttons", "btn__broadcast_off.svg")
+        }
+        Text {
+            anchors.fill: parent
+            anchors.leftMargin: 15
+            color: broadcastIndicator.status > 0 ? LateNightTheme.toolbarButtonActiveTextColor : LateNightTheme.toolbarButtonInactiveTextColor
+            font.family: "Open Sans"
+            font.pixelSize: 11
+            font.styleName: "Bold"
+            font.weight: Font.Bold
+            horizontalAlignment: Text.AlignHCenter
+            opacity: broadcastIndicator.status === 1.0 || broadcastIndicator.status === 3.0 || broadcastIndicator.status === 4.0 ? broadcastIndicator.pulseOpacity : 1.0
+            renderType: Text.NativeRendering
+            text: broadcastIndicator.status === 1.0 ? "..." : (broadcastIndicator.status === 3.0 || broadcastIndicator.status === 4.0 ? "ERROR" : "ON AIR")
+            verticalAlignment: Text.AlignVCenter
+        }
+    }
+    component ClockIndicator: Text {
+        Layout.alignment: Qt.AlignVCenter
+        Layout.preferredWidth: 82
+        color: LateNightTheme.toolbarClockTextColor
+        font.family: "Open Sans"
+        font.pixelSize: 16
+        horizontalAlignment: Text.AlignHCenter
+        text: "--:-- --"
+        verticalAlignment: Text.AlignVCenter
+    }
+    component LateNightToolbarButton: MouseArea {
+        id: toolbarButton
+
+        property int buttonWidth: 52
+        property bool checked: false
+        property string text: ""
+
+        signal activated
+
+        Layout.alignment: Qt.AlignVCenter
+        Layout.preferredHeight: 20
+        Layout.preferredWidth: buttonWidth
+        cursorShape: Qt.PointingHandCursor
+
+        onClicked: {
+            checked = !checked;
+            toolbarButton.activated();
+        }
+
+        LateNightToolbarButtonBackground {
+            active: toolbarButton.checked
+        }
+        Text {
+            anchors.fill: parent
+            color: toolbarButton.checked ? LateNightTheme.toolbarButtonActiveTextColor : LateNightTheme.toolbarButtonInactiveTextColor
+            elide: Text.ElideRight
+            font.family: "Open Sans"
+            font.pixelSize: 11
+            font.styleName: "Bold"
+            font.weight: Font.Bold
+            horizontalAlignment: Text.AlignHCenter
+            renderType: Text.NativeRendering
+            text: toolbarButton.text
+            verticalAlignment: Text.AlignVCenter
+        }
+    }
+    component LateNightToolbarButtonBackground: Item {
+        property bool active: false
+        property color fillColor: active ? LateNightTheme.toolbarButtonActiveBackgroundColor : LateNightTheme.toolbarButtonInactiveBackgroundColor
+
+        anchors.fill: parent
+
+        Rectangle {
+            anchors.fill: parent
+            anchors.margins: 2
+            color: parent.fillColor
+        }
+        BorderImage {
+            anchors.fill: parent
+            border.bottom: 2
+            border.left: 2
+            border.right: 2
+            border.top: 2
+            horizontalTileMode: BorderImage.Stretch
+            source: parent.active ? LateNightTheme.legacyAsset("buttons", "btn_embedded_library_active.svg") : LateNightTheme.legacyAsset("buttons", "btn_embedded_library.svg")
+            verticalTileMode: BorderImage.Stretch
+        }
+    }
+    component LateNightToolbarDropButton: MouseArea {
+        id: dropButton
+
+        required property var popup
+
+        Layout.alignment: Qt.AlignVCenter
+        Layout.preferredHeight: 20
+        Layout.preferredWidth: 18
+        cursorShape: Qt.PointingHandCursor
+
+        LateNightToolbarButtonBackground {
+            active: dropButton.popup.visible
+        }
+        Image {
+            anchors.centerIn: parent
+            fillMode: Image.PreserveAspectFit
+            height: 16
+            source: LateNightTheme.assetToolbarDropdownIcon
+            width: 12
+        }
+    }
+    component LatencyIndicator: Item {
+        id: latencyIndicator
+
+        required property bool overload
+        required property real overloadOpacity
+        required property real usage
+
+        Layout.alignment: Qt.AlignVCenter
+        Layout.preferredHeight: 18
+        Layout.preferredWidth: 61
+
+        Column {
+            anchors.centerIn: parent
+            spacing: 1
+
+            Rectangle {
+                border.color: latencyIndicator.overload ? "#ffff00" : "#040404"
+                border.width: 1
+                color: "#040404"
+                height: 7
+                opacity: latencyIndicator.overload ? latencyIndicator.overloadOpacity : 1.0
+                width: 61
+
+                Image {
+                    anchors.centerIn: parent
+                    fillMode: Image.Stretch
+                    height: 5
+                    source: LateNightTheme.legacyAsset("style", "latency_bg.png")
+                    width: 59
+                }
+                Item {
+                    anchors.left: parent.left
+                    anchors.leftMargin: 1
+                    anchors.verticalCenter: parent.verticalCenter
+                    clip: true
+                    height: 5
+                    width: Math.max(0, Math.min(1, latencyIndicator.usage) * 59)
+
+                    Image {
+                        fillMode: Image.Stretch
+                        height: 5
+                        source: LateNightTheme.legacyAsset("style", "latency_over.png")
+                        width: 59
+                    }
+                }
+            }
+            Text {
+                color: "#444444"
+                font.family: "Open Sans"
+                font.pixelSize: 8
+                height: 10
+                horizontalAlignment: Text.AlignHCenter
+                text: "Buffer %"
+                verticalAlignment: Text.AlignVCenter
+                width: 61
+            }
+        }
+    }
+    component RecordingIndicator: MouseArea {
+        id: recordingIndicator
+
+        readonly property bool active: status > 0
+        required property string durationText
+        required property real pulseOpacity
+        required property real status
+
+        Layout.alignment: Qt.AlignVCenter
+        Layout.preferredHeight: 20
+        Layout.preferredWidth: 72
+        cursorShape: Qt.PointingHandCursor
+
+        LateNightToolbarButtonBackground {
+            active: recordingIndicator.active
+            fillColor: root.recordingBackgroundColor(recordingIndicator.status)
+        }
+        RowLayout {
+            anchors.fill: parent
+            spacing: 0
+
+            Image {
+                Layout.preferredHeight: 20
+                Layout.preferredWidth: 15
+                fillMode: Image.PreserveAspectFit
+                opacity: recordingIndicator.status === 1.0 ? recordingIndicator.pulseOpacity : 1.0
+                source: recordingIndicator.active ? LateNightTheme.legacyAsset("buttons", "btn__rec_dot_active.svg") : LateNightTheme.legacyAsset("buttons", "btn__rec_dot.svg")
+            }
+            Text {
+                Layout.fillWidth: true
+                color: recordingIndicator.active ? LateNightTheme.toolbarButtonActiveTextColor : LateNightTheme.toolbarButtonInactiveTextColor
+                elide: Text.ElideRight
+                font.family: "Open Sans"
+                font.pixelSize: 16
+                horizontalAlignment: Text.AlignHCenter
+                text: recordingIndicator.status === 2.0 || recordingIndicator.status === 3.0 ? recordingIndicator.durationText : "REC"
+                verticalAlignment: Text.AlignVCenter
+            }
+        }
+    }
+    component ToolbarMenuChoice: Item {
+        property bool checked: false
+        property string text: ""
+
+        signal clicked
+
+        Layout.fillWidth: true
+        implicitHeight: 18
+        implicitWidth: menuChoiceText.implicitWidth + 22
+        opacity: enabled ? 1.0 : 0.45
+
+        MouseArea {
+            anchors.fill: parent
+
+            onClicked: {
+                if (parent.enabled) {
+                    parent.clicked();
+                }
+            }
+        }
+        Image {
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            fillMode: Image.PreserveAspectFit
+            height: 18
+            source: parent.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+            width: 18
+        }
+        Text {
+            id: menuChoiceText
+
+            anchors.left: parent.left
+            anchors.leftMargin: 22
+            anchors.verticalCenter: parent.verticalCenter
+            color: "#d2d2d2"
+            elide: Text.ElideRight
+            font.family: "Open Sans"
+            font.pixelSize: 13
+            text: parent.text
+            width: parent.width - anchors.leftMargin
+        }
+    }
+    component ToolbarMenuInlineChoice: Item {
+        id: inlineChoice
+        property bool checked: false
+        property string text: ""
+
+        signal clicked
+
+        Layout.preferredHeight: 18
+        Layout.preferredWidth: 28
+        opacity: enabled ? 1.0 : 0.45
+
+        Rectangle {
+            anchors.fill: parent
+            color: inlineMouseArea.containsMouse ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent"
+            radius: 1
+        }
+
+        MouseArea {
+            id: inlineMouseArea
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+
+            onClicked: {
+                if (inlineChoice.enabled) {
+                    inlineChoice.clicked();
+                }
+            }
+        }
+        Text {
+            anchors.centerIn: parent
+            color: inlineMouseArea.containsMouse ? "#ffffff" : (inlineChoice.checked ? LateNightTheme.primaryDeckTextColor : "#777777")
+            font.family: "Open Sans"
+            font.pixelSize: 17
+            font.underline: inlineChoice.checked && !inlineMouseArea.containsMouse
+            text: inlineChoice.text
+        }
+    }
+    component ToolbarMenuSection: ColumnLayout {
+        required property string title
+
+        Layout.fillWidth: true
+        Layout.bottomMargin: 7
+        Layout.leftMargin: 5
+        Layout.rightMargin: 5
+        Layout.topMargin: 2
+        spacing: 0
+
+        Text {
+            Layout.fillWidth: true
+            color: LateNightTheme.primaryDeckTextColor
+            elide: Text.ElideRight
+            font.family: "Open Sans"
+            font.pixelSize: 17
+            text: parent.title
+        }
+    }
+    component ToolbarMenuSectionToggle: ColumnLayout {
+        id: sectionToggle
+        required property string title
+        required property var control
+
+        Layout.fillWidth: true
+        Layout.bottomMargin: 7
+        Layout.leftMargin: 5
+        Layout.rightMargin: 5
+        Layout.topMargin: 2
+        spacing: 0
+
+        Item {
+            id: headerToggle
+            property bool checked: sectionToggle.control ? sectionToggle.control.value > 0 : false
+
+            Layout.fillWidth: true
+            implicitHeight: 22
+            implicitWidth: headerText.implicitWidth + 22
+
+            MouseArea {
+                anchors.fill: parent
+
+                onClicked: {
+                    if (sectionToggle.enabled) {
+                        sectionToggle.control.value = headerToggle.checked ? 0.0 : 1.0;
+                    }
+                }
+            }
+            Image {
+                anchors.left: parent.left
+                anchors.verticalCenter: parent.verticalCenter
+                fillMode: Image.PreserveAspectFit
+                height: 18
+                source: headerToggle.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+                width: 18
+            }
+            Text {
+                id: headerText
+
+                anchors.left: parent.left
+                anchors.leftMargin: 22
+                anchors.verticalCenter: parent.verticalCenter
+                color: LateNightTheme.primaryDeckTextColor
+                elide: Text.ElideRight
+                font.family: "Open Sans"
+                font.pixelSize: 17
+                text: sectionToggle.title
+                width: parent.width - anchors.leftMargin
+            }
+        }
+    }
+    component ToolbarMenuToggle: Item {
+        property bool checked: control ? control.value > 0 : false
+        required property var control
+        property int indent: 0
+        property string text: ""
+
+        Layout.fillWidth: true
+        implicitHeight: 18
+        implicitWidth: menuText.implicitWidth + indent + 22
+        opacity: enabled ? 1.0 : 0.45
+
+        MouseArea {
+            anchors.fill: parent
+
+            onClicked: {
+                if (parent.enabled) {
+                    parent.control.value = parent.checked ? 0.0 : 1.0;
+                }
+            }
+        }
+        Image {
+            anchors.left: parent.left
+            anchors.leftMargin: parent.indent
+            anchors.verticalCenter: parent.verticalCenter
+            fillMode: Image.PreserveAspectFit
+            height: 18
+            source: parent.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+            width: 18
+        }
+        Text {
+            id: menuText
+
+            anchors.left: parent.left
+            anchors.leftMargin: parent.indent + 22
+            anchors.verticalCenter: parent.verticalCenter
+            color: "#d2d2d2"
+            elide: Text.ElideRight
+            font.family: "Open Sans"
+            font.pixelSize: 13
+            text: parent.text
+            width: parent.width - anchors.leftMargin
+        }
+    }
+    component ToolbarSettingsPopup: Popup {
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
+        modal: false
+        padding: 3
+        width: 190
+
+        background: Rectangle {
+            border.color: "#585858"
+            border.width: 1
+            color: "#0f0f0f"
+            radius: 2
+        }
+        contentItem: ColumnLayout {
+            spacing: 0
         }
     }
 }

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -20,6 +20,9 @@ Rectangle {
     property alias showMixer: showMixerButton.checked
     property alias showSamplers: showSamplersButton.checked
     property alias showWaveforms: showWaveformsButton.checked
+    property var recentlyClosedPopup: null
+    property var recentlyClosedPopupButton: null
+    property double recentlyClosedPopupTimestamp: 0
 
     function formatTime(date) {
         const hours = date.getHours();
@@ -78,6 +81,16 @@ Rectangle {
         popup.y = root.height + 2;
     }
     function openPopupForButton(popup, button) {
+        const popupWasJustClosedByThisButton = recentlyClosedPopup === popup &&
+                recentlyClosedPopupButton === button &&
+                Date.now() - recentlyClosedPopupTimestamp < 250;
+        if (popupWasJustClosedByThisButton) {
+            recentlyClosedPopup = null;
+            recentlyClosedPopupButton = null;
+            recentlyClosedPopupTimestamp = 0;
+            button.wasPopupOpenOnPress = false;
+            return;
+        }
         if (button.wasPopupOpenOnPress || (popup.visible && popup.anchorButton === button)) {
             popup.close();
             button.wasPopupOpenOnPress = false;
@@ -144,6 +157,9 @@ Rectangle {
             return LateNightTheme.toolbarRecordOnColor;
         }
         return LateNightTheme.toolbarButtonInactiveBackgroundColor;
+    }
+    function menuHoverColor(hovered, enabled) {
+        return hovered && enabled ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent";
     }
 
     color: "#151517"
@@ -887,7 +903,7 @@ Rectangle {
                         id: hideMixerMouseArea
                         anchors.fill: parent
                         hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
+                        cursorShape: Qt.ArrowCursor
                         onClicked: {
                             root.setShowMixer(false);
                         }
@@ -1075,8 +1091,17 @@ Rectangle {
                 implicitHeight: 22
                 implicitWidth: effectUnitsHeaderContent.implicitWidth
 
-                MouseArea {
+                Rectangle {
                     anchors.fill: parent
+                    color: root.menuHoverColor(effectUnitsHeaderMouseArea.containsMouse, effectUnitsHeader.enabled)
+                    radius: 1
+                }
+
+                MouseArea {
+                    id: effectUnitsHeaderMouseArea
+                    anchors.fill: parent
+                    cursorShape: Qt.ArrowCursor
+                    hoverEnabled: true
 
                     onClicked: {
                         showEffectRackControl.value = effectUnitsHeader.checked ? 0.0 : 1.0;
@@ -1097,7 +1122,7 @@ Rectangle {
                     }
 
                     Text {
-                        color: LateNightTheme.primaryDeckTextColor
+                        color: effectUnitsHeaderMouseArea.containsMouse ? "#ffffff" : LateNightTheme.primaryDeckTextColor
                         elide: Text.ElideRight
                         font.family: "Open Sans"
                         font.pixelSize: 17
@@ -1157,8 +1182,17 @@ Rectangle {
                 implicitHeight: 22
                 implicitWidth: samplersHeaderContent.implicitWidth
 
-                MouseArea {
+                Rectangle {
                     anchors.fill: parent
+                    color: root.menuHoverColor(samplersHeaderMouseArea.containsMouse, samplersHeader.enabled)
+                    radius: 1
+                }
+
+                MouseArea {
+                    id: samplersHeaderMouseArea
+                    anchors.fill: parent
+                    cursorShape: Qt.ArrowCursor
+                    hoverEnabled: true
 
                     onClicked: {
                         showSamplersControl.value = samplersHeader.checked ? 0.0 : 1.0;
@@ -1179,7 +1213,7 @@ Rectangle {
                     }
 
                     Text {
-                        color: LateNightTheme.primaryDeckTextColor
+                        color: samplersHeaderMouseArea.containsMouse ? "#ffffff" : LateNightTheme.primaryDeckTextColor
                         elide: Text.ElideRight
                         font.family: "Open Sans"
                         font.pixelSize: 17
@@ -1271,7 +1305,7 @@ Rectangle {
                         id: loadBankMouseArea
                         anchors.fill: parent
                         hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
+                        cursorShape: Qt.ArrowCursor
                         onClicked: {
                             loadSamplerBankControl.value = 1.0;
                         }
@@ -1309,7 +1343,7 @@ Rectangle {
                         id: saveBankMouseArea
                         anchors.fill: parent
                         hoverEnabled: true
-                        cursorShape: Qt.PointingHandCursor
+                        cursorShape: Qt.ArrowCursor
                         onClicked: {
                             saveSamplerBankControl.value = 1.0;
                         }
@@ -1606,6 +1640,8 @@ Rectangle {
         }
     }
     component ToolbarMenuChoice: Item {
+        id: menuChoice
+
         property bool checked: false
         property string text: ""
 
@@ -1616,8 +1652,17 @@ Rectangle {
         implicitWidth: menuChoiceText.implicitWidth + 22
         opacity: enabled ? 1.0 : 0.45
 
-        MouseArea {
+        Rectangle {
             anchors.fill: parent
+            color: root.menuHoverColor(menuChoiceMouseArea.containsMouse, menuChoice.enabled)
+            radius: 1
+        }
+
+        MouseArea {
+            id: menuChoiceMouseArea
+            anchors.fill: parent
+            cursorShape: Qt.ArrowCursor
+            hoverEnabled: true
 
             onClicked: {
                 if (parent.enabled) {
@@ -1639,7 +1684,7 @@ Rectangle {
             anchors.left: parent.left
             anchors.leftMargin: 22
             anchors.verticalCenter: parent.verticalCenter
-            color: "#d2d2d2"
+            color: menuChoiceMouseArea.containsMouse ? "#ffffff" : "#d2d2d2"
             elide: Text.ElideRight
             font.family: "Open Sans"
             font.pixelSize: 13
@@ -1661,7 +1706,7 @@ Rectangle {
 
         Rectangle {
             anchors.fill: parent
-            color: inlineMouseArea.containsMouse ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent"
+            color: root.menuHoverColor(inlineMouseArea.containsMouse, inlineChoice.enabled)
             radius: 1
         }
 
@@ -1669,7 +1714,7 @@ Rectangle {
             id: inlineMouseArea
             anchors.fill: parent
             hoverEnabled: true
-            cursorShape: Qt.PointingHandCursor
+            cursorShape: Qt.ArrowCursor
 
             onClicked: {
                 if (inlineChoice.enabled) {
@@ -1727,8 +1772,17 @@ Rectangle {
             implicitHeight: 22
             implicitWidth: headerText.implicitWidth + 22
 
-            MouseArea {
+            Rectangle {
                 anchors.fill: parent
+                color: root.menuHoverColor(headerToggleMouseArea.containsMouse, headerToggle.enabled)
+                radius: 1
+            }
+
+            MouseArea {
+                id: headerToggleMouseArea
+                anchors.fill: parent
+                cursorShape: Qt.ArrowCursor
+                hoverEnabled: true
 
                 onClicked: {
                     if (sectionToggle.enabled) {
@@ -1750,7 +1804,7 @@ Rectangle {
                 anchors.left: parent.left
                 anchors.leftMargin: 22
                 anchors.verticalCenter: parent.verticalCenter
-                color: LateNightTheme.primaryDeckTextColor
+                color: headerToggleMouseArea.containsMouse ? "#ffffff" : LateNightTheme.primaryDeckTextColor
                 elide: Text.ElideRight
                 font.family: "Open Sans"
                 font.pixelSize: 17
@@ -1772,8 +1826,17 @@ Rectangle {
         implicitWidth: menuText.implicitWidth + indent + 22
         opacity: enabled ? 1.0 : 0.45
 
-        MouseArea {
+        Rectangle {
             anchors.fill: parent
+            color: root.menuHoverColor(menuToggleMouseArea.containsMouse, menuToggle.enabled)
+            radius: 1
+        }
+
+        MouseArea {
+            id: menuToggleMouseArea
+            anchors.fill: parent
+            cursorShape: Qt.ArrowCursor
+            hoverEnabled: true
 
             onClicked: {
                 if (menuToggle.enabled && menuToggle.control && menuToggle.control.initialized) {
@@ -1796,7 +1859,7 @@ Rectangle {
             anchors.left: parent.left
             anchors.leftMargin: parent.indent + 22
             anchors.verticalCenter: parent.verticalCenter
-            color: "#d2d2d2"
+            color: menuToggleMouseArea.containsMouse ? "#ffffff" : "#d2d2d2"
             elide: Text.ElideRight
             font.family: "Open Sans"
             font.pixelSize: 13
@@ -1816,6 +1879,11 @@ Rectangle {
         width: Math.min(root.width, Math.max(minimumWidth, contentColumn.implicitWidth + leftPadding + rightPadding))
 
         onClosed: {
+            if (anchorButton) {
+                root.recentlyClosedPopup = toolbarSettingsPopup;
+                root.recentlyClosedPopupButton = anchorButton;
+                root.recentlyClosedPopupTimestamp = Date.now();
+            }
             anchorButton = null;
         }
         onWidthChanged: {

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -65,7 +65,6 @@ Rectangle {
         deckSettingsPopup.close();
         effectSettingsPopup.close();
         librarySettingsPopup.close();
-        micAuxSettingsPopup.close();
         mixerSettingsPopup.close();
         samplerSettingsPopup.close();
         waveformSettingsPopup.close();
@@ -75,7 +74,8 @@ Rectangle {
         pinnedAppMenuSubmenu = "";
     }
     function positionPopupForButton(popup, button) {
-        const mapped = button.mapToItem(root, 0, 0);
+        const anchorButton = button.popupAnchor ? button.popupAnchor : button;
+        const mapped = anchorButton.mapToItem(root, 0, 0);
         popup.x = Math.max(0, Math.min(root.width - popup.width, mapped.x));
         popup.y = root.height + 2;
     }
@@ -132,9 +132,6 @@ Rectangle {
     }
     function setDeckSize(size) {
         deckSizeControl.value = size;
-        showFullDeckControl.value = size === Toolbar.Full ? 1.0 : 0.0;
-        showCompactDeckControl.value = size === Toolbar.Compact ? 1.0 : 0.0;
-        showMiniDeckControl.value = size === Toolbar.Mini ? 1.0 : 0.0;
     }
     function broadcastBackgroundColor(status) {
         if (status === 1.0) {
@@ -271,24 +268,6 @@ Rectangle {
 
         group: "[LateNight]"
         key: "deck_size_without_mixer"
-    }
-    Mixxx.ControlProxy {
-        id: showFullDeckControl
-
-        group: "[LateNight]"
-        key: "show_full_deck"
-    }
-    Mixxx.ControlProxy {
-        id: showCompactDeckControl
-
-        group: "[LateNight]"
-        key: "show_compact_deck"
-    }
-    Mixxx.ControlProxy {
-        id: showMiniDeckControl
-
-        group: "[LateNight]"
-        key: "show_mini_deck"
     }
     Mixxx.ControlProxy {
         id: showHotcuesControl
@@ -622,6 +601,7 @@ Rectangle {
             }
             LateNightToolbarDropButton {
                 popup: librarySettingsPopup
+                popupAnchor: maximizeLibraryButton
 
                 onClicked: {
                     root.openPopupForButton(popup, this);
@@ -649,6 +629,7 @@ Rectangle {
                 }
                 LateNightToolbarDropButton {
                     popup: waveformSettingsPopup
+                    popupAnchor: showWaveformsButton
 
                     onClicked: {
                         root.openPopupForButton(popup, this);
@@ -672,6 +653,7 @@ Rectangle {
                 }
                 LateNightToolbarDropButton {
                     popup: deckSettingsPopup
+                    popupAnchor: show4DecksButton
 
                     onClicked: {
                         root.openPopupForButton(popup, this);
@@ -694,6 +676,7 @@ Rectangle {
                 }
                 LateNightToolbarDropButton {
                     popup: mixerSettingsPopup
+                    popupAnchor: showMixerButton
 
                     onClicked: {
                         root.openPopupForButton(popup, this);
@@ -716,6 +699,7 @@ Rectangle {
                 }
                 LateNightToolbarDropButton {
                     popup: effectSettingsPopup
+                    popupAnchor: showEffectsButton
 
                     onClicked: {
                         root.openPopupForButton(popup, this);
@@ -738,6 +722,7 @@ Rectangle {
                 }
                 LateNightToolbarDropButton {
                     popup: samplerSettingsPopup
+                    popupAnchor: showSamplersButton
 
                     onClicked: {
                         root.openPopupForButton(popup, this);
@@ -758,13 +743,6 @@ Rectangle {
                         showMicAuxControl.value = checked ? 1.0 : 0.0;
                     }
                 }
-                LateNightToolbarDropButton {
-                    popup: micAuxSettingsPopup
-
-                    onClicked: {
-                        root.openPopupForButton(popup, this);
-                    }
-                }
             }
         }
         RowLayout {
@@ -779,7 +757,7 @@ Rectangle {
                 LateNightToolbarButton {
                     id: maxLibraryDecksButton
 
-                    buttonWidth: 80
+                    buttonWidth: 52
                     text: "DECKS"
 
                     onActivated: {
@@ -788,6 +766,7 @@ Rectangle {
                 }
                 LateNightToolbarDropButton {
                     popup: deckSettingsPopup
+                    popupAnchor: maxLibraryDecksButton
 
                     onClicked: {
                         root.openPopupForButton(popup, this);
@@ -808,13 +787,6 @@ Rectangle {
 
                     onActivated: {
                         root.setShow4Decks(checked);
-                    }
-                }
-                LateNightToolbarDropButton {
-                    popup: deckSettingsPopup
-
-                    onClicked: {
-                        root.openPopupForButton(popup, this);
                     }
                 }
             }
@@ -1265,7 +1237,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: deckSettingsPopup
 
-        minimumWidth: 205
+        minimumWidth: 175
 
         ColumnLayout {
             Layout.fillWidth: true
@@ -1280,18 +1252,6 @@ Rectangle {
                 Layout.minimumWidth: implicitWidth
                 Layout.preferredHeight: 22
                 spacing: 5
-
-                Text {
-                    color: LateNightTheme.primaryDeckTextColor
-                    elide: Text.ElideRight
-                    font.family: "Open Sans"
-                    font.pixelSize: 17
-                    text: "Decks"
-                }
-
-                Item {
-                    Layout.preferredWidth: 10
-                }
 
                 ToolbarMenuInlineChoice {
                     checked: !show4DecksButton.checked
@@ -1309,6 +1269,12 @@ Rectangle {
                         root.setShow4Decks(true);
                     }
                 }
+                Text {
+                    color: LateNightTheme.toolbarMenuTextColor
+                    font.family: "Open Sans"
+                    font.pixelSize: 13
+                    text: "decks"
+                }
             }
             RowLayout {
                 Layout.fillWidth: true
@@ -1317,7 +1283,7 @@ Rectangle {
                 spacing: 5
 
                 Text {
-                    color: LateNightTheme.textColor
+                    color: LateNightTheme.toolbarMenuTextColor
                     font.family: "Open Sans"
                     font.pixelSize: 12
                     text: "Deck Size:"
@@ -1340,7 +1306,7 @@ Rectangle {
                         anchors.left: parent.left
                         anchors.leftMargin: 4
                         anchors.verticalCenter: parent.verticalCenter
-                        color: hideMixerMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.textColor
+                        color: hideMixerMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
                         font.family: "Open Sans"
                         font.pixelSize: 12
                         text: "hide mixer to select"
@@ -1363,7 +1329,7 @@ Rectangle {
                     visible: !showMixerButton.checked
 
                     ToolbarMenuInlineChoice {
-                        checked: deckSizeControl.value === Toolbar.Full || showFullDeckControl.value > 0
+                        checked: deckSizeControl.value === Toolbar.Full
                         minimumWidth: 40
                         text: "Full"
 
@@ -1372,7 +1338,7 @@ Rectangle {
                         }
                     }
                     ToolbarMenuInlineChoice {
-                        checked: deckSizeControl.value === Toolbar.Compact || showCompactDeckControl.value > 0
+                        checked: deckSizeControl.value === Toolbar.Compact
                         minimumWidth: 66
                         text: "Compact"
 
@@ -1381,7 +1347,7 @@ Rectangle {
                         }
                     }
                     ToolbarMenuInlineChoice {
-                        checked: deckSizeControl.value === Toolbar.Mini || showMiniDeckControl.value > 0
+                        checked: deckSizeControl.value === Toolbar.Mini
                         minimumWidth: 40
                         text: "Mini"
 
@@ -1519,7 +1485,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: effectSettingsPopup
 
-        minimumWidth: 230
+        minimumWidth: 185
 
         ColumnLayout {
             Layout.fillWidth: true
@@ -1535,7 +1501,7 @@ Rectangle {
 
                 Layout.fillWidth: true
                 Layout.minimumWidth: implicitWidth
-                implicitHeight: 22
+                implicitHeight: 18
                 implicitWidth: effectUnitsHeaderContent.implicitWidth
 
                 Rectangle {
@@ -1562,21 +1528,12 @@ Rectangle {
                     spacing: 5
 
                     Image {
-                        Layout.preferredHeight: 18
-                        Layout.preferredWidth: 18
+                        Layout.leftMargin: 2
+                        Layout.preferredHeight: 14
+                        Layout.preferredWidth: 14
                         fillMode: Image.PreserveAspectFit
-                        source: effectUnitsHeader.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
+                        source: effectUnitsHeader.checked ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
                     }
-
-                    Text {
-                        color: effectUnitsHeaderMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.primaryDeckTextColor
-                        elide: Text.ElideRight
-                        font.family: "Open Sans"
-                        font.pixelSize: 17
-                        text: "Effect Units"
-                    }
-
-                    Item { Layout.fillWidth: true } // spacer
 
                     ToolbarMenuInlineChoice {
                         checked: show4EffectUnitsControl.value === 0.0
@@ -1587,7 +1544,6 @@ Rectangle {
                             show4EffectUnitsControl.value = 0.0;
                         }
                     }
-
                     ToolbarMenuInlineChoice {
                         checked: show4EffectUnitsControl.value === 1.0
                         enabled: showEffectRackControl.value > 0
@@ -1597,12 +1553,17 @@ Rectangle {
                             show4EffectUnitsControl.value = 1.0;
                         }
                     }
+                    Text {
+                        color: effectUnitsHeaderMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
+                        font.family: "Open Sans"
+                        font.pixelSize: 13
+                        text: "units"
+                    }
                 }
             }
 
             ToolbarMenuToggle {
                 control: showSuperKnobsControl
-                enabled: showEffectRackControl.value > 0
                 text: "Super Knobs"
             }
         }
@@ -1610,7 +1571,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: samplerSettingsPopup
 
-        minimumWidth: 250
+        minimumWidth: 245
 
         ColumnLayout {
             Layout.fillWidth: true
@@ -1626,7 +1587,7 @@ Rectangle {
 
                 Layout.fillWidth: true
                 Layout.minimumWidth: implicitWidth
-                implicitHeight: 22
+                implicitHeight: 18
                 implicitWidth: samplersHeaderContent.implicitWidth
 
                 Rectangle {
@@ -1653,21 +1614,12 @@ Rectangle {
                     spacing: 5
 
                     Image {
-                        Layout.preferredHeight: 18
-                        Layout.preferredWidth: 18
+                        Layout.leftMargin: 2
+                        Layout.preferredHeight: 14
+                        Layout.preferredWidth: 14
                         fillMode: Image.PreserveAspectFit
-                        source: samplersHeader.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
+                        source: samplersHeader.checked ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
                     }
-
-                    Text {
-                        color: samplersHeaderMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.primaryDeckTextColor
-                        elide: Text.ElideRight
-                        font.family: "Open Sans"
-                        font.pixelSize: 17
-                        text: "Samplers"
-                    }
-
-                    Item { Layout.fillWidth: true } // spacer
 
                     ToolbarMenuInlineChoice {
                         checked: samplerRowsControl.value === 0.0
@@ -1692,8 +1644,8 @@ Rectangle {
                     ToolbarMenuInlineChoice {
                         checked: samplerRowsControl.value === 2.0
                         enabled: showSamplersControl.value > 0
-                        text: "16"
                         minimumWidth: 32
+                        text: "16"
 
                         onClicked: {
                             samplerRowsControl.value = 2.0;
@@ -1703,29 +1655,34 @@ Rectangle {
                     ToolbarMenuInlineChoice {
                         checked: samplerRowsControl.value === 4.0
                         enabled: showSamplersControl.value > 0
-                        text: "64"
                         minimumWidth: 32
+                        text: "64"
 
                         onClicked: {
                             samplerRowsControl.value = 4.0;
                         }
+                    }
+                    Text {
+                        color: samplersHeaderMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
+                        font.family: "Open Sans"
+                        font.pixelSize: 13
+                        text: "sample decks"
                     }
                 }
             }
 
             ToolbarMenuToggle {
                 control: showSamplerFxControl
-                enabled: showSamplersControl.value > 0
                 text: "Fx controls"
             }
 
             RowLayout {
                 Layout.fillWidth: true
-                Layout.leftMargin: 22
+                Layout.leftMargin: 20
                 Layout.minimumWidth: implicitWidth
                 Layout.preferredHeight: 18
                 spacing: 3
-                enabled: showSamplersControl.value > 0
+                enabled: showSamplerFxControl.value > 0
                 opacity: enabled ? 1.0 : 0.45
 
                 Item {
@@ -1742,7 +1699,7 @@ Rectangle {
                     Text {
                         id: loadBankText
                         anchors.centerIn: parent
-                        color: loadBankMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.textColor
+                        color: loadBankMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
                         font.family: "Open Sans"
                         font.pixelSize: 12
                         text: "Load"
@@ -1760,7 +1717,7 @@ Rectangle {
                 }
 
                 Text {
-                    color: LateNightTheme.textColor
+                    color: LateNightTheme.toolbarMenuTextColor
                     font.family: "Open Sans"
                     font.pixelSize: 12
                     text: "/"
@@ -1780,7 +1737,7 @@ Rectangle {
                     Text {
                         id: saveBankText
                         anchors.centerIn: parent
-                        color: saveBankMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.textColor
+                        color: saveBankMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
                         font.family: "Open Sans"
                         font.pixelSize: 12
                         text: "Save"
@@ -1799,7 +1756,7 @@ Rectangle {
 
                 Text {
                     id: samplerBankText
-                    color: LateNightTheme.textColor
+                    color: LateNightTheme.toolbarMenuTextColor
                     font.family: "Open Sans"
                     font.pixelSize: 12
                     text: "Sampler Bank"
@@ -1826,21 +1783,6 @@ Rectangle {
             }
         }
     }
-    ToolbarSettingsPopup {
-        id: micAuxSettingsPopup
-
-        minimumWidth: 140
-
-        ToolbarMenuSection {
-            title: "Mic/Aux"
-
-            ToolbarMenuToggle {
-                control: showMicAuxControl
-                text: "Microphones"
-            }
-        }
-    }
-
     component AutoDjIndicator: Image {
         required property bool active
 
@@ -1992,6 +1934,7 @@ Rectangle {
         id: dropButton
 
         required property var popup
+        property var popupAnchor: null
         property bool wasPopupOpenOnPress: false
 
         Layout.alignment: Qt.AlignVCenter
@@ -2212,7 +2155,7 @@ Rectangle {
             anchors.verticalCenter: parent.verticalCenter
             fillMode: Image.PreserveAspectFit
             height: 14
-            source: appMenuAction.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
+            source: appMenuAction.checked ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
             visible: appMenuAction.checkable
             width: 14
         }
@@ -2288,17 +2231,18 @@ Rectangle {
         }
         Image {
             anchors.left: parent.left
+            anchors.leftMargin: 2
             anchors.verticalCenter: parent.verticalCenter
             fillMode: Image.PreserveAspectFit
-            height: 18
-            source: parent.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
-            width: 18
+            height: 14
+            source: parent.checked ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
+            width: 14
         }
         Text {
             id: menuChoiceText
 
             anchors.left: parent.left
-            anchors.leftMargin: 22
+            anchors.leftMargin: 20
             anchors.verticalCenter: parent.verticalCenter
             color: menuChoiceMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
             elide: Text.ElideRight
@@ -2342,9 +2286,9 @@ Rectangle {
             id: inlineChoiceText
 
             anchors.centerIn: parent
-            color: inlineMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : (inlineChoice.checked ? LateNightTheme.primaryDeckTextColor : LateNightTheme.toolbarMenuDisabledTextColor)
+            color: inlineMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : (inlineChoice.checked ? LateNightTheme.toolbarMenuTextColor : LateNightTheme.toolbarMenuDisabledTextColor)
             font.family: "Open Sans"
-            font.pixelSize: 17
+            font.pixelSize: 13
             font.underline: inlineChoice.checked && !inlineMouseArea.containsMouse
             text: inlineChoice.text
         }
@@ -2361,10 +2305,10 @@ Rectangle {
 
         Text {
             Layout.fillWidth: true
-            color: LateNightTheme.primaryDeckTextColor
+            color: LateNightTheme.toolbarMenuTextColor
             elide: Text.ElideRight
             font.family: "Open Sans"
-            font.pixelSize: 17
+            font.pixelSize: 13
             text: parent.title
         }
     }
@@ -2385,8 +2329,8 @@ Rectangle {
             property bool checked: sectionToggle.control ? sectionToggle.control.value > 0 : false
 
             Layout.fillWidth: true
-            implicitHeight: 22
-            implicitWidth: headerText.implicitWidth + 22
+            implicitHeight: 18
+            implicitWidth: headerText.implicitWidth + 20
 
             Rectangle {
                 anchors.fill: parent
@@ -2408,22 +2352,23 @@ Rectangle {
             }
             Image {
                 anchors.left: parent.left
+                anchors.leftMargin: 2
                 anchors.verticalCenter: parent.verticalCenter
                 fillMode: Image.PreserveAspectFit
-                height: 18
-                source: headerToggle.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
-                width: 18
+                height: 14
+                source: headerToggle.checked ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
+                width: 14
             }
             Text {
                 id: headerText
 
                 anchors.left: parent.left
-                anchors.leftMargin: 22
+                anchors.leftMargin: 20
                 anchors.verticalCenter: parent.verticalCenter
-                color: headerToggleMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.primaryDeckTextColor
+                color: headerToggleMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
                 elide: Text.ElideRight
                 font.family: "Open Sans"
-                font.pixelSize: 17
+                font.pixelSize: 13
                 text: sectionToggle.title
                 width: parent.width - anchors.leftMargin
             }
@@ -2439,7 +2384,7 @@ Rectangle {
 
         Layout.fillWidth: true
         implicitHeight: 18
-        implicitWidth: menuText.implicitWidth + indent + 22
+        implicitWidth: menuText.implicitWidth + indent + 20
         opacity: enabled ? 1.0 : 0.45
 
         Rectangle {
@@ -2462,18 +2407,18 @@ Rectangle {
         }
         Image {
             anchors.left: parent.left
-            anchors.leftMargin: parent.indent
+            anchors.leftMargin: parent.indent + 2
             anchors.verticalCenter: parent.verticalCenter
             fillMode: Image.PreserveAspectFit
-            height: 18
-            source: parent.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
-            width: 18
+            height: 14
+            source: parent.checked ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
+            width: 14
         }
         Text {
             id: menuText
 
             anchors.left: parent.left
-            anchors.leftMargin: parent.indent + 22
+            anchors.leftMargin: parent.indent + 20
             anchors.verticalCenter: parent.verticalCenter
             color: menuToggleMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
             elide: Text.ElideRight

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -159,15 +159,15 @@ Rectangle {
         return LateNightTheme.toolbarButtonInactiveBackgroundColor;
     }
     function menuHoverColor(hovered, enabled) {
-        return hovered && enabled ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent";
+        return hovered && enabled ? LateNightTheme.toolbarMenuHoverColor : "transparent";
     }
 
-    color: "#151517"
+    color: LateNightTheme.toolbarRootBackgroundColor
     height: 26
 
     Rectangle {
         anchors.bottom: parent.bottom
-        color: "#020202"
+        color: LateNightTheme.toolbarBottomBorderColor
         height: 1
         width: parent.width
     }
@@ -812,7 +812,7 @@ Rectangle {
             Layout.preferredHeight: 24
             Layout.preferredWidth: 74
             fillMode: Image.PreserveAspectFit
-            source: LateNightTheme.legacyAsset("style", "mixxx_logo_small.svg")
+            source: LateNightTheme.lateNightAsset("style", "mixxx_logo_small.svg")
         }
     }
     ToolbarSettingsPopup {
@@ -884,7 +884,7 @@ Rectangle {
 
                     Rectangle {
                         anchors.fill: parent
-                        color: hideMixerMouseArea.containsMouse ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent"
+                        color: hideMixerMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverColor : "transparent"
                         radius: 1
                     }
 
@@ -893,7 +893,7 @@ Rectangle {
                         anchors.left: parent.left
                         anchors.leftMargin: 4
                         anchors.verticalCenter: parent.verticalCenter
-                        color: hideMixerMouseArea.containsMouse ? "#ffffff" : LateNightTheme.textColor
+                        color: hideMixerMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.textColor
                         font.family: "Open Sans"
                         font.pixelSize: 12
                         text: "hide mixer to select"
@@ -1118,11 +1118,11 @@ Rectangle {
                         Layout.preferredHeight: 18
                         Layout.preferredWidth: 18
                         fillMode: Image.PreserveAspectFit
-                        source: effectUnitsHeader.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+                        source: effectUnitsHeader.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
                     }
 
                     Text {
-                        color: effectUnitsHeaderMouseArea.containsMouse ? "#ffffff" : LateNightTheme.primaryDeckTextColor
+                        color: effectUnitsHeaderMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.primaryDeckTextColor
                         elide: Text.ElideRight
                         font.family: "Open Sans"
                         font.pixelSize: 17
@@ -1209,11 +1209,11 @@ Rectangle {
                         Layout.preferredHeight: 18
                         Layout.preferredWidth: 18
                         fillMode: Image.PreserveAspectFit
-                        source: samplersHeader.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+                        source: samplersHeader.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
                     }
 
                     Text {
-                        color: samplersHeaderMouseArea.containsMouse ? "#ffffff" : LateNightTheme.primaryDeckTextColor
+                        color: samplersHeaderMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.primaryDeckTextColor
                         elide: Text.ElideRight
                         font.family: "Open Sans"
                         font.pixelSize: 17
@@ -1288,14 +1288,14 @@ Rectangle {
 
                     Rectangle {
                         anchors.fill: parent
-                        color: loadBankMouseArea.containsMouse ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent"
+                        color: loadBankMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverColor : "transparent"
                         radius: 1
                     }
 
                     Text {
                         id: loadBankText
                         anchors.centerIn: parent
-                        color: loadBankMouseArea.containsMouse ? "#ffffff" : LateNightTheme.textColor
+                        color: loadBankMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.textColor
                         font.family: "Open Sans"
                         font.pixelSize: 12
                         text: "Load"
@@ -1326,14 +1326,14 @@ Rectangle {
 
                     Rectangle {
                         anchors.fill: parent
-                        color: saveBankMouseArea.containsMouse ? (LateNightTheme.isPaleMoon ? "#2c454f" : "#5e4507") : "transparent"
+                        color: saveBankMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverColor : "transparent"
                         radius: 1
                     }
 
                     Text {
                         id: saveBankText
                         anchors.centerIn: parent
-                        color: saveBankMouseArea.containsMouse ? "#ffffff" : LateNightTheme.textColor
+                        color: saveBankMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.textColor
                         font.family: "Open Sans"
                         font.pixelSize: 12
                         text: "Save"
@@ -1401,16 +1401,16 @@ Rectangle {
         Layout.preferredHeight: 22
         Layout.preferredWidth: active ? 30 : 0
         fillMode: Image.PreserveAspectFit
-        source: LateNightTheme.legacyAsset("style", "autodj_status.svg")
+        source: LateNightTheme.lateNightAsset("style", "autodj_status.svg")
         visible: active
     }
     component BatteryIndicator: Shared.BatteryIcon {
         Layout.alignment: Qt.AlignVCenter
         Layout.preferredHeight: 24
         Layout.preferredWidth: 24
-        chargedSource: LateNightTheme.legacyAsset("style/batt", "ic_battery_charged.svg")
-        chargingSources: [LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_0.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_1.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_2.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_3.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_4.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_5.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_6.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_charging_7.svg")]
-        dischargingSources: [LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_0.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_1.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_2.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_3.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_4.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_5.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_6.svg"), LateNightTheme.legacyAsset("style/batt", "ic_battery_discharging_7.svg")]
+        chargedSource: LateNightTheme.lateNightAsset("style/batt", "ic_battery_charged.svg")
+        chargingSources: [LateNightTheme.lateNightAsset("style/batt", "ic_battery_charging_0.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_charging_1.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_charging_2.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_charging_3.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_charging_4.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_charging_5.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_charging_6.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_charging_7.svg")]
+        dischargingSources: [LateNightTheme.lateNightAsset("style/batt", "ic_battery_discharging_0.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_discharging_1.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_discharging_2.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_discharging_3.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_discharging_4.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_discharging_5.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_discharging_6.svg"), LateNightTheme.lateNightAsset("style/batt", "ic_battery_discharging_7.svg")]
         fillMode: Image.PreserveAspectFit
     }
     component BroadcastIndicator: MouseArea {
@@ -1430,7 +1430,7 @@ Rectangle {
         Image {
             anchors.fill: parent
             fillMode: Image.Stretch
-            source: broadcastIndicator.status > 0 ? LateNightTheme.legacyAsset("buttons", "btn__broadcast_on.svg") : LateNightTheme.legacyAsset("buttons", "btn__broadcast_off.svg")
+            source: broadcastIndicator.status > 0 ? LateNightTheme.lateNightAsset("buttons", "btn__broadcast_on.svg") : LateNightTheme.lateNightAsset("buttons", "btn__broadcast_off.svg")
         }
         Text {
             anchors.fill: parent
@@ -1511,7 +1511,7 @@ Rectangle {
             border.right: 2
             border.top: 2
             horizontalTileMode: BorderImage.Stretch
-            source: parent.active ? LateNightTheme.legacyAsset("buttons", "btn_embedded_library_active.svg") : LateNightTheme.legacyAsset("buttons", "btn_embedded_library.svg")
+            source: parent.active ? LateNightTheme.lateNightAsset("buttons", "btn_embedded_library_active.svg") : LateNightTheme.lateNightAsset("buttons", "btn_embedded_library.svg")
             verticalTileMode: BorderImage.Stretch
         }
     }
@@ -1557,9 +1557,9 @@ Rectangle {
             spacing: 1
 
             Rectangle {
-                border.color: latencyIndicator.overload ? "#ffff00" : "#040404"
+                border.color: latencyIndicator.overload ? LateNightTheme.toolbarLatencyOverloadColor : LateNightTheme.toolbarLatencyBorderColor
                 border.width: 1
-                color: "#040404"
+                color: LateNightTheme.toolbarLatencyBorderColor
                 height: 7
                 opacity: latencyIndicator.overload ? latencyIndicator.overloadOpacity : 1.0
                 width: 61
@@ -1568,7 +1568,7 @@ Rectangle {
                     anchors.centerIn: parent
                     fillMode: Image.Stretch
                     height: 5
-                    source: LateNightTheme.legacyAsset("style", "latency_bg.png")
+                    source: LateNightTheme.lateNightAsset("style", "latency_bg.png")
                     width: 59
                 }
                 Item {
@@ -1582,13 +1582,13 @@ Rectangle {
                     Image {
                         fillMode: Image.Stretch
                         height: 5
-                        source: LateNightTheme.legacyAsset("style", "latency_over.png")
+                        source: LateNightTheme.lateNightAsset("style", "latency_over.png")
                         width: 59
                     }
                 }
             }
             Text {
-                color: "#444444"
+                color: LateNightTheme.toolbarLatencyLabelColor
                 font.family: "Open Sans"
                 font.pixelSize: 8
                 height: 10
@@ -1625,7 +1625,7 @@ Rectangle {
                 Layout.preferredWidth: 15
                 fillMode: Image.PreserveAspectFit
                 opacity: recordingIndicator.status === 1.0 ? recordingIndicator.pulseOpacity : 1.0
-                source: recordingIndicator.active ? LateNightTheme.legacyAsset("buttons", "btn__rec_dot_active.svg") : LateNightTheme.legacyAsset("buttons", "btn__rec_dot.svg")
+                source: recordingIndicator.active ? LateNightTheme.lateNightAsset("buttons", "btn__rec_dot_active.svg") : LateNightTheme.lateNightAsset("buttons", "btn__rec_dot.svg")
             }
             Text {
                 Layout.fillWidth: true
@@ -1675,7 +1675,7 @@ Rectangle {
             anchors.verticalCenter: parent.verticalCenter
             fillMode: Image.PreserveAspectFit
             height: 18
-            source: parent.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+            source: parent.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
             width: 18
         }
         Text {
@@ -1684,7 +1684,7 @@ Rectangle {
             anchors.left: parent.left
             anchors.leftMargin: 22
             anchors.verticalCenter: parent.verticalCenter
-            color: menuChoiceMouseArea.containsMouse ? "#ffffff" : "#d2d2d2"
+            color: menuChoiceMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
             elide: Text.ElideRight
             font.family: "Open Sans"
             font.pixelSize: 13
@@ -1726,7 +1726,7 @@ Rectangle {
             id: inlineChoiceText
 
             anchors.centerIn: parent
-            color: inlineMouseArea.containsMouse ? "#ffffff" : (inlineChoice.checked ? LateNightTheme.primaryDeckTextColor : "#777777")
+            color: inlineMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : (inlineChoice.checked ? LateNightTheme.primaryDeckTextColor : LateNightTheme.toolbarMenuDisabledTextColor)
             font.family: "Open Sans"
             font.pixelSize: 17
             font.underline: inlineChoice.checked && !inlineMouseArea.containsMouse
@@ -1795,7 +1795,7 @@ Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 fillMode: Image.PreserveAspectFit
                 height: 18
-                source: headerToggle.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+                source: headerToggle.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
                 width: 18
             }
             Text {
@@ -1804,7 +1804,7 @@ Rectangle {
                 anchors.left: parent.left
                 anchors.leftMargin: 22
                 anchors.verticalCenter: parent.verticalCenter
-                color: headerToggleMouseArea.containsMouse ? "#ffffff" : LateNightTheme.primaryDeckTextColor
+                color: headerToggleMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.primaryDeckTextColor
                 elide: Text.ElideRight
                 font.family: "Open Sans"
                 font.pixelSize: 17
@@ -1850,7 +1850,7 @@ Rectangle {
             anchors.verticalCenter: parent.verticalCenter
             fillMode: Image.PreserveAspectFit
             height: 18
-            source: parent.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.legacyAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.legacyAsset("buttons", "btn__menu_checkbox.svg")
+            source: parent.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
             width: 18
         }
         Text {
@@ -1859,7 +1859,7 @@ Rectangle {
             anchors.left: parent.left
             anchors.leftMargin: parent.indent + 22
             anchors.verticalCenter: parent.verticalCenter
-            color: menuToggleMouseArea.containsMouse ? "#ffffff" : "#d2d2d2"
+            color: menuToggleMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
             elide: Text.ElideRight
             font.family: "Open Sans"
             font.pixelSize: 13
@@ -1893,9 +1893,9 @@ Rectangle {
         }
 
         background: Rectangle {
-            border.color: "#585858"
+            border.color: LateNightTheme.toolbarPopupBorderColor
             border.width: 1
-            color: "#0f0f0f"
+            color: LateNightTheme.toolbarPopupBackgroundColor
             radius: 2
         }
         contentItem: ColumnLayout {

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -10,6 +10,12 @@ import QtQuick.Layouts
 Rectangle {
     id: root
 
+    enum DeckSize {
+        Mini = 0,
+        Compact = 1,
+        Full = 2
+    }
+
     property bool editDeck: false
     property alias maximizeLibrary: maximizeLibraryButton.checked
     readonly property bool show4decks: show4DecksButton.checked && show4DecksButton.visible
@@ -48,28 +54,10 @@ Rectangle {
         setControlValueIfInitialized(show4DecksControl, 0.0);
         showMaximizedLibraryControl.value = 0.0;
         maxLibraryDecksControl.value = 1.0;
-        deckSizeControl.value = 1.0;
-        eqKnobsControl.value = 1.0;
-        eqKillsControl.value = 1.0;
-        crossfaderControl.value = 1.0;
-        mainHeadMixerControl.value = 1.0;
-        show4EffectUnitsControl.value = 0.0;
-        showSuperKnobsControl.value = 0.0;
+        deckSizeControl.value = Toolbar.Compact;
         showPreviewDecksControl.value = 0.0;
         showLibraryCoverArtControl.value = 1.0;
         samplerRowsControl.value = 1.0;
-        showHotcuesControl.value = 1.0;
-        show8HotcuesControl.value = 1.0;
-        showIntroOutroCuesControl.value = 1.0;
-        showLoopControlsControl.value = 1.0;
-        showBeatjumpControlsControl.value = 1.0;
-        showRateControlsControl.value = 1.0;
-        showRateControlButtonsControl.value = 1.0;
-        showKeyControlsControl.value = 1.0;
-        showVinylControlsControl.value = 0.0;
-        showSpinniesControl.value = 1.0;
-        showCoverArtControl.value = 1.0;
-        selectBigSpinnyOrCoverControl.value = 0.0;
         toolbarDefaultsControl.value = 1.0;
     }
     function closeSettingsPopups() {
@@ -144,9 +132,9 @@ Rectangle {
     }
     function setDeckSize(size) {
         deckSizeControl.value = size;
-        showFullDeckControl.value = size === 2.0 ? 1.0 : 0.0;
-        showCompactDeckControl.value = size === 1.0 ? 1.0 : 0.0;
-        showMiniDeckControl.value = size === 0.0 ? 1.0 : 0.0;
+        showFullDeckControl.value = size === Toolbar.Full ? 1.0 : 0.0;
+        showCompactDeckControl.value = size === Toolbar.Compact ? 1.0 : 0.0;
+        showMiniDeckControl.value = size === Toolbar.Mini ? 1.0 : 0.0;
     }
     function broadcastBackgroundColor(status) {
         if (status === 1.0) {
@@ -1375,30 +1363,30 @@ Rectangle {
                     visible: !showMixerButton.checked
 
                     ToolbarMenuInlineChoice {
-                        checked: deckSizeControl.value === 2.0 || showFullDeckControl.value > 0
+                        checked: deckSizeControl.value === Toolbar.Full || showFullDeckControl.value > 0
+                        minimumWidth: 40
                         text: "Full"
-                        minimumWidth: 40
 
                         onClicked: {
-                            root.setDeckSize(2.0);
+                            root.setDeckSize(Toolbar.Full);
                         }
                     }
                     ToolbarMenuInlineChoice {
-                        checked: deckSizeControl.value === 1.0 || showCompactDeckControl.value > 0
-                        text: "Compact"
+                        checked: deckSizeControl.value === Toolbar.Compact || showCompactDeckControl.value > 0
                         minimumWidth: 66
+                        text: "Compact"
 
                         onClicked: {
-                            root.setDeckSize(1.0);
+                            root.setDeckSize(Toolbar.Compact);
                         }
                     }
                     ToolbarMenuInlineChoice {
-                        checked: deckSizeControl.value === 0.0 || showMiniDeckControl.value > 0
-                        text: "Mini"
+                        checked: deckSizeControl.value === Toolbar.Mini || showMiniDeckControl.value > 0
                         minimumWidth: 40
+                        text: "Mini"
 
                         onClicked: {
-                            root.setDeckSize(0.0);
+                            root.setDeckSize(Toolbar.Mini);
                         }
                     }
                 }

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -14,6 +14,7 @@ Rectangle {
     property alias maximizeLibrary: maximizeLibraryButton.checked
     readonly property bool show4decks: show4DecksButton.checked && show4DecksButton.visible
     property bool show4decksAvailable: true
+    property alias showMaximizedDecks: maxLibraryDecksButton.checked
     property alias showEffects: showEffectsButton.checked
     property alias showMicAux: showMicAuxButton.checked
     property alias showMixer: showMixerButton.checked
@@ -88,6 +89,16 @@ Rectangle {
     function setShowMixer(enabled) {
         showMixerButton.checked = enabled;
         setControlValueIfInitialized(showMixerControl, enabled ? 1.0 : 0.0);
+    }
+    function setShowMaximizedDecks(enabled) {
+        maxLibraryDecksButton.checked = enabled;
+        setControlValueIfInitialized(maxLibraryDecksControl, enabled ? 1.0 : 0.0);
+    }
+    function setDeckSize(size) {
+        deckSizeControl.value = size;
+        showFullDeckControl.value = size === 2.0 ? 1.0 : 0.0;
+        showCompactDeckControl.value = size === 1.0 ? 1.0 : 0.0;
+        showMiniDeckControl.value = size === 0.0 ? 1.0 : 0.0;
     }
     function broadcastBackgroundColor(status) {
         if (status === 1.0) {
@@ -208,6 +219,13 @@ Rectangle {
 
         group: "[LateNight]"
         key: "max_lib_show_decks"
+
+        onInitializedChanged: {
+            maxLibraryDecksButton.checked = value > 0;
+        }
+        onValueChanged: {
+            maxLibraryDecksButton.checked = value > 0;
+        }
     }
     Mixxx.ControlProxy {
         id: deckSizeControl
@@ -663,12 +681,13 @@ Rectangle {
                 spacing: -2
 
                 LateNightToolbarButton {
+                    id: maxLibraryDecksButton
+
                     buttonWidth: 80
-                    checked: maxLibraryDecksControl.value > 0
                     text: "DECKS"
 
                     onActivated: {
-                        maxLibraryDecksControl.value = checked ? 1.0 : 0.0;
+                        root.setShowMaximizedDecks(checked);
                     }
                 }
                 LateNightToolbarDropButton {
@@ -759,7 +778,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: deckSettingsPopup
 
-        width: 230
+        width: 205
 
         ColumnLayout {
             Layout.fillWidth: true
@@ -782,7 +801,9 @@ Rectangle {
                     text: "Decks"
                 }
 
-                Item { Layout.fillWidth: true } // spacer
+                Item {
+                    Layout.preferredWidth: 10
+                }
 
                 ToolbarMenuInlineChoice {
                     checked: !show4DecksButton.checked
@@ -803,8 +824,8 @@ Rectangle {
             }
             RowLayout {
                 Layout.fillWidth: true
+                Layout.preferredHeight: 18
                 spacing: 5
-                visible: showMixerButton.checked
 
                 Text {
                     color: LateNightTheme.textColor
@@ -816,6 +837,7 @@ Rectangle {
                     id: hideMixerBtn
                     Layout.preferredHeight: 18
                     Layout.fillWidth: true
+                    visible: showMixerButton.checked
 
                     Rectangle {
                         anchors.fill: parent
@@ -843,41 +865,38 @@ Rectangle {
                         }
                     }
                 }
-            }
-            ToolbarMenuChoice {
-                checked: deckSizeControl.value === 2.0 || showFullDeckControl.value > 0
-                text: "Full"
-                visible: !showMixerButton.checked
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 4
+                    visible: !showMixerButton.checked
 
-                onClicked: {
-                    deckSizeControl.value = 2.0;
-                    showFullDeckControl.value = 1.0;
-                    showCompactDeckControl.value = 0.0;
-                    showMiniDeckControl.value = 0.0;
-                }
-            }
-            ToolbarMenuChoice {
-                checked: deckSizeControl.value === 1.0 || showCompactDeckControl.value > 0
-                text: "Compact"
-                visible: !showMixerButton.checked
+                    ToolbarMenuInlineChoice {
+                        checked: deckSizeControl.value === 2.0 || showFullDeckControl.value > 0
+                        text: "Full"
+                        widthOverride: 40
 
-                onClicked: {
-                    deckSizeControl.value = 1.0;
-                    showFullDeckControl.value = 0.0;
-                    showCompactDeckControl.value = 1.0;
-                    showMiniDeckControl.value = 0.0;
-                }
-            }
-            ToolbarMenuChoice {
-                checked: deckSizeControl.value === 0.0 || showMiniDeckControl.value > 0
-                text: "Mini"
-                visible: !showMixerButton.checked
+                        onClicked: {
+                            root.setDeckSize(2.0);
+                        }
+                    }
+                    ToolbarMenuInlineChoice {
+                        checked: deckSizeControl.value === 1.0 || showCompactDeckControl.value > 0
+                        text: "Compact"
+                        widthOverride: 66
 
-                onClicked: {
-                    deckSizeControl.value = 0.0;
-                    showFullDeckControl.value = 0.0;
-                    showCompactDeckControl.value = 0.0;
-                    showMiniDeckControl.value = 1.0;
+                        onClicked: {
+                            root.setDeckSize(1.0);
+                        }
+                    }
+                    ToolbarMenuInlineChoice {
+                        checked: deckSizeControl.value === 0.0 || showMiniDeckControl.value > 0
+                        text: "Mini"
+                        widthOverride: 40
+
+                        onClicked: {
+                            root.setDeckSize(0.0);
+                        }
+                    }
                 }
             }
             RowLayout {
@@ -1086,7 +1105,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: samplerSettingsPopup
 
-        width: 230
+        width: 250
 
         ColumnLayout {
             Layout.fillWidth: true
@@ -1156,6 +1175,7 @@ Rectangle {
                         checked: samplerRowsControl.value === 2.0
                         enabled: showSamplersControl.value > 0
                         text: "16"
+                        widthOverride: 32
 
                         onClicked: {
                             samplerRowsControl.value = 2.0;
@@ -1166,6 +1186,7 @@ Rectangle {
                         checked: samplerRowsControl.value === 4.0
                         enabled: showSamplersControl.value > 0
                         text: "64"
+                        widthOverride: 32
 
                         onClicked: {
                             samplerRowsControl.value = 4.0;
@@ -1586,11 +1607,12 @@ Rectangle {
         id: inlineChoice
         property bool checked: false
         property string text: ""
+        property int widthOverride: 28
 
         signal clicked
 
         Layout.preferredHeight: 18
-        Layout.preferredWidth: 28
+        Layout.preferredWidth: widthOverride
         opacity: enabled ? 1.0 : 0.45
 
         Rectangle {

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -63,11 +63,35 @@ Rectangle {
         selectBigSpinnyOrCoverControl.value = 0.0;
         toolbarDefaultsControl.value = 1.0;
     }
-    function openPopupForButton(popup, button) {
+    function closeSettingsPopups() {
+        deckSettingsPopup.close();
+        effectSettingsPopup.close();
+        librarySettingsPopup.close();
+        micAuxSettingsPopup.close();
+        mixerSettingsPopup.close();
+        samplerSettingsPopup.close();
+        waveformSettingsPopup.close();
+    }
+    function positionPopupForButton(popup, button) {
         const mapped = button.mapToItem(root, 0, 0);
         popup.x = Math.max(0, Math.min(root.width - popup.width, mapped.x));
         popup.y = root.height + 2;
+    }
+    function openPopupForButton(popup, button) {
+        if (button.wasPopupOpenOnPress || (popup.visible && popup.anchorButton === button)) {
+            popup.close();
+            button.wasPopupOpenOnPress = false;
+            return;
+        }
+        closeSettingsPopups();
+        popup.anchorButton = button;
+        positionPopupForButton(popup, button);
         popup.open();
+        Qt.callLater(function() {
+            if (popup.visible && popup.anchorButton === button) {
+                positionPopupForButton(popup, button);
+            }
+        });
     }
     function setControlValueIfInitialized(control, value) {
         if (control.initialized) {
@@ -778,7 +802,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: deckSettingsPopup
 
-        width: 205
+        minimumWidth: 205
 
         ColumnLayout {
             Layout.fillWidth: true
@@ -790,6 +814,7 @@ Rectangle {
 
             RowLayout {
                 Layout.fillWidth: true
+                Layout.minimumWidth: implicitWidth
                 Layout.preferredHeight: 22
                 spacing: 5
 
@@ -824,6 +849,7 @@ Rectangle {
             }
             RowLayout {
                 Layout.fillWidth: true
+                Layout.minimumWidth: implicitWidth
                 Layout.preferredHeight: 18
                 spacing: 5
 
@@ -837,6 +863,7 @@ Rectangle {
                     id: hideMixerBtn
                     Layout.preferredHeight: 18
                     Layout.fillWidth: true
+                    implicitWidth: hideMixerText.implicitWidth + 8
                     visible: showMixerButton.checked
 
                     Rectangle {
@@ -846,6 +873,7 @@ Rectangle {
                     }
 
                     Text {
+                        id: hideMixerText
                         anchors.left: parent.left
                         anchors.leftMargin: 4
                         anchors.verticalCenter: parent.verticalCenter
@@ -867,13 +895,14 @@ Rectangle {
                 }
                 RowLayout {
                     Layout.fillWidth: true
+                    Layout.minimumWidth: implicitWidth
                     spacing: 4
                     visible: !showMixerButton.checked
 
                     ToolbarMenuInlineChoice {
                         checked: deckSizeControl.value === 2.0 || showFullDeckControl.value > 0
                         text: "Full"
-                        widthOverride: 40
+                        minimumWidth: 40
 
                         onClicked: {
                             root.setDeckSize(2.0);
@@ -882,7 +911,7 @@ Rectangle {
                     ToolbarMenuInlineChoice {
                         checked: deckSizeControl.value === 1.0 || showCompactDeckControl.value > 0
                         text: "Compact"
-                        widthOverride: 66
+                        minimumWidth: 66
 
                         onClicked: {
                             root.setDeckSize(1.0);
@@ -891,7 +920,7 @@ Rectangle {
                     ToolbarMenuInlineChoice {
                         checked: deckSizeControl.value === 0.0 || showMiniDeckControl.value > 0
                         text: "Mini"
-                        widthOverride: 40
+                        minimumWidth: 40
 
                         onClicked: {
                             root.setDeckSize(0.0);
@@ -901,6 +930,7 @@ Rectangle {
             }
             RowLayout {
                 Layout.fillWidth: true
+                Layout.minimumWidth: implicitWidth
                 spacing: 5
 
                 ToolbarMenuToggle {
@@ -1026,7 +1056,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: effectSettingsPopup
 
-        width: 230
+        minimumWidth: 230
 
         ColumnLayout {
             Layout.fillWidth: true
@@ -1041,7 +1071,9 @@ Rectangle {
                 property bool checked: showEffectRackControl.value > 0
 
                 Layout.fillWidth: true
+                Layout.minimumWidth: implicitWidth
                 implicitHeight: 22
+                implicitWidth: effectUnitsHeaderContent.implicitWidth
 
                 MouseArea {
                     anchors.fill: parent
@@ -1052,6 +1084,8 @@ Rectangle {
                 }
 
                 RowLayout {
+                    id: effectUnitsHeaderContent
+
                     anchors.fill: parent
                     spacing: 5
 
@@ -1104,7 +1138,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: samplerSettingsPopup
 
-        width: 250
+        minimumWidth: 250
 
         ColumnLayout {
             Layout.fillWidth: true
@@ -1119,7 +1153,9 @@ Rectangle {
                 property bool checked: showSamplersControl.value > 0
 
                 Layout.fillWidth: true
+                Layout.minimumWidth: implicitWidth
                 implicitHeight: 22
+                implicitWidth: samplersHeaderContent.implicitWidth
 
                 MouseArea {
                     anchors.fill: parent
@@ -1130,6 +1166,8 @@ Rectangle {
                 }
 
                 RowLayout {
+                    id: samplersHeaderContent
+
                     anchors.fill: parent
                     spacing: 5
 
@@ -1174,7 +1212,7 @@ Rectangle {
                         checked: samplerRowsControl.value === 2.0
                         enabled: showSamplersControl.value > 0
                         text: "16"
-                        widthOverride: 32
+                        minimumWidth: 32
 
                         onClicked: {
                             samplerRowsControl.value = 2.0;
@@ -1185,7 +1223,7 @@ Rectangle {
                         checked: samplerRowsControl.value === 4.0
                         enabled: showSamplersControl.value > 0
                         text: "64"
-                        widthOverride: 32
+                        minimumWidth: 32
 
                         onClicked: {
                             samplerRowsControl.value = 4.0;
@@ -1203,6 +1241,7 @@ Rectangle {
             RowLayout {
                 Layout.fillWidth: true
                 Layout.leftMargin: 22
+                Layout.minimumWidth: implicitWidth
                 Layout.preferredHeight: 18
                 spacing: 3
                 enabled: showSamplersControl.value > 0
@@ -1278,6 +1317,7 @@ Rectangle {
                 }
 
                 Text {
+                    id: samplerBankText
                     color: LateNightTheme.textColor
                     font.family: "Open Sans"
                     font.pixelSize: 12
@@ -1290,7 +1330,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: librarySettingsPopup
 
-        width: 140
+        minimumWidth: 140
 
         ToolbarMenuSection {
             title: "Library"
@@ -1308,7 +1348,7 @@ Rectangle {
     ToolbarSettingsPopup {
         id: micAuxSettingsPopup
 
-        width: 140
+        minimumWidth: 140
 
         ToolbarMenuSection {
             title: "Mic/Aux"
@@ -1395,7 +1435,7 @@ Rectangle {
         Layout.alignment: Qt.AlignVCenter
         Layout.preferredHeight: 20
         Layout.preferredWidth: buttonWidth
-        cursorShape: Qt.PointingHandCursor
+        cursorShape: Qt.ArrowCursor
 
         onClicked: {
             checked = !checked;
@@ -1445,11 +1485,16 @@ Rectangle {
         id: dropButton
 
         required property var popup
+        property bool wasPopupOpenOnPress: false
 
         Layout.alignment: Qt.AlignVCenter
         Layout.preferredHeight: 20
         Layout.preferredWidth: 18
-        cursorShape: Qt.PointingHandCursor
+        cursorShape: Qt.ArrowCursor
+
+        onPressed: {
+            wasPopupOpenOnPress = popup.visible && popup.anchorButton === dropButton;
+        }
 
         LateNightToolbarButtonBackground {
             active: dropButton.popup.visible
@@ -1531,7 +1576,7 @@ Rectangle {
         Layout.alignment: Qt.AlignVCenter
         Layout.preferredHeight: 20
         Layout.preferredWidth: 72
-        cursorShape: Qt.PointingHandCursor
+        cursorShape: Qt.ArrowCursor
 
         LateNightToolbarButtonBackground {
             active: recordingIndicator.active
@@ -1606,12 +1651,12 @@ Rectangle {
         id: inlineChoice
         property bool checked: false
         property string text: ""
-        property int widthOverride: 28
+        property int minimumWidth: 28
 
         signal clicked
 
         Layout.preferredHeight: 18
-        Layout.preferredWidth: widthOverride
+        Layout.preferredWidth: Math.max(minimumWidth, inlineChoiceText.implicitWidth + 8)
         opacity: enabled ? 1.0 : 0.45
 
         Rectangle {
@@ -1633,6 +1678,8 @@ Rectangle {
             }
         }
         Text {
+            id: inlineChoiceText
+
             anchors.centerIn: parent
             color: inlineMouseArea.containsMouse ? "#ffffff" : (inlineChoice.checked ? LateNightTheme.primaryDeckTextColor : "#777777")
             font.family: "Open Sans"
@@ -1758,10 +1805,24 @@ Rectangle {
         }
     }
     component ToolbarSettingsPopup: Popup {
+        id: toolbarSettingsPopup
+
+        property var anchorButton: null
+        property int minimumWidth: 190
+
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
         modal: false
         padding: 3
-        width: 190
+        width: Math.min(root.width, Math.max(minimumWidth, contentColumn.implicitWidth + leftPadding + rightPadding))
+
+        onClosed: {
+            anchorButton = null;
+        }
+        onWidthChanged: {
+            if (visible && anchorButton) {
+                root.positionPopupForButton(toolbarSettingsPopup, anchorButton);
+            }
+        }
 
         background: Rectangle {
             border.color: "#585858"
@@ -1770,6 +1831,8 @@ Rectangle {
             radius: 2
         }
         contentItem: ColumnLayout {
+            id: contentColumn
+
             spacing: 0
         }
     }

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -20,6 +20,12 @@ Rectangle {
     property alias showMixer: showMixerButton.checked
     property alias showSamplers: showSamplersButton.checked
     property alias showWaveforms: showWaveformsButton.checked
+    readonly property string activeAppMenuSection: hoveredAppMenuSection.length > 0 ? hoveredAppMenuSection : selectedAppMenuSection
+    readonly property string activeAppMenuSubmenu: hoveredAppMenuSubmenu.length > 0 ? hoveredAppMenuSubmenu : pinnedAppMenuSubmenu
+    property string hoveredAppMenuSection: ""
+    property string hoveredAppMenuSubmenu: ""
+    property string pinnedAppMenuSubmenu: ""
+    property string selectedAppMenuSection: "Options"
     property var recentlyClosedPopup: null
     property var recentlyClosedPopupButton: null
     property double recentlyClosedPopupTimestamp: 0
@@ -67,6 +73,7 @@ Rectangle {
         toolbarDefaultsControl.value = 1.0;
     }
     function closeSettingsPopups() {
+        appMenuPopup.close();
         deckSettingsPopup.close();
         effectSettingsPopup.close();
         librarySettingsPopup.close();
@@ -74,6 +81,10 @@ Rectangle {
         mixerSettingsPopup.close();
         samplerSettingsPopup.close();
         waveformSettingsPopup.close();
+    }
+    function clearAppMenuSubmenu() {
+        hoveredAppMenuSubmenu = "";
+        pinnedAppMenuSubmenu = "";
     }
     function positionPopupForButton(popup, button) {
         const mapped = button.mapToItem(root, 0, 0);
@@ -503,6 +514,54 @@ Rectangle {
         key: "status"
     }
     Mixxx.ControlProxy {
+        id: loadSelectedTrackDeck1Control
+
+        group: "[Channel1]"
+        key: "LoadSelectedTrack"
+    }
+    Mixxx.ControlProxy {
+        id: loadSelectedTrackDeck2Control
+
+        group: "[Channel2]"
+        key: "LoadSelectedTrack"
+    }
+    Mixxx.ControlProxy {
+        id: loadSelectedTrackDeck3Control
+
+        group: "[Channel3]"
+        key: "LoadSelectedTrack"
+    }
+    Mixxx.ControlProxy {
+        id: loadSelectedTrackDeck4Control
+
+        group: "[Channel4]"
+        key: "LoadSelectedTrack"
+    }
+    Mixxx.ControlProxy {
+        id: vinylDeck1Control
+
+        group: "[Channel1]"
+        key: "vinylcontrol_enabled"
+    }
+    Mixxx.ControlProxy {
+        id: vinylDeck2Control
+
+        group: "[Channel2]"
+        key: "vinylcontrol_enabled"
+    }
+    Mixxx.ControlProxy {
+        id: vinylDeck3Control
+
+        group: "[Channel3]"
+        key: "vinylcontrol_enabled"
+    }
+    Mixxx.ControlProxy {
+        id: vinylDeck4Control
+
+        group: "[Channel4]"
+        key: "vinylcontrol_enabled"
+    }
+    Mixxx.ControlProxy {
         id: autoDjControl
 
         group: "[AutoDJ]"
@@ -550,6 +609,15 @@ Rectangle {
         anchors.rightMargin: 2
         spacing: 4
 
+        LateNightToolbarMenuButton {
+            id: appMenuButton
+
+            popup: appMenuPopup
+
+            onClicked: {
+                root.openPopupForButton(appMenuPopup, this);
+            }
+        }
         RowLayout {
             Layout.alignment: Qt.AlignVCenter
             spacing: -2
@@ -813,6 +881,397 @@ Rectangle {
             Layout.preferredWidth: 74
             fillMode: Image.PreserveAspectFit
             source: LateNightTheme.lateNightAsset("style", "mixxx_logo_small.svg")
+        }
+    }
+    ToolbarSettingsPopup {
+        id: appMenuPopup
+
+        minimumWidth: 260
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 0
+
+            ColumnLayout {
+                Layout.alignment: Qt.AlignTop
+                Layout.preferredWidth: 58
+                spacing: 0
+
+                ToolbarAppMenuTab {
+                    selected: root.activeAppMenuSection === "File"
+                    text: "File"
+
+                    onTriggered: {
+                        root.selectedAppMenuSection = "File";
+                    }
+                }
+                ToolbarAppMenuTab {
+                    selected: root.activeAppMenuSection === "Library"
+                    text: "Library"
+
+                    onTriggered: {
+                        root.selectedAppMenuSection = "Library";
+                    }
+                }
+                ToolbarAppMenuTab {
+                    selected: root.activeAppMenuSection === "View"
+                    text: "View"
+
+                    onTriggered: {
+                        root.selectedAppMenuSection = "View";
+                    }
+                }
+                ToolbarAppMenuTab {
+                    selected: root.activeAppMenuSection === "Options"
+                    text: "Options"
+
+                    onTriggered: {
+                        root.selectedAppMenuSection = "Options";
+                    }
+                }
+                ToolbarAppMenuTab {
+                    selected: root.activeAppMenuSection === "Help"
+                    text: "Help"
+
+                    onTriggered: {
+                        root.selectedAppMenuSection = "Help";
+                    }
+                }
+            }
+            Rectangle {
+                Layout.fillHeight: true
+                Layout.preferredWidth: 1
+                color: LateNightTheme.toolbarPopupBorderColor
+            }
+            ColumnLayout {
+                Layout.alignment: Qt.AlignTop
+                Layout.minimumWidth: 180
+                spacing: 0
+
+                ToolbarAppMenuAction {
+                    shortcut: "Ctrl+O"
+                    text: "Load Track to Deck 1"
+                    visible: root.activeAppMenuSection === "File"
+
+                    onTriggered: {
+                        loadSelectedTrackDeck1Control.trigger();
+                    }
+                }
+                ToolbarAppMenuAction {
+                    shortcut: "Ctrl+Shift+O"
+                    text: "Load Track to Deck 2"
+                    visible: root.activeAppMenuSection === "File"
+
+                    onTriggered: {
+                        loadSelectedTrackDeck2Control.trigger();
+                    }
+                }
+                ToolbarAppMenuAction {
+                    enabled: show4DecksButton.checked
+                    text: "Load Track to Deck 3"
+                    visible: root.activeAppMenuSection === "File"
+
+                    onTriggered: {
+                        loadSelectedTrackDeck3Control.trigger();
+                    }
+                }
+                ToolbarAppMenuAction {
+                    enabled: show4DecksButton.checked
+                    text: "Load Track to Deck 4"
+                    visible: root.activeAppMenuSection === "File"
+
+                    onTriggered: {
+                        loadSelectedTrackDeck4Control.trigger();
+                    }
+                }
+                ToolbarAppMenuSeparator {
+                    visible: root.activeAppMenuSection === "File"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    shortcut: "Ctrl+Q"
+                    text: "Exit"
+                    visible: root.activeAppMenuSection === "File"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    shortcut: "Ctrl+Shift+L"
+                    text: "Rescan Library"
+                    visible: root.activeAppMenuSection === "Library"
+                }
+                ToolbarAppMenuSeparator {
+                    visible: root.activeAppMenuSection === "Library"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    shortcut: "Ctrl+F"
+                    text: "Search in Current View..."
+                    visible: root.activeAppMenuSection === "Library"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    shortcut: "Ctrl+Shift+F"
+                    text: "Search in Tracks Library..."
+                    visible: root.activeAppMenuSection === "Library"
+                }
+                ToolbarAppMenuSeparator {
+                    visible: root.activeAppMenuSection === "Library"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    shortcut: "Ctrl+N"
+                    text: "Create New Playlist"
+                    visible: root.activeAppMenuSection === "Library"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    shortcut: "Ctrl+Shift+N"
+                    text: "Create New Crate"
+                    visible: root.activeAppMenuSection === "Library"
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: Mixxx.Config.libraryHideMenuBar
+                    text: "Auto-hide menu bar"
+                    visible: root.activeAppMenuSection === "View"
+
+                    onTriggered: {
+                        Mixxx.Config.libraryHideMenuBar = !Mixxx.Config.libraryHideMenuBar;
+                    }
+                }
+                ToolbarAppMenuSeparator {
+                    visible: root.activeAppMenuSection === "View"
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: showMicAuxControl.value > 0
+                    shortcut: "Ctrl+2"
+                    text: "Show Microphone Section"
+                    visible: root.activeAppMenuSection === "View"
+
+                    onTriggered: {
+                        showMicAuxControl.value = showMicAuxControl.value > 0 ? 0.0 : 1.0;
+                    }
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: showVinylControlsControl.value > 0
+                    shortcut: "Ctrl+3"
+                    text: "Show Vinyl Control Section"
+                    visible: root.activeAppMenuSection === "View"
+
+                    onTriggered: {
+                        showVinylControlsControl.value = showVinylControlsControl.value > 0 ? 0.0 : 1.0;
+                    }
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: showPreviewDecksControl.value > 0
+                    enabled: false
+                    shortcut: "Ctrl+4"
+                    text: "Show Preview Deck"
+                    visible: root.activeAppMenuSection === "View"
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: showLibraryCoverArtControl.value > 0
+                    shortcut: "Ctrl+6"
+                    text: "Show Cover Art"
+                    visible: root.activeAppMenuSection === "View"
+
+                    onTriggered: {
+                        showLibraryCoverArtControl.value = showLibraryCoverArtControl.value > 0 ? 0.0 : 1.0;
+                    }
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: maximizeLibraryButton.checked
+                    shortcut: "Space"
+                    text: "Maximize Library"
+                    visible: root.activeAppMenuSection === "View"
+
+                    onTriggered: {
+                        showMaximizedLibraryControl.value = maximizeLibraryButton.checked ? 0.0 : 1.0;
+                    }
+                }
+                ToolbarAppMenuSeparator {
+                    visible: root.activeAppMenuSection === "View"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    shortcut: "Ctrl+9"
+                    text: "Show Auto DJ"
+                    visible: root.activeAppMenuSection === "View"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    shortcut: "F11"
+                    text: "Full Screen"
+                    visible: root.activeAppMenuSection === "View"
+                }
+                ToolbarAppMenuAction {
+                    hasSubmenu: true
+                    selected: root.activeAppMenuSubmenu === "Vinyl Control"
+                    text: "Vinyl Control"
+                    visible: root.activeAppMenuSection === "Options"
+
+                    onHovered: {
+                        root.hoveredAppMenuSubmenu = "Vinyl Control";
+                    }
+                    onTriggered: {
+                        root.hoveredAppMenuSubmenu = "";
+                        root.pinnedAppMenuSubmenu = root.pinnedAppMenuSubmenu === "Vinyl Control" ? "" : "Vinyl Control";
+                    }
+                }
+                ToolbarAppMenuSeparator {
+                    visible: root.activeAppMenuSection === "Options"
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: recordingStatusControl.value > 0
+                    shortcut: "Ctrl+R"
+                    text: "Record Mix"
+                    visible: root.activeAppMenuSection === "Options"
+
+                    onHovered: {
+                        root.hoveredAppMenuSubmenu = "";
+                    }
+                    onTriggered: {
+                        recordingToggleControl.trigger();
+                    }
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: broadcastEnabledControl.value > 0
+                    shortcut: "Ctrl+L"
+                    text: "Enable Live Broadcasting"
+                    visible: root.activeAppMenuSection === "Options"
+
+                    onHovered: {
+                        root.hoveredAppMenuSubmenu = "";
+                    }
+                    onTriggered: {
+                        broadcastEnabledControl.value = broadcastEnabledControl.value > 0 ? 0.0 : 1.0;
+                    }
+                }
+                ToolbarAppMenuSeparator {
+                    visible: root.activeAppMenuSection === "Options"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    checkable: true
+                    checked: true
+                    shortcut: "Ctrl+`"
+                    text: "Enable Keyboard Shortcuts"
+                    visible: root.activeAppMenuSection === "Options"
+
+                    onHovered: {
+                        root.hoveredAppMenuSubmenu = "";
+                    }
+                }
+                ToolbarAppMenuSeparator {
+                    visible: root.activeAppMenuSection === "Options"
+                }
+                ToolbarAppMenuAction {
+                    shortcut: "Ctrl+P"
+                    text: "Preferences"
+                    visible: root.activeAppMenuSection === "Options"
+
+                    onHovered: {
+                        root.hoveredAppMenuSubmenu = "";
+                    }
+                    onTriggered: {
+                        Mixxx.PreferencesDialog.show();
+                        appMenuPopup.close();
+                    }
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    text: "Community Support"
+                    visible: root.activeAppMenuSection === "Help"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    text: "User Manual"
+                    visible: root.activeAppMenuSection === "Help"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    text: "Keyboard Shortcuts"
+                    visible: root.activeAppMenuSection === "Help"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    text: "Settings directory"
+                    visible: root.activeAppMenuSection === "Help"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    text: "Translate This Application"
+                    visible: root.activeAppMenuSection === "Help"
+                }
+                ToolbarAppMenuSeparator {
+                    visible: root.activeAppMenuSection === "Help"
+                }
+                ToolbarAppMenuAction {
+                    enabled: false
+                    text: "About"
+                    visible: root.activeAppMenuSection === "Help"
+                }
+            }
+            Rectangle {
+                Layout.fillHeight: true
+                Layout.preferredWidth: 1
+                color: LateNightTheme.toolbarPopupBorderColor
+                visible: root.activeAppMenuSection === "Options" && root.activeAppMenuSubmenu === "Vinyl Control"
+            }
+            ColumnLayout {
+                Layout.alignment: Qt.AlignTop
+                Layout.minimumWidth: 180
+                spacing: 0
+                visible: root.activeAppMenuSection === "Options" && root.activeAppMenuSubmenu === "Vinyl Control"
+
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: vinylDeck1Control.value > 0
+                    shortcut: "Ctrl+T"
+                    text: "Enable Vinyl Control 1"
+
+                    onTriggered: {
+                        vinylDeck1Control.value = vinylDeck1Control.value > 0 ? 0.0 : 1.0;
+                    }
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: vinylDeck2Control.value > 0
+                    shortcut: "Ctrl+Y"
+                    text: "Enable Vinyl Control 2"
+
+                    onTriggered: {
+                        vinylDeck2Control.value = vinylDeck2Control.value > 0 ? 0.0 : 1.0;
+                    }
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: vinylDeck3Control.value > 0
+                    shortcut: "Ctrl+U"
+                    text: "Enable Vinyl Control 3"
+
+                    onTriggered: {
+                        vinylDeck3Control.value = vinylDeck3Control.value > 0 ? 0.0 : 1.0;
+                    }
+                }
+                ToolbarAppMenuAction {
+                    checkable: true
+                    checked: vinylDeck4Control.value > 0
+                    shortcut: "Ctrl+I"
+                    text: "Enable Vinyl Control 4"
+
+                    onTriggered: {
+                        vinylDeck4Control.value = vinylDeck4Control.value > 0 ? 0.0 : 1.0;
+                    }
+                }
+            }
         }
     }
     ToolbarSettingsPopup {
@@ -1457,6 +1916,32 @@ Rectangle {
         text: "--:-- --"
         verticalAlignment: Text.AlignVCenter
     }
+    component LateNightToolbarMenuButton: MouseArea {
+        id: menuButton
+
+        required property var popup
+        property bool wasPopupOpenOnPress: false
+
+        Layout.alignment: Qt.AlignVCenter
+        Layout.preferredHeight: 20
+        Layout.preferredWidth: 26
+        cursorShape: Qt.ArrowCursor
+
+        onPressed: {
+            wasPopupOpenOnPress = popup.visible && popup.anchorButton === menuButton;
+        }
+
+        LateNightToolbarButtonBackground {
+            active: menuButton.popup.visible
+        }
+        Image {
+            anchors.centerIn: parent
+            fillMode: Image.PreserveAspectFit
+            height: 13
+            source: LateNightTheme.assetToolbarMenuIcon
+            width: 13
+        }
+    }
     component LateNightToolbarButton: MouseArea {
         id: toolbarButton
 
@@ -1637,6 +2122,149 @@ Rectangle {
                 text: recordingIndicator.status === 2.0 || recordingIndicator.status === 3.0 ? recordingIndicator.durationText : "REC"
                 verticalAlignment: Text.AlignVCenter
             }
+        }
+    }
+    component ToolbarAppMenuTab: Item {
+        id: appMenuTab
+
+        property bool selected: false
+        property string text: ""
+
+        signal triggered
+
+        Layout.fillWidth: true
+        implicitHeight: 17
+        implicitWidth: appMenuTabText.implicitWidth + 8
+
+        Rectangle {
+            anchors.fill: parent
+            color: appMenuTabMouseArea.containsMouse || appMenuTab.selected ? LateNightTheme.toolbarMenuHoverColor : "transparent"
+        }
+        MouseArea {
+            id: appMenuTabMouseArea
+
+            anchors.fill: parent
+            cursorShape: Qt.ArrowCursor
+            hoverEnabled: true
+
+            onEntered: {
+                root.hoveredAppMenuSection = appMenuTab.text;
+                root.clearAppMenuSubmenu();
+            }
+            onClicked: {
+                root.hoveredAppMenuSection = "";
+                root.clearAppMenuSubmenu();
+                appMenuTab.triggered();
+            }
+        }
+        Text {
+            id: appMenuTabText
+
+            anchors.left: parent.left
+            anchors.leftMargin: 5
+            anchors.verticalCenter: parent.verticalCenter
+            color: appMenuTabMouseArea.containsMouse || appMenuTab.selected ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
+            elide: Text.ElideRight
+            font.family: "Open Sans"
+            font.pixelSize: 12
+            text: appMenuTab.text
+            width: parent.width - anchors.leftMargin
+        }
+    }
+    component ToolbarAppMenuSeparator: Rectangle {
+        Layout.fillWidth: true
+        Layout.leftMargin: 4
+        Layout.rightMargin: 4
+        Layout.preferredHeight: 1
+        color: LateNightTheme.toolbarPopupBorderColor
+    }
+    component ToolbarAppMenuAction: Item {
+        id: appMenuAction
+
+        property bool checkable: false
+        property bool checked: false
+        property bool hasSubmenu: false
+        property bool selected: false
+        property string shortcut: ""
+        property string text: ""
+
+        signal hovered
+        signal triggered
+
+        Layout.fillWidth: true
+        implicitHeight: 17
+        implicitWidth: appMenuActionText.implicitWidth + appMenuShortcutText.implicitWidth + 42
+        opacity: enabled ? 1.0 : 0.45
+
+        Rectangle {
+            anchors.fill: parent
+            color: root.menuHoverColor(appMenuActionMouseArea.containsMouse || appMenuAction.selected, appMenuAction.enabled)
+        }
+        MouseArea {
+            id: appMenuActionMouseArea
+
+            anchors.fill: parent
+            cursorShape: Qt.ArrowCursor
+            hoverEnabled: true
+
+            onEntered: {
+                if (appMenuAction.enabled) {
+                    appMenuAction.hovered();
+                }
+            }
+            onClicked: {
+                if (appMenuAction.enabled) {
+                    appMenuAction.triggered();
+                }
+            }
+        }
+        Image {
+            anchors.left: parent.left
+            anchors.leftMargin: 3
+            anchors.verticalCenter: parent.verticalCenter
+            fillMode: Image.PreserveAspectFit
+            height: 14
+            source: appMenuAction.checked ? (LateNightTheme.isPaleMoon ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_grey.svg")) : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
+            visible: appMenuAction.checkable
+            width: 14
+        }
+        Text {
+            id: appMenuActionText
+
+            anchors.left: parent.left
+            anchors.leftMargin: appMenuAction.checkable ? 22 : 6
+            anchors.right: appMenuShortcutText.left
+            anchors.rightMargin: 8
+            anchors.verticalCenter: parent.verticalCenter
+            color: appMenuActionMouseArea.containsMouse || appMenuAction.selected ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
+            elide: Text.ElideRight
+            font.family: "Open Sans"
+            font.pixelSize: 11
+            text: appMenuAction.text
+        }
+        Text {
+            id: appMenuShortcutText
+
+            anchors.right: appMenuArrowText.left
+            anchors.rightMargin: 8
+            anchors.verticalCenter: parent.verticalCenter
+            color: appMenuActionMouseArea.containsMouse || appMenuAction.selected ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
+            font.family: "Open Sans"
+            font.pixelSize: 10
+            text: appMenuAction.shortcut
+            visible: text.length > 0
+        }
+        Text {
+            id: appMenuArrowText
+
+            anchors.right: parent.right
+            anchors.rightMargin: 6
+            anchors.verticalCenter: parent.verticalCenter
+            color: appMenuActionMouseArea.containsMouse || appMenuAction.selected ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
+            font.family: "Open Sans"
+            font.pixelSize: 11
+            text: appMenuAction.hasSubmenu ? ">" : ""
+            width: 8
         }
     }
     component ToolbarMenuChoice: Item {

--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -32,8 +32,8 @@ Rectangle {
     property string hoveredAppMenuSubmenu: ""
     property string pinnedAppMenuSubmenu: ""
     property string selectedAppMenuSection: "Options"
-    property var recentlyClosedPopup: null
-    property var recentlyClosedPopupButton: null
+    property ToolbarSettingsPopup recentlyClosedPopup: null
+    property MouseArea recentlyClosedPopupButton: null
     property double recentlyClosedPopupTimestamp: 0
 
     function formatTime(date) {
@@ -991,19 +991,6 @@ Rectangle {
                 }
                 ToolbarAppMenuAction {
                     checkable: true
-                    checked: Mixxx.Config.libraryHideMenuBar
-                    text: "Auto-hide menu bar"
-                    visible: root.activeAppMenuSection === "View"
-
-                    onTriggered: {
-                        Mixxx.Config.libraryHideMenuBar = !Mixxx.Config.libraryHideMenuBar;
-                    }
-                }
-                ToolbarAppMenuSeparator {
-                    visible: root.activeAppMenuSection === "View"
-                }
-                ToolbarAppMenuAction {
-                    checkable: true
                     checked: showMicAuxControl.value > 0
                     shortcut: "Ctrl+2"
                     text: "Show Microphone Section"
@@ -1825,10 +1812,12 @@ Rectangle {
             anchors.fill: parent
             anchors.leftMargin: 15
             color: broadcastIndicator.status > 0 ? LateNightTheme.toolbarButtonActiveTextColor : LateNightTheme.toolbarButtonInactiveTextColor
-            font.family: "Open Sans"
-            font.pixelSize: 11
-            font.styleName: "Bold"
-            font.weight: Font.Bold
+            font {
+                family: "Open Sans"
+                pixelSize: 11
+                styleName: "Bold"
+                weight: Font.Bold
+            }
             horizontalAlignment: Text.AlignHCenter
             opacity: broadcastIndicator.status === 1.0 || broadcastIndicator.status === 3.0 || broadcastIndicator.status === 4.0 ? broadcastIndicator.pulseOpacity : 1.0
             renderType: Text.NativeRendering
@@ -1849,7 +1838,7 @@ Rectangle {
     component LateNightToolbarMenuButton: MouseArea {
         id: menuButton
 
-        required property var popup
+        required property ToolbarSettingsPopup popup
         property bool wasPopupOpenOnPress: false
 
         Layout.alignment: Qt.AlignVCenter
@@ -1898,10 +1887,12 @@ Rectangle {
             anchors.fill: parent
             color: toolbarButton.checked ? LateNightTheme.toolbarButtonActiveTextColor : LateNightTheme.toolbarButtonInactiveTextColor
             elide: Text.ElideRight
-            font.family: "Open Sans"
-            font.pixelSize: 11
-            font.styleName: "Bold"
-            font.weight: Font.Bold
+            font {
+                family: "Open Sans"
+                pixelSize: 11
+                styleName: "Bold"
+                weight: Font.Bold
+            }
             horizontalAlignment: Text.AlignHCenter
             renderType: Text.NativeRendering
             text: toolbarButton.text
@@ -1933,8 +1924,8 @@ Rectangle {
     component LateNightToolbarDropButton: MouseArea {
         id: dropButton
 
-        required property var popup
-        property var popupAnchor: null
+        required property ToolbarSettingsPopup popup
+        property MouseArea popupAnchor: null
         property bool wasPopupOpenOnPress: false
 
         Layout.alignment: Qt.AlignVCenter
@@ -2198,60 +2189,6 @@ Rectangle {
             width: 8
         }
     }
-    component ToolbarMenuChoice: Item {
-        id: menuChoice
-
-        property bool checked: false
-        property string text: ""
-
-        signal clicked
-
-        Layout.fillWidth: true
-        implicitHeight: 18
-        implicitWidth: menuChoiceText.implicitWidth + 22
-        opacity: enabled ? 1.0 : 0.45
-
-        Rectangle {
-            anchors.fill: parent
-            color: root.menuHoverColor(menuChoiceMouseArea.containsMouse, menuChoice.enabled)
-            radius: 1
-        }
-
-        MouseArea {
-            id: menuChoiceMouseArea
-            anchors.fill: parent
-            cursorShape: Qt.ArrowCursor
-            hoverEnabled: true
-
-            onClicked: {
-                if (parent.enabled) {
-                    parent.clicked();
-                }
-            }
-        }
-        Image {
-            anchors.left: parent.left
-            anchors.leftMargin: 2
-            anchors.verticalCenter: parent.verticalCenter
-            fillMode: Image.PreserveAspectFit
-            height: 14
-            source: parent.checked ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
-            width: 14
-        }
-        Text {
-            id: menuChoiceText
-
-            anchors.left: parent.left
-            anchors.leftMargin: 20
-            anchors.verticalCenter: parent.verticalCenter
-            color: menuChoiceMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
-            elide: Text.ElideRight
-            font.family: "Open Sans"
-            font.pixelSize: 13
-            text: parent.text
-            width: parent.width - anchors.leftMargin
-        }
-    }
     component ToolbarMenuInlineChoice: Item {
         id: inlineChoice
         property bool checked: false
@@ -2315,7 +2252,7 @@ Rectangle {
     component ToolbarMenuSectionToggle: ColumnLayout {
         id: sectionToggle
         required property string title
-        required property var control
+        required property Mixxx.ControlProxy control
 
         Layout.fillWidth: true
         Layout.bottomMargin: 7
@@ -2378,7 +2315,7 @@ Rectangle {
         id: menuToggle
 
         property bool checked: control ? control.value > 0 : false
-        required property var control
+        required property Mixxx.ControlProxy control
         property int indent: 0
         property string text: ""
 
@@ -2431,7 +2368,7 @@ Rectangle {
     component ToolbarSettingsPopup: Popup {
         id: toolbarSettingsPopup
 
-        property var anchorButton: null
+        property MouseArea anchorButton: null
         property int minimumWidth: 190
 
         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside

--- a/res/skins/LateNightQML/main.qml
+++ b/res/skins/LateNightQML/main.qml
@@ -19,6 +19,7 @@ ApplicationWindow {
     readonly property int numDecks: 4
     readonly property int numSamplers: 64
     readonly property bool show4decks: toolbar.show4decks
+    readonly property bool showMaximizedDecks: toolbar.showMaximizedDecks
     readonly property bool showMixer: toolbar.showMixer
     property alias showEffects: toolbar.showEffects
     property alias showSamplers: toolbar.showSamplers
@@ -255,8 +256,9 @@ ApplicationWindow {
 
                     editMode: root.editDeck
                     group: "[Channel1]"
-                    height: root.maximizeLibrary ? root.minimizedDeckHeight : root.fullDeckHeight
+                    height: root.maximizeLibrary ? (root.showMaximizedDecks ? root.minimizedDeckHeight : 0) : root.fullDeckHeight
                     minimized: root.maximizeLibrary
+                    visible: !root.maximizeLibrary || root.showMaximizedDecks
 
                     Behavior on height {
                         SpringAnimation {
@@ -379,8 +381,9 @@ ApplicationWindow {
 
                     editMode: root.editDeck
                     group: "[Channel2]"
-                    height: root.maximizeLibrary ? root.minimizedDeckHeight : root.fullDeckHeight
+                    height: root.maximizeLibrary ? (root.showMaximizedDecks ? root.minimizedDeckHeight : 0) : root.fullDeckHeight
                     minimized: root.maximizeLibrary
+                    visible: !root.maximizeLibrary || root.showMaximizedDecks
 
                     Behavior on height {
                         SpringAnimation {
@@ -417,7 +420,7 @@ ApplicationWindow {
 
                     readonly property string group: "[Channel3]"
 
-                    active: root.show4decks
+                    active: root.show4decks && (!root.maximizeLibrary || root.showMaximizedDecks)
                     clip: true
                     height: active ? (root.maximizeLibrary ? root.minimizedDeckHeight : root.fullDeckHeight) : 0
 
@@ -461,7 +464,7 @@ ApplicationWindow {
 
                     readonly property string group: "[Channel4]"
 
-                    active: root.show4decks
+                    active: root.show4decks && (!root.maximizeLibrary || root.showMaximizedDecks)
                     clip: true
                     height: active ? (root.maximizeLibrary ? root.minimizedDeckHeight : root.fullDeckHeight) : 0
 
@@ -532,7 +535,15 @@ ApplicationWindow {
                     }
                     states: [
                         State {
-                            when: root.maximizeLibrary && root.show4decks
+                            when: root.maximizeLibrary && !root.showMaximizedDecks
+
+                            AnchorChanges {
+                                anchors.top: parent.top
+                                target: library
+                            }
+                        },
+                        State {
+                            when: root.maximizeLibrary && root.showMaximizedDecks && root.show4decks
 
                             AnchorChanges {
                                 anchors.top: deck4.bottom
@@ -540,7 +551,7 @@ ApplicationWindow {
                             }
                         },
                         State {
-                            when: root.maximizeLibrary && !root.show4decks
+                            when: root.maximizeLibrary && root.showMaximizedDecks && !root.show4decks
 
                             AnchorChanges {
                                 anchors.top: deck1.bottom

--- a/res/skins/LateNightQML/main.qml
+++ b/res/skins/LateNightQML/main.qml
@@ -1,6 +1,7 @@
 import "../../qml" as Skin
 import "LateNightTheme"
 import "Deck" as LateNightDeck
+import "Toolbar" as LateNightToolbar
 import "Waveforms" as LateNightWaveforms
 import Mixxx 1.0 as Mixxx
 import QtQuick
@@ -10,16 +11,18 @@ import QtQuick.Layouts
 ApplicationWindow {
     id: root
 
-    property alias editDeck: editDeckButton.checked
+    property alias editDeck: toolbar.editDeck
     property var focusedDeck: null
-    property alias maximizeLibrary: maximizeLibraryButton.checked
+    property alias maximizeLibrary: toolbar.maximizeLibrary
     readonly property int fullDeckHeight: 206
     readonly property int minimizedDeckHeight: 80
     readonly property int numDecks: 4
-    readonly property int numSamplers: 16
-    readonly property bool show4decks: show4DecksButton.checked && show4DecksButton.visible
-    property alias showEffects: showEffectsButton.checked
-    property alias showSamplers: showSamplersButton.checked
+    readonly property int numSamplers: 64
+    readonly property bool show4decks: toolbar.show4decks
+    readonly property bool showMixer: toolbar.showMixer
+    property alias showEffects: toolbar.showEffects
+    property alias showSamplers: toolbar.showSamplers
+    readonly property bool showWaveforms: toolbar.showWaveforms
 
     color: LateNightTheme.backgroundColor
     height: 1008
@@ -181,120 +184,11 @@ ApplicationWindow {
             }
         }
 
-        Rectangle {
+        LateNightToolbar.Toolbar {
             id: toolbar
 
-            color: LateNightTheme.toolbarBackgroundColor
-            height: 36
-            radius: 1
+            show4decksAvailable: root.height > 515
             width: parent.width
-
-            RowLayout {
-                anchors.fill: parent
-
-                Skin.Button {
-                    id: show4DecksButton
-
-                    activeColor: LateNightTheme.white
-                    checkable: true
-                    text: "4 Decks"
-                    visible: root.height > 515
-                }
-                Skin.Button {
-                    id: maximizeLibraryButton
-
-                    activeColor: LateNightTheme.white
-                    checkable: true
-                    text: "Library"
-
-                    onCheckedChanged: () => {
-                        showMaximizedLibrary.value = this.checked;
-                    }
-
-                    Mixxx.ControlProxy {
-                        id: showMaximizedLibrary
-
-                        group: "[Skin]"
-                        key: "show_maximized_library"
-
-                        onValueChanged: () => {
-                            maximizeLibraryButton.checked = this.value;
-                        }
-                    }
-                }
-                Skin.Button {
-                    id: showEffectsButton
-
-                    activeColor: LateNightTheme.white
-                    checkable: true
-                    text: "Effects"
-                }
-                Skin.Button {
-                    id: showAuxButton
-
-                    activeColor: LateNightTheme.white
-                    checkable: true
-                    text: "Aux"
-                }
-                Skin.Button {
-                    id: showSamplersButton
-
-                    activeColor: LateNightTheme.white
-                    checkable: true
-                    text: "Sampler"
-                }
-                Item {
-                    Layout.fillWidth: true
-                }
-                Skin.Button {
-                    id: editDeckButton
-
-                    activeColor: LateNightTheme.white
-                    checkable: true
-                    text: "Edit"
-                }
-                Skin.Button {
-                    id: showDevToolsButton
-
-                    activeColor: LateNightTheme.white
-                    checkable: true
-                    checked: devToolsWindow.visible
-                    text: "Develop"
-
-                    onClicked: {
-                        if (devToolsWindow.visible)
-                            devToolsWindow.close();
-                        else
-                            devToolsWindow.show();
-                    }
-
-                    Skin.DeveloperToolsWindow {
-                        id: devToolsWindow
-
-                        height: 480
-                        width: 640
-                    }
-                }
-                Skin.Button {
-                    id: showPreferencesButton
-
-                    activeColor: LateNightTheme.white
-                    checked: settingsPopup.opened
-                    icon.height: 16
-                    icon.source: "images/gear.svg"
-                    icon.width: 16
-                    implicitWidth: implicitHeight
-
-                    onClicked: {
-                        if (!settingsPopup.opened) {
-                            settingsPopup.open();
-                        }
-                    }
-                    onPressAndHold: {
-                        Mixxx.PreferencesDialog.show();
-                    }
-                }
-            }
         }
         SplitView {
             id: splitView
@@ -341,7 +235,7 @@ ApplicationWindow {
 
                 SplitView.fillHeight: !library.active
                 SplitView.preferredHeight: library.active ? 120 : undefined
-                visible: !root.maximizeLibrary
+                visible: root.showWaveforms && !root.maximizeLibrary
                 show4decks: root.show4decks
 
                 Skin.FadeBehavior on visible {
@@ -400,9 +294,9 @@ ApplicationWindow {
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.top: parent.top
                     groups: [deck1.group, deck2.group, deck3.group, deck4.group]
-                    width: implicitWidth
+                    width: visible ? implicitWidth : 0
                     show4decks: root.show4decks
-                    visible: !root.maximizeLibrary
+                    visible: root.showMixer && !root.maximizeLibrary
 
                     Behavior on height {
                         SpringAnimation {
@@ -671,23 +565,5 @@ ApplicationWindow {
             }
         }
     }
-    Skin.Settings {
-        id: settingsPopup
 
-        height: Math.min(840, parent.height)
-        modal: true
-        width: Math.min(1400, parent.width)
-        x: Math.round((parent.width - width) / 2)
-        y: Math.round((parent.height - height) / 2)
-
-        Overlay.modal: Rectangle {
-            id: overlayModal
-
-            readonly property bool hasHardwareAcceleration: Mixxx.Config.useAcceleration
-            property real radius: 12
-
-            anchors.fill: parent
-            color: Qt.alpha('#00000010', hasHardwareAcceleration ? 1.0 : 0.6)
-        }
-    }
 }


### PR DESCRIPTION
This PR implements the visual styling, theme integration, and interactive control bindings for the **LateNightQML** toolbar, covering both the Classic and PaleMoon color schemes.

## Testing the Experimental Skin

Since this is an early experimental milestone, you must first run Mixxx with the developer flag:

```bash
./build/mixxx --developer
```

Once Mixxx is open, switch to the experimental skin:
**Preferences -> Interface -> LateNight QML (Experimental)**

You can dynamically toggle between the **Classic** and **PaleMoon** color schemes under preferences.

## Previews

### Classic
<img width="1470" height="25" alt="image" src="https://github.com/user-attachments/assets/2ffe8c9d-2803-4ce0-a7be-b1fe2bfdf53d" />

### PaleMoon
<img width="1470" height="25" alt="image" src="https://github.com/user-attachments/assets/135d7900-fd01-409c-ae3b-551d8ae54bfa" />

## New Styling
The original skin settings button has been removed, with each toolbar section now exposing its relevant settings through a dedicated dropdown placed next to the corresponding toolbar button.

### Example
<img width="593" height="282" alt="image" src="https://github.com/user-attachments/assets/221aba0d-5814-49c7-916d-020e586ebbcd" />


## Scope of Changes

### Implemented in this PR:
* **Standalone Toolbar Layout:** Replaces the shared prototype toolbar with a LateNightQML-specific toolbar that matches the LateNight visual language and leaves the shared QML toolbar untouched.
* **Toolbar Controls & Status Indicators:** Wires the library, waveform, deck count, mixer, effects, samplers, mic/aux, recording, broadcast, latency, battery, clock, and logo areas into the toolbar layout.
* **Integrated Toolbar Settings:** Moves toolbar settings into per-section dropdown overlays next to the relevant toolbar buttons, including deck, waveform, mixer, effects, samplers, mic/aux, and library settings.
* **64 Samplers Options in Samplers Menu:** With LateNightQML, the plan is to drop a separate 64 samplers LateNight skin and have it integrated inside LateNightQML itself.
* **LateNight Theme Integration:** Uses LateNight theme assets, colors, and named toolbar tokens for Classic/PaleMoon parity, including dropdown icons, button states, status colors, popup styling, and menu hover behavior.

## Todos
- [x] Hamburger Menu Icon to go away from a global menu bar in Windows and some Linux Desktop Environments

## Tracking

GSoC: LateNightQML PR-5
