### PR TITLE
bind `end_of_track` to outro end position

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -86,6 +86,7 @@ EngineBuffer::EngineBuffer(const QString& group,
           m_bSlipEnabledProcessing(false),
           m_slipModeState(SlipModeState::Disabled),
           m_quantize(ControlFlag::AllowMissingOrInvalid),
+          m_outroEndSamplePos(ControlFlag::AllowMissingOrInvalid),
           m_pRepeat(nullptr),
           m_startButton(nullptr),
           m_endButton(nullptr),
@@ -265,6 +266,8 @@ EngineBuffer::EngineBuffer(const QString& group,
             m_pLoopingControl,
             &LoopingControl::slotLoopRemove,
             Qt::DirectConnection);
+
+    m_outroEndSamplePos = PollingControlProxy(group, QStringLiteral("outro_end_position"));
 
     m_pReadAheadManager = new ReadAheadManager(m_pReader,
             m_pLoopingControl,
@@ -639,6 +642,7 @@ void EngineBuffer::ejectTrack() {
             false,
             false,
             false,
+            0.0,
             0.0,
             0.0,
             0.0,
@@ -1506,8 +1510,16 @@ void EngineBuffer::updateIndicators(double speed, std::size_t bufferSize) {
         fFractionalLoopEndPos = fractionalPlayposFromAbsolute(loopInfo.endPosition);
     }
 
-    const double tempoTrackSeconds = m_trackEndPositionOld.value() /
-            m_trackSampleRateOld / getRateRatio();
+    const double tempoTrackSeconds = getRateRatio() *
+            m_trackEndPositionOld.value() / m_trackSampleRateOld;
+
+    double tempoOutroEndSeconds = tempoTrackSeconds;
+    const double outroEndPos = m_outroEndSamplePos.get();
+    if (outroEndPos > 0) {
+        tempoOutroEndSeconds = getRateRatio() * outroEndPos /
+                (m_trackSampleRateOld * mixxx::kEngineChannelOutputCount);
+    }
+
     if (speed > 0 && fFractionalPlaypos == 1.0) {
         // Play pos at Track end
         speed = 0;
@@ -1545,6 +1557,7 @@ void EngineBuffer::updateIndicators(double speed, std::size_t bufferSize) {
             fFractionalLoopStartPos,
             fFractionalLoopEndPos,
             tempoTrackSeconds,
+            tempoOutroEndSeconds,
             bufferSize / mixxx::kEngineChannelOutputCount / m_sampleRate.toDouble() * 1000000.0);
 
     // TODO: Especially with long audio buffers, jitter is visible. This can be fixed by moving the

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -424,6 +424,7 @@ class EngineBuffer : public EngineObject {
     ControlPushButton* m_pSlipButton;
 
     PollingControlProxy m_quantize;
+    PollingControlProxy m_outroEndSamplePos;
     ControlPotmeter* m_playposSlider;
     ControlProxy* m_pSampleRate;
     ControlProxy* m_pKeylockEngine;

--- a/src/qml/qmlwaveformdisplay.cpp
+++ b/src/qml/qmlwaveformdisplay.cpp
@@ -51,6 +51,7 @@ QmlWaveformDisplay::QmlWaveformDisplay(QQuickItem* parent)
             0.0,
             0.0,
             0.0,
+            0.0,
             0.0);
     setFlag(QQuickItem::ItemHasContents, true);
 
@@ -100,6 +101,7 @@ void QmlWaveformDisplay::setPosition(double value) {
             0,
             0,
             m_pTrack->internal()->getDuration(),
+            0.0,
             0);
     update();
 }
@@ -133,6 +135,10 @@ void QmlWaveformDisplay::setStaticTrack(QmlTrackProxy* track) {
             0,
             0,
             m_pTrack->internal()->getDuration(),
+            // outro end position, disabled for now with invalid value
+            // Used to set/unset the `end_of_track` CO
+            // TODO get `outro_end_position`, convert to seconds
+            0.0,
             1024. / static_cast<double>(mixxx::kEngineChannelOutputCount) /
                     static_cast<double>(m_pTrack->internal()->getSampleRate()) * 1000000.0);
     setCurrentTrack(track->internal());

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -35,6 +35,7 @@ void VisualPlayPosition::set(
         double loopStartPosition,
         double loopEndPosition,
         double tempoTrackSeconds,
+        double tempoOutroEndSeconds,
         double audioBufferMicroS) {
     VisualPlayPositionData data;
     data.m_referenceTime = m_timeInfoTime;
@@ -51,6 +52,7 @@ void VisualPlayPosition::set(
     data.m_loopStartPos = loopStartPosition;
     data.m_loopEndPos = loopEndPosition;
     data.m_tempoTrackSeconds = tempoTrackSeconds;
+    data.m_tempoOutroEndSeconds = tempoOutroEndSeconds;
     data.m_audioBufferMicroS = audioBufferMicroS;
 
     // Atomic write
@@ -202,6 +204,13 @@ void VisualPlayPosition::getTrackTime(double* pPlayPosition, double* pTempoTrack
     }
 }
 
+double VisualPlayPosition::getTrackEndSeconds() const {
+    if (!m_valid.load()) {
+        return -1.0;
+    }
+    VisualPlayPositionData data = m_data.getValue();
+    return data.m_tempoOutroEndSeconds;
+}
 //static
 QSharedPointer<VisualPlayPosition> VisualPlayPosition::getVisualPlayPosition(const QString& group) {
     QSharedPointer<VisualPlayPosition> vpp = m_listVisualPlayPosition.value(group);

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -42,6 +42,9 @@ class VisualPlayPositionData {
     double m_loopStartPos;
     double m_loopEndPos;
     double m_tempoTrackSeconds; // total track time, taking the current tempo into account
+    // outro end position in seconds, taking the current tempo into account
+    // is same as m_tempoTrackSeconds if outro end is not set
+    double m_tempoOutroEndSeconds;
     double m_audioBufferMicroS;
 };
 
@@ -66,6 +69,7 @@ class VisualPlayPosition : public QObject {
             double loopStartPos,
             double loopEndPos,
             double tempoTrackSeconds,
+            double tempoOutroEndSeconds,
             double audioBufferMicroS);
 
     double getAtNextVSync(VSyncTimeProvider* pSyncTimeProvider);
@@ -76,6 +80,7 @@ class VisualPlayPosition : public QObject {
             const VisualPlayPositionData& data, const double& offset);
     double getEnginePlayPos();
     void getTrackTime(double* pPlayPosition, double* pTempoTrackSeconds);
+    double getTrackEndSeconds() const;
 
     // WARNING: Not thread safe. This function must only be called from the main
     // thread.

--- a/src/waveform/visualsmanager.cpp
+++ b/src/waveform/visualsmanager.cpp
@@ -30,9 +30,17 @@ void DeckVisuals::process(double remainingTimeTriggerSeconds) {
         return;
     }
 
-    double timeRemaining = (1.0 - playPosition) * tempoTrackSeconds;
+    const double playPosSeconds = playPosition * tempoTrackSeconds;
+    double timeRemaining = tempoTrackSeconds - playPosSeconds;
     m_timeRemaining.set(timeRemaining);
-    m_timeElapsed.set(tempoTrackSeconds - timeRemaining);
+    m_timeElapsed.set(playPosSeconds);
+
+    // get position of outro end and use it as remaining time
+    // for end-of-track warning if it's valid
+    const double outroEndPosSeconds = m_pVisualPlayPos->getTrackEndSeconds();
+    if (outroEndPosSeconds > 0) {
+        timeRemaining = outroEndPosSeconds - playPosSeconds;
+    }
 
     if (!m_playButton.toBool() ||                               // not playing
             m_loopEnabled.toBool() ||                           // in loop

--- a/src/waveform/visualsmanager.cpp
+++ b/src/waveform/visualsmanager.cpp
@@ -1,21 +1,20 @@
 #include "waveform/visualsmanager.h"
 
-#include "control/controlobject.h"
 #include "waveform/visualplayposition.h"
 
 DeckVisuals::DeckVisuals(const QString& group)
         : m_group(group),
           m_SlowTickCnt(0),
           m_trackLoaded(false),
-          m_pPlayButton(std::make_unique<ControlProxy>(ConfigKey(group, "play"))),
-          m_pLoopEnabled(std::make_unique<ControlProxy>(ConfigKey(group, "loop_enabled"))),
-          m_pEngineBpm(std::make_unique<ControlProxy>(ConfigKey(group, "bpm"))),
-          m_pVisualBpm(std::make_unique<ControlProxy>(ConfigKey(m_group, "visual_bpm"))),
-          m_pEngineKey(std::make_unique<ControlProxy>(ConfigKey(group, "key"))),
-          m_pVisualKey(std::make_unique<ControlProxy>(ConfigKey(m_group, "visual_key"))),
-          m_pTimeElapsed(std::make_unique<ControlProxy>(ConfigKey(m_group, "time_elapsed"))),
-          m_pTimeRemaining(std::make_unique<ControlProxy>(ConfigKey(m_group, "time_remaining"))),
-          m_pEndOfTrack(std::make_unique<ControlProxy>(ConfigKey(m_group, "end_of_track"))) {
+          m_playButton(ConfigKey(m_group, QStringLiteral("play"))),
+          m_loopEnabled(ConfigKey(m_group, QStringLiteral("loop_enabled"))),
+          m_engineBpm(ConfigKey(m_group, QStringLiteral("bpm"))),
+          m_visualBpm(ConfigKey(m_group, QStringLiteral("visual_bpm"))),
+          m_engineKey(ConfigKey(m_group, QStringLiteral("key"))),
+          m_visualKey(ConfigKey(m_group, QStringLiteral("visual_key"))),
+          m_timeElapsed(ConfigKey(m_group, QStringLiteral("time_elapsed"))),
+          m_timeRemaining(ConfigKey(m_group, QStringLiteral("time_remaining"))),
+          m_endOfTrack(ConfigKey(m_group, QStringLiteral("end_of_track"))) {
     // Control used to communicate ratio playpos to GUI thread
     m_pVisualPlayPos = VisualPlayPosition::getVisualPlayPosition(m_group);
 }
@@ -32,24 +31,24 @@ void DeckVisuals::process(double remainingTimeTriggerSeconds) {
     }
 
     double timeRemaining = (1.0 - playPosition) * tempoTrackSeconds;
-    m_pTimeRemaining->set(timeRemaining);
-    m_pTimeElapsed->set(tempoTrackSeconds - timeRemaining);
+    m_timeRemaining.set(timeRemaining);
+    m_timeElapsed.set(tempoTrackSeconds - timeRemaining);
 
-    if (!m_pPlayButton->toBool() ||                             // not playing
-            m_pLoopEnabled->toBool() ||                         // in loop
+    if (!m_playButton.toBool() ||                               // not playing
+            m_loopEnabled.toBool() ||                           // in loop
             tempoTrackSeconds <= remainingTimeTriggerSeconds || // track too short
             timeRemaining > remainingTimeTriggerSeconds) {      // before the trigger
-        m_pEndOfTrack->set(0.0);
+        m_endOfTrack.set(0.0);
     } else {
-        m_pEndOfTrack->set(1.0);
+        m_endOfTrack.set(1.0);
     }
 
     // Update the BPM even more slowly
     m_SlowTickCnt = (m_SlowTickCnt + 1) % kSlowUpdateDivider;
     if (m_SlowTickCnt == 0 || !trackLoaded) {
-        m_pVisualBpm->set(m_pEngineBpm->get());
+        m_visualBpm.set(m_engineBpm.get());
     }
-    m_pVisualKey->set(m_pEngineKey->get());
+    m_visualKey.set(m_engineKey.get());
 
     m_trackLoaded = trackLoaded;
 }

--- a/src/waveform/visualsmanager.h
+++ b/src/waveform/visualsmanager.h
@@ -3,8 +3,7 @@
 #include <memory>
 #include <vector>
 
-#include "control/controlobject.h"
-#include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
 #include "util/duration.h"
 #include "util/performancetimer.h"
 
@@ -35,18 +34,18 @@ class DeckVisuals {
     int m_SlowTickCnt;
     bool m_trackLoaded;
 
-    std::unique_ptr<ControlProxy> m_pPlayButton;
-    std::unique_ptr<ControlProxy> m_pLoopEnabled;
+    PollingControlProxy m_playButton;
+    PollingControlProxy m_loopEnabled;
 
-    std::unique_ptr<ControlProxy> m_pEngineBpm;
-    std::unique_ptr<ControlProxy> m_pVisualBpm;
+    PollingControlProxy m_engineBpm;
+    PollingControlProxy m_visualBpm;
 
-    std::unique_ptr<ControlProxy> m_pEngineKey;
-    std::unique_ptr<ControlProxy> m_pVisualKey;
+    PollingControlProxy m_engineKey;
+    PollingControlProxy m_visualKey;
 
-    std::unique_ptr<ControlProxy> m_pTimeElapsed;
-    std::unique_ptr<ControlProxy> m_pTimeRemaining;
-    std::unique_ptr<ControlProxy> m_pEndOfTrack;
+    PollingControlProxy m_timeElapsed;
+    PollingControlProxy m_timeRemaining;
+    PollingControlProxy m_endOfTrack;
 
     QSharedPointer<VisualPlayPosition> m_pVisualPlayPos;
 };


### PR DESCRIPTION
Fixes #13970 

While the end_of_track warning is helpful, there are tracks that "end" way earlier, ie. the last audible sound is significantly before the track end (last sample), so the warning might kick in just 10 sec before the track fades to silence.

Now it's bound to `outro_end_position` if that's valid/set.

This has the benefit that you can set "end" warning marker manually, eg. in order to be warned about undesired noise or "hidden tracks".

Drawback:
there's now an inconsistency between the end-of-track warning and the remaining time display.
So we might make this optional?



