### PR TITLE
HIDController: Close descriptor thread afer poll

### DIFF
--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -418,6 +418,8 @@ void HidController::fetchReportDescriptorInBackground() {
                     nullptr);
         }
         if (!pHidDevice) {
+            lock.unlock();
+            QThread::currentThread()->quit();
             return;
         }
         hid_set_nonblocking(pHidDevice, 1);
@@ -433,6 +435,8 @@ void HidController::fetchReportDescriptorInBackground() {
             m_deviceUsesReportIds = m_reportDescriptor->isDeviceWithReportIds();
         }
         hid_close(pHidDevice);
+        lock.unlock();
+        QThread::currentThread()->quit();
     });
 #else
     Q_UNUSED(m_reportDescriptorFuture);


### PR DESCRIPTION
During Mixxx startup, the ControllerManager will create a thread as in order to poll for HID descriptor information, for each discovered HID device. The application startup may then proceed, while each USB device is polled under the application thread pool.

When testing with gdb on Fedora 44, it appeared that each of these threads was relatively long-running. The thread creation would be indicated with gdb, immediately after each HID device was discovered.
> [New Thread 0x7ffe4cff96c0 (LWP 244310)]

The corresponding thread-exit event might not have followed until when the application process was shutting down.
> [Thread 0x7ffe4cff96c0 (LWP 244310) exited]

Each of these QThreads may have entered a Qt event loop. This may have followed after the thread function would have returned.

This changeset ensures that the thread closes after either hid_open() has failed, or an HID descriptor was found. This will also ensure that the descriptor lock is directly released before return, when previously acquired within the polling thread.

The descriptor poll thread may then exit just after the descriptor poll has completed. This might serve to prevent a certain memory management error that was showing up intermittently - though in this sense persistently - during pthread shutdown at application exit, with local testing (Clang 22, Qt 6, Fedora 44)