### PR TITLE
fix effect of potential race condition with QuantizeControl #16320

### DIFF
--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -65,6 +65,17 @@ void QuantizeControl::setFrameInfo(mixxx::audio::FramePos currentPosition,
 
 void QuantizeControl::playPosChanged(mixxx::audio::FramePos position) {
     DEBUG_ASSERT(position.isValid());
+    // kInitialPlayPosition is used during track loading to indicate
+    // that no valid playback position has been set yet.
+    // It may happen this is called before we have valid position, so
+    // skip processing to avoid passing an extreme value to the beat
+    // lookup functions.
+    // The correct position will be set once the track is fully loaded and
+    // the engine processes the initial seek (e.g. to the cue point).
+    if (position == kInitialPlayPosition) {
+        return;
+    }
+
     // We only need to update the prev or next if the current sample is
     // out of range of the existing beat positions or if we've been forced to
     // do so.


### PR DESCRIPTION
Apparently it may happen that `QuantizeControl::setFrameInfo()` is called with `kInitialPlayPosition` (which is `std::numeric_limits<double>::lowest()` / 2), which in turn calls `playPosChanged()` which would try to `lookUpBeatPositions()`
-> this leads to #16320

I added a guard to ignore the request when it still holds the initial value (same pattern as in [BpmControl::updateLocalBpm()](https://github.com/mixxxdj/mixxx/blob/2.5/src/engine/controls/bpmcontrol.cpp#L1212))

Fixes #16320