### PR TITLE
Fixes for Clazy 1.17 errors introduced since branching of 2.6

### DIFF
--- a/src/controllers/scripting/javascriptplayerproxy.h
+++ b/src/controllers/scripting/javascriptplayerproxy.h
@@ -47,17 +47,17 @@ class JavascriptPlayerProxy : public QObject {
 
   signals:
     void trackUnloaded();
-    void albumChanged(QString newAlbum);
-    void titleChanged(QString newTitle);
-    void artistChanged(QString newArtist);
-    void albumArtistChanged(QString newAlbumArtist);
-    void genreChanged(QString newGenre);
-    void composerChanged(QString newComposer);
-    void groupingChanged(QString grouping);
-    void yearChanged(QString newYear);
-    void trackNumberChanged(QString newTrackNumber);
-    void trackTotalChanged(QString newTrackTotal);
-    void keyChanged(QString newKey);
+    void albumChanged(const QString& newAlbum);
+    void titleChanged(const QString& newTitle);
+    void artistChanged(const QString& newArtist);
+    void albumArtistChanged(const QString& newAlbumArtist);
+    void genreChanged(const QString& newGenre);
+    void composerChanged(const QString& newComposer);
+    void groupingChanged(const QString& grouping);
+    void yearChanged(const QString& newYear);
+    void trackNumberChanged(const QString& newTrackNumber);
+    void trackTotalChanged(const QString& newTrackTotal);
+    void keyChanged(const QString& newKey);
 
   private slots:
     // Track::keyChanged has no arguments,

--- a/src/qml/qmllibrarysource.h
+++ b/src/qml/qmllibrarysource.h
@@ -65,7 +65,7 @@ class QmlLibrarySource : public QObject {
     Q_OBJECT
     Q_PROPERTY(QString label MEMBER m_label)
     Q_PROPERTY(QString icon MEMBER m_icon)
-    Q_PROPERTY(QQmlListProperty<QmlLibraryTrackListColumn> columns READ columnsQml)
+    Q_PROPERTY(QQmlListProperty<mixxx::qml::QmlLibraryTrackListColumn> columns READ columnsQml)
     Q_CLASSINFO("DefaultProperty", "columns")
     QML_NAMED_ELEMENT(LibrarySource)
     QML_UNCREATABLE("Only accessible via its specialization")
@@ -73,7 +73,7 @@ class QmlLibrarySource : public QObject {
     explicit QmlLibrarySource(QObject* parent = nullptr,
             const QList<QmlLibraryTrackListColumn*>& columns = {});
 
-    QQmlListProperty<QmlLibraryTrackListColumn> columnsQml() {
+    QQmlListProperty<mixxx::qml::QmlLibraryTrackListColumn> columnsQml() {
         return {this, &m_columns};
     }
 
@@ -85,11 +85,7 @@ class QmlLibrarySource : public QObject {
     void slotShowTrackModel(QAbstractItemModel* pModel);
 
   signals:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-    void requestTrackModel(std::shared_ptr<QmlLibraryTrackListModel> pModel);
-#else
     void requestTrackModel(std::shared_ptr<mixxx::qml::QmlLibraryTrackListModel> pModel);
-#endif
 
   protected:
     QString m_label;

--- a/src/qml/qmllibrarysourcetree.h
+++ b/src/qml/qmllibrarysourcetree.h
@@ -19,8 +19,8 @@ namespace qml {
 class QmlLibrarySourceTree : public QQuickItem {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
-    Q_PROPERTY(QQmlListProperty<QmlLibrarySource> sources READ sources)
-    Q_PROPERTY(QQmlListProperty<QmlLibraryTrackListColumn> defaultColumns READ
+    Q_PROPERTY(QQmlListProperty<mixxx::qml::QmlLibrarySource> sources READ sources)
+    Q_PROPERTY(QQmlListProperty<mixxx::qml::QmlLibraryTrackListColumn> defaultColumns READ
                     defaultColumns CONSTANT)
     Q_CLASSINFO("DefaultProperty", "sources")
     QML_NAMED_ELEMENT(LibrarySourceTree)
@@ -32,11 +32,11 @@ class QmlLibrarySourceTree : public QQuickItem {
 
     void componentComplete() override;
 
-    QQmlListProperty<QmlLibraryTrackListColumn> defaultColumns() {
+    QQmlListProperty<mixxx::qml::QmlLibraryTrackListColumn> defaultColumns() {
         return {this, &m_defaultColumns};
     }
 
-    QQmlListProperty<QmlLibrarySource> sources();
+    QQmlListProperty<mixxx::qml::QmlLibrarySource> sources();
     Q_INVOKABLE mixxx::qml::QmlSidebarModelProxy* sidebar() const {
         return m_model.get();
     };

--- a/src/qml/qmllibrarytracklistmodel.h
+++ b/src/qml/qmllibrarytracklistmodel.h
@@ -12,7 +12,7 @@ namespace qml {
 class QmlLibraryTrackListModel : public QIdentityProxyModel {
     Q_OBJECT
     QML_NAMED_ELEMENT(LibraryTrackListModel)
-    Q_PROPERTY(QQmlListProperty<QmlLibraryTrackListColumn> columns READ columns FINAL)
+    Q_PROPERTY(QQmlListProperty<mixxx::qml::QmlLibraryTrackListColumn> columns READ columns FINAL)
     QML_UNCREATABLE("Only accessible via Mixxx.Library")
 
   public:
@@ -55,7 +55,7 @@ class QmlLibraryTrackListModel : public QIdentityProxyModel {
             QObject* pParent = nullptr);
     ~QmlLibraryTrackListModel() = default;
 
-    QQmlListProperty<QmlLibraryTrackListColumn> columns() {
+    QQmlListProperty<mixxx::qml::QmlLibraryTrackListColumn> columns() {
         return {this,
                 &m_columns,
                 parent_qlist_append,

--- a/src/qml/qmlpreferencesproxy.h
+++ b/src/qml/qmlpreferencesproxy.h
@@ -162,6 +162,9 @@ class QmlControllerSettingGroup : public QmlControllerSettingElement {
 };
 
 class QmlControllerDeviceProxy;
+
+using QmlControllerScreenElementList = QList<QmlControllerScreenElement*>;
+
 class QmlControllerMappingProxy : public QObject {
     Q_OBJECT
     Q_PROPERTY(QString name READ getName CONSTANT)
@@ -185,7 +188,7 @@ class QmlControllerMappingProxy : public QObject {
             const mixxx::qml::QmlConfigProxy* pConfig,
             mixxx::qml::QmlControllerDeviceProxy* pController);
 
-    Q_INVOKABLE QList<mixxx::qml::QmlControllerScreenElement*> loadScreens(
+    Q_INVOKABLE mixxx::qml::QmlControllerScreenElementList loadScreens(
             const mixxx::qml::QmlConfigProxy* pConfig,
             mixxx::qml::QmlControllerDeviceProxy* pController);
 
@@ -304,13 +307,10 @@ class QmlControllerDeviceProxy : public QObject {
             std::shared_ptr<LegacyControllerMapping> pMapping,
             bool bEnabled);
 
-    void mappingCreated(QmlControllerDeviceProxy::Type type, const MappingInfo& mapping);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-    void mappingUpdated(QmlControllerMappingProxy* pMapping, const MappingInfo& mapping);
-#else
+    void mappingCreated(mixxx::qml::QmlControllerDeviceProxy::Type type,
+            const MappingInfo& mapping);
     void mappingUpdated(mixxx::qml::QmlControllerMappingProxy* pMapping,
             const MappingInfo& mapping);
-#endif
     void deviceLearned();
 
   private:
@@ -325,6 +325,8 @@ class QmlControllerDeviceProxy : public QObject {
 
     QHash<QString, std::shared_ptr<LegacyControllerMapping>> m_mappingInstance;
 };
+
+using QmlControllerMappingProxyList = QList<QmlControllerMappingProxy*>;
 
 class QmlControllerManagerProxy : public QObject {
     Q_OBJECT
@@ -347,7 +349,7 @@ class QmlControllerManagerProxy : public QObject {
 
     std::shared_ptr<ControllerManager> internal() const;
 
-    Q_INVOKABLE QList<mixxx::qml::QmlControllerMappingProxy*> mappings(
+    Q_INVOKABLE mixxx::qml::QmlControllerMappingProxyList mappings(
             mixxx::qml::QmlControllerDeviceProxy::Type type) const {
         return m_knownMappings.value(type);
     }
@@ -362,13 +364,10 @@ class QmlControllerManagerProxy : public QObject {
   private slots:
     void refreshKnownDevices();
     void refreshMappings();
-    void loadNewMapping(QmlControllerDeviceProxy::Type type, const MappingInfo& mapping);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-    void updateExistingMapping(QmlControllerMappingProxy* pMapping, const MappingInfo& mapping);
-#else
+    void loadNewMapping(mixxx::qml::QmlControllerDeviceProxy::Type type,
+            const MappingInfo& mapping);
     void updateExistingMapping(mixxx::qml::QmlControllerMappingProxy* pMapping,
             const MappingInfo& mapping);
-#endif
 
   signals:
     void deviceListChanged();

--- a/src/qml/qmlskincontrolcreator.h
+++ b/src/qml/qmlskincontrolcreator.h
@@ -59,7 +59,7 @@ class QmlSkinControlCreator : public QObject, public QQmlParserStatus {
     void keyChanged(const QString& key);
     void persistChanged(bool persist);
     void defaultValueChanged(double defaultValue);
-    void buttonModeChanged(ButtonMode buttonMode);
+    void buttonModeChanged(mixxx::qml::QmlSkinControlCreator::ButtonMode buttonMode);
 
   private:
     static mixxx::control::ButtonMode toControlButtonMode(ButtonMode buttonMode);

--- a/src/qml/qmlsoundmanagerproxy.cpp
+++ b/src/qml/qmlsoundmanagerproxy.cpp
@@ -31,10 +31,10 @@ SoundDeviceId QmlSoundDeviceProxy::getDeviceId() const {
     return m_pInternal->getDeviceId();
 }
 
-QList<QmlSoundDeviceConnection*> QmlSoundInputDeviceProxy::connections(
+QmlSoundDeviceConnectionList QmlSoundInputDeviceProxy::connections(
         mixxx::qml::QmlSoundManagerProxy* manager) {
     DEBUG_ASSERT(qml_owned_ptr<mixxx::qml::QmlSoundManagerProxy>(manager));
-    QList<QmlSoundDeviceConnection*> connections;
+    QmlSoundDeviceConnectionList connections;
 
     auto pManager = manager->internal();
     auto config = pManager->getConfig();
@@ -49,10 +49,10 @@ QList<QmlSoundDeviceConnection*> QmlSoundInputDeviceProxy::connections(
     return connections;
 }
 
-QList<QmlSoundDeviceConnection*> QmlSoundOutputDeviceProxy::connections(
+QmlSoundDeviceConnectionList QmlSoundOutputDeviceProxy::connections(
         mixxx::qml::QmlSoundManagerProxy* manager) {
     DEBUG_ASSERT(qml_owned_ptr<mixxx::qml::QmlSoundManagerProxy>(manager));
-    QList<QmlSoundDeviceConnection*> connections;
+    QmlSoundDeviceConnectionList connections;
 
     auto pManager = manager->internal();
     auto config = pManager->getConfig();
@@ -121,8 +121,8 @@ QList<QString> QmlSoundManagerProxy::getHostAPIList() const {
     return m_pSoundManager->getHostAPIList();
 }
 
-QList<QmlSoundDeviceProxy*> QmlSoundManagerProxy::availableInputDevices(const QString& filterAPI) {
-    QList<QmlSoundDeviceProxy*> devicesQml;
+QmlSoundDeviceProxyList QmlSoundManagerProxy::availableInputDevices(const QString& filterAPI) {
+    QmlSoundDeviceProxyList devicesQml;
     const QList<SoundDevicePointer> devices =
             m_pSoundManager->getDeviceList(filterAPI, false, true);
     for (const auto& device : devices) {
@@ -131,8 +131,8 @@ QList<QmlSoundDeviceProxy*> QmlSoundManagerProxy::availableInputDevices(const QS
     return devicesQml;
 }
 
-QList<QmlSoundDeviceProxy*> QmlSoundManagerProxy::availableOutputDevices(const QString& filterAPI) {
-    QList<QmlSoundDeviceProxy*> devicesQml;
+QmlSoundDeviceProxyList QmlSoundManagerProxy::availableOutputDevices(const QString& filterAPI) {
+    QmlSoundDeviceProxyList devicesQml;
     const QList<SoundDevicePointer> devices =
             m_pSoundManager->getDeviceList(filterAPI, true, false);
     for (const auto& device : devices) {

--- a/src/qml/qmlsoundmanagerproxy.h
+++ b/src/qml/qmlsoundmanagerproxy.h
@@ -21,6 +21,11 @@ namespace qml {
 
 class QmlSoundManagerProxy;
 class QmlSoundDeviceConnection;
+class QmlSoundDeviceProxy;
+
+using QmlSoundDeviceConnectionList = QList<QmlSoundDeviceConnection*>;
+using QmlSoundDeviceProxyList = QList<QmlSoundDeviceProxy*>;
+
 class QmlSoundDeviceProxy : public QObject {
     Q_OBJECT
     Q_PROPERTY(QString displayName READ getDisplayName CONSTANT)
@@ -39,7 +44,7 @@ class QmlSoundDeviceProxy : public QObject {
     virtual uint getChannelCount() const = 0;
     SoundDeviceId getDeviceId() const;
 
-    Q_INVOKABLE virtual QList<mixxx::qml::QmlSoundDeviceConnection*> connections(
+    Q_INVOKABLE virtual mixxx::qml::QmlSoundDeviceConnectionList connections(
             mixxx::qml::QmlSoundManagerProxy* manager) = 0;
 
   protected:
@@ -55,7 +60,7 @@ class QmlSoundInputDeviceProxy : public QmlSoundDeviceProxy {
             : QmlSoundDeviceProxy(std::move(pInternal), parent) {
     }
     uint getChannelCount() const override;
-    Q_INVOKABLE QList<mixxx::qml::QmlSoundDeviceConnection*> connections(
+    Q_INVOKABLE mixxx::qml::QmlSoundDeviceConnectionList connections(
             mixxx::qml::QmlSoundManagerProxy* manager) override;
 };
 
@@ -68,7 +73,7 @@ class QmlSoundOutputDeviceProxy : public QmlSoundDeviceProxy {
             : QmlSoundDeviceProxy(std::move(pInternal), parent) {
     }
     uint getChannelCount() const override;
-    Q_INVOKABLE QList<mixxx::qml::QmlSoundDeviceConnection*> connections(
+    Q_INVOKABLE mixxx::qml::QmlSoundDeviceConnectionList connections(
             mixxx::qml::QmlSoundManagerProxy* manager) override;
 };
 
@@ -122,9 +127,8 @@ class QmlSoundManagerProxy : public QObject {
             QObject* parent = nullptr);
 
     Q_INVOKABLE QList<QString> getHostAPIList() const;
-    Q_INVOKABLE QList<mixxx::qml::QmlSoundDeviceProxy*> availableInputDevices(
-            const QString& filterAPI);
-    Q_INVOKABLE QList<mixxx::qml::QmlSoundDeviceProxy*> availableOutputDevices(
+    Q_INVOKABLE mixxx::qml::QmlSoundDeviceProxyList availableInputDevices(const QString& filterAPI);
+    Q_INVOKABLE mixxx::qml::QmlSoundDeviceProxyList availableOutputDevices(
             const QString& filterAPI);
 
     Q_INVOKABLE QList<EngineBuffer::KeylockEngine> getKeylockEngines() const;

--- a/src/qml/qmlwaveformdisplay.h
+++ b/src/qml/qmlwaveformdisplay.h
@@ -111,12 +111,14 @@ class QmlWaveformDisplay : public QQuickItem, VSyncTimeProvider, public Waveform
 
     QQmlListProperty<mixxx::qml::QmlWaveformRendererFactory> renderers();
     static void renderers_append(
-            QQmlListProperty<QmlWaveformRendererFactory>* property,
-            QmlWaveformRendererFactory* value);
-    static qsizetype renderers_count(QQmlListProperty<QmlWaveformRendererFactory>* property);
-    static QmlWaveformRendererFactory* renderers_at(
-            QQmlListProperty<QmlWaveformRendererFactory>* property, qsizetype index);
-    static void renderers_clear(QQmlListProperty<QmlWaveformRendererFactory>* property);
+            QQmlListProperty<mixxx::qml::QmlWaveformRendererFactory>* property,
+            mixxx::qml::QmlWaveformRendererFactory* value);
+    static qsizetype renderers_count(
+            QQmlListProperty<mixxx::qml::QmlWaveformRendererFactory>* property);
+    static mixxx::qml::QmlWaveformRendererFactory* renderers_at(
+            QQmlListProperty<mixxx::qml::QmlWaveformRendererFactory>* property, qsizetype index);
+    static void renderers_clear(
+            QQmlListProperty<mixxx::qml::QmlWaveformRendererFactory>* property);
 
     WaveformRendererSignalBaseOptions options() const {
         return m_options;
@@ -138,18 +140,10 @@ class QmlWaveformDisplay : public QQuickItem, VSyncTimeProvider, public Waveform
     void playerChanged();
     void zoomChanged();
     void groupChanged(const QString& group);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-    void trackChanged(QmlTrackProxy* track);
-#else
     void trackChanged(mixxx::qml::QmlTrackProxy* track);
-#endif
     void positionChanged(double);
     void backgroundColorChanged();
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-    void optionsChanged(WaveformRendererSignalBaseOptions);
-#else
     void optionsChanged(mixxx::qml::WaveformRendererSignalBaseOptions);
-#endif
 
   private:
     void setCurrentTrack(TrackPointer pTrack);

--- a/src/qml/qmlwaveformrenderer.h
+++ b/src/qml/qmlwaveformrenderer.h
@@ -33,7 +33,7 @@ using WaveformRendererSignalBaseOptions = WaveformRendererSignalBase::Options;
 
 class QmlWaveformRendererFactory : public QObject {
     Q_OBJECT
-    Q_PROPERTY(WaveformRendererPositionSource position MEMBER
+    Q_PROPERTY(WaveformRendererAbstract::PositionSource position MEMBER
                     m_position NOTIFY positionChanged)
     QML_ANONYMOUS
   public:
@@ -50,11 +50,7 @@ class QmlWaveformRendererFactory : public QObject {
             mixxx::qml::WaveformRendererSignalBaseOptions options) const = 0;
 
   signals:
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-    void positionChanged(WaveformRendererPositionSource);
-#else
-    void positionChanged(mixxx::qml::WaveformRendererPositionSource);
-#endif
+    void positionChanged(WaveformRendererAbstract::PositionSource);
 
   protected:
     WaveformRendererPositionSource m_position{::WaveformRendererAbstract::Play};
@@ -216,11 +212,7 @@ class QmlWaveformRendererHSV
     void gainLowChanged(double);
     void gainMidChanged(double);
     void gainHighChanged(double);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-    void optionsChanged(WaveformRendererSignalBaseOptions);
-#else
     void optionsChanged(mixxx::qml::WaveformRendererSignalBaseOptions);
-#endif
 
   private:
     QColor m_axesColor;
@@ -260,11 +252,7 @@ class QmlWaveformRendererSimple
     void colorChanged(const QColor&);
     void ignoreStemChanged(bool);
     void gainChanged(double);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
-    void optionsChanged(WaveformRendererSignalBaseOptions);
-#else
     void optionsChanged(mixxx::qml::WaveformRendererSignalBaseOptions);
-#endif
 
   private:
     QColor m_axesColor;
@@ -598,7 +586,7 @@ class QmlWaveformRendererMark
             mixxx::qml::WaveformRendererSignalBaseOptions options)
             const override;
 
-    QQmlListProperty<QmlWaveformMark> marks() {
+    QQmlListProperty<mixxx::qml::QmlWaveformMark> marks() {
         return {this, &m_marks};
     }
   signals:

--- a/src/widget/wbpmeditor.h
+++ b/src/widget/wbpmeditor.h
@@ -64,7 +64,7 @@ class WBpmEditor : public WWidget {
     void setEditButtonTooltip(const QString& tooltip);
 
   private slots:
-    void switchMode(Mode mode);
+    void switchMode(WBpmEditor::Mode mode);
 
   private:
     bool eventFilter(QObject* pObj, QEvent* pEvent) override;


### PR DESCRIPTION
Follow-Up of https://github.com/mixxxdj/mixxx/pull/16625 and https://github.com/mixxxdj/mixxx/pull/16688
signal arguments need to be fully-qualified [-Wclazy-fully-qualified-moc-types] resulting at some places in [-Wclazy-qproperty-type-mismatch]