### PR TITLE
Improve SoundDevice and Channel naming on Sound Hardware preference page for PipeWire API

### DIFF
--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -175,17 +175,16 @@ void DlgPrefSoundItem::deviceChanged(int index) {
         // Count down from the max so that stereo channels are first.
         for (int channelsForType = maxChannelsForType;
                  channelsForType >= minChannelsForType; --channelsForType) {
-            for (unsigned int i = 1; i + (channelsForType - 1) <= numChannels;
+            for (unsigned int i = 0; i + channelsForType <= numChannels;
                     i += channelsForType) {
                 ChannelGroup channels(i, mixxx::audio::ChannelCount(channelsForType));
                 QString channelString = selectedDevice->getChannelString(channels, m_isInput);
 
                 // Because QComboBox supports QPoint natively (via QVariant) we
                 // use a QPoint to store the channel info. x is the channel base
-                // and y is the channel count. We use i - 1 because the channel
-                // base is 0-indexed.
+                // and y is the channel count.
                 channelComboBox->addItem(channelString,
-                                         QPoint(i - 1, channelsForType));
+                        QPoint(i, channelsForType));
             }
         }
         channelComboBox->setCurrentIndex(-1); // clear selection

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -2,9 +2,11 @@
 
 #include <QPoint>
 
+#include "audio/types.h"
 #include "moc_dlgprefsounditem.cpp"
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
+#include "soundio/soundmanagerutil.h"
 #include "util/assert.h"
 
 /// Constructs a new preferences sound item, representing an AudioPath and SoundDevice
@@ -43,7 +45,6 @@ DlgPrefSoundItem::DlgPrefSoundItem(
 }
 
 DlgPrefSoundItem::~DlgPrefSoundItem() {
-
 }
 
 /// Slot called when the parent preferences pane updates its list of sound
@@ -146,11 +147,14 @@ void DlgPrefSoundItem::deviceChanged(int index) {
     channelComboBox->clear();
     SoundDeviceId selection = deviceComboBox->itemData(index).value<SoundDeviceId>();
     mixxx::audio::ChannelCount numChannels;
+    SoundDevicePointer selectedDevice;
+
     if (selection == SoundDeviceId()) {
         goto emitAndReturn;
     } else {
         for (const auto& pDevice : std::as_const(m_devices)) {
             if (pDevice->getDeviceId() == selection) {
+                selectedDevice = pDevice;
                 if (m_isInput) {
                     numChannels = pDevice->getNumInputChannels();
                 } else {
@@ -172,15 +176,9 @@ void DlgPrefSoundItem::deviceChanged(int index) {
         for (int channelsForType = maxChannelsForType;
                  channelsForType >= minChannelsForType; --channelsForType) {
             for (unsigned int i = 1; i + (channelsForType - 1) <= numChannels;
-                     i += channelsForType) {
-                QString channelString;
-                if (channelsForType == 1) {
-                    channelString = tr("Channel %1").arg(i);
-                } else {
-                    channelString = tr("Channels %1 - %2").arg(
-                            QString::number(i),
-                            QString::number(i + channelsForType - 1));
-                }
+                    i += channelsForType) {
+                ChannelGroup channels(i, mixxx::audio::ChannelCount(channelsForType));
+                QString channelString = selectedDevice->getChannelString(channels, m_isInput);
 
                 // Because QComboBox supports QPoint natively (via QVariant) we
                 // use a QPoint to store the channel info. x is the channel base

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -28,21 +28,48 @@ namespace {
 constexpr int kCpuUsageUpdateRate = 30; // in 1/s, fits to display frame rate
 const QString kAppGroup = QStringLiteral("[App]");
 
-static const char* find_node_name(const struct spa_dict* props) {
-    static const char* const name_keys[] = {
-            PW_KEY_NODE_NAME,
+static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
+    std::string name;
+    static const char* const nameKeys[] = {
             PW_KEY_NODE_DESCRIPTION,
-            PW_KEY_APP_NAME,
+            PW_KEY_NODE_NICK,
             PW_KEY_MEDIA_NAME,
+            PW_KEY_APP_NAME,
+            PW_KEY_NODE_NAME,
     };
 
-    for (const char* key : name_keys) {
-        const char* name = spa_dict_lookup(props, key);
-        if (name) {
-            return name;
+    for (const char* key : nameKeys) {
+        const char* prop = spa_dict_lookup(props, key);
+        if (prop) {
+            name = prop;
+            break;
         }
     }
-    return nullptr;
+
+    const char* mediaClass = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS);
+    static const char* const subtypes[] = {
+            "Output",
+            "Input",
+            "Source",
+            "Sink",
+            "Duplex",
+    };
+
+    if (mediaClass) {
+        for (const char* subtype : subtypes) {
+            if (std::strstr(mediaClass, subtype)) {
+                name = name + " (" + subtype + ")";
+            }
+        }
+    } else {
+        const char* mediaCategory = spa_dict_lookup(props, PW_KEY_MEDIA_CATEGORY);
+        if (mediaCategory) {
+            name = name + " (" + mediaCategory + ")";
+        }
+    }
+
+    // worst case scenario, we still have node ID as name
+    return name + ":" + std::to_string(id);
 }
 } // namespace
 
@@ -215,7 +242,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
             return;
         }
 
-        const char* name = find_node_name(pProps);
+        std::string name = find_node_name(id, pProps);
 
         m_objects.insert_or_assign(id, Object{Node{}});
         auto pDevice = QSharedPointer<SoundDevicePipewire>::create(
@@ -225,9 +252,11 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         // any previous element is either invalid or already removed
         m_soundDevices.insert_or_assign(id, std::move(pDevice));
 
-        // this can be fooled if a different application names its node "Mixxx"
-        if (strcmp(name, "Mixxx") == 0) {
-            m_filterId = id;
+        if (name.find("Mixxx") != std::string::npos) {
+            uint32_t filterId = pw_filter_get_node_id(m_pPwFilter);
+            if (filterId == id) {
+                m_filterId = filterId;
+            }
         }
     } else if (strcmp(pType, PW_TYPE_INTERFACE_Port) == 0) {
         const uint32_t node_id = pw_properties_parse_int(spa_dict_lookup(pProps, PW_KEY_NODE_ID));

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -731,7 +731,11 @@ std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createPorts(
             // see pipewire/keys.h header
             PW_KEY_FORMAT_DSP,
             "32 bit float mono audio",
+            PW_KEY_AUDIO_CHANNEL,
+            "FL",
             nullptr);
+    // any changes to port name needs to update port name parsing logic in
+    // PipewireEnumerator::registryEventGlobal
     pw_properties_setf(props, PW_KEY_PORT_NAME, "%s:FL", name.data());
 
     void* leftPort = pw_filter_add_port(m_pPwFilter,
@@ -746,7 +750,11 @@ std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createPorts(
             // see pipewire/keys.h header
             PW_KEY_FORMAT_DSP,
             "32 bit float mono audio",
+            PW_KEY_AUDIO_CHANNEL,
+            "FR",
             nullptr);
+    // any changes to port name needs to update port name parsing logic in
+    // PipewireEnumerator::registryEventGlobal
     pw_properties_setf(props, PW_KEY_PORT_NAME, "%s:FR", name.data());
 
     void* rightPort = pw_filter_add_port(m_pPwFilter,

--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -227,10 +227,11 @@ void SoundDevice::clearInputBuffer(const SINT framesToPush,
 
 QString SoundDevice::getChannelString(ChannelGroup channelGroup, bool) {
     mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
-    unsigned char base = channelGroup.getChannelBase();
+    unsigned char channelBase = channelGroup.getChannelBase();
     if (count == 1) {
-        return "Channel " + QString::number(base);
+        return "Channel " + QString::number(channelBase + 1);
     } else {
-        return "Channels " + QString::number(base) + " - " + QString::number(base + count - 1);
+        return "Channels " + QString::number(channelBase + 1) + " - " +
+                QString::number(channelBase + count);
     }
 }

--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -1,5 +1,6 @@
 #include "soundio/sounddevice.h"
 
+#include "audio/types.h"
 #include "soundio/soundmanagerconfig.h"
 #include "soundio/soundmanagerutil.h"
 #include "soundmanagerconfig.h"
@@ -221,5 +222,15 @@ void SoundDevice::clearInputBuffer(const SINT framesToPush,
         const AudioInputBuffer& in = *i;
         CSAMPLE* pInputBuffer = in.getBuffer();  // Always stereo
         SampleUtil::clear(&pInputBuffer[framesWriteOffset * 2], framesToPush * 2);
+    }
+}
+
+QString SoundDevice::getChannelString(ChannelGroup channelGroup, bool) {
+    mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
+    unsigned char base = channelGroup.getChannelBase();
+    if (count == 1) {
+        return "Channel " + QString::number(base);
+    } else {
+        return "Channels " + QString::number(base) + " - " + QString::number(base + count - 1);
     }
 }

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -38,6 +38,7 @@ class SoundDevice {
     virtual void writeProcess(SINT framesPerBuffer) = 0;
     virtual QString getError() const = 0;
     virtual mixxx::audio::SampleRate getDefaultSampleRate() const = 0;
+    virtual QString getChannelString(ChannelGroup channelGroup, bool input);
     mixxx::audio::ChannelCount getNumOutputChannels() const;
     mixxx::audio::ChannelCount getNumInputChannels() const;
     SoundDeviceStatus addOutput(const AudioOutputBuffer& out);

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -188,7 +188,7 @@ QString SoundDevicePipewire::getChannelString(ChannelGroup channelGroup, bool in
     std::span<Port> ports = input ? m_outPorts : m_inPorts;
     std::span<Port> subspan = ports.subspan(base - 1, count);
 
-    static const QRegularExpression regex{R"(^(.+?)[._:-]?(FL|FR|[0-9]+)$)",
+    static const QRegularExpression regex{R"(^(.+?)[._:-]?(FL|FR|FC|LFE|SL|SR|RL|RR|[0-9]+)$)",
             QRegularExpression::CaseInsensitiveOption};
 
     QString channelString;

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -112,25 +112,31 @@ void SoundDevicePipewire::writeInput(
 }
 
 void SoundDevicePipewire::registerPort(uint32_t id, const struct spa_dict* props) {
-    const char* nameStr = spa_dict_lookup(props, PW_KEY_PORT_NAME);
+    const char* portName = spa_dict_lookup(props, PW_KEY_PORT_NAME);
+    const char* channel = spa_dict_lookup(props, PW_KEY_AUDIO_CHANNEL);
     const char* direction = spa_dict_lookup(props, PW_KEY_PORT_DIRECTION);
-    std::string name;
+    const char* portId = spa_dict_lookup(props, PW_KEY_PORT_ID);
 
-    if (nameStr) {
-        name = nameStr;
-    } else {
-        name = direction;
-        name += ":";
-        name += spa_dict_lookup(props, PW_KEY_PORT_ID);
+    Port port{};
+    port.id = id;
+    port.channel = channel ? channel : (portName ? portName : portId);
+
+    if (portName && channel) {
+        std::string_view name = portName;
+        const size_t last = name.find_last_of("_:-");
+        const bool nameContainsChannel = last != std::string_view::npos and
+                port.channel == name.substr(last + 1);
+        port.name = nameContainsChannel ? name.substr(0, last) : portName;
+        port.name += ':';
     }
 
     // m_numInputChannels, m_numOutputChannels, m_audioInputs, m_audioOutputs
     // are with respect to Mixxx and not the SoundDevice
     if (strcmp(direction, "in") == 0) {
-        m_inPorts.emplace_back(id, name);
+        m_inPorts.push_back(std::move(port));
         m_numOutputChannels = mixxx::audio::ChannelCount::fromInt(m_inPorts.size());
     } else if (strcmp(direction, "out") == 0) {
-        m_outPorts.emplace_back(id, name);
+        m_outPorts.push_back(std::move(port));
         m_numInputChannels = mixxx::audio::ChannelCount::fromInt(m_outPorts.size());
     }
 }
@@ -186,27 +192,20 @@ QString SoundDevicePipewire::getChannelString(ChannelGroup channelGroup, bool in
     mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
 
     std::span<Port> ports = input ? m_outPorts : m_inPorts;
-    std::span<Port> subspan = ports.subspan(base, count);
+    std::span<Port> subspan = ports.subspan(base + 1, count - 1);
 
-    static const QRegularExpression regex{R"(^(.+?)[._:-]?(FL|FR|FC|LFE|SL|SR|RL|RR|[0-9]+)$)",
-            QRegularExpression::CaseInsensitiveOption};
+    // without this 1st port will always take else branch, inserting unnecessary ' '
+    Port& firstPort = ports[base];
+    std::string_view currentCommonSubstr = firstPort.name;
+    std::string channelString = firstPort.name + firstPort.channel;
 
-    QString channelString;
-    QString currentCommonSubstr;
-    for (auto it = subspan.begin(); it != subspan.end(); it++) {
-        const auto match = regex.match(it->name.c_str());
-        if (match.hasMatch()) {
-            const QStringView name = match.capturedView(1);
-            const QStringView suffix = match.capturedView(2);
-            if (name == currentCommonSubstr) {
-                channelString = channelString + '/' + suffix;
-            } else {
-                currentCommonSubstr = name.toString();
-                channelString = channelString + ' ' + name + ':' + suffix;
-            }
+    for (Port& port : subspan) {
+        if (!port.name.empty() and port.name == currentCommonSubstr) {
+            channelString = channelString + '/' + port.channel;
         } else {
-            channelString = channelString + ' ' + it->name.c_str();
+            channelString = channelString + ' ' + port.name + port.channel;
+            currentCommonSubstr = port.name;
         }
     }
-    return channelString;
+    return QString::fromStdString(channelString);
 }

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -186,7 +186,7 @@ QString SoundDevicePipewire::getChannelString(ChannelGroup channelGroup, bool in
     mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
 
     std::span<Port> ports = input ? m_outPorts : m_inPorts;
-    std::span<Port> subspan = ports.subspan(base - 1, count);
+    std::span<Port> subspan = ports.subspan(base, count);
 
     static const QRegularExpression regex{R"(^(.+?)[._:-]?(FL|FR|FC|LFE|SL|SR|RL|RR|[0-9]+)$)",
             QRegularExpression::CaseInsensitiveOption};

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -2,6 +2,9 @@
 
 #include <spa/utils/defs.h>
 
+#include <QRegularExpression>
+#include <string_view>
+
 #include "audio/types.h"
 #include "soundio/pipewireenumerator.h"
 #include "soundio/sounddevice.h"
@@ -183,11 +186,27 @@ QString SoundDevicePipewire::getChannelString(ChannelGroup channelGroup, bool in
     mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
 
     std::span<Port> ports = input ? m_outPorts : m_inPorts;
-    std::span<Port> subspan = ports.subspan(base, count - 1);
+    std::span<Port> subspan = ports.subspan(base - 1, count);
 
-    QString channelString = ports[base - 1].name.c_str();
-    for (const auto& port : subspan) {
-        channelString = channelString + "/" + port.name.c_str();
+    static const QRegularExpression regex{R"(^(.+?)[._:-]?(FL|FR|[0-9]+)$)",
+            QRegularExpression::CaseInsensitiveOption};
+
+    QString channelString;
+    QString currentCommonSubstr;
+    for (auto it = subspan.begin(); it != subspan.end(); it++) {
+        const auto match = regex.match(it->name.c_str());
+        if (match.hasMatch()) {
+            const QStringView name = match.capturedView(1);
+            const QStringView suffix = match.capturedView(2);
+            if (name == currentCommonSubstr) {
+                channelString = channelString + '/' + suffix;
+            } else {
+                currentCommonSubstr = name.toString();
+                channelString = channelString + ' ' + name + ':' + suffix;
+            }
+        } else {
+            channelString = channelString + ' ' + it->name.c_str();
+        }
     }
     return channelString;
 }

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -2,6 +2,7 @@
 
 #include <spa/utils/defs.h>
 
+#include "audio/types.h"
 #include "soundio/pipewireenumerator.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddevicestatus.h"
@@ -108,13 +109,9 @@ void SoundDevicePipewire::writeInput(
 }
 
 void SoundDevicePipewire::registerPort(uint32_t id, const struct spa_dict* props) {
-    const char* nameStr = spa_dict_lookup(props, PW_KEY_PORT_ALIAS);
+    const char* nameStr = spa_dict_lookup(props, PW_KEY_PORT_NAME);
     const char* direction = spa_dict_lookup(props, PW_KEY_PORT_DIRECTION);
     std::string name;
-
-    if (!nameStr) {
-        nameStr = spa_dict_lookup(props, PW_KEY_PORT_NAME);
-    }
 
     if (nameStr) {
         name = nameStr;
@@ -179,4 +176,18 @@ void SoundDevicePipewire::unregisterLink(uint32_t id, spa_direction direction) {
             m_outLinks.erase(it);
         }
     }
+}
+
+QString SoundDevicePipewire::getChannelString(ChannelGroup channelGroup, bool input) {
+    unsigned char base = channelGroup.getChannelBase();
+    mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
+
+    std::span<Port> ports = input ? m_outPorts : m_inPorts;
+    std::span<Port> subspan = ports.subspan(base, count - 1);
+
+    QString channelString = ports[base - 1].name.c_str();
+    for (const auto& port : subspan) {
+        channelString = channelString + "/" + port.name.c_str();
+    }
+    return channelString;
 }

--- a/src/soundio/sounddevicepipewire.h
+++ b/src/soundio/sounddevicepipewire.h
@@ -4,6 +4,7 @@
 
 #include "sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
+#include "soundio/soundmanagerutil.h"
 
 class SoundManager;
 class PipewireEnumerator;
@@ -27,6 +28,7 @@ class SoundDevicePipewire : public SoundDevice {
         return m_error.c_str();
     }
 
+    QString getChannelString(ChannelGroup channelGroup, bool input) override;
     mixxx::audio::SampleRate getDefaultSampleRate() const override;
 
     void writeOutput(float* output, int channel, int framesPerBuffer, int offset = 0);

--- a/src/soundio/sounddevicepipewire.h
+++ b/src/soundio/sounddevicepipewire.h
@@ -52,8 +52,17 @@ class SoundDevicePipewire : public SoundDevice {
     }
 
     struct Port {
+        std::string getDisplayName() const {
+            return name + channel;
+        }
+
         uint32_t id;
+        // this is port.name after stripping out channel and delimiter,
+        // and appending a ':' to simplify logic
         std::string name;
+        // in case port had no recognizable channel, entire name is put
+        // here so SoundDevicePipewire::getChannelString logic works fine
+        std::string channel;
     };
 
     std::span<const Port> getInPorts() const {


### PR DESCRIPTION
We display node name, node class, node id. Node class can be helpful for cases like sinks having monitor ports, so for Input, you would pick Output/Source over Sink class for nodes with same name. Finally we have node id, since we can have totally identical nodes, here I think the patchbay manually appends a node-1, node-2 to the node names.