### PR TITLE
Fix QML slider bar settings

### DIFF
--- a/res/qml/Mixxx/Controls/Slider.qml
+++ b/res/qml/Mixxx/Controls/Slider.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.12
 import QtQuick.Shapes 1.12
-import QtQml 2.12
 
 Item {
     id: root
@@ -14,6 +13,7 @@ Item {
     readonly property real availableHeight: Math.max(0, height - topPadding - bottomPadding)
     readonly property real availableWidth: Math.max(0, width - leftPadding - rightPadding)
     property alias background: backgroundItem.data
+    // A typed property is required so inherited controls accept grouped bindings such as bar.margin.
     property BarSettings bar: BarSettings {
     }
     property real bottomPadding: 0

--- a/res/qml/Mixxx/Controls/Slider.qml
+++ b/res/qml/Mixxx/Controls/Slider.qml
@@ -1,5 +1,6 @@
 import QtQuick 2.12
 import QtQuick.Shapes 1.12
+import QtQml 2.12
 
 Item {
     id: root
@@ -13,7 +14,8 @@ Item {
     readonly property real availableHeight: Math.max(0, height - topPadding - bottomPadding)
     readonly property real availableWidth: Math.max(0, width - leftPadding - rightPadding)
     property alias background: backgroundItem.data
-    property alias bar: barPath
+    property BarSettings bar: BarSettings {
+    }
     property real bottomPadding: 0
     readonly property real displayValue: dragHandler.active ? dragHandler.value : value
     property real from: 0
@@ -115,17 +117,11 @@ Item {
         ShapePath {
             id: barPath
 
-            property color color: "transparent"
-            property bool enabled: false
-            property real margin: 0
-            property real start: 0
-            property real width: 2
-
             fillColor: "transparent"
             startX: barShape.width * (root.horizontal ? (1 - root.bar.start) : 0.5)
             startY: barShape.height * (root.vertical ? (1 - root.bar.start) : 0.5)
-            strokeColor: color
-            strokeWidth: width
+            strokeColor: root.bar.color
+            strokeWidth: root.bar.width
 
             PathLine {
                 x: root.horizontal ? (barShape.width * root.position) : barPath.startX
@@ -180,5 +176,13 @@ Item {
             root.moved(root.stepValue(event.angleDelta.y > 0 ? 1 : -1));
             event.accepted = true;
         }
+    }
+
+    component BarSettings: QtObject {
+        property color color: "transparent"
+        property bool enabled: false
+        property real margin: 0
+        property real start: 0
+        property real width: 2
     }
 }


### PR DESCRIPTION
## Summary
- expose `Slider.bar` as a typed QML settings object
- keep the grouped `bar.*` API introduced for slider bar styling
- move the bar drawing properties off the internal `ShapePath`
