### PR TITLE
Analysis: add Stop Analysis action to sidebar menu

### DIFF
--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -1,6 +1,7 @@
 #include "library/analysis/analysisfeature.h"
 
 #include <QList>
+#include <QMenu>
 #include <QtDebug>
 
 #include "analyzer/analyzerscheduledtrack.h"
@@ -13,6 +14,7 @@
 #include "util/dnd.h"
 #include "util/logger.h"
 #include "widget/wlibrary.h"
+#include "widget/wlibrarysidebar.h"
 
 namespace {
 
@@ -118,7 +120,18 @@ void AnalysisFeature::bindLibraryWidget(WLibrary* libraryWidget,
     // Let the DlgAnalysis know whether or not analysis is active.
     emit analysisActive(static_cast<bool>(m_pTrackAnalysisScheduler));
 
+    m_pStopAction = make_parented<QAction>(tr("Stop Analysis"), this);
+    connect(m_pStopAction.get(),
+            &QAction::triggered,
+            m_pAnalysisView,
+            &DlgAnalysis::stopAnalysis);
+
     libraryWidget->registerView(kViewName, m_pAnalysisView);
+}
+
+void AnalysisFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    // store the sidebar widget pointer for later use in onRightClickChild
+    m_pSidebarWidget = pSidebarWidget;
 }
 
 TreeItemModel* AnalysisFeature::sidebarModel() const {
@@ -138,6 +151,14 @@ void AnalysisFeature::activate() {
         emit restoreSearch(m_pAnalysisView->currentSearch());
     }
     emit enableCoverArtDisplay(true);
+}
+
+void AnalysisFeature::onRightClick(const QPoint& globalPos) {
+    if (m_pAnalysisView->isAnalysisActive()) {
+        QMenu menu(m_pSidebarWidget);
+        menu.addAction(m_pStopAction.get());
+        menu.exec(globalPos);
+    }
 }
 
 void AnalysisFeature::analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks) {

--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -1,6 +1,7 @@
 #include "library/analysis/analysisfeature.h"
 
 #include <QList>
+#include <QMenu>
 #include <QtDebug>
 
 #include "analyzer/analyzerscheduledtrack.h"
@@ -13,6 +14,7 @@
 #include "util/dnd.h"
 #include "util/logger.h"
 #include "widget/wlibrary.h"
+#include "widget/wlibrarysidebar.h"
 
 namespace {
 
@@ -118,7 +120,18 @@ void AnalysisFeature::bindLibraryWidget(WLibrary* libraryWidget,
     // Let the DlgAnalysis know whether or not analysis is active.
     emit analysisActive(static_cast<bool>(m_pTrackAnalysisScheduler));
 
+    m_pStopAnalysisAction = make_parented<QAction>(tr("Stop Analysis"), this);
+    connect(m_pStopAnalysisAction.get(),
+            &QAction::triggered,
+            m_pAnalysisView,
+            &DlgAnalysis::stopAnalysis);
+
     libraryWidget->registerView(kViewName, m_pAnalysisView);
+}
+
+void AnalysisFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    // store the sidebar widget pointer for later use in onRightClickChild
+    m_pSidebarWidget = pSidebarWidget;
 }
 
 TreeItemModel* AnalysisFeature::sidebarModel() const {
@@ -138,6 +151,13 @@ void AnalysisFeature::activate() {
         emit restoreSearch(m_pAnalysisView->currentSearch());
     }
     emit enableCoverArtDisplay(true);
+}
+
+void AnalysisFeature::onRightClick(const QPoint& globalPos) {
+    QMenu menu(m_pSidebarWidget);
+    menu.addAction(m_pStopAnalysisAction.get());
+    m_pStopAnalysisAction->setEnabled(m_pAnalysisView->isAnalysisActive());
+    menu.exec(globalPos);
 }
 
 void AnalysisFeature::analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks) {

--- a/src/library/analysis/analysisfeature.h
+++ b/src/library/analysis/analysisfeature.h
@@ -2,6 +2,7 @@
 
 #include <QList>
 #include <QObject>
+#include <QPointer>
 #include <QUrl>
 #include <QVariant>
 
@@ -12,6 +13,7 @@
 #include "util/parented_ptr.h"
 
 class DlgAnalysis;
+class WLibrarySidebar;
 
 class AnalysisFeature : public LibraryFeature {
     Q_OBJECT
@@ -28,6 +30,7 @@ class AnalysisFeature : public LibraryFeature {
     bool dragMoveAccept(const QList<QUrl>& urls) override;
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard) override;
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
     TreeItemModel* sidebarModel() const override;
     void refreshLibraryModels();
@@ -38,6 +41,8 @@ class AnalysisFeature : public LibraryFeature {
 
   public slots:
     void activate() override;
+    void onRightClick(const QPoint& globalPos) override;
+
     void analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks);
 
     void suspendAnalysis();
@@ -61,6 +66,9 @@ class AnalysisFeature : public LibraryFeature {
     const QString m_baseTitle;
 
     TrackAnalysisScheduler::Pointer m_pTrackAnalysisScheduler;
+
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
+    parented_ptr<QAction> m_pStopAction;
 
     parented_ptr<TreeItemModel> m_pSidebarModel;
     DlgAnalysis* m_pAnalysisView;

--- a/src/library/analysis/analysisfeature.h
+++ b/src/library/analysis/analysisfeature.h
@@ -2,6 +2,7 @@
 
 #include <QList>
 #include <QObject>
+#include <QPointer>
 #include <QUrl>
 #include <QVariant>
 
@@ -12,6 +13,7 @@
 #include "util/parented_ptr.h"
 
 class DlgAnalysis;
+class WLibrarySidebar;
 
 class AnalysisFeature : public LibraryFeature {
     Q_OBJECT
@@ -28,6 +30,7 @@ class AnalysisFeature : public LibraryFeature {
     bool dragMoveAccept(const QList<QUrl>& urls) override;
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard) override;
+    void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
     TreeItemModel* sidebarModel() const override;
     void refreshLibraryModels();
@@ -38,6 +41,8 @@ class AnalysisFeature : public LibraryFeature {
 
   public slots:
     void activate() override;
+    void onRightClick(const QPoint& globalPos) override;
+
     void analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks);
 
     void suspendAnalysis();
@@ -61,6 +66,9 @@ class AnalysisFeature : public LibraryFeature {
     const QString m_baseTitle;
 
     TrackAnalysisScheduler::Pointer m_pTrackAnalysisScheduler;
+
+    QPointer<WLibrarySidebar> m_pSidebarWidget;
+    parented_ptr<QAction> m_pStopAnalysisAction;
 
     parented_ptr<TreeItemModel> m_pSidebarModel;
     DlgAnalysis* m_pAnalysisView;

--- a/src/library/analysis/dlganalysis.h
+++ b/src/library/analysis/dlganalysis.h
@@ -32,6 +32,10 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
     void saveCurrentViewState() override;
     bool restoreCurrentViewState() override;
 
+    bool isAnalysisActive() {
+        return m_bAnalysisActive;
+    };
+
   public slots:
     void tableSelectionChanged(const QItemSelection& selected,
             const QItemSelection& deselected);


### PR DESCRIPTION
A small helper so you can stop batch analysis from the **Analyze** tree item menu
(no need anymore to activate Analyze and click Stop there)