### PR TITLE
Cover menu: extract cover image to file, or just show it in file browser

### DIFF
--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -2,41 +2,72 @@
 
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QImage>
+#include <QMessageBox>
 
 #include "library/coverartutils.h"
 #include "moc_wcoverartmenu.cpp"
+#include "sources/soundsourceproxy.h"
 #include "util/assert.h"
+#include "util/desktophelper.h"
+#include "util/fileaccess.h"
+#include "util/fileinfo.h"
+#include "util/sandbox.h"
 
 WCoverArtMenu::WCoverArtMenu(QWidget* parent)
         : QMenu(parent),
           m_isWorkerRunning(false) {
-    createActions();
-}
-
-WCoverArtMenu::~WCoverArtMenu() {
-    delete m_pChange;
-    delete m_pReload;
-    delete m_pUnset;
 }
 
 void WCoverArtMenu::createActions() {
-    m_pChange = new QAction(tr("Choose file", "change cover art location"), this);
+    clear();
+
+    VERIFY_OR_DEBUG_ASSERT(!m_coverInfo.trackLocation.isEmpty()) {
+        return;
+    }
+
+    m_pChange = make_parented<QAction>(tr("Choose file", "change cover art location"), this);
     connect(m_pChange, &QAction::triggered, this, &WCoverArtMenu::slotChange);
     addAction(m_pChange);
 
-    m_pUnset = new QAction(tr("Clear cover",
-            "clears the set cover art -- does not touch files on disk"), this);
+    m_pUnset = make_parented<QAction>(
+            tr("Clear cover",
+                    "clears the set cover art -- does not touch files on disk"),
+            this);
     connect(m_pUnset, &QAction::triggered, this, &WCoverArtMenu::slotUnset);
     addAction(m_pUnset);
 
-    m_pReload = new QAction(tr("Reload from file/folder",
-            "reload cover art from file metadata or folder"), this);
+    m_pReload = make_parented<QAction>(tr("Reload from file/folder",
+                                               "reload cover art from file metadata or folder"),
+            this);
     connect(m_pReload, &QAction::triggered, this, &WCoverArtMenu::reloadCoverArt);
     addAction(m_pReload);
+
+    addSeparator();
+
+    if (m_coverInfo.type == CoverInfo::FILE) {
+        m_pShowCoverFileInBrowser = make_parented<QAction>(
+                tr("Show cover file in browser",
+                        "open a file browser with the cover file selected"),
+                this);
+        connect(m_pShowCoverFileInBrowser,
+                &QAction::triggered,
+                this,
+                &WCoverArtMenu::slotShowCoverInFileBrowser);
+        addAction(m_pShowCoverFileInBrowser);
+    } else {
+        m_pExtractCover = make_parented<QAction>(tr("Extract cover, save to file",
+                                                         "extract cover art from track "
+                                                         "metadata and save it to a file"),
+                this);
+        connect(m_pExtractCover, &QAction::triggered, this, &WCoverArtMenu::slotExtractCover);
+        addAction(m_pExtractCover);
+    }
 }
 
 void WCoverArtMenu::setCoverArt(const CoverInfo& coverInfo) {
     m_coverInfo = coverInfo;
+    createActions();
 }
 
 void WCoverArtMenu::slotChange() {
@@ -115,6 +146,111 @@ void WCoverArtMenu::slotUnset() {
     coverInfo.source = CoverInfo::USER_SELECTED;
     qDebug() << "WCoverArtMenu::slotUnset emit" << coverInfo;
     emit coverInfoSelected(coverInfo);
+}
+
+void WCoverArtMenu::slotShowCoverInFileBrowser() {
+    VERIFY_OR_DEBUG_ASSERT(!m_coverInfo.trackLocation.isEmpty()) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_coverInfo.type == CoverInfo::FILE) {
+        return;
+    }
+
+    QFileInfo trackFileInfo(m_coverInfo.trackLocation);
+    QFileInfo coverFileInfo(trackFileInfo.dir(), m_coverInfo.coverLocation);
+    if (!coverFileInfo.exists()) {
+        qWarning() << "WCoverArtMenu::slotShowCoverInFileBrowser: source file not found!";
+        return;
+    }
+    // FIXME Do we need this? We either have permission because we are
+    // already allowed to open the track, or we assigned the cover file
+    // manually which also required permissions.
+    mixxx::FileInfo mixxxCoverFileInfo(coverFileInfo);
+    SecurityTokenPointer pToken =
+            Sandbox::openSecurityToken(
+                    &mixxxCoverFileInfo, true);
+
+    mixxx::DesktopHelper::openInFileBrowser(QStringList(coverFileInfo.absoluteFilePath()));
+}
+
+void WCoverArtMenu::slotExtractCover() {
+    VERIFY_OR_DEBUG_ASSERT(!m_coverInfo.trackLocation.isEmpty()) {
+        return;
+    }
+
+    VERIFY_OR_DEBUG_ASSERT(m_coverInfo.type == CoverInfo::METADATA) {
+        qWarning() << "WCoverArtMenu::slotExtractCover() unknown CoverInfo type"
+                   << static_cast<int>(m_coverInfo.type);
+    }
+
+    // Extract embedded cover from the audio file's metadata
+    QImage image = CoverArtUtils::extractEmbeddedCover(
+            mixxx::FileAccess(mixxx::FileInfo(m_coverInfo.trackLocation)));
+
+    if (image.isNull()) {
+        QMessageBox msgBox(this);
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setText(tr("No cover art found."));
+        msgBox.setDetailedText(tr(
+                "The track does not contain embedded cover art "
+                "and no external cover file was found."));
+        msgBox.exec();
+        return;
+    }
+
+    QFileInfo trackFileInfo(m_coverInfo.trackLocation);
+    QString defaultFileName = trackFileInfo.completeBaseName() + QStringLiteral(".jpg");
+
+    QString savePath = QFileDialog::getSaveFileName(
+            this,
+            tr("Save cover art to file"),
+            trackFileInfo.absolutePath() + QStringLiteral("/") + defaultFileName,
+            tr("Image Files (*.jpg *.jpeg *.png *.bmp *.gif *.tiff *.tif)"));
+    if (savePath.isEmpty()) {
+        return;
+    }
+
+    // Determine the image format from the file extension
+    QString format = QFileInfo(savePath).suffix();
+    if (format.compare(QStringLiteral("jpg"), Qt::CaseInsensitive) == 0 ||
+            format.compare(QStringLiteral("jpeg"), Qt::CaseInsensitive) == 0) {
+        format = QStringLiteral("JPEG");
+    } else if (format.compare(QStringLiteral("png"), Qt::CaseInsensitive) == 0) {
+        format = QStringLiteral("PNG");
+    } else if (format.compare(QStringLiteral("bmp"), Qt::CaseInsensitive) == 0) {
+        format = QStringLiteral("BMP");
+    } else if (format.compare(QStringLiteral("gif"), Qt::CaseInsensitive) == 0) {
+        format = QStringLiteral("GIF");
+    } else if (format.compare(QStringLiteral("tiff"), Qt::CaseInsensitive) == 0 ||
+            format.compare(QStringLiteral("tif"), Qt::CaseInsensitive) == 0) {
+        format = QStringLiteral("TIFF");
+    } else {
+        // Default to PNG for unknown extensions
+        format = QStringLiteral("PNG");
+        savePath += QStringLiteral(".png");
+    }
+
+    // use src/util/ImageFileData ??
+    if (!image.save(savePath, format.toUtf8().constData())) {
+        QMessageBox msgBox(this);
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(tr("Failed to save cover art."));
+        msgBox.setDetailedText(tr("Could not write the image to:\n%1").arg(savePath));
+        msgBox.exec();
+        return;
+    }
+
+    // Success message
+    // Disabled, too much noise
+    //
+    // QMessageBox msgBox(this);
+    // msgBox.setIcon(QMessageBox::Information);
+    // msgBox.setText(tr("Cover art saved successfully."));
+    // msgBox.setDetailedText(tr("Cover art extracted and saved to:\n%1").arg(savePath));
+    // msgBox.exec();
+
+    // Open file browser
+    mixxx::DesktopHelper::openInFileBrowser(QStringList(savePath));
 }
 
 void WCoverArtMenu::slotStarted() {

--- a/src/widget/wcoverartmenu.h
+++ b/src/widget/wcoverartmenu.h
@@ -4,6 +4,7 @@
 
 #include "library/coverart.h"
 #include "library/export/coverartcopyworker.h"
+#include "util/parented_ptr.h"
 
 class QAction;
 
@@ -16,9 +17,11 @@ class WCoverArtMenu : public QMenu {
     Q_OBJECT
   public:
     explicit WCoverArtMenu(QWidget *parent = nullptr);
-    ~WCoverArtMenu() override;
 
     void setCoverArt(const CoverInfo& coverInfo);
+
+  public slots:
+    void slotUnset();
 
   signals:
     void coverInfoSelected(const CoverInfoRelative& coverInfo);
@@ -26,7 +29,8 @@ class WCoverArtMenu : public QMenu {
 
   private slots:
     void slotChange();
-    void slotUnset();
+    void slotExtractCover();
+    void slotShowCoverInFileBrowser();
     void slotStarted();
     void slotAskOverwrite(const QString& coverArtAbsolutePath,
             std::promise<CoverArtCopyWorker::OverwriteAnswer>* promise);
@@ -37,9 +41,11 @@ class WCoverArtMenu : public QMenu {
   private:
     void createActions();
 
-    QAction* m_pChange;
-    QAction* m_pReload;
-    QAction* m_pUnset;
+    parented_ptr<QAction> m_pChange;
+    parented_ptr<QAction> m_pReload;
+    parented_ptr<QAction> m_pUnset;
+    parented_ptr<QAction> m_pExtractCover;
+    parented_ptr<QAction> m_pShowCoverFileInBrowser;
 
     CoverInfo m_coverInfo;
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1116,6 +1116,7 @@ void WTrackMenu::updateMenus() {
 
         // We use the last selected track for the cover art context to be
         // consistent with selectionChanged above.
+        // This clears the menu and creates all actions as required
         m_pCoverMenu->setCoverArt(getCoverInfoOfLastTrack());
     }
 


### PR DESCRIPTION
Another small helper.

This adds two actions to the Cover menu, one for embedded covers, one for assigned image files:
* Show cover file in browser
* Extract cover, save to file -> also shows file in the file browser

<img width="781" height="276" alt="image" src="https://github.com/user-attachments/assets/4a6843d5-16f9-43f7-bc4a-2c6598c6da0b" />


________
Background:
Ocassionally I want to modify a cover (crop, change background).
For images embedded in file tags the workflow is currently tedious:
track menu -> File Manager -> [audio tag tool] -> extract -> find in file browser ...
For file covers it's simpler but still.
