### PR TITLE
Add shared QML mixer control primitives

### DIFF
--- a/res/qml/ControlFader.qml
+++ b/res/qml/ControlFader.qml
@@ -10,7 +10,7 @@ Skin.Fader {
 
     value: control.parameter
 
-    onMoved: function(value) {
+    onMoved: function (value) {
         control.parameter = value;
     }
 
@@ -25,6 +25,7 @@ Skin.Fader {
     }
     TapHandler {
         acceptedButtons: Qt.RightButton
+
         onTapped: control.reset()
     }
 }

--- a/res/qml/ControlKnob.qml
+++ b/res/qml/ControlKnob.qml
@@ -9,17 +9,18 @@ Skin.Knob {
     property alias key: control.key
 
     value: control.parameter
+
     onTurned: control.parameter = value
 
     Mixxx.ControlProxy {
         id: control
     }
-
     TapHandler {
         onDoubleTapped: control.reset()
     }
     TapHandler {
         acceptedButtons: Qt.RightButton
+
         onTapped: control.reset()
     }
 }

--- a/res/qml/CrossfaderRow.qml
+++ b/res/qml/CrossfaderRow.qml
@@ -53,8 +53,8 @@ Item {
             anchors.right: parent.right
             anchors.rightMargin: 5
             anchors.verticalCenter: parent.verticalCenter
-            barColor: Theme.crossfaderBarColor
-            barStart: 0.5
+            bar.color: Theme.crossfaderBarColor
+            bar.start: 0.5
             bg: Theme.imgCrossfaderBackground
             fg: Theme.imgCrossfaderHandle
             group: "[Master]"

--- a/res/qml/Deck/HotcueAndStem.qml
+++ b/res/qml/Deck/HotcueAndStem.qml
@@ -423,7 +423,7 @@ Item {
                                 id: volumeSlider
 
                                 anchors.fill: parent
-                                barColor: Theme.volumeSliderBarColor
+                                bar.color: Theme.volumeSliderBarColor
                                 bg: Theme.imgVolumeSliderBackground
                                 group: stem.group
                                 implicitWidth: 10

--- a/res/qml/Deck/TempoColumn.qml
+++ b/res/qml/Deck/TempoColumn.qml
@@ -177,9 +177,9 @@ ColumnLayout {
 
         Layout.fillHeight: true
         Layout.fillWidth: true
-        barColor: Theme.bpmSliderBarColor
-        barMargin: 0
-        barStart: 0.5
+        bar.color: Theme.bpmSliderBarColor
+        bar.margin: 0
+        bar.start: 0.5
         bg: Theme.imgBpmSliderBackground
         group: root.group
         key: "rate"

--- a/res/qml/Fader.qml
+++ b/res/qml/Fader.qml
@@ -11,8 +11,8 @@ MixxxControls.Fader {
     property alias handleImage: handleImage
     property bool showDefaultHandle: true
 
-    bar: true
-    barMargin: 10
+    bar.enabled: true
+    bar.margin: 10
     implicitHeight: backgroundImage.implicitHeight
     implicitWidth: backgroundImage.implicitWidth
 
@@ -20,7 +20,7 @@ MixxxControls.Fader {
         id: backgroundImage
 
         anchors.fill: parent
-        anchors.margins: root.barMargin
+        anchors.margins: root.bar.margin
     }
     handle: Item {
         id: handleItem

--- a/res/qml/Knob.qml
+++ b/res/qml/Knob.qml
@@ -5,52 +5,56 @@ import "Theme"
 MixxxControls.Knob {
     id: root
 
+    property url backgroundSource: Theme.imgKnob
     required property color color
     property url shadowSource: Theme.imgKnobShadow
-    property url backgroundSource: Theme.imgKnob
+    property bool showDefaultBackground: true
+    property bool showDefaultForeground: true
 
-    implicitWidth: background.width
-    implicitHeight: implicitWidth
-    arc: true
-    arcRadius: width * 0.45
-    arcOffsetY: width * 0.01
-    arcColor: root.color
-    arcWidth: 2
     angle: 116
-
-    Image {
-        id: shadow
-
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.right: parent.right
-        height: width * 7 / 6
-        fillMode: Image.PreserveAspectFit
-        source: root.shadowSource
-    }
+    arc: true
+    arcColor: root.color
+    arcOffsetY: width * 0.01
+    arcRadius: width * 0.45
+    arcWidth: 2
+    implicitHeight: implicitWidth
+    implicitWidth: background.width
 
     background: Image {
         id: background
 
-        anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
+        anchors.top: parent.top
         height: width
         source: root.backgroundSource
+        visible: root.showDefaultBackground
     }
-
     foreground: Item {
-        anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
+        anchors.top: parent.top
         height: width
+        visible: root.showDefaultForeground
 
         Rectangle {
             anchors.horizontalCenter: parent.horizontalCenter
-            width: 2
-            height: root.width / 5
-            y: height
             color: root.color
+            height: root.width / 5
+            width: 2
+            y: height
         }
+    }
+
+    Image {
+        id: shadow
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        fillMode: Image.PreserveAspectFit
+        height: width * 7 / 6
+        source: root.shadowSource
+        visible: root.showDefaultBackground
     }
 }

--- a/res/qml/MicrophoneDuckingPanel.qml
+++ b/res/qml/MicrophoneDuckingPanel.qml
@@ -12,8 +12,8 @@ Column {
     }
 
     Skin.ControlFader {
-        barColor: Theme.crossfaderBarColor
-        barStart: 1
+        bar.color: Theme.crossfaderBarColor
+        bar.start: 1
         bg: Theme.imgMicDuckingSlider
         fg: Theme.imgMicDuckingSliderHandle
         group: "[Master]"

--- a/res/qml/Mixer.qml
+++ b/res/qml/Mixer.qml
@@ -240,8 +240,8 @@ Item {
                 Skin.ControlFader {
                     id: crossfaderSlider
 
-                    barColor: Theme.crossfaderBarColor
-                    barStart: 0.5
+                    bar.color: Theme.crossfaderBarColor
+                    bar.start: 0.5
                     bg: Theme.imgCrossfaderBackground
                     fg: Theme.imgCrossfaderHandle
                     group: "[Master]"

--- a/res/qml/MixerColumn.qml
+++ b/res/qml/MixerColumn.qml
@@ -56,7 +56,7 @@ Item {
             id: volumeSlider
 
             anchors.fill: parent
-            barColor: Theme.volumeSliderBarColor
+            bar.color: Theme.volumeSliderBarColor
             bg: Theme.imgVolumeSliderBackground
             group: root.group
             key: "volume"

--- a/res/qml/Mixxx/Controls/Knob.qml
+++ b/res/qml/Mixxx/Controls/Knob.qml
@@ -40,7 +40,9 @@ Item {
     property real min: 0
     property real value: min
     readonly property real valueCenter: (max - min) / 2
-    property real wheelStepSize: (root.max - root.min) / 127
+    readonly property int wheelDeltaStep: 120
+    property real wheelStepSize: (root.max - root.min) / root.wheelSteps
+    readonly property int wheelSteps: 127
 
     signal turned(real value)
 
@@ -117,8 +119,7 @@ Item {
             if ((y_dominant && diff_y > 0) || (!y_dominant && diff_x < 0))
                 dist = -dist;
 
-            // For legacy (MIDI) reasons this is tuned to 127.
-            let value = root.value + dist / 127;
+            let value = root.value + dist / root.wheelSteps;
             // Clamp to [0.0, 1.0].
             value = Mixxx.MathUtils.clamp(value, 0, 1);
             root.turned(value);
@@ -141,11 +142,11 @@ Item {
         acceptedButtons: Qt.NoButton
         anchors.fill: parent
 
-        onWheel: {
-            const wheelAdjustment = wheel.angleDelta.y / 120 * root.wheelStepSize;
+        onWheel: event => {
+            const wheelAdjustment = event.angleDelta.y / root.wheelDeltaStep * root.wheelStepSize;
             const value = Mixxx.MathUtils.clamp(root.value + wheelAdjustment, root.min, root.max);
             root.turned(value);
-            wheel.accepted = true;
+            event.accepted = true;
             wheelHandler.value = value;
         }
     }

--- a/res/qml/Mixxx/Controls/Knob.qml
+++ b/res/qml/Mixxx/Controls/Knob.qml
@@ -40,8 +40,10 @@ Item {
     property real min: 0
     property real value: min
     readonly property real valueCenter: (max - min) / 2
+    // QWheelEvent::angleDelta() reports one standard mouse-wheel step as 120.
     readonly property int wheelDeltaStep: 120
     property real wheelStepSize: (root.max - root.min) / root.wheelSteps
+    // Match the legacy MIDI-style knob resolution across the control range.
     readonly property int wheelSteps: 127
 
     signal turned(real value)

--- a/res/qml/Mixxx/Controls/Knob.qml
+++ b/res/qml/Mixxx/Controls/Knob.qml
@@ -34,11 +34,13 @@ Item {
     property alias arcWidth: arcPath.strokeWidth
     property alias background: background.data
     property alias foreground: foreground.data
+    property real knobCenterOffsetX: 0
+    property real knobCenterOffsetY: 0
     property real max: 1
     property real min: 0
     property real value: min
     readonly property real valueCenter: (max - min) / 2
-    property real wheelStepSize: (root.max - root.min) / 100
+    property real wheelStepSize: (root.max - root.min) / 127
 
     signal turned(real value)
 
@@ -55,7 +57,12 @@ Item {
         id: foreground
 
         anchors.fill: parent
-        rotation: root.angleFrom(root.value - root.valueCenter)
+
+        transform: Rotation {
+            angle: root.angleFrom(root.value - root.valueCenter)
+            origin.x: root.width / 2 + root.knobCenterOffsetX
+            origin.y: root.height / 2 + root.knobCenterOffsetY
+        }
     }
     Shape {
         // Enable smooth curves. For QtQuick Shapes, this currently only works
@@ -78,7 +85,7 @@ Item {
 
             PathAngleArc {
                 centerX: root.width / 2 + root.arcOffsetX
-                centerY: root.width / 2 + root.arcOffsetY
+                centerY: root.height / 2 + root.arcOffsetY
                 radiusX: root.arcRadius
                 radiusY: root.arcRadius
                 startAngle: root.angleFrom(root.arcStartValue - root.valueCenter) - 90
@@ -135,9 +142,11 @@ Item {
         anchors.fill: parent
 
         onWheel: {
-            const value = (wheel.angleDelta.y < 0) ? Math.min(root.max, root.value + root.wheelStepSize) : Math.max(root.min, root.value - root.wheelStepSize);
+            const wheelAdjustment = wheel.angleDelta.y / 120 * root.wheelStepSize;
+            const value = Mixxx.MathUtils.clamp(root.value + wheelAdjustment, root.min, root.max);
             root.turned(value);
-            dragHandler.value = value;
+            wheel.accepted = true;
+            wheelHandler.value = value;
         }
     }
     Binding {

--- a/res/qml/Mixxx/Controls/Slider.qml
+++ b/res/qml/Mixxx/Controls/Slider.qml
@@ -34,6 +34,7 @@ Item {
     readonly property real visualPosition: vertical ? 1 - position : position
     property bool wheelEnabled: true
     property real wheelStepSize: (root.to - root.from) / root.wheelSteps
+    // Match the legacy MIDI-style fader resolution across the control range.
     readonly property int wheelSteps: 127
 
     signal moved(real value)

--- a/res/qml/Mixxx/Controls/Slider.qml
+++ b/res/qml/Mixxx/Controls/Slider.qml
@@ -10,47 +10,46 @@ Item {
         SnapOnRelease
     }
 
-    property bool bar: false
+    readonly property real availableHeight: Math.max(0, height - topPadding - bottomPadding)
+    readonly property real availableWidth: Math.max(0, width - leftPadding - rightPadding)
     property alias background: backgroundItem.data
-    property real barMargin: 0
+    property bool bar: false
     property alias barColor: barPath.strokeColor
-    property alias barWidth: barPath.strokeWidth
+    property real barMargin: 0
     property real barStart: 0
+    property alias barWidth: barPath.strokeWidth
     property real bottomPadding: 0
+    readonly property real displayValue: dragHandler.active ? dragHandler.value : value
     property real from: 0
     property alias handle: handleItem.data
+    readonly property bool horizontal: orientation === Qt.Horizontal
     property real leftPadding: 0
     property bool live: true
     property int orientation: Qt.Vertical
+    readonly property real position: valueToPosition(displayValue)
+    readonly property bool pressed: dragHandler.active
     property real rightPadding: 0
     property int snapMode: Slider.NoSnap
     property real stepSize: 0
     property real to: 1
     property real topPadding: 0
     property real value: from
-    property bool wheelEnabled: true
-    property real wheelStepSize: (root.to - root.from) / 100
-
-    readonly property real availableHeight: Math.max(0, height - topPadding - bottomPadding)
-    readonly property real availableWidth: Math.max(0, width - leftPadding - rightPadding)
-    readonly property bool horizontal: orientation === Qt.Horizontal
-    readonly property real position: valueToPosition(displayValue)
-    readonly property bool pressed: dragHandler.active
     readonly property bool vertical: orientation === Qt.Vertical
     readonly property real visualPosition: vertical ? 1 - position : position
-
-    readonly property real displayValue: dragHandler.active ? dragHandler.value : value
+    property bool wheelEnabled: true
+    property real wheelStepSize: (root.to - root.from) / 127
 
     signal moved(real value)
 
-    activeFocusOnTab: true
-    implicitHeight: Math.max(backgroundItem.implicitHeight, handleItem.implicitHeight)
-    implicitWidth: Math.max(backgroundItem.implicitWidth, handleItem.implicitWidth)
-
+    function applyInteractiveValue(targetValue, isFinal) {
+        dragHandler.value = clamp(snapValue(targetValue, isFinal));
+        if (root.live || isFinal) {
+            root.moved(dragHandler.value);
+        }
+    }
     function clamp(targetValue) {
         return Math.max(Math.min(root.from, root.to), Math.min(Math.max(root.from, root.to), targetValue));
     }
-
     function snapValue(targetValue, isFinal) {
         if (root.stepSize <= 0 || root.snapMode === Slider.NoSnap || (!isFinal && root.snapMode !== Slider.SnapAlways)) {
             return targetValue;
@@ -59,17 +58,14 @@ Item {
         const stepSize = Math.abs(root.stepSize);
         return root.from + Math.round((targetValue - root.from) / stepSize) * stepSize;
     }
-
     function stepValue(direction) {
         const rangeDirection = root.to >= root.from ? 1 : -1;
         return root.clamp(root.value + direction * rangeDirection * Math.abs(root.stepSize || root.wheelStepSize));
     }
-
     function valueAt(targetPosition) {
         targetPosition = Math.max(0, Math.min(1, targetPosition));
         return snapValue(root.from + targetPosition * (root.to - root.from), false);
     }
-
     function valueToPosition(targetValue) {
         if (root.from === root.to) {
             return 0;
@@ -77,14 +73,11 @@ Item {
         return Math.max(0, Math.min(1, (targetValue - root.from) / (root.to - root.from)));
     }
 
-    function applyInteractiveValue(targetValue, isFinal) {
-        dragHandler.value = clamp(snapValue(targetValue, isFinal));
-        if (root.live || isFinal) {
-            root.moved(dragHandler.value);
-        }
-    }
+    activeFocusOnTab: true
+    implicitHeight: Math.max(backgroundItem.implicitHeight, handleItem.implicitHeight)
+    implicitWidth: Math.max(backgroundItem.implicitWidth, handleItem.implicitWidth)
 
-    Keys.onPressed: event => {
+    Keys.onPressed: function (event) {
         if (event.key === Qt.Key_Left || event.key === Qt.Key_Down) {
             root.moved(stepValue(-1));
             event.accepted = true;
@@ -106,14 +99,12 @@ Item {
         anchors.fill: parent
         z: 0
     }
-
     Item {
         id: handleItem
 
         anchors.fill: parent
         z: 2
     }
-
     Shape {
         id: barShape
 
@@ -126,11 +117,11 @@ Item {
         ShapePath {
             id: barPath
 
-            strokeColor: "transparent"
-            strokeWidth: 2
             fillColor: "transparent"
             startX: barShape.width * (root.horizontal ? (1 - root.barStart) : 0.5)
             startY: barShape.height * (root.vertical ? (1 - root.barStart) : 0.5)
+            strokeColor: "transparent"
+            strokeWidth: 2
 
             PathLine {
                 x: root.horizontal ? (barShape.width * root.position) : barPath.startX
@@ -138,7 +129,6 @@ Item {
             }
         }
     }
-
     DragHandler {
         id: dragHandler
 
@@ -177,14 +167,13 @@ Item {
         value: dragHandler.value
         when: dragHandler.active && root.live
     }
-
     MouseArea {
         acceptedButtons: Qt.NoButton
         anchors.fill: parent
         enabled: root.enabled && root.wheelEnabled
 
         onWheel: {
-            root.moved(root.stepValue(wheel.angleDelta.y < 0 ? 1 : -1));
+            root.moved(root.stepValue(wheel.angleDelta.y > 0 ? 1 : -1));
         }
     }
 }

--- a/res/qml/Mixxx/Controls/Slider.qml
+++ b/res/qml/Mixxx/Controls/Slider.qml
@@ -13,11 +13,7 @@ Item {
     readonly property real availableHeight: Math.max(0, height - topPadding - bottomPadding)
     readonly property real availableWidth: Math.max(0, width - leftPadding - rightPadding)
     property alias background: backgroundItem.data
-    property bool bar: false
-    property alias barColor: barPath.strokeColor
-    property real barMargin: 0
-    property real barStart: 0
-    property alias barWidth: barPath.strokeWidth
+    property alias bar: barPath
     property real bottomPadding: 0
     readonly property real displayValue: dragHandler.active ? dragHandler.value : value
     property real from: 0
@@ -37,7 +33,8 @@ Item {
     readonly property bool vertical: orientation === Qt.Vertical
     readonly property real visualPosition: vertical ? 1 - position : position
     property bool wheelEnabled: true
-    property real wheelStepSize: (root.to - root.from) / 127
+    property real wheelStepSize: (root.to - root.from) / root.wheelSteps
+    readonly property int wheelSteps: 127
 
     signal moved(real value)
 
@@ -77,7 +74,7 @@ Item {
     implicitHeight: Math.max(backgroundItem.implicitHeight, handleItem.implicitHeight)
     implicitWidth: Math.max(backgroundItem.implicitWidth, handleItem.implicitWidth)
 
-    Keys.onPressed: function (event) {
+    Keys.onPressed: event => {
         if (event.key === Qt.Key_Left || event.key === Qt.Key_Down) {
             root.moved(stepValue(-1));
             event.accepted = true;
@@ -109,19 +106,25 @@ Item {
         id: barShape
 
         anchors.fill: parent
-        anchors.margins: root.barMargin
+        anchors.margins: root.bar.margin
         antialiasing: true
-        visible: root.bar
+        visible: root.bar.enabled
         z: 1
 
         ShapePath {
             id: barPath
 
+            property color color: "transparent"
+            property bool enabled: false
+            property real margin: 0
+            property real start: 0
+            property real width: 2
+
             fillColor: "transparent"
-            startX: barShape.width * (root.horizontal ? (1 - root.barStart) : 0.5)
-            startY: barShape.height * (root.vertical ? (1 - root.barStart) : 0.5)
-            strokeColor: "transparent"
-            strokeWidth: 2
+            startX: barShape.width * (root.horizontal ? (1 - root.bar.start) : 0.5)
+            startY: barShape.height * (root.vertical ? (1 - root.bar.start) : 0.5)
+            strokeColor: color
+            strokeWidth: width
 
             PathLine {
                 x: root.horizontal ? (barShape.width * root.position) : barPath.startX
@@ -172,8 +175,9 @@ Item {
         anchors.fill: parent
         enabled: root.enabled && root.wheelEnabled
 
-        onWheel: {
-            root.moved(root.stepValue(wheel.angleDelta.y > 0 ? 1 : -1));
+        onWheel: event => {
+            root.moved(root.stepValue(event.angleDelta.y > 0 ? 1 : -1));
+            event.accepted = true;
         }
     }
 }

--- a/res/qml/OrientationToggleButton.qml
+++ b/res/qml/OrientationToggleButton.qml
@@ -6,34 +6,30 @@ import QtQuick 2.12
 Item {
     id: root
 
+    property color color: "white"
     required property string group
     required property string key
     property alias orientation: orientationSlider.value
-    property color color: "white"
 
-    implicitWidth: 56
     implicitHeight: 26
+    implicitWidth: 56
 
     Skin.Fader {
         id: orientationSlider
 
+        anchors.bottomMargin: 2
         anchors.fill: parent
         anchors.leftMargin: 10
         anchors.rightMargin: 10
         anchors.topMargin: 2
-        anchors.bottomMargin: 2
-        wheelEnabled: false
-        live: false
         from: 0
-        to: 2
-        stepSize: 1
-        value: control.value
+        live: false
         orientation: Qt.Horizontal
         snapMode: MixxxControls.Slider.SnapOnRelease
-        onMoved: function(value) {
-            if (value != control.value)
-                control.value = value;
-        }
+        stepSize: 1
+        to: 2
+        value: control.value
+        wheelEnabled: false
 
         background: Rectangle {
             id: sliderBackground
@@ -41,19 +37,18 @@ Item {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            height: 2
             color: root.color
+            height: 2
         }
-
         handle: Rectangle {
             id: indicator
 
-            anchors.top: parent.top
             anchors.bottom: parent.bottom
             anchors.margins: 5
-            x: orientationSlider.visualPosition * (sliderBackground.width - width)
-            width: 3
+            anchors.top: parent.top
             color: root.color
+            width: 3
+            x: orientationSlider.visualPosition * (sliderBackground.width - width)
 
             Behavior on x {
                 NumberAnimation {
@@ -61,8 +56,12 @@ Item {
                 }
             }
         }
-    }
 
+        onMoved: function (value) {
+            if (value != control.value)
+                control.value = value;
+        }
+    }
     Mixxx.ControlProxy {
         id: control
 

--- a/res/skins/LateNightQML/Deck/RatePlaceholder.qml
+++ b/res/skins/LateNightQML/Deck/RatePlaceholder.qml
@@ -283,10 +283,10 @@ Item {
                     y: 2
                     width: 40
                     height: 119
-                    bar: true
-                    barColor: "#888888"
-                    barMargin: 7
-                    barStart: 0.5
+                    bar.enabled: true
+                    bar.color: "#888888"
+                    bar.margin: 7
+                    bar.start: 0.5
                     showDefaultHandle: false
                     group: root.group
                     key: "rate"


### PR DESCRIPTION
## Summary

This adds the shared QML control pieces needed by the LateNightQML mixer work:

- align QML knob and fader wheel behavior with the legacy widget controls
- add reusable QML fader/knob wrappers for skin controls
- add knob foreground rotation origin offsets for image-backed knobs
- make knob arc positioning respect rectangular control bounds
- add shared fader and orientation-toggle behavior used by the mixer
