### PR TITLE
Extend the Traktor MX2s mapping

### DIFF
--- a/res/controllers/Traktor MX2.hid.xml
+++ b/res/controllers/Traktor MX2.hid.xml
@@ -18,17 +18,17 @@
   <settings>
     <group label="Controller modes">
       <option
-              variable="enableMasterGain"
-              label="Enable Master gain"
-              type="boolean"
-              description="Use Master gain knob, or send output directly to soundcard"
-              default="false"
-      />
-      <option
               variable="usePatternModeForSamplers"
               label="Use Pattern Mode for Samplers"
               type="boolean"
               description="Map pads to trigger samplers in (Traktors) Pattern Mode"
+              default="false"
+      />
+      <option
+              variable="enableMasterGain"
+              label="Enable Master Gain – EXPERIMENTAL: IF YOUR VOLUME STARTS FLUCTUATING, TURN THIS OFF!"
+              type="boolean"
+              description="Adjust mixxxs' master gain when the master knob is turned"
               default="false"
       />
     </group>

--- a/res/controllers/Traktor MX2.hid.xml
+++ b/res/controllers/Traktor MX2.hid.xml
@@ -24,6 +24,13 @@
               description="Use Master gain knob, or send output directly to soundcard"
               default="false"
       />
+      <option
+              variable="usePatternModeForSamplers"
+              label="Use Pattern Mode for Samplers"
+              type="boolean"
+              description="Map pads to trigger samplers in (Traktors) Pattern Mode"
+              default="false"
+      />
     </group>
   </settings>
 </MixxxControllerPreset>

--- a/res/controllers/Traktor-MX2-hid-scripts.js
+++ b/res/controllers/Traktor-MX2-hid-scripts.js
@@ -55,7 +55,9 @@ class TraktorMX2Class {
         this.jogModeState = {"[Channel1]": 0, "[Channel2]": 0}; // 0 = Scratch, 1 = Bend
         this.jogTimer = {"[Channel1]": 0, "[Channel2]": 0};
 
-        this.padModeState = {"[Channel1]": 0, "[Channel2]": 0}; // 0 = Hotcues, 1 = Stems, 2 = Patterns, 3 = Loops
+        this.effectUnitMode = {"EffectUnit1": 0, "EffectUnit2": 0}; // 0 = Group, 1 = Single
+
+        this.padModeState = {"[Channel1]": 0, "[Channel2]": 0}; // 0 = Hotcues, 1 = Stems, 2 = Samplers (Patterns in Traktor), 3 = Loops
         this.padPressed = {
             "[Channel1]": {5: false, 6: false, 7: false, 8: false},
             "[Channel2]": {5: false, 6: false, 7: false, 8: false}
@@ -67,6 +69,7 @@ class TraktorMX2Class {
         };
 
         this.enableMasterGain = false;
+        this.usePatternModeForSamplers = false;
 
         // Knob encoder states (hold values between 0x0 and 0xF)
         // Rotate to the right is +1 and to the left is means -1
@@ -114,6 +117,7 @@ class TraktorMX2Class {
         this.id = _id;
 
         this.enableMasterGain = engine.getSetting("enableMasterGain");
+        this.usePatternModeForSamplers = engine.getSetting("usePatternModeForSamplers");
         this.registerInputPackets();
         this.registerOutputPackets();
 
@@ -135,7 +139,7 @@ class TraktorMX2Class {
         // Channel 1
 
         // // Channel FX
-        this.registerInputButton(inputReportButton, "EffectUnit1", "misc", 0x01, 0x01, this.fxHandler.bind(this));
+        this.registerInputButton(inputReportButton, "EffectUnit1", "misc", 0x01, 0x01, this.fxMiscHandler.bind(this));
         this.registerInputButton(inputReportButton, "EffectUnit1", "Effect1", 0x01, 0x02, this.fxHandler.bind(this));
         this.registerInputButton(inputReportButton, "EffectUnit1", "Effect2", 0x01, 0x04, this.fxHandler.bind(this));
         this.registerInputButton(inputReportButton, "EffectUnit1", "Effect3", 0x01, 0x08, this.fxHandler.bind(this));
@@ -183,7 +187,7 @@ class TraktorMX2Class {
         // Channel 2
 
         // // Channel FX
-        this.registerInputButton(inputReportButton, "EffectUnit2", "misc", 0x04, 0x40, this.fxHandler.bind(this));
+        this.registerInputButton(inputReportButton, "EffectUnit2", "misc", 0x04, 0x40, this.fxMiscHandler.bind(this));
         this.registerInputButton(inputReportButton, "EffectUnit2", "Effect1", 0x04, 0x80, this.fxHandler.bind(this));
         this.registerInputButton(inputReportButton, "EffectUnit2", "Effect2", 0x05, 0x01, this.fxHandler.bind(this));
         this.registerInputButton(inputReportButton, "EffectUnit2", "Effect3", 0x05, 0x02, this.fxHandler.bind(this));
@@ -296,15 +300,15 @@ class TraktorMX2Class {
         this.registerInputScaler(inputReportKnob, "[Channel2]", "rate", 0x33, 0xffff, this.parameterHandler.bind(this));
 
         // FX Parameter
-        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit1]", "mix", 0x01, 0xffff, this.parameterHandler.bind(this));
-        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit1_Effect1]", "meta", 0x03, 0xffff, this.parameterHandler.bind(this));
-        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit1_Effect2]", "meta", 0x05, 0xffff, this.parameterHandler.bind(this));
-        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit1_Effect3]", "meta", 0x07, 0xffff, this.parameterHandler.bind(this));
+        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit1]", "mix", 0x01, 0xffff, this.fxParameterHandler.bind(this));
+        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit1_Effect1]", "meta", 0x03, 0xffff, this.fxParameterHandler.bind(this));
+        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit1_Effect2]", "meta", 0x05, 0xffff, this.fxParameterHandler.bind(this));
+        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit1_Effect3]", "meta", 0x07, 0xffff, this.fxParameterHandler.bind(this));
 
-        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit2]", "mix", 0x09, 0xffff, this.parameterHandler.bind(this));
-        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit2_Effect1]", "meta", 0x0b, 0xffff, this.parameterHandler.bind(this));
-        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit2_Effect2]", "meta", 0x0d, 0xffff, this.parameterHandler.bind(this));
-        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit2_Effect3]", "meta", 0x0f, 0xffff, this.parameterHandler.bind(this));
+        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit2]", "mix", 0x09, 0xffff, this.fxParameterHandler.bind(this));
+        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit2_Effect1]", "meta", 0x0b, 0xffff, this.fxParameterHandler.bind(this));
+        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit2_Effect2]", "meta", 0x0d, 0xffff, this.fxParameterHandler.bind(this));
+        this.registerInputScaler(inputReportKnob, "[EffectRack1_EffectUnit2_Effect3]", "meta", 0x0f, 0xffff, this.fxParameterHandler.bind(this));
 
         // EQ Parameter
         this.registerInputScaler(inputReportKnob, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x13, 0xffff, this.parameterHandler.bind(this));
@@ -802,6 +806,23 @@ class TraktorMX2Class {
         engine.setParameter(field.group, field.name, field.value / 4095);
     };
 
+    fxParameterHandler(field) {
+        let group = field.group;
+        let name = field.name;
+
+        const effectUnit = `EffectUnit${group[23]}`;
+        const mode = this.effectUnitMode[effectUnit];
+        if (mode > 0) { // Single mode
+            if (name === "meta") {
+                const effectNum = group[31];
+                group = `[EffectRack1_${effectUnit}_Effect${mode}]`;
+                name = `parameter${effectNum}`;
+            }
+        }
+
+        engine.setParameter(group, name, field.value / 4095);
+    };
+
     masterGainHandler(field) {
         if (this.enableMasterGain) {
             engine.setParameter(field.group, field.name, field.value / 4095);
@@ -987,19 +1008,51 @@ class TraktorMX2Class {
     };
 
 
-    fxHandler(field) {
-        if (field.value === 0 || field.name === "misc") {
+    fxMiscHandler(field) {
+        if (field.value === 0) {
             return;
         }
 
-        const group = `[EffectRack1_${field.group}_${field.name}]`;
-        if (!this.shiftPressed[`[Channel${field.group[field.group.length - 1]}]`]) {
-            script.toggleControl(group, "enabled");
+        const unit = field.group;
+        const channel = `[Channel${unit[unit.length - 1]}]`;
+
+        if (this.shiftPressed[channel]) {
+            this.effectUnitMode[unit] = (this.effectUnitMode[unit] + 1) % 4;
+            engine.setParameter(`[EffectRack1_${unit}]`, "focused_effect", this.effectUnitMode[unit]);
+            this.updateFxLeds(unit);
         } else {
-            script.triggerControl(group, "next_effect");
+            const mode = this.effectUnitMode[unit];
+            if (mode > 0) {
+                script.toggleControl(`[EffectRack1_${unit}_Effect${mode}]`, "enabled");
+            }
+        }
+    };
+
+    fxHandler(field) {
+        if (field.value === 0) {
+            return;
         }
 
+        const unit = field.group;
+        const channel = `[Channel${unit[unit.length - 1]}]`;
+        const mode = this.effectUnitMode[unit];
 
+        if (mode === 0) { // Group mode
+            const group = `[EffectRack1_${field.group}_${field.name}]`;
+            if (this.shiftPressed[channel]) {
+                script.triggerControl(group, "next_effect");
+            } else {
+                script.toggleControl(group, "enabled");
+            }
+        } else { // Single mode
+            const paramIndex = field.name[6];
+            const group = `[EffectRack1_${unit}_Effect${mode}]`;
+            if (this.shiftPressed[channel]) {
+                script.triggerControl(group, "next_effect");
+            } else {
+                script.toggleControl(group, `button_parameter${paramIndex}`);
+            }
+        }
     };
 
     fxSelectHandler(field) {
@@ -1255,9 +1308,13 @@ class TraktorMX2Class {
         // Link outputs to handlers
 
         // Channel 1
-        engine.makeConnection("[EffectRack1_EffectUnit1_Effect1]", "enabled", this.fxOutputHandler.bind(this));
-        engine.makeConnection("[EffectRack1_EffectUnit1_Effect2]", "enabled", this.fxOutputHandler.bind(this));
-        engine.makeConnection("[EffectRack1_EffectUnit1_Effect3]", "enabled", this.fxOutputHandler.bind(this));
+        for (let i = 1; i <= 3; i++) {
+            engine.makeConnection(`[EffectRack1_EffectUnit1_Effect${i}]`, "enabled", this.fxOutputHandler.bind(this));
+            engine.makeConnection(`[EffectRack1_EffectUnit1_Effect${i}]`, "next_effect", this.fxOutputHandler.bind(this));
+            for (let j = 1; j <= 3; j++) {
+                engine.makeConnection(`[EffectRack1_EffectUnit1_Effect${i}]`, `button_parameter${j}`, this.fxOutputHandler.bind(this));
+            }
+        }
 
         // Favorites
         // Add to List
@@ -1280,9 +1337,14 @@ class TraktorMX2Class {
 
         // Channel 2
 
-        engine.makeConnection("[EffectRack1_EffectUnit2_Effect1]", "enabled", this.fxOutputHandler.bind(this));
-        engine.makeConnection("[EffectRack1_EffectUnit2_Effect2]", "enabled", this.fxOutputHandler.bind(this));
-        engine.makeConnection("[EffectRack1_EffectUnit2_Effect3]", "enabled", this.fxOutputHandler.bind(this));
+        for (let i = 1; i <= 3; i++) {
+            engine.makeConnection(`[EffectRack1_EffectUnit2_Effect${i}]`, "enabled", this.fxOutputHandler.bind(this));
+            engine.makeConnection(`[EffectRack1_EffectUnit2_Effect${i}]`, "next_effect", this.fxOutputHandler.bind(this));
+            for (let j = 1; j <= 3; j++) {
+                engine.makeConnection(`[EffectRack1_EffectUnit2_Effect${i}]`, `button_parameter${j}`, this.fxOutputHandler.bind(this));
+            }
+        }
+
 
         // Favorites
         // Add to List
@@ -1420,8 +1482,53 @@ class TraktorMX2Class {
         this.outputHandler(engine.getValue(group, name), `[Channel${name[name.length - 9]}]`, `fx_select_${group[group.length - 2]}`);
     };
 
+ 	updateFxLeds(unit) {
+        const channel = `[Channel${unit[unit.length - 1]}]`;
+        const mode = this.effectUnitMode[unit];
+        if (mode > 0) {
+            const group = `[EffectRack1_${unit}_Effect${mode}]`;
+            this.fxOutputHandler(0, group, "enabled");
+            this.fxOutputHandler(0, group, "button_parameter1");
+            this.fxOutputHandler(0, group, "button_parameter2");
+            this.fxOutputHandler(0, group, "button_parameter3");
+        } else {
+            this.outputHandler(this.baseColors.off, channel, "fx_misc");
+            this.fxOutputHandler(0, `[EffectRack1_${unit}_Effect1]`, "enabled");
+            this.fxOutputHandler(0, `[EffectRack1_${unit}_Effect2]`, "enabled");
+            this.fxOutputHandler(0, `[EffectRack1_${unit}_Effect3]`, "enabled");
+        }
+    };
+
     fxOutputHandler(_value, group, name) {
-        this.outputHandler(engine.getValue(group, name), `[Channel${group[group.length - 10]}]`, `fx_${group[group.length - 2]}`);
+        const unit = `EffectUnit${group[23]}`;
+        const effectNum = parseInt(group[31]);
+        const channel = `[Channel${unit[unit.length - 1]}]`;
+        const mode = this.effectUnitMode[unit];
+
+        if (mode > 0) { // Single mode
+            if (effectNum === mode) {
+                if (name === "enabled") {
+                    const enabled = engine.getValue(group, name);
+                    const color = mode === 1 ? (enabled ? this.baseColors.red : this.baseColors.dimmedRed) :
+                        mode === 2 ? (enabled ? this.baseColors.blue : this.baseColors.dimmedBlue) :
+                            mode === 3 ? (enabled ? this.baseColors.green : this.baseColors.dimmedGreen) : this.baseColors.off;
+
+                    this.colorOutputHandler(color, channel, "fx_misc");
+                } else if (name.startsWith("button_parameter")) {
+                    const paramNum = name[name.length - 1];
+
+                    if (paramNum <=engine.getValue(group, "num_button_parameters")) {
+                        this.outputHandler(engine.getValue(group, name), channel, `fx_${paramNum}`);
+                    } else {
+                        this.colorOutputHandler(this.baseColors.off, channel, `fx_${paramNum}`);
+                    }
+                }
+            }
+        } else { // Group mode
+            if (name === "enabled") {
+                this.outputHandler(engine.getValue(group, name), channel, `fx_${effectNum}`);
+            }
+        }
     };
 
     gfxOutputHandler() {
@@ -1672,7 +1779,7 @@ class TraktorMX2Class {
         return {
             // Channel 1
             "[Channel1]": {
-                "fx_misc": {dim: this.baseColors.dimmedOrange, full: this.baseColors.orange},
+                "fx_misc": {dim: this.baseColors.off, full: this.baseColors.white},
                 "fx_1": {dim: this.baseColors.dimmedOrange, full: this.baseColors.orange},
                 "fx_2": {dim: this.baseColors.dimmedOrange, full: this.baseColors.orange},
                 "fx_3": {dim: this.baseColors.dimmedOrange, full: this.baseColors.orange},
@@ -1699,7 +1806,7 @@ class TraktorMX2Class {
                 "pfl": {dim: this.baseColors.dimmedWhite, full: this.baseColors.white},
             }, // Channel 2 (same structure)
             "[Channel2]": {
-                "fx_misc": {dim: this.baseColors.dimmedOrange, full: this.baseColors.orange},
+                "fx_misc": {dim: this.baseColors.off, full: this.baseColors.white},
                 "fx_1": {dim: this.baseColors.dimmedOrange, full: this.baseColors.orange},
                 "fx_2": {dim: this.baseColors.dimmedOrange, full: this.baseColors.orange},
                 "fx_3": {dim: this.baseColors.dimmedOrange, full: this.baseColors.orange},

--- a/res/controllers/Traktor-MX2-hid-scripts.js
+++ b/res/controllers/Traktor-MX2-hid-scripts.js
@@ -1241,7 +1241,7 @@ class TraktorMX2Class {
 
         // Favorites
         // Add to List
-        engine.makeConnection("[PreviewDeck1]", "indicatorL", this.previewOutputHandler.bind(this));
+        engine.makeConnection("[PreviewDeck1]", "play_indicator", this.previewOutputHandler.bind(this));
         // Maximize Library
 
         this.linkOutput("[Channel1]", "slip_enabled", this.outputHandler.bind(this));

--- a/res/controllers/Traktor-MX2-hid-scripts.js
+++ b/res/controllers/Traktor-MX2-hid-scripts.js
@@ -46,6 +46,9 @@ class TraktorMX2Class {
 
         this.shiftPressed = {"[Channel1]": false, "[Channel2]": false};
 
+        this.gfxPressed = {"[Channel1]": false, "[Channel2]": false};
+        this.gfxUsedAsModifier = {"[Channel1]": false, "[Channel2]": false};
+
         this.keylockPressed = {"[Channel1]": false, "[Channel2]": false};
         this.keylockIgnore = {"[Channel1]": false, "[Channel2]": false};
 
@@ -597,11 +600,11 @@ class TraktorMX2Class {
 
         if (this.shiftPressed[field.group]) {
             engine.setValue("[Library]", "focused_widget", 2);
-            engine.setValue("[Library]", "MoveVertical", delta);
         } else {
             engine.setValue("[Library]", "focused_widget", 3);
-            engine.setValue("[Library]", "MoveVertical", delta);
         }
+
+        engine.setValue("[Library]", "MoveVertical", delta);
 
         this.browseKnobEncoderState[field.group] = field.value;
     };
@@ -609,7 +612,7 @@ class TraktorMX2Class {
     loadTrackHandler(field) {
         if (this.shiftPressed[field.group]) {
             engine.setValue("[Library]", "GoToItem", field.value);
-        } else {
+        } else if (engine.getValue("[Library]", "focused_widget") === 3) {
             engine.setValue(field.group, "LoadSelectedTrack", field.value);
         }
     };
@@ -1011,25 +1014,40 @@ class TraktorMX2Class {
     };
 
     gfxToggleHandler(field) {
-        if (field.value === 0) {
-            return;
+        this.gfxPressed[field.group] = field.value;
+        if (field.value !== 0) {
+            this.gfxUsedAsModifier[field.group] = false;
+        } else {
+            if (!this.gfxUsedAsModifier[field.group]) {
+                const group = `[QuickEffectRack1_${field.group}]`;
+                const control = "enabled";
+                script.toggleControl(group, control);
+            }
         }
-        const group = `[QuickEffectRack1_${field.group}]`;
-        const control = "enabled";
-
-        script.toggleControl(group, control);
     };
 
     globalfxHandler(field) {
         /* We support 8 effects in total by having 2 effects per fx button. *
          * First press of the button will load the preset at the index of the quick effect preset list *
          * Second press will load the preset index + 4 *
-         * Arrange your quick effect preset list from 1 to 8 like this: 1/5, 2/6, 3/7, 4/8 */
+         * Arrange your quick effect preset list from 1 to 8 like this: 1/5, 2/6, 3/7, 4/8
+         * Holding fxToggle while pressing one of the gfx_toggle buttons will apply the preset only to the deck that whose button was pressed. */
         if (field.value === 0) {
             return;
         }
 
-        const availableGroups = ["[Channel1]", "[Channel2]"];
+        let availableGroups = ["[Channel1]", "[Channel2]"];
+        if (this.gfxPressed["[Channel1]"] && !this.gfxPressed["[Channel2]"]) {
+            availableGroups = ["[Channel1]"];
+            this.gfxUsedAsModifier["[Channel1]"] = true;
+        } else if (!this.gfxPressed["[Channel1]"] && this.gfxPressed["[Channel2]"]) {
+            availableGroups = ["[Channel2]"];
+            this.gfxUsedAsModifier["[Channel2]"] = true;
+        } else if (this.gfxPressed["[Channel1]"] && this.gfxPressed["[Channel2]"]) {
+            this.gfxUsedAsModifier["[Channel1]"] = true;
+            this.gfxUsedAsModifier["[Channel2]"] = true;
+        }
+
         const fxButtonCount = 4;
         const fxNumber = parseInt(field.id[field.id.length - 1]);
 
@@ -1051,18 +1069,20 @@ class TraktorMX2Class {
             }
         }
 
-        const [deck1, deck2] = availableGroups;
-        const activeFxDeck1 = activeFx[deck1];
-        const activeFxDeck2 = activeFx[deck2];
-        const fxToApplyDeck1 = fxToApply[deck1];
-        const fxToApplyDeck2 = fxToApply[deck2];
+        if (availableGroups.length === 2) {
+            const [deck1, deck2] = availableGroups;
+            const activeFxDeck1 = activeFx[deck1];
+            const activeFxDeck2 = activeFx[deck2];
+            const fxToApplyDeck1 = fxToApply[deck1];
+            const fxToApplyDeck2 = fxToApply[deck2];
 
-        // If any of deck has already fx enabled but different value to apply
-        if ((activeFxDeck1 === fxNumber || activeFxDeck2 === fxNumber) && fxToApplyDeck1 !== fxToApplyDeck2) {
-            // find lower value to reset both to the same one
-            const fxToApplyAll = Math.min(fxToApplyDeck1, fxToApplyDeck2);
-            fxToApply[deck1] = fxToApplyAll;
-            fxToApply[deck2] = fxToApplyAll;
+            // If any of deck has already fx enabled but different value to apply
+            if ((activeFxDeck1 === fxNumber || activeFxDeck2 === fxNumber) && fxToApplyDeck1 !== fxToApplyDeck2) {
+                // find lower value to reset both to the same one
+                const fxToApplyAll = Math.min(fxToApplyDeck1, fxToApplyDeck2);
+                fxToApply[deck1] = fxToApplyAll;
+                fxToApply[deck2] = fxToApplyAll;
+            }
         }
 
         // Now apply the new fx value
@@ -1407,10 +1427,11 @@ class TraktorMX2Class {
     gfxOutputHandler() {
         const fxButtonCount = 4;
 
-        const presetNum = engine.getValue("[QuickEffectRack1_[Channel1]]", "loaded_chain_preset") - 1;
+        const preset1 = engine.getValue("[QuickEffectRack1_[Channel1]]", "loaded_chain_preset") - 1;
+        const preset2 = engine.getValue("[QuickEffectRack1_[Channel2]]", "loaded_chain_preset") - 1;
 
         for (let fxButton = 0; fxButton <= fxButtonCount; fxButton++) {
-            const active = (presetNum === fxButton || (fxButton !== 0 && (fxButton === presetNum - fxButtonCount)));
+            const active = (preset1 === fxButton || (fxButton !== 0 && (fxButton === preset1 - fxButtonCount))) || (preset2 === fxButton || (fxButton !== 0 && (fxButton === preset2 - fxButtonCount)));
             this.outputHandler(active, "[ChannelX]", `gfx_${fxButton}`);
         }
     };

--- a/res/controllers/Traktor-MX2-hid-scripts.js
+++ b/res/controllers/Traktor-MX2-hid-scripts.js
@@ -108,9 +108,6 @@ class TraktorMX2Class {
             vu6: 8 / 9,
         };
 
-        this.baseColors = this.getBaseColors();
-        this.outputColorMap = this.getOutputColorMap();
-        this.padColorMap = this.getPadColorMap();
     }
 
     init(_id) {
@@ -118,6 +115,11 @@ class TraktorMX2Class {
 
         this.enableMasterGain = engine.getSetting("enableMasterGain");
         this.usePatternModeForSamplers = engine.getSetting("usePatternModeForSamplers");
+
+        this.baseColors = this.getBaseColors();
+        this.outputColorMap = this.getOutputColorMap();
+        this.padColorMap = this.getPadColorMap();
+
         this.registerInputPackets();
         this.registerOutputPackets();
 
@@ -411,7 +413,18 @@ class TraktorMX2Class {
         if (this.keylockIgnore[field.group]) {
             this.keylockIgnore[field.group] = false;
         } else {
-            script.toggleControl(field.group, "keylock");
+            if (this.padModeState[field.group] === 2 && Object.values(this.padPressed[field.group]).reduce((v, a) => v || a, false)) {
+                // Change Functionality in Pattern Mode with pressed any of Pad 5-8: Toggle Keylock for the corresponding Sampler(s)
+                for (const padNum in this.padPressed[field.group]) {
+                    if (this.padPressed[field.group][padNum]) {
+                        const samplerNum = (padNum - 4) + (field.group[field.group.length - 2] - 1) * 4;
+                        script.toggleControl(`[Sampler${samplerNum}]`, "keylock");
+                    }
+                }
+            } else {
+                // Default Functionality: Toggle Keylock for the current Deck
+                script.toggleControl(field.group, "keylock");
+            }
         }
     };
 
@@ -472,8 +485,9 @@ class TraktorMX2Class {
             this.outputHandler(0, field.group, "stems");
             this.outputHandler(0, field.group, "patterns");
             this.outputHandler(0, field.group, "loops");
+
             // Light LEDs (blue for all enabled hotcues, dimmed white for disabled)
-            for (let padIdx = 1; padIdx <= 8; ++padIdx) {
+            for (let padIdx = 1; padIdx <= 8; padIdx++) {
                 const active = engine.getValue(field.group, `hotcue_${padIdx}_status`);
                 if (active) {
                     const color = engine.getValue(field.group, `hotcue_${padIdx}_color`);
@@ -501,16 +515,14 @@ class TraktorMX2Class {
             break;
 
         case "!patterns":
-            // Patterns mode not implemented yet -> does nothing except lighting
-            this.padModeState[field.group] = 2;
+            // Samplers Mode (Traktor Pattern Mode)
+            this.padModeState[field.group] = this.usePatternModeForSamplers ? 2 : -2;
             this.outputHandler(0, field.group, "hotcues");
             this.outputHandler(0, field.group, "stems");
             this.outputHandler(1, field.group, "patterns");
             this.outputHandler(0, field.group, "loops");
-            // Turn off LEDs
-            for (let padIdx = 1; padIdx <= 8; ++padIdx) {
-                this.outputHandler(0x00, field.group, `pad_${padIdx}`);
-            }
+            // Light LEDs as play_indicators
+            this.patternOutputHandler(field.value, field.group, field.name);
             break;
 
         case "!loops":
@@ -520,7 +532,7 @@ class TraktorMX2Class {
             this.outputHandler(0, field.group, "patterns");
             this.outputHandler(1, field.group, "loops");
             // Turn LEDs green
-            for (let padIdx = 1; padIdx <= 8; ++padIdx) {
+            for (let padIdx = 1; padIdx <= 8; padIdx++) {
                 this.outputHandler(this.baseColors.dimmedGreen, field.group, `pad_${padIdx}`);
             }
             break;
@@ -567,7 +579,29 @@ class TraktorMX2Class {
             break;
 
         case 2:
-            // Patterns Mode
+            // Samplers (Traktor Pattern) Mode
+            // ignore if no samplers available
+            if (engine.getValue("[App]", "num_samplers") === 0) {
+                return;
+            }
+
+            // only first 4 pads are used for sample play / pause
+            if (padNumber <= 4) {
+                if (field.value === 0) {
+                    return;
+                }
+
+                const channelNumber = field.group[field.group.length - 2];
+                const samplerNumber = padNumber + (channelNumber - 1) * 4;
+
+                if (samplerNumber <= Math.min(8, engine.getValue("[App]", "num_samplers"))) {
+                	script.toggleControl(`[Sampler${samplerNumber}]`, "play");
+                }
+
+            } else {
+                // pads 5-8 are used for volume and filter control of the stems
+                this.padPressed[field.group][padNumber] = field.value;
+            }
             break;
 
         case 3:
@@ -592,8 +626,18 @@ class TraktorMX2Class {
             return;
         }
 
-        script.toggleControl(field.group, "pfl");
-        this.outputHandler(engine.getValue(field.group, "pfl"), field.group, "pfl");
+        if (this.padModeState[field.group] === 2 && Object.values(this.padPressed[field.group]).reduce((v, a) => v || a, false)) {
+            // Change Functionality in Pattern Mode with pressed any of Pad 5-8: Toggle PFL for the corresponding Sampler(s)
+            for (const padNum in this.padPressed[field.group]) {
+                if (this.padPressed[field.group][padNum]) {
+                    const samplerNum = (padNum - 4) + (field.group[field.group.length - 2] - 1) * 4;
+                    script.toggleControl(`[Sampler${samplerNum}]`, "pfl");
+                }
+            }
+        } else {
+            // Default functionality: toggle PFL for the channel
+            script.toggleControl(field.group, "pfl");
+        }
     };
 
     selectTrackHandler(field) {
@@ -602,14 +646,33 @@ class TraktorMX2Class {
             delta = -1;
         }
 
-        if (this.shiftPressed[field.group]) {
-            engine.setValue("[Library]", "focused_widget", 2);
+        if (this.padModeState[field.group] === 2 && Object.values(this.padPressed[field.group]).reduce((v, a) => v || a, false)) {
+            for (const padNum in this.padPressed[field.group]) {
+                if (this.padPressed[field.group][padNum]) {
+                    const samplerNum = (padNum - 4) + (field.group[field.group.length - 2] - 1) * 4;
+                    if (delta > 0) {
+                        script.toggleControl(`[Sampler${samplerNum}]`, "pregain_up_small");
+                    } else {
+                        script.toggleControl(`[Sampler${samplerNum}]`, "pregain_down_small");
+                    }
+                }
+            }
+        } else if (engine.getValue("[PreviewDeck1]", "play")) {
+            // Change Functionality when Preview Deck is playing: seek through the Preview Deck
+            if (delta > 0) {
+                script.toggleControl("[PreviewDeck1]", "playposition_up_small");
+            } else {
+                script.toggleControl("[PreviewDeck1]", "playposition_down_small");
+            }
         } else {
-            engine.setValue("[Library]", "focused_widget", 3);
+        	if (this.shiftPressed[field.group]) {
+            	engine.setValue("[Library]", "focused_widget", 2);
+        	} else {
+            	engine.setValue("[Library]", "focused_widget", 3);
+        	}
+
+        	engine.setValue("[Library]", "MoveVertical", delta);
         }
-
-        engine.setValue("[Library]", "MoveVertical", delta);
-
         this.browseKnobEncoderState[field.group] = field.value;
     };
 
@@ -617,7 +680,18 @@ class TraktorMX2Class {
         if (this.shiftPressed[field.group]) {
             engine.setValue("[Library]", "GoToItem", field.value);
         } else if (engine.getValue("[Library]", "focused_widget") === 3) {
-            engine.setValue(field.group, "LoadSelectedTrack", field.value);
+            if (this.padModeState[field.group] === 2 && Object.values(this.padPressed[field.group]).reduce((v, a) => v || a, false)) {
+                // Change Functionality in Pattern Mode with pressed any of Pad 5-8: load selected track to sampler
+                for (const padNum in this.padPressed[field.group]) {
+                    if (this.padPressed[field.group][padNum]) {
+                        const samplerNum = (padNum - 4) + (field.group[field.group.length - 2] - 1) * 4;
+                        engine.setValue(`[Sampler${samplerNum}]`, "LoadSelectedTrack", field.value);
+                    }
+                }
+            } else {
+                // Default functionality: load selected track to deck
+                engine.setValue(field.group, "LoadSelectedTrack", field.value);
+            }
         }
     };
 
@@ -686,6 +760,17 @@ class TraktorMX2Class {
 
                 }
             }
+        } else if (this.padModeState[field.group] === 2 && Object.values(this.padPressed[field.group]).reduce((v, a) => v || a, false)) {
+            for (const padNum in this.padPressed[field.group]) {
+                if (this.padPressed[field.group][padNum]) {
+                    const samplerNum = (padNum - 4) + (field.group[field.group.length - 2] - 1) * 4;
+                    if (delta > 0) {
+                        script.triggerControl(`[Sampler${samplerNum}]`, "rate_down_small");
+                    } else {
+                        script.triggerControl(`[Sampler${samplerNum}]`, "rate_up_small");
+                    }
+                }
+            }
         } else if (this.keylockPressed[field.group]) {
 
             this.keylockIgnore[field.group] = true;
@@ -714,14 +799,22 @@ class TraktorMX2Class {
         }
 
         if (this.padModeState[field.group] === 1 && Object.values(this.padPressed[field.group]).reduce((v, a) => v || a, false)) {
-            // Change Functionality in Stems Mode with pressed any of Pad 5-8
+            // Change Functionality in Stems Mode with pressed any of Pad 5-8: toggle effect for the corresponding stem
             for (const padNum in this.padPressed[field.group]) {
                 if (this.padPressed[field.group][padNum]) {
                     script.toggleControl(`[QuickEffectRack1_[Channel${field.group[field.group.length - 2]}_Stem${padNum - 4}]]`, "enabled");
                 }
             }
+        } else if (this.padModeState[field.group] === 2 && Object.values(this.padPressed[field.group]).reduce((v, a) => v || a, false)) {
+            // Change Functionality in Pattern Mode with pressed any of Pad 5-8: toggle repeat for the corresponding sampler
+            for (const padNum in this.padPressed[field.group]) {
+                if (this.padPressed[field.group][padNum]) {
+                    const samplerNum = (padNum - 4) + (field.group[field.group.length - 2] - 1) * 4;
+                    script.toggleControl(`[Sampler${samplerNum}]`, "repeat");
+                }
+            }
         } else {
-            //Default Functionality
+            //Default Functionality: loop roll if shift is pressed, otherwise toggle loop
             if (this.shiftPressed[field.group]) {
                 engine.setValue(field.group, "reloop_toggle", field.value);
             } else {
@@ -748,7 +841,17 @@ class TraktorMX2Class {
 
                 }
             }
-
+        } else if (this.padModeState[field.group] === 2 && Object.values(this.padPressed[field.group]).reduce((v, a) => v || a, false)) {
+            for (const padNum in this.padPressed[field.group]) {
+                if (this.padPressed[field.group][padNum]) {
+                    const samplerNum = (padNum - 4) + (field.group[field.group.length - 2] - 1) * 4;
+                    if (delta > 0) {
+                        script.triggerControl(`[Sampler${samplerNum}]`, "playposition_up_small");
+                    } else {
+                        	script.triggerControl(`[Sampler${samplerNum}]`, "playposition_down_small");
+                    }
+                }
+            }
         } else {
             //Default Functionality
             if (this.shiftPressed[field.group]) {
@@ -1385,15 +1488,19 @@ class TraktorMX2Class {
 
         this.linkOutput("[Microphone]", "talkover", this.outputHandler.bind(this));
 
-        for (let padIdx = 1; padIdx <= 8; ++padIdx) {
+        for (let padIdx = 1; padIdx <= 8; padIdx++) {
             engine.makeConnection("[Channel1]", `hotcue_${padIdx}_status`, this.hotcueOutputHandler.bind(this));
             engine.makeConnection("[Channel2]", `hotcue_${padIdx}_status`, this.hotcueOutputHandler.bind(this));
 
             engine.makeConnection("[Channel1]", `hotcue_${padIdx}_color`, this.hotcueColorHandler.bind(this));
             engine.makeConnection("[Channel2]", `hotcue_${padIdx}_color`, this.hotcueColorHandler.bind(this));
         }
-        engine.makeConnection("[Channel1]", "stem_count", this.patternOutputHandler.bind(this));
-        engine.makeConnection("[Channel2]", "stem_count", this.patternOutputHandler.bind(this));
+        engine.makeConnection("[Channel1]", "stem_count", this.stemOutputHandler.bind(this));
+        engine.makeConnection("[Channel2]", "stem_count", this.stemOutputHandler.bind(this));
+
+        for (let samplerIdx = 1; samplerIdx <= 8; samplerIdx++) {
+            engine.makeConnection(`[Sampler${samplerIdx}]`, "play_indicator", this.patternOutputHandler.bind(this));
+        }
 
         // Bottom LEDs
 
@@ -1565,13 +1672,25 @@ class TraktorMX2Class {
         }
     };
 
-    patternOutputHandler(value, group, name) {
+    stemOutputHandler(value, group, name) {
         if (this.padModeState[group] === 1) {
             for (let padIdx = 1; padIdx <= engine.getValue(group, name); padIdx++) {
                 const color = engine.getValue(`[Channel${group[group.length - 2]}_Stem${padIdx}]`, "color");
                 const status = engine.getValue(`[Channel${group[group.length - 2]}_Stem${padIdx}]`, "mute");
                 const colorValue = status ? this.baseColors.dimmedRed : this.padColorMap.getValueForNearestColor(color);
                 this.outputHandler(colorValue, group, `pad_${padIdx}`);
+            }
+        }
+    };
+
+    patternOutputHandler(_value, _group, _name) {
+        for (const group of ["[Channel1]", "[Channel2]"]) {
+        	if (this.padModeState[group] === 2) {
+                for (let padIdx = 1; padIdx <= 4; padIdx++) {
+                    const samplerIdx = padIdx + 4 * (group[group.length - 2] - 1);
+            		const state = engine.getValue(`[Sampler${samplerIdx}]`, "play_indicator");
+                    this.outputHandler(state ? this.baseColors.green : this.baseColors.dimmedGreen, group, `pad_${padIdx}`);
+             	}
             }
         }
     };
@@ -1660,7 +1779,7 @@ class TraktorMX2Class {
         current = engine.getValue("[Channel2]", "keylock");
         this.controller.setOutput("[Channel2]", "keylock", getColorValue("[Channel2]", "keylock", current), false);
 
-        for (let padIdx = 1; padIdx <= 8; ++padIdx) {
+        for (let padIdx = 1; padIdx <= 8; padIdx++) {
             if (switchOff) {
                 // do not dim but turn completely off
                 this.outputHandler(0x00, "[Channel1]", `pad_${padIdx}`);
@@ -1796,7 +1915,7 @@ class TraktorMX2Class {
                 "keylock": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
                 "hotcues": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
                 "stems": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
-                "patterns": {dim: this.baseColors.off, full: this.baseColors.red},
+                "patterns": {dim: this.usePatternModeForSamplers? this.baseColors.dimmedBlue : this.baseColors.off, full: this.usePatternModeForSamplers? this.baseColors.blue : this.baseColors.red},
                 "loops": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
                 "cue_indicator": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
                 "play_indicator": {dim: this.baseColors.dimmedGreen, full: this.baseColors.green},
@@ -1823,7 +1942,7 @@ class TraktorMX2Class {
                 "keylock": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
                 "hotcues": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
                 "stems": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
-                "patterns": {dim: this.baseColors.off, full: this.baseColors.red},
+                "patterns": {dim: this.usePatternModeForSamplers? this.baseColors.dimmedBlue : this.baseColors.off, full: this.usePatternModeForSamplers? this.baseColors.blue : this.baseColors.red},
                 "loops": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
                 "cue_indicator": {dim: this.baseColors.dimmedBlue, full: this.baseColors.blue},
                 "play_indicator": {dim: this.baseColors.dimmedGreen, full: this.baseColors.green},

--- a/res/controllers/Traktor-MX2-hid-scripts.js
+++ b/res/controllers/Traktor-MX2-hid-scripts.js
@@ -1525,25 +1525,31 @@ class TraktorMX2Class {
     };
 
     outputHandler(value, group, key) {
-        // Custom value for multi-colored LEDs
 
-        let ledValue = value;
+        let ledValue;
 
         // Look up color from map
         const colorConfig = this.outputColorMap[group]?.[key];
 
         if (colorConfig) {
+            // Should use colors from colorConfig
             if (value === 0 || value === false) {
                 ledValue = colorConfig.dim;
             } else if (value === 1 || value === true) {
                 ledValue = colorConfig.full;
+            } else {
+                // If value is not boolean, use the value directly (for multi-color LEDs)
+                ledValue = value;
             }
+        } else {
+            // If no color config is found, use the value directly
+            ledValue = value;
         }
 
         this.controller.setOutput(group, key, ledValue, true);
     };
 
-    colorOutputHandler(value, group, key) {
+    padOutputHandler(value, group, key) {
         // Custom value for multi-colored LEDs
         const colorValue = this.padColorMap.getValueForNearestColor(value);
         this.controller.setOutput(group, key, colorValue, true);
@@ -1620,14 +1626,14 @@ class TraktorMX2Class {
                         mode === 2 ? (enabled ? this.baseColors.blue : this.baseColors.dimmedBlue) :
                             mode === 3 ? (enabled ? this.baseColors.green : this.baseColors.dimmedGreen) : this.baseColors.off;
 
-                    this.colorOutputHandler(color, channel, "fx_misc");
+                    this.outputHandler(color, channel, "fx_misc");
                 } else if (name.startsWith("button_parameter")) {
                     const paramNum = name[name.length - 1];
 
                     if (paramNum <=engine.getValue(group, "num_button_parameters")) {
                         this.outputHandler(engine.getValue(group, name), channel, `fx_${paramNum}`);
                     } else {
-                        this.colorOutputHandler(this.baseColors.off, channel, `fx_${paramNum}`);
+                        this.outputHandler(this.baseColors.off, channel, `fx_${paramNum}`);
                     }
                 }
             }
@@ -1657,7 +1663,7 @@ class TraktorMX2Class {
             const color = engine.getValue(group, colorKey);
             const padNum = name[7];
             if (value > 0) {
-                this.colorOutputHandler(color, group, `pad_${padNum}`);
+                this.padOutputHandler(color, group, `pad_${padNum}`);
             } else {
                 this.outputHandler(this.baseColors.dimmedWhite, group, `pad_${padNum}`);
             }
@@ -1668,7 +1674,7 @@ class TraktorMX2Class {
         // Light button LED only when we are in hotcue mode
         const padNum = name[7];
         if (this.padModeState[group] === 0) {
-            this.colorOutputHandler(value, group, `pad_${padNum}`);
+            this.padOutputHandler(value, group, `pad_${padNum}`);
         }
     };
 


### PR DESCRIPTION
### 1. Pad Modes for Samplers (Patterns):
  - Pattern mode equivalent → samplers:
    - Added a new controller preference: "Use Pattern Mode for Samplers",
      allowing the Pattern mode to take control of Mixxx's sampler decks.
      The following will only apply if this is enabled:

    - Sampler Mode (3rd key in pad mode row):
      - As a Pattern player is afaik not planned in the near future you
        can choose to keep this pad mode unused or map it to sampler
        controls
      - The top row of pads (Pads 1-4) toggles the playback state of the
        samplers and displays it.
      - Pressing and holding the bottom row of pads (Pads 5-8) is used
        as a modifier key:
        - Pressing keylock toggles sampler keylock
        - Pressing loop knob toggles sampler repeat
        - Turning library browse knob changes pregain of sampler
        - Turing beatjump knob seeks through sampler track
        - Turning loop knob changes rate (speed, pitch depending
          keylock) of sampler

### 2. Add Single Effect Modes

The effect units now support cycling through four distinct modes by
pressing `Shift + Misc` (leftmost button): Group Mode, Single 1,
Single 2, and Single 3.

  - Common behavior:
    - The `Mix` scaler (leftmost) controls dry/wet for the whole unit
    - Shift + Button (fx 2-4) cycles the selected effect in the
      buttons effect slot (button 2 → effect1, button 3 → effect2,
      button 4 → effect3)

  - Group Mode: Behaves identically to the old implementation. The
    three effect buttons toggle their respective effects on or off.
    The scalers (2,3,4) control `Meta` for the effects.
  - Single Mode (1, 2, or 3): Focuses the controller on one specific
    effect slot.
    - The `Misc` button (leftmost) acts as an on/off toggle for the
      focused effect. It lights up in Red (Single 1), Blue (Single 2),
      or Green (Single 3) to clearly indicate the active slot.
    - The three effect buttons control the first, second, and third
      button parameters of the focused effect, respectively.
    - The three scalers control, the first, second and third parameter
      of the focused effect, respectively.

### 3. Allow Mixer effects per channel
  - Holding gfx_toggle while pressing gfx{0...4} will enable the effect only on this channel

### 4. improve preview handling
  - Turning library browse knob while a preview is playing will seek
    through the preview.

### 5. fix: incorrect linking of previewdeck's `playback_indicator`


See also the PR for the manual: [link](https://github.com/mixxxdj/manual/pull/901)