### PR TITLE
Use ubuntu-latest for pr-command

### DIFF
--- a/.github/workflows/pr-command.yml
+++ b/.github/workflows/pr-command.yml
@@ -7,7 +7,7 @@ jobs:
   softfix:
     name: Softfix action
     if: github.event.issue.pull_request != '' && startsWith(github.event.comment.body, '/softfix')
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Check if commenter is maintainer
         id: check-maintainer


### PR DESCRIPTION
I assume that ubuntu-slim does not support docker. 

https://github.com/mixxxdj/mixxx/actions/runs/29245885835/job/86802569935

```
/usr/bin/docker build -t 791f9f:fcd590132f0b4bbe948d033bcffe5e81 -f "/home/runner/work/_actions/daschuer/softfix/v4/Dockerfile" "/home/runner/work/_actions/daschuer/softfix/v4"
  ERROR: failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
  Warning: Docker build failed with exit code 1, back off 7.415 seconds before retry.
  /usr/bin/docker build -t 791f9f:fcd590132f0b4bbe948d033bcffe5e81 -f "/home/runner/work/_actions/daschuer/softfix/v4/Dockerfile" "/home/runner/work/_actions/daschuer/softfix/v4"
``` 

This is a regression fix since: 
https://github.com/mixxxdj/mixxx/pull/16659