### PR TITLE
Search Related: use compact BPM query `bpm:100-115` instead of `bpm:>=100 bpm:<=115`

### DIFF
--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -167,14 +167,14 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             double bpmUpperBound = 0.0;
             std::tie(bpmLowerBound, bpmUpperBound) = pBpmNode->getBpmRange();
             const QString searchQuery =
-                    QStringLiteral("bpm:>=") +
+                    QStringLiteral("bpm:") +
                     QString::number(bpmLowerBound) +
-                    QStringLiteral(" bpm:<=") +
+                    QStringLiteral("-") +
                     QString::number(bpmUpperBound);
             addTriggerSearchAction(&addSeparatorBeforeNextAction,
                     searchQuery,
                     tr("BPM"),
-                    tr("between %1 and %2")
+                    tr("%1 - %2")
                             .arg(QString::number(bpmLowerBound),
                                     QString::number(bpmUpperBound)));
         }


### PR DESCRIPTION
This makes the query more compact (more space for additional filters) and editing it a little easier