### PR TITLE
Moving playlist static functions to BaseTrackSetFeature

### DIFF
--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -3,8 +3,6 @@
 #include <QStandardPaths>
 
 #include "library/library.h"
-#include "library/parserm3u.h"
-#include "library/parserpls.h"
 #include "moc_libraryfeature.cpp"
 #include "util/logger.h"
 
@@ -40,72 +38,5 @@ void LibraryFeature::selectAndActivate(const QModelIndex& index) {
         // calling featureSelect with invalid index will select the root item
         emit featureSelect(this, QModelIndex());
         activate();
-    }
-}
-
-QStringList LibraryFeature::getPlaylistFiles(QFileDialog::FileMode mode) const {
-    QString lastPlaylistDirectory = m_pConfig->getValue(
-            ConfigKey("[Library]", "LastImportExportPlaylistDirectory"),
-            QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
-
-    QFileDialog dialog(nullptr,
-            tr("Import Playlist"),
-            lastPlaylistDirectory,
-            tr("Playlist Files (*.m3u *.m3u8 *.pls *.csv)"));
-    dialog.setAcceptMode(QFileDialog::AcceptOpen);
-    dialog.setFileMode(mode);
-    dialog.setModal(true);
-
-    // If the user refuses return
-    if (!dialog.exec()) {
-        return QStringList();
-    }
-    return dialog.selectedFiles();
-}
-
-bool LibraryFeature::exportPlaylistItemsIntoFile(
-        QString playlistFilePath,
-        const QList<QString>& playlistItemLocations,
-        bool useRelativePath)    {
-    if (playlistFilePath.endsWith(
-            QStringLiteral(".pls"),
-            Qt::CaseInsensitive)) {
-        return ParserPls::writePLSFile(
-                playlistFilePath,
-                playlistItemLocations,
-                useRelativePath);
-    } else if (playlistFilePath.endsWith(
-            QStringLiteral(".m3u8"),
-            Qt::CaseInsensitive)) {
-        return ParserM3u::writeM3U8File(
-                playlistFilePath,
-                playlistItemLocations,
-                useRelativePath);
-    } else {
-        //default export to M3U if file extension is missing
-        if (!playlistFilePath.endsWith(
-                QStringLiteral(".m3u"),
-                Qt::CaseInsensitive)) {
-            kLogger.debug()
-                    << "No valid file extension for playlist export specified."
-                    << "Appending .m3u and exporting to M3U.";
-            playlistFilePath.append(QStringLiteral(".m3u"));
-            if (QFileInfo::exists(playlistFilePath)) {
-                auto overwrite = QMessageBox::question(
-                        nullptr,
-                        tr("Overwrite File?"),
-                        tr("A playlist file with the name \"%1\" already exists.\n"
-                           "The default \"m3u\" extension was added because none was specified.\n\n"
-                           "Do you really want to overwrite it?")
-                                .arg(playlistFilePath));
-                if (overwrite != QMessageBox::StandardButton::Yes) {
-                    return false;
-                }
-            }
-        }
-        return ParserM3u::writeM3UFile(
-                playlistFilePath,
-                playlistItemLocations,
-                useRelativePath);
     }
 }

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -89,18 +89,6 @@ class LibraryFeature : public QObject {
     }
 
   protected:
-    QStringList getPlaylistFiles() const {
-        return getPlaylistFiles(QFileDialog::ExistingFiles);
-    }
-    QString getPlaylistFile() const {
-        const QStringList playListFiles = getPlaylistFiles();
-        if (playListFiles.isEmpty()) {
-            return QString(); // no file chosen
-        } else {
-            return playListFiles.first();
-        }
-    }
-
     Library* const m_pLibrary;
 
     const UserSettingsPointer m_pConfig;
@@ -170,17 +158,7 @@ class LibraryFeature : public QObject {
     void enableCoverArtDisplay(bool);
     void trackSelected(TrackPointer pTrack);
 
-  protected:
-    // TODO: Move common crate/playlist functions into
-    // a separate base class
-    static bool exportPlaylistItemsIntoFile(
-            QString playlistFilePath,
-            const QList<QString>& playlistItemLocations,
-            bool useRelativePath);
-
   private:
-    QStringList getPlaylistFiles(QFileDialog::FileMode mode) const;
-
     QString m_iconName;
     QIcon m_icon;
 };

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -553,7 +553,7 @@ void BasePlaylistFeature::slotImportPlaylistFile(const QString& playlistFile,
 
 void BasePlaylistFeature::slotCreateImportPlaylist() {
     // Get file to read
-    const QStringList playlistFiles = LibraryFeature::getPlaylistFiles();
+    const QStringList playlistFiles = BaseTrackSetFeature::getPlaylistFiles();
     if (playlistFiles.isEmpty()) {
         return;
     }

--- a/src/library/trackset/basetracksetfeature.cpp
+++ b/src/library/trackset/basetracksetfeature.cpp
@@ -1,13 +1,12 @@
 
+#include "library/trackset/basetracksetfeature.h"
+
 #include <QStandardPaths>
 
 #include "library/parserm3u.h"
 #include "library/parserpls.h"
-#include "library/trackset/basetracksetfeature.h"
-#include "util/logger.h"
-
-#include "analyzer/analyzerscheduledtrack.h"
 #include "moc_basetracksetfeature.cpp"
+#include "util/logger.h"
 
 namespace {
 const mixxx::Logger kLogger("BaseTrackSetFeature");

--- a/src/library/trackset/basetracksetfeature.cpp
+++ b/src/library/trackset/basetracksetfeature.cpp
@@ -1,7 +1,17 @@
+
+#include <QStandardPaths>
+
+#include "library/parserm3u.h"
+#include "library/parserpls.h"
 #include "library/trackset/basetracksetfeature.h"
+#include "util/logger.h"
 
 #include "analyzer/analyzerscheduledtrack.h"
 #include "moc_basetracksetfeature.cpp"
+
+namespace {
+const mixxx::Logger kLogger("BaseTrackSetFeature");
+} // anonymous namespace
 
 BaseTrackSetFeature::BaseTrackSetFeature(
         Library* pLibrary,
@@ -21,4 +31,84 @@ void BaseTrackSetFeature::activate() {
     emit switchToView(m_rootViewName);
     emit disableSearch();
     emit enableCoverArtDisplay(true);
+}
+
+QStringList BaseTrackSetFeature::getPlaylistFiles(QFileDialog::FileMode mode) const {
+    QString lastPlaylistDirectory = m_pConfig->getValue(
+            ConfigKey("[Library]", "LastImportExportPlaylistDirectory"),
+            QStandardPaths::writableLocation(QStandardPaths::MusicLocation));
+
+    QFileDialog dialog(nullptr,
+            tr("Import Playlist"),
+            lastPlaylistDirectory,
+            tr("Playlist Files (*.m3u *.m3u8 *.pls *.csv)"));
+    dialog.setAcceptMode(QFileDialog::AcceptOpen);
+    dialog.setFileMode(mode);
+    dialog.setModal(true);
+
+    // If the user refuses return
+    if (!dialog.exec()) {
+        return QStringList();
+    }
+    return dialog.selectedFiles();
+}
+
+QStringList BaseTrackSetFeature::getPlaylistFiles() const {
+    return getPlaylistFiles(QFileDialog::ExistingFiles);
+}
+
+QString BaseTrackSetFeature::getPlaylistFile() const {
+    const QStringList playListFiles = getPlaylistFiles();
+    if (playListFiles.isEmpty()) {
+        return QString(); // no file chosen
+    } else {
+        return playListFiles.first();
+    }
+}
+
+bool BaseTrackSetFeature::exportPlaylistItemsIntoFile(
+        QString playlistFilePath,
+        const QList<QString>& playlistItemLocations,
+        bool useRelativePath) {
+    if (playlistFilePath.endsWith(
+                QStringLiteral(".pls"),
+                Qt::CaseInsensitive)) {
+        return ParserPls::writePLSFile(
+                playlistFilePath,
+                playlistItemLocations,
+                useRelativePath);
+    } else if (playlistFilePath.endsWith(
+                       QStringLiteral(".m3u8"),
+                       Qt::CaseInsensitive)) {
+        return ParserM3u::writeM3U8File(
+                playlistFilePath,
+                playlistItemLocations,
+                useRelativePath);
+    } else {
+        // default export to M3U if file extension is missing
+        if (!playlistFilePath.endsWith(
+                    QStringLiteral(".m3u"),
+                    Qt::CaseInsensitive)) {
+            kLogger.debug()
+                    << "No valid file extension for playlist export specified."
+                    << "Appending .m3u and exporting to M3U.";
+            playlistFilePath.append(QStringLiteral(".m3u"));
+            if (QFileInfo::exists(playlistFilePath)) {
+                auto overwrite = QMessageBox::question(
+                        nullptr,
+                        tr("Overwrite File?"),
+                        tr("A playlist file with the name \"%1\" already exists.\n"
+                           "The default \"m3u\" extension was added because none was specified.\n\n"
+                           "Do you really want to overwrite it?")
+                                .arg(playlistFilePath));
+                if (overwrite != QMessageBox::StandardButton::Yes) {
+                    return false;
+                }
+            }
+        }
+        return ParserM3u::writeM3UFile(
+                playlistFilePath,
+                playlistItemLocations,
+                useRelativePath);
+    }
 }

--- a/src/library/trackset/basetracksetfeature.h
+++ b/src/library/trackset/basetracksetfeature.h
@@ -2,10 +2,9 @@
 
 #include <QFileDialog>
 
+#include "analyzer/analyzerscheduledtrack.h"
 #include "library/libraryfeature.h"
 #include "util/parented_ptr.h"
-
-class AnalyzerScheduledTrack;
 
 class BaseTrackSetFeature : public LibraryFeature {
     Q_OBJECT

--- a/src/library/trackset/basetracksetfeature.h
+++ b/src/library/trackset/basetracksetfeature.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QFileDialog>
+
 #include "library/libraryfeature.h"
 #include "util/parented_ptr.h"
 
@@ -25,4 +27,13 @@ class BaseTrackSetFeature : public LibraryFeature {
     const QString m_rootViewName;
 
     parented_ptr<TreeItemModel> m_pSidebarModel;
+
+    QStringList getPlaylistFiles(QFileDialog::FileMode mode) const;
+    QStringList getPlaylistFiles() const;
+    QString getPlaylistFile() const;
+
+    static bool exportPlaylistItemsIntoFile(
+            QString playlistFilePath,
+            const QList<QString>& playlistItemLocations,
+            bool useRelativePath);
 };

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -701,7 +701,7 @@ void CrateFeature::slotImportPlaylistFile(const QString& playlistFile, CrateId c
 
 void CrateFeature::slotCreateImportCrate() {
     // Get file to read
-    const QStringList playlistFiles = LibraryFeature::getPlaylistFiles();
+    const QStringList playlistFiles = BaseTrackSetFeature::getPlaylistFiles();
     if (playlistFiles.isEmpty()) {
         return;
     }


### PR DESCRIPTION
`libraryfeature.h` was annotated with a TODO for moving the static playlist export functions to a more specific type.

This changeset would move these functions to `BaseTrackSetFeature`, as a common base class for both `CrateFeature` and `BasePlaylistFeature`.