### PR TITLE
Fix wrong windows-arm condition in workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -131,8 +131,8 @@ jobs:
       - name: "[Windows] Set up cmake"
         uses: jwlawson/actions-setup-cmake@v2.2
         # Ubuntu 24.04 should use the CMake version from the repos.
-        # On windows-11-arm this action installs the x64 version which has unwanted side effects
-        if: matrix.os == 'windows-2022'
+        # On Windows ARM64 this action installs the x64 version which has unwanted side effects
+        if: runner.os == 'Windows' && runner.arch != 'ARM64'
         with:
           # This is a workaround for a SSL false positive in cmake 3.26.4
           # When downloading the manual. 3.21 is required for installing the
@@ -146,14 +146,13 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: "[Windows 11 ARM64] Install ARM64 CMake"
-        if: matrix.os == 'windows-11-arm'
+        if: runner.os == 'Windows' && runner.arch == 'ARM64'
         run: |
           Invoke-WebRequest -Uri https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-windows-arm64.zip -OutFile cmake-arm64.zip
           Expand-Archive cmake-arm64.zip -DestinationPath $env:USERPROFILE\cmake
           $cmakePath = "$env:USERPROFILE\cmake\cmake-3.30.1-windows-arm64\bin"
           $cmakePath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           $env:Path += ";$cmakePath"
-          cmake --version
 
       - name: "[macOS] install ccache and make"
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,8 +212,8 @@ jobs:
       - name: "[Windows] Set up cmake"
         uses: jwlawson/actions-setup-cmake@v2.2
         # Ubuntu 24.04 should use the CMake version from the repos.
-        # On windows-11-arm this action installs the x64 version which has unwanted side effects
-        if: matrix.os == 'windows-2022'
+        # On Windows ARM64 this action installs the x64 version which has unwanted side effects
+        if: runner.os == 'Windows' && runner.arch != 'ARM64'
         with:
           # This version of CMake is needed for Wix Toolset >= v4 support,
           # see: https://cmake.org/cmake/help/latest/cpack_gen/wix.html#variable:CPACK_WIX_VERSION
@@ -226,14 +226,13 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: "[Windows 11 ARM64] Install ARM64 CMake"
-        if: matrix.os == 'windows-11-arm'
+        if: runner.os == 'Windows' && runner.arch == 'ARM64'
         run: |
           Invoke-WebRequest -Uri https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-windows-arm64.zip -OutFile cmake-arm64.zip
           Expand-Archive cmake-arm64.zip -DestinationPath $env:USERPROFILE\cmake
           $cmakePath = "$env:USERPROFILE\cmake\cmake-3.30.1-windows-arm64\bin"
           $cmakePath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           $env:Path += ";$cmakePath"
-          cmake --version
 
       - name: "[macOS] install ccache and make"
         if: runner.os == 'macOS'


### PR DESCRIPTION
- Check for the architecture instead of the GitHub runner-image name. The runner image differs on main branch.
- Removed printing of the wrong cmake version (it printed the version that comes with the runner image, the really used one is printed in Configure step)