### PR TITLE
(feat) Search Related: allow to reuse previously used criteria (restore check states)

### DIFF
--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -23,6 +23,8 @@ namespace {
 constexpr double kMaxMenuToAvailableScreenWidthRatio = 0.2;
 
 const QString kActionTextPrefixSuffixSeparator = QStringLiteral(": ");
+const char* kQueryProp = "query";
+const char* kCriterionProp = "criterion";
 
 inline QString quoteSearchQueryText(const QString& text) {
     return QChar('"') + text + QChar('"');
@@ -55,6 +57,8 @@ QString extractCalendarYearNumberFromReleaseDate(
 
 } // namespace
 
+SearchCriteria WSearchRelatedTracksMenu::s_prevCriteria;
+
 WSearchRelatedTracksMenu::WSearchRelatedTracksMenu(
         QWidget* pParent)
         : QMenu(tr("Search related Tracks"), pParent) {
@@ -64,6 +68,7 @@ void WSearchRelatedTracksMenu::addTriggerSearchAction(
         bool* /*in/out*/ pAddSeparatorBeforeNextAction,
         /*!by-value-because-captured-by-lambda!*/
         QString searchQuery, // clazy:exclude=function-args-by-ref
+        SearchCriterion criterion,
         const QString& actionTextPrefix,
         const QString& elidableTextSuffix) {
     DEBUG_ASSERT(pAddSeparatorBeforeNextAction);
@@ -80,7 +85,11 @@ void WSearchRelatedTracksMenu::addTriggerSearchAction(
     auto pCheckBox = make_parented<WSearchRelatedCheckBox>(
             mixxx::escapeTextPropertyWithoutShortcuts(elidedActionText),
             this);
-    pCheckBox->setProperty("query", searchQuery);
+    pCheckBox->setProperty(kQueryProp, searchQuery);
+    pCheckBox->setProperty(kCriterionProp, QVariant::fromValue(criterion));
+    if (s_prevCriteria.testFlag(criterion)) {
+        pCheckBox->setChecked(true);
+    }
     connect(pCheckBox.get(),
             &QCheckBox::toggled,
             this,
@@ -95,10 +104,14 @@ void WSearchRelatedTracksMenu::addTriggerSearchAction(
     connect(pAction.get(),
             &QAction::triggered,
             this,
-            [this, searchQuery]() {
+            [this, criterion, searchQuery]() {
                 // TODO Call combineQueriesTriggerSearch() so we can check multiple
                 // actions and press return on the last selected action without
                 // having to go to the Search button?
+                //
+                // Clear the saved criteria and save this one
+                s_prevCriteria = SearchCriteria();
+                s_prevCriteria.setFlag(criterion);
                 emit triggerSearch(searchQuery);
             });
     addAction(pAction.get());
@@ -153,6 +166,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,
                     searchQuery,
+                    SearchCriterion::Key,
                     tr("Key"),
                     tr("harmonic with %1").arg(keyText));
         }
@@ -173,6 +187,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
                     QString::number(bpmUpperBound);
             addTriggerSearchAction(&addSeparatorBeforeNextAction,
                     searchQuery,
+                    SearchCriterion::Bpm,
                     tr("BPM"),
                     tr("between %1 and %2")
                             .arg(QString::number(bpmLowerBound),
@@ -213,6 +228,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
                     addTriggerSearchAction(
                             &addSeparatorBeforeNextAction,
                             searchQuery,
+                            SearchCriterion::Artist,
                             actionTextPrefix,
                             primaryArtist);
                 }
@@ -223,6 +239,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
                     addTriggerSearchAction(
                             &addSeparatorBeforeNextAction,
                             searchQuery,
+                            SearchCriterion::Artist,
                             actionTextPrefix,
                             secondaryArtist);
                 }
@@ -237,6 +254,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
                     addTriggerSearchAction(
                             &addSeparatorBeforeNextAction,
                             searchQuery,
+                            SearchCriterion::AlbumArtist,
                             actionTextPrefix,
                             primaryArtist);
                 }
@@ -247,6 +265,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
                     addTriggerSearchAction(
                             &addSeparatorBeforeNextAction,
                             searchQuery,
+                            SearchCriterion::AlbumArtist,
                             actionTextPrefix,
                             secondaryArtist);
                 }
@@ -262,6 +281,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,
                     searchQuery,
+                    SearchCriterion::Composer,
                     tr("Composer"),
                     composer);
         }
@@ -278,6 +298,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,
                     searchQuery,
+                    SearchCriterion::Title,
                     tr("Title"),
                     title);
         }
@@ -291,6 +312,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,
                     searchQuery,
+                    SearchCriterion::Album,
                     tr("Album"),
                     album);
         }
@@ -304,6 +326,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,
                     searchQuery,
+                    SearchCriterion::Grouping,
                     tr("Grouping"),
                     grouping);
         }
@@ -321,6 +344,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,
                     searchQuery,
+                    SearchCriterion::Year,
                     tr("Year"),
                     releaseYearNumber);
         }
@@ -334,6 +358,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,
                     searchQuery,
+                    SearchCriterion::Genre,
                     tr("Genre"),
                     genre);
         }
@@ -352,6 +377,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,
                     searchQuery,
+                    SearchCriterion::Location,
                     tr("Directory"),
                     locationPathWithTerminator);
         }
@@ -379,12 +405,16 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             &QCheckBox::toggled,
             this,
             &WSearchRelatedTracksMenu::combineQueriesTriggerSearch);
+
+    // Update Search button since we might have auto-checked some
+    // previously used criteria
+    updateSearchButton();
 }
 
 bool WSearchRelatedTracksMenu::eventFilter(QObject* pObj, QEvent* e) {
     if (e->type() == QEvent::MouseButtonRelease) {
         // Note: QCheckBox/QAbstractButton and QMenu act on release, not on click.
-        // Since we want tp provide a toggle function that allows to check multiple
+        // Since we want to provide a toggle function that allows to check multiple
         // criteria (ie. don't auto-close the menu on first click) we need to
         // figure the intended click target.
         // Simply checking whether the click is inside the indicator's rectangle
@@ -404,7 +434,10 @@ bool WSearchRelatedTracksMenu::eventFilter(QObject* pObj, QEvent* e) {
             QMouseEvent* pMe = static_cast<QMouseEvent*>(e);
             if (pMe->pos().x() > labelRect.left()) {
                 // Label region was clicked, trigger the search.
-                const QString query = pBox->property("query").toString();
+                const QString query = pBox->property(kQueryProp).toString();
+                SearchCriterion cr = pBox->property(kCriterionProp).value<SearchCriterion>();
+                s_prevCriteria = SearchCriteria();
+                s_prevCriteria.setFlag(cr);
                 emit triggerSearch(query);
                 // Note that this click will not emit QAction::triggered like
                 // when pressing Return on a selected action, hence we need to
@@ -436,15 +469,19 @@ void WSearchRelatedTracksMenu::updateSearchButton() {
 void WSearchRelatedTracksMenu::combineQueriesTriggerSearch() {
     // collect queries of all checked checkboxes
     QStringList queries;
+    // Unset search criteria to store only what we are using for this search
+    s_prevCriteria = SearchCriteria();
     for (const auto* pChild : std::as_const(children())) {
         if (pChild == m_pSearchAction) {
             continue;
         }
         const auto* pBox = qobject_cast<const QCheckBox*>(pChild);
         if (pBox && pBox->isChecked()) {
-            QString query = pBox->property("query").toString();
+            QString query = pBox->property(kQueryProp).toString();
             if (!query.isEmpty()) {
                 queries.append(query);
+                SearchCriterion cr = pBox->property(kCriterionProp).value<SearchCriterion>();
+                s_prevCriteria.setFlag(cr);
             }
         }
     }

--- a/src/widget/wsearchrelatedtracksmenu.h
+++ b/src/widget/wsearchrelatedtracksmenu.h
@@ -8,6 +8,24 @@
 class Track;
 class QWidgetAction;
 
+// enum that allows reusing previously selected search criteria
+enum SearchCriterion {
+    Key = 1 << 1,
+    Bpm = 1 << 2,
+    Artist = 1 << 3,
+    Title = 1 << 4,
+    AlbumArtist = 1 << 5,
+    Album = 1 << 6,
+    Composer = 1 << 7,
+    Grouping = 1 << 8,
+    Year = 1 << 9,
+    Genre = 1 << 10,
+    Location = 1 << 11
+};
+Q_DECLARE_FLAGS(SearchCriteria, SearchCriterion)
+Q_DECLARE_OPERATORS_FOR_FLAGS(SearchCriteria);
+Q_DECLARE_METATYPE(SearchCriteria);
+
 /// Extension of WMenuCheckBox with a vertical separator bar in between the
 /// label and the indicator box. This is supposed to clarify the different
 /// behavior of clicks in these two regions.
@@ -52,6 +70,7 @@ class WSearchRelatedTracksMenu : public QMenu {
     void addTriggerSearchAction(
             bool* /*in/out*/ pAddSeparatorBeforeNextAction,
             QString searchQuery,
+            SearchCriterion criterion,
             const QString& actionTextPrefix,
             const QString& elidableTextSuffix = QString());
     QString elideActionText(
@@ -59,4 +78,6 @@ class WSearchRelatedTracksMenu : public QMenu {
             const QString& elidableTextSuffix) const;
 
     parented_ptr<QWidgetAction> m_pSearchAction;
+
+    static SearchCriteria s_prevCriteria;
 };


### PR DESCRIPTION
This simplifies the workflow where you want to repeatedly use the same search criteria, eg. Key and Genre, or Key and BPM.
This is especially helpful when you want to trigger Search Related with a controller mapping script by emulating keypresses with `[Library],MoveVertical` and `[Library],GoToItem`.
(there were a few related requests in the forum lately)

Criteria are stored in static member so it works across multiple track menu instances (Library, decks, samplers).
Only criteria that are available are stored, so if a track has no Genre set and Genre was used in a previous search it'll be dropped.