### PR TITLE
PipeWire link hotplug

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -391,7 +391,11 @@ void MixxxMainWindow::initialize() {
     // that says "mixxx will barely work with no outs".
     // In case of persisting errors, the user has already received a message
     // above. So we can just check the output count here.
-    while (m_pCoreServices->getSoundManager()->getConfig().getOutputs().isEmpty()) {
+    while (m_pCoreServices->getSoundManager()
+                    ->getConfig()
+                    .getOutputs()
+                    .isEmpty() &&
+            !m_pCoreServices->getSoundManager()->pipewireSkipConfig()) {
         // Exit when we press the Exit button in the noSoundDlg dialog
         // only call it if result != OK
         bool continueClicked = false;

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -1,6 +1,8 @@
 #include "preferences/dialog/dlgprefsound.h"
 
+#include <QBoxLayout>
 #include <QCheckBox>
+#include <QGroupBox>
 #include <QMessageBox>
 #include <QtDebug>
 #include <algorithm>
@@ -260,9 +262,13 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                     m_settingsModified = true;
                 });
 
+        auto pipewireGroupBox = make_parented<QGroupBox>("PipeWire Settings", this);
+        auto pipewireSettings = make_parented<QVBoxLayout>(pipewireGroupBox);
+        verticalLayout_2->insertWidget(2, pipewireGroupBox.get());
+
         bool checked = m_pSettings->getValue(kPipeWirePatchbay, false);
         m_pipewirePatchbayCheckBox->setChecked(checked);
-        verticalLayout_2->addWidget(m_pipewirePatchbayCheckBox.get());
+        pipewireSettings->addWidget(m_pipewirePatchbayCheckBox.get());
     }
 #endif
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -37,6 +37,8 @@ const ConfigKey kKeylockMultiThreadingCfgkey =
         ConfigKey(kAppGroup, QStringLiteral("keylock_multithreading"));
 const ConfigKey kPipeWire =
         ConfigKey(kAppGroup, QStringLiteral("pipewire"));
+const ConfigKey kPipeWirePatchbay =
+        ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay"));
 
 bool soundItemAlreadyExists(const AudioPath& output, const QWidget& widget) {
     for (const QObject* pObj : widget.children()) {
@@ -118,6 +120,16 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             &SoundManager::deviceChannelsUpdated,
             this,
             &DlgPrefSound::updateDeviceChannels);
+
+    connect(m_pSoundManager.get(),
+            &SoundManager::pathChannelUpdated,
+            this,
+            &DlgPrefSound::updatePathChannel);
+
+    connect(m_pSoundManager.get(),
+            &SoundManager::pathDeviceUpdated,
+            this,
+            &DlgPrefSound::updatePathDevice);
 
     apiComboBox->clear();
     apiComboBox->addItem(SoundManagerConfig::kEmptyComboBox,
@@ -236,6 +248,24 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                                    "API selection to take effect."));
                     }
                 });
+    }
+
+    if (m_pSoundManager->isPipewireSelected()) {
+        m_pipewirePatchbayCheckBox = make_parented<QCheckBox>(this);
+        m_pipewirePatchbayCheckBox->setText(tr("Sync with external patchbay"));
+        m_pPipewirePatchbay = make_parented<ControlProxy>(
+                kPipeWirePatchbay.group, kPipeWirePatchbay.item, this);
+        connect(m_pipewirePatchbayCheckBox,
+                &QCheckBox::toggled,
+                this,
+                [this](bool checked) {
+                    m_pSettings->setValue(kPipeWirePatchbay, checked);
+                    m_pPipewirePatchbay->set(checked);
+                });
+
+        bool checked = m_pSettings->getValue(kPipeWirePatchbay, false);
+        m_pipewirePatchbayCheckBox->setChecked(checked);
+        verticalLayout_2->addWidget(m_pipewirePatchbayCheckBox.get());
     }
 #endif
 
@@ -557,6 +587,7 @@ void DlgPrefSound::connectSoundItem(DlgPrefSoundItem* pItem) {
             &DlgPrefSound::configuredDeviceNotFound);
     connect(this, &DlgPrefSound::loadPaths, pItem, &DlgPrefSoundItem::loadPath);
     connect(this, &DlgPrefSound::writePaths, pItem, &DlgPrefSoundItem::writePath);
+    connect(this, &DlgPrefSound::writePath, pItem, &DlgPrefSoundItem::updatePath);
     if (pItem->isInput()) {
         connect(this, &DlgPrefSound::refreshInputDevices, pItem, &DlgPrefSoundItem::refreshDevices);
         connect(this, &DlgPrefSound::addInputDevice, pItem, &DlgPrefSoundItem::addDevice);
@@ -575,7 +606,8 @@ void DlgPrefSound::connectSoundItem(DlgPrefSoundItem* pItem) {
             &DlgPrefSound::deviceChannelsUpdated,
             pItem,
             &DlgPrefSoundItem::updateDeviceChannels);
-    connect(this, &DlgPrefSound::deviceRouteUpdated, pItem, &DlgPrefSoundItem::updateDeviceRoute);
+    connect(this, &DlgPrefSound::pathChannelUpdated, pItem, &DlgPrefSoundItem::updateChannel);
+    connect(this, &DlgPrefSound::pathDeviceUpdated, pItem, &DlgPrefSoundItem::updateDevice);
 }
 
 void DlgPrefSound::insertItem(DlgPrefSoundItem *pItem, QVBoxLayout *pLayout) {
@@ -918,6 +950,24 @@ void DlgPrefSound::updateDeviceChannels(SoundDevicePointer pDevice) {
         m_outputDevices.append(pDevice);
         emit addOutputDevice(pDevice);
     }
+}
+
+void DlgPrefSound::updatePathChannel(const AudioPath* pPath, ChannelGroup channelGroup) {
+    emit pathChannelUpdated(pPath, channelGroup);
+    m_config.clearInputs();
+    m_config.clearOutputs();
+    emit writePaths(&m_config);
+
+    m_pSoundManager->updateConfig(m_config);
+}
+
+void DlgPrefSound::updatePathDevice(const AudioPath* pPath, const SoundDeviceId& deviceId) {
+    emit pathDeviceUpdated(pPath, deviceId);
+    m_config.clearInputs();
+    m_config.clearOutputs();
+    emit writePaths(&m_config);
+
+    m_pSoundManager->updateConfig(m_config);
 }
 
 /// Called when any of the combo boxes in this dialog are changed. Enables the

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -236,14 +236,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
         connect(m_pipewireCheckBox,
                 &QCheckBox::toggled,
                 this,
-                [this](bool checked) {
+                [this](bool) {
                     m_settingsModified = true;
-                    if (m_pSoundManager->isPipewireSelected() xor checked) {
-                        QMessageBox::information(this,
-                                tr("Information"),
-                                tr("Mixxx must be restarted for the PipeWire "
-                                   "API selection to take effect."));
-                    }
+                    QMessageBox::information(this,
+                            tr("Information"),
+                            tr("Mixxx must be restarted for the PipeWire "
+                               "API selection to take effect."));
                 });
     }
 
@@ -730,12 +728,6 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig& config) {
                     QPair<SoundDeviceId, int>(id, pItem->getChannelIndex()));
         }
     }
-
-#ifdef __PIPEWIRE__
-    if (CmdlineArgs::Instance().getDeveloper()) {
-        m_pipewireCheckBox->setChecked(m_pSoundManager->isPipewireSelected());
-    }
-#endif
 
     m_loading = false;
     // DlgPrefSoundItem has it's own inhibit flag

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -38,7 +38,7 @@ const ConfigKey kKeylockMultiThreadingCfgkey =
 const ConfigKey kPipeWire =
         ConfigKey(kAppGroup, QStringLiteral("pipewire"));
 const ConfigKey kPipeWirePatchbay =
-        ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay"));
+        ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"));
 
 bool soundItemAlreadyExists(const AudioPath& output, const QWidget& widget) {
     for (const QObject* pObj : widget.children()) {
@@ -122,14 +122,9 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             &DlgPrefSound::updateDeviceChannels);
 
     connect(m_pSoundManager.get(),
-            &SoundManager::pathChannelUpdated,
+            &SoundManager::configInvalidated,
             this,
-            &DlgPrefSound::updatePathChannel);
-
-    connect(m_pSoundManager.get(),
-            &SoundManager::pathDeviceUpdated,
-            this,
-            &DlgPrefSound::updatePathDevice);
+            &DlgPrefSound::invalidateConfig);
 
     apiComboBox->clear();
     apiComboBox->addItem(SoundManagerConfig::kEmptyComboBox,
@@ -261,6 +256,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                 [this](bool checked) {
                     m_pSettings->setValue(kPipeWirePatchbay, checked);
                     m_pPipewirePatchbay->set(checked);
+                    ioTabs->setDisabled(checked);
+                    m_settingsModified = true;
                 });
 
         bool checked = m_pSettings->getValue(kPipeWirePatchbay, false);
@@ -587,7 +584,6 @@ void DlgPrefSound::connectSoundItem(DlgPrefSoundItem* pItem) {
             &DlgPrefSound::configuredDeviceNotFound);
     connect(this, &DlgPrefSound::loadPaths, pItem, &DlgPrefSoundItem::loadPath);
     connect(this, &DlgPrefSound::writePaths, pItem, &DlgPrefSoundItem::writePath);
-    connect(this, &DlgPrefSound::writePath, pItem, &DlgPrefSoundItem::updatePath);
     if (pItem->isInput()) {
         connect(this, &DlgPrefSound::refreshInputDevices, pItem, &DlgPrefSoundItem::refreshDevices);
         connect(this, &DlgPrefSound::addInputDevice, pItem, &DlgPrefSoundItem::addDevice);
@@ -606,8 +602,6 @@ void DlgPrefSound::connectSoundItem(DlgPrefSoundItem* pItem) {
             &DlgPrefSound::deviceChannelsUpdated,
             pItem,
             &DlgPrefSoundItem::updateDeviceChannels);
-    connect(this, &DlgPrefSound::pathChannelUpdated, pItem, &DlgPrefSoundItem::updateChannel);
-    connect(this, &DlgPrefSound::pathDeviceUpdated, pItem, &DlgPrefSoundItem::updateDevice);
 }
 
 void DlgPrefSound::insertItem(DlgPrefSoundItem *pItem, QVBoxLayout *pLayout) {
@@ -952,24 +946,6 @@ void DlgPrefSound::updateDeviceChannels(SoundDevicePointer pDevice) {
     }
 }
 
-void DlgPrefSound::updatePathChannel(const AudioPath* pPath, ChannelGroup channelGroup) {
-    emit pathChannelUpdated(pPath, channelGroup);
-    m_config.clearInputs();
-    m_config.clearOutputs();
-    emit writePaths(&m_config);
-
-    m_pSoundManager->updateConfig(m_config);
-}
-
-void DlgPrefSound::updatePathDevice(const AudioPath* pPath, const SoundDeviceId& deviceId) {
-    emit pathDeviceUpdated(pPath, deviceId);
-    m_config.clearInputs();
-    m_config.clearOutputs();
-    emit writePaths(&m_config);
-
-    m_pSoundManager->updateConfig(m_config);
-}
-
 /// Called when any of the combo boxes in this dialog are changed. Enables the
 /// apply button and marks that settings have been changed so that
 /// DlgPrefSound::slotApply knows to apply them.
@@ -1283,4 +1259,8 @@ void DlgPrefSound::updateSampleRates(const QList<mixxx::audio::SampleRate>& samp
                     QVariant::fromValue(sampleRate));
         }
     }
+}
+
+void DlgPrefSound::invalidateConfig() {
+    m_settingsModified = true;
 }

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -48,8 +48,6 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void removeInputDevice(SoundDevicePointer pDevice);
     void updatingAPI();
     void updatedAPI();
-    void pathChannelUpdated(const AudioPath* path, ChannelGroup channelGroup);
-    void pathDeviceUpdated(const AudioPath* path, const SoundDeviceId& deviceId);
     void deviceChannelsUpdated(SoundDevicePointer devices);
 
   public slots:
@@ -93,9 +91,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void addDevice(SoundDevicePointer pDevice);
     void removeDevice(SoundDevicePointer pDevice);
     void updateDeviceChannels(SoundDevicePointer pDevice);
-    void updatePathChannel(const AudioPath* path, ChannelGroup channelGroup);
-    void updatePathDevice(const AudioPath* path, const SoundDeviceId& deviceId);
     void updateSampleRates(const QList<mixxx::audio::SampleRate>& sampleRates);
+    void invalidateConfig();
 
   private:
     void initializePaths();

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -9,6 +9,7 @@
 #include "preferences/usersettings.h"
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
+#include "soundio/soundmanagerutil.h"
 #include "util/parented_ptr.h"
 
 class ControlObject;
@@ -37,6 +38,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
 
   signals:
     void loadPaths(const SoundManagerConfig &config);
+    void writePath(const AudioPath* pPath, SoundManagerConfig* config);
     void writePaths(SoundManagerConfig *config);
     void refreshOutputDevices(const QList<SoundDevicePointer>& devices);
     void refreshInputDevices(const QList<SoundDevicePointer>& devices);
@@ -46,7 +48,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void removeInputDevice(SoundDevicePointer pDevice);
     void updatingAPI();
     void updatedAPI();
-    void deviceRouteUpdated(const SoundDeviceId& device, const AudioPath* pPath);
+    void pathChannelUpdated(const AudioPath* path, ChannelGroup channelGroup);
+    void pathDeviceUpdated(const AudioPath* path, const SoundDeviceId& deviceId);
     void deviceChannelsUpdated(SoundDevicePointer devices);
 
   public slots:
@@ -90,6 +93,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void addDevice(SoundDevicePointer pDevice);
     void removeDevice(SoundDevicePointer pDevice);
     void updateDeviceChannels(SoundDevicePointer pDevice);
+    void updatePathChannel(const AudioPath* path, ChannelGroup channelGroup);
+    void updatePathDevice(const AudioPath* path, const SoundDeviceId& deviceId);
     void updateSampleRates(const QList<mixxx::audio::SampleRate>& sampleRates);
 
   private:
@@ -127,5 +132,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
 
 #ifdef __PIPEWIRE__
     parented_ptr<QCheckBox> m_pipewireCheckBox;
+    parented_ptr<QCheckBox> m_pipewirePatchbayCheckBox;
+    parented_ptr<ControlProxy> m_pPipewirePatchbay;
 #endif
 };

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -7,6 +7,7 @@
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
 #include "soundio/soundmanagerutil.h"
+#include "util/assert.h"
 
 /// Constructs a new preferences sound item, representing an AudioPath and SoundDevice
 /// with a label and two combo boxes.
@@ -107,35 +108,6 @@ void DlgPrefSoundItem::updateDeviceChannels(SoundDevicePointer pDevice) {
         channelComboBox->setCurrentIndex(newIndex);
         m_emitSettingChanged = true;
     }
-}
-
-void DlgPrefSoundItem::updateChannel(const AudioPath* pPath, ChannelGroup channelGroup) {
-    if (pPath->getType() != m_type || pPath->getIndex() != m_index) {
-        return;
-    }
-
-    qDebug() << "DlgPrefSoundItem::updateChannel" << pPath->getString()
-             << channelGroup.getChannelBase()
-             << channelGroup.getChannelCount();
-    setChannel(channelGroup.getChannelBase(), channelGroup.getChannelCount());
-}
-
-void DlgPrefSoundItem::updateDevice(const AudioPath* pPath, const SoundDeviceId& deviceId) {
-    if (pPath->getType() != m_type || pPath->getIndex() != m_index) {
-        return;
-    }
-
-    qDebug() << "DlgPrefSoundItem::updateDevice" << pPath->getString()
-             << deviceId.deviceIndex << deviceId.name;
-    setDevice(deviceId);
-}
-
-void DlgPrefSoundItem::updatePath(const AudioPath* pPath, SoundManagerConfig* config) const {
-    if (pPath->getType() != m_type || pPath->getIndex() != m_index) {
-        return;
-    }
-
-    writePath(config);
 }
 
 /// Slot called when the device combo box selection changes. Updates the channel
@@ -287,7 +259,6 @@ void DlgPrefSoundItem::reload() {
     int newDevice = deviceComboBox->findData(QVariant::fromValue(m_savedDevice));
     if (newDevice > -1) {
         deviceComboBox->setCurrentIndex(newDevice);
-        qDebug() << "DlgPrefSoundItem::reload deviceComboBox->setCurrentIndex";
     }
     int newChannel = channelComboBox->findData(m_savedChannel);
     if (newChannel > -1) {
@@ -310,7 +281,6 @@ SoundDevicePointer DlgPrefSoundItem::getDevice() const {
     }
     // looks like something became invalid ???
     deviceComboBox->setCurrentIndex(0); // set it to none
-    qDebug() << "DlgPrefSoundItem::getDevice deviceComboBox->setCurrentIndex";
     return SoundDevicePointer();
 }
 
@@ -337,17 +307,11 @@ void DlgPrefSoundItem::setDevice(const SoundDeviceId& device) {
 /// or selects the first channel if the given channel isn't found.
 void DlgPrefSoundItem::setChannel(unsigned int channelBase,
                                   unsigned int channels) {
-    qDebug() << "DlgPrefSoundItem::setChannel" << channelBase << channels;
     // Because QComboBox supports QPoint natively (via QVariant) we use a QPoint
     // to store the channel info. x is the channel base and y is the channel
     // count.
     int index = channelComboBox->findData(QPoint(channelBase, channels));
-    // PipeWire uses unselected checkbox to represent nonstandard routing
-#ifdef __PIPEWIRE__
-    if (false) {
-#else
     if (index == -1) {
-#endif
         // channel(s) not found
         channelComboBox->setCurrentIndex(0); // 1
         emit selectedChannelsChanged();

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -7,7 +7,6 @@
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
 #include "soundio/soundmanagerutil.h"
-#include "util/assert.h"
 
 /// Constructs a new preferences sound item, representing an AudioPath and SoundDevice
 /// with a label and two combo boxes.
@@ -71,13 +70,7 @@ void DlgPrefSoundItem::refreshDevices(const QList<SoundDevicePointer>& devices) 
 }
 
 void DlgPrefSoundItem::addDevice(const SoundDevicePointer pDevice) {
-    // SoundDeviceId oldDev =
-    // deviceComboBox->itemData(deviceComboBox->currentIndex()).value<SoundDeviceId>();
     deviceComboBox->addItem(pDevice->getDisplayName(), QVariant::fromValue(pDevice->getDeviceId()));
-
-    // int newIndex = deviceComboBox->findData(QVariant::fromValue(oldDev));
-    // deviceComboBox->setCurrentIndex(newIndex);
-
     m_devices.push_back(pDevice);
 }
 
@@ -116,29 +109,33 @@ void DlgPrefSoundItem::updateDeviceChannels(SoundDevicePointer pDevice) {
     }
 }
 
-void DlgPrefSoundItem::updateDeviceRoute(const SoundDeviceId& id, const AudioPath* pPath) {
+void DlgPrefSoundItem::updateChannel(const AudioPath* pPath, ChannelGroup channelGroup) {
     if (pPath->getType() != m_type || pPath->getIndex() != m_index) {
         return;
     }
 
-    // qWarning() << "DlgPrefSoundItem::updateDevice" << id.name;
-    int index = deviceComboBox->findData(QVariant::fromValue(id));
+    qDebug() << "DlgPrefSoundItem::updateChannel" << pPath->getString()
+             << channelGroup.getChannelBase()
+             << channelGroup.getChannelCount();
+    setChannel(channelGroup.getChannelBase(), channelGroup.getChannelCount());
+}
 
-    VERIFY_OR_DEBUG_ASSERT(index >= 0) {
+void DlgPrefSoundItem::updateDevice(const AudioPath* pPath, const SoundDeviceId& deviceId) {
+    if (pPath->getType() != m_type || pPath->getIndex() != m_index) {
         return;
     }
 
-    if (index != deviceComboBox->currentIndex()) {
-        deviceComboBox->blockSignals(true);
-        deviceComboBox->setCurrentIndex(index);
-        deviceComboBox->blockSignals(false);
-        deviceChanged(index);
+    qDebug() << "DlgPrefSoundItem::updateDevice" << pPath->getString()
+             << deviceId.deviceIndex << deviceId.name;
+    setDevice(deviceId);
+}
+
+void DlgPrefSoundItem::updatePath(const AudioPath* pPath, SoundManagerConfig* config) const {
+    if (pPath->getType() != m_type || pPath->getIndex() != m_index) {
+        return;
     }
 
-    auto channelGroup = pPath->getChannelGroup();
-    QPoint point = QPoint(channelGroup.getChannelBase(), channelGroup.getChannelCount());
-    int channelIndex = channelComboBox->findData(QVariant::fromValue(point));
-    channelComboBox->setCurrentIndex(channelIndex);
+    writePath(config);
 }
 
 /// Slot called when the device combo box selection changes. Updates the channel
@@ -290,6 +287,7 @@ void DlgPrefSoundItem::reload() {
     int newDevice = deviceComboBox->findData(QVariant::fromValue(m_savedDevice));
     if (newDevice > -1) {
         deviceComboBox->setCurrentIndex(newDevice);
+        qDebug() << "DlgPrefSoundItem::reload deviceComboBox->setCurrentIndex";
     }
     int newChannel = channelComboBox->findData(m_savedChannel);
     if (newChannel > -1) {
@@ -312,6 +310,7 @@ SoundDevicePointer DlgPrefSoundItem::getDevice() const {
     }
     // looks like something became invalid ???
     deviceComboBox->setCurrentIndex(0); // set it to none
+    qDebug() << "DlgPrefSoundItem::getDevice deviceComboBox->setCurrentIndex";
     return SoundDevicePointer();
 }
 
@@ -338,11 +337,17 @@ void DlgPrefSoundItem::setDevice(const SoundDeviceId& device) {
 /// or selects the first channel if the given channel isn't found.
 void DlgPrefSoundItem::setChannel(unsigned int channelBase,
                                   unsigned int channels) {
+    qDebug() << "DlgPrefSoundItem::setChannel" << channelBase << channels;
     // Because QComboBox supports QPoint natively (via QVariant) we use a QPoint
     // to store the channel info. x is the channel base and y is the channel
     // count.
     int index = channelComboBox->findData(QPoint(channelBase, channels));
+    // PipeWire uses unselected checkbox to represent nonstandard routing
+#ifdef __PIPEWIRE__
+    if (false) {
+#else
     if (index == -1) {
+#endif
         // channel(s) not found
         channelComboBox->setCurrentIndex(0); // 1
         emit selectedChannelsChanged();

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -44,15 +44,12 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     void deviceChanged(int index);
     void channelChanged();
     void loadPath(const SoundManagerConfig& config);
-    void updatePath(const AudioPath* pPath, SoundManagerConfig* config) const;
     void writePath(SoundManagerConfig *config) const;
     void save();
     void reload();
     void addDevice(SoundDevicePointer pDevice);
     void removeDevice(SoundDevicePointer pDevice);
     void updateDeviceChannels(SoundDevicePointer pDevice);
-    void updateChannel(const AudioPath* pPath, ChannelGroup channelGroup);
-    void updateDevice(const AudioPath* pPath, const SoundDeviceId& deviceId);
 
   private:
     SoundDevicePointer getDevice() const; // if this returns NULL, we don't have a valid AudioPath

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -44,13 +44,15 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     void deviceChanged(int index);
     void channelChanged();
     void loadPath(const SoundManagerConfig& config);
+    void updatePath(const AudioPath* pPath, SoundManagerConfig* config) const;
     void writePath(SoundManagerConfig *config) const;
     void save();
     void reload();
     void addDevice(SoundDevicePointer pDevice);
     void removeDevice(SoundDevicePointer pDevice);
     void updateDeviceChannels(SoundDevicePointer pDevice);
-    void updateDeviceRoute(const SoundDeviceId& pDevice, const AudioPath* pPath);
+    void updateChannel(const AudioPath* pPath, ChannelGroup channelGroup);
+    void updateDevice(const AudioPath* pPath, const SoundDeviceId& deviceId);
 
   private:
     SoundDevicePointer getDevice() const; // if this returns NULL, we don't have a valid AudioPath

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -28,6 +28,7 @@
 namespace {
 
 constexpr int kCpuUsageUpdateRate = 30; // in 1/s, fits to display frame rate
+constexpr int kPatchbayWaitTime = 3;    // wait for patchbay to connect inputs
 const QString kAppGroup = QStringLiteral("[App]");
 
 static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
@@ -1056,10 +1057,37 @@ void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int frames
     ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
 }
 
+bool PipewireEnumerator::portsEmpty() {
+    for (auto& portPair : std::views::values(m_outputs)) {
+        if (portPair.active.load()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void PipewireEnumerator::patchbayWaitTimer() {
+    pw_loop* loop = pw_thread_loop_get_loop(m_pPwThreadLoop);
+    pw_loop_destroy_source(loop, m_patchbayWaitTimer);
+    m_patchbayWaitTimer = nullptr;
+    if (portsEmpty()) {
+        // patchbay didn't connect any ports, load config
+        QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::devicesEnumerated);
+    }
+}
+
 void PipewireEnumerator::coreEventDone(uint32_t id, int seq) {
     qDebug() << "PipewireEnumerator::coreEventDone" << id << seq << m_coreSyncSeq;
     if (id == 0 && seq == m_coreSyncSeq) {
-        QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::devicesEnumerated);
+        if (portsEmpty()) {
+            // No device open till now, wait for 2 seconds for any external
+            // patchbay to open devices, and then check again
+            pw_loop* loop = pw_thread_loop_get_loop(m_pPwThreadLoop);
+            m_patchbayWaitTimer = pw_loop_add_timer(loop, patchbayWaitTimer, this);
+            struct timespec when = {.tv_sec = kPatchbayWaitTime, .tv_nsec = 0};
+            pw_loop_update_timer(loop, m_patchbayWaitTimer, &when, nullptr, false);
+        }
     }
 }
 

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -7,6 +7,7 @@
 
 #include <QList>
 #include <QMessageBox>
+#include <QMetaObject>
 #include <QSharedPointer>
 #include <QStringView>
 #include <ranges>
@@ -200,6 +201,7 @@ void PipewireEnumerator::initialize() {
                  << spa_strerror(res);
     }
 
+    m_coreSyncSeq = pw_core_sync(m_pPwCore, PW_ID_CORE, 0);
     pw_thread_loop_start(m_pPwThreadLoop);
 
     m_initialized = true;
@@ -1046,6 +1048,13 @@ void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int frames
             ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
             m_framesPerBuffer * 1000 / m_sampleRate);
     ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
+}
+
+void PipewireEnumerator::coreEventDone(uint32_t id, int seq) {
+    qDebug() << "PipewireEnumerator::coreEventDone" << id << seq << m_coreSyncSeq;
+    if (id == 0 && seq == m_coreSyncSeq) {
+        QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::devicesEnumerated);
+    }
 }
 
 void PipewireEnumerator::coreEventError(uint32_t id, int seq, int res, const char* message) {

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -412,11 +412,11 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
                         const SoundDeviceId& deviceId =
                                 m_soundDevices.at(ports.activeDevice)
                                         ->getDeviceId();
-                        m_pSoundManager->updatePathDevice(input, deviceId);
+                        m_pSoundManager->updatePathDevice(input, deviceId, true);
                     }
                     const Node& deviceNode = m_nodes.at(ports.activeDevice);
                     m_pSoundManager->updatePathChannel(
-                            input, ports.inputChannel(deviceNode.outputs));
+                            input, ports.inputChannel(deviceNode.outputs), true);
                 }
 
                 break;
@@ -445,11 +445,11 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
                         const SoundDeviceId& deviceId =
                                 m_soundDevices.at(ports.activeDevice)
                                         ->getDeviceId();
-                        m_pSoundManager->updatePathDevice(output, deviceId);
+                        m_pSoundManager->updatePathDevice(output, deviceId, false);
                     }
                     const Node& deviceNode = m_nodes.at(ports.activeDevice);
                     m_pSoundManager->updatePathChannel(
-                            output, ports.outputChannel(deviceNode.inputs));
+                            output, ports.outputChannel(deviceNode.inputs), false);
                 }
                 break;
             }
@@ -508,20 +508,22 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
 
                 if (m_manageExternalLinks and deviceChanged) {
                     if (ports.connectedDevices.empty()) {
-                        m_pSoundManager->updatePathDevice(input, SoundDeviceId{});
+                        m_pSoundManager->updatePathDevice(input, SoundDeviceId{}, true);
                         ports.active.store(false);
                         m_pSoundManager->unconfigureInput(input);
                     } else {
                         m_pSoundManager->updatePathDevice(input,
                                 m_soundDevices.at(ports.activeDevice)
-                                        ->getDeviceId());
+                                        ->getDeviceId(),
+                                true);
                     }
                 }
 
                 if (m_manageExternalLinks and ports.activeDevice) {
                     const Node& activeDeviceNode = m_nodes.at(ports.activeDevice);
                     m_pSoundManager->updatePathChannel(input,
-                            ports.inputChannel(activeDeviceNode.outputs));
+                            ports.inputChannel(activeDeviceNode.outputs),
+                            true);
                 }
                 break;
             }
@@ -540,19 +542,21 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
 
                 if (m_manageExternalLinks and deviceChanged) {
                     if (ports.connectedDevices.empty()) {
-                        m_pSoundManager->updatePathDevice(output, SoundDeviceId{});
+                        m_pSoundManager->updatePathDevice(output, SoundDeviceId{}, false);
                         ports.active.store(false);
                         m_pSoundManager->unconfigureOutput(output);
                     } else {
                         m_pSoundManager->updatePathDevice(output,
                                 m_soundDevices.at(ports.activeDevice)
-                                        ->getDeviceId());
+                                        ->getDeviceId(),
+                                false);
                     }
                 }
                 if (m_manageExternalLinks and ports.activeDevice) {
                     m_pSoundManager->updatePathChannel(output,
                             ports.outputChannel(
-                                    m_nodes.at(ports.activeDevice).inputs));
+                                    m_nodes.at(ports.activeDevice).inputs),
+                            false);
                 }
                 break;
             }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -383,18 +383,9 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         outputPort.links.push_back(id);
 
         if (in_node == m_filterId) {
-            bool deviceChanged;
             // device output, mixxx input
             for (auto& [input, ports] : m_inputs) {
-                if (ports.left.id == in_port) {
-                    if (m_manageExternalLinks) {
-                        deviceChanged = ports.addPort(out_node, out_port, true);
-                    }
-                } else if (ports.right.id == in_port) {
-                    if (m_manageExternalLinks) {
-                        deviceChanged = ports.addPort(out_node, out_port, false);
-                    }
-                } else {
+                if (ports.left.id != in_port and ports.right.id != in_port) {
                     continue;
                 }
 
@@ -408,10 +399,12 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
                 }
 
                 if (m_manageExternalLinks) {
-                    const SoundDeviceId& deviceId =
-                            m_soundDevices.at(ports.activeDevice)
-                                    ->getDeviceId();
+                    bool deviceChanged = ports.addPort(
+                            out_node, out_port, ports.left.id == in_port);
                     if (deviceChanged) {
+                        const SoundDeviceId& deviceId =
+                                m_soundDevices.at(ports.activeDevice)
+                                        ->getDeviceId();
                         m_pSoundManager->updatePathDevice(input, deviceId);
                     }
                     const Node& deviceNode = m_nodes.at(ports.activeDevice);
@@ -423,18 +416,9 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
             }
 
         } else if (out_node == m_filterId) {
-            bool deviceChanged;
             // device input, mixxx output
             for (auto& [output, ports] : m_outputs) {
-                if (ports.left.id == out_port) {
-                    if (m_manageExternalLinks) {
-                        deviceChanged = ports.addPort(in_node, in_port, true);
-                    }
-                } else if (ports.right.id == out_port) {
-                    if (m_manageExternalLinks) {
-                        deviceChanged = ports.addPort(in_node, in_port, false);
-                    }
-                } else {
+                if (ports.left.id != out_port and ports.right.id != out_port) {
                     continue;
                 }
 
@@ -448,6 +432,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
                 }
 
                 if (m_manageExternalLinks) {
+                    bool deviceChanged = ports.addPort(in_node, in_port, ports.left.id == out_port);
                     if (deviceChanged) {
                         const SoundDeviceId& deviceId =
                                 m_soundDevices.at(ports.activeDevice)

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -1,6 +1,7 @@
 #include "soundio/pipewireenumerator.h"
 
 #include <pipewire/pipewire.h>
+#include <qobjectdefs.h>
 #include <spa/utils/defs.h>
 #include <spa/utils/dict.h>
 #include <spa/utils/result.h>
@@ -28,7 +29,6 @@
 namespace {
 
 constexpr int kCpuUsageUpdateRate = 30; // in 1/s, fits to display frame rate
-constexpr int kPatchbayWaitTime = 3;    // wait for patchbay to connect inputs
 const QString kAppGroup = QStringLiteral("[App]");
 
 static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
@@ -87,11 +87,12 @@ PipewireEnumerator::PipewireEnumerator(
           m_pPwFilter(nullptr),
           m_sampleRate(48000),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
-          m_COmanageExternalLinks(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay"))),
+          m_COmanageExternalLinks(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
           m_framesPerBuffer(0),
-          m_manageExternalLinks(static_cast<bool>(pConfig->getValue(
-                  ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay")),
-                  false))) {
+          m_manageExternalLinks(pConfig->getValue(
+                  ConfigKey(
+                          kAppGroup, QStringLiteral("pipewire_patchbay_sync")),
+                  false)) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -104,8 +105,9 @@ PipewireEnumerator::PipewireEnumerator(
     connect(this, &PipewireEnumerator::deviceAdded, m_pSoundManager, &SoundManager::addDevice);
     connect(this, &PipewireEnumerator::deviceRemoved, m_pSoundManager, &SoundManager::removeDevice);
     connect(&m_COmanageExternalLinks, &ControlObject::valueChanged, this, [this](double value) {
-        // TODO(pri-yan-shu) cleanup any invalid state here, or make the toggle startup only
+        pw_thread_loop_lock(m_pPwThreadLoop);
         m_manageExternalLinks = static_cast<bool>(value);
+        pw_thread_loop_unlock(m_pPwThreadLoop);
     });
 
     pw_init(nullptr, nullptr);
@@ -205,6 +207,7 @@ void PipewireEnumerator::initialize() {
     // queue an event when device enumeration is complete
     // so we can compare from Mixxx config and configure the devices
     m_coreSyncSeq = pw_core_sync(m_pPwCore, PW_ID_CORE, 0);
+
     pw_thread_loop_start(m_pPwThreadLoop);
 
     m_initialized = true;
@@ -399,27 +402,9 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
 
                 const bool portsActive = ports.active.load();
                 if (!portsActive) {
-                    ports.active.store(true);
                     m_pSoundManager->configureInput(input);
-                    // if (!deviceChanged) {
-                    // qDebug() << "portsActive == false but device not changed, this is bad";
-                    // }
+                    ports.active.store(true);
                 }
-
-                if (m_manageExternalLinks) {
-                    bool deviceChanged = ports.addPort(
-                            out_node, out_port, ports.left.id == in_port);
-                    if (deviceChanged) {
-                        const SoundDeviceId& deviceId =
-                                m_soundDevices.at(ports.activeDevice)
-                                        ->getDeviceId();
-                        m_pSoundManager->updatePathDevice(input, deviceId, true);
-                    }
-                    const Node& deviceNode = m_nodes.at(ports.activeDevice);
-                    m_pSoundManager->updatePathChannel(
-                            input, ports.inputChannel(deviceNode.outputs), true);
-                }
-
                 break;
             }
         }
@@ -433,27 +418,15 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
 
                 const bool portsActive = ports.active.load();
                 if (!portsActive) {
-                    ports.active.store(true);
                     m_pSoundManager->configureOutput(output);
-                    // if (!deviceChanged) {
-                    // qDebug() << "portsActive == false but device not changed, this is bad";
-                    // }
-                }
-
-                if (m_manageExternalLinks) {
-                    bool deviceChanged = ports.addPort(in_node, in_port, ports.left.id == out_port);
-                    if (deviceChanged) {
-                        const SoundDeviceId& deviceId =
-                                m_soundDevices.at(ports.activeDevice)
-                                        ->getDeviceId();
-                        m_pSoundManager->updatePathDevice(output, deviceId, false);
-                    }
-                    const Node& deviceNode = m_nodes.at(ports.activeDevice);
-                    m_pSoundManager->updatePathChannel(
-                            output, ports.outputChannel(deviceNode.inputs), false);
+                    ports.active.store(true);
                 }
                 break;
             }
+        }
+
+        if (!m_manageExternalLinks) {
+            QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::invalidateConfig);
         }
     }
 }
@@ -493,75 +466,58 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
         std::erase(inputPort.links, id);
         std::erase(outputPort.links, id);
 
-        if (inputPort.node == m_filterId) {
-            for (auto& [input, ports] : m_inputs) {
-                bool deviceChanged;
-                if (ports.left.id == link.input) {
-                    deviceChanged = ports.removePort(outputPort.node, link.output, true);
-                } else if (ports.right.id == link.input) {
-                    deviceChanged = ports.removePort(outputPort.node, link.output, false);
-                } else {
-                    continue;
-                }
-
-                // TODO(pri-yan-shu) It would be nice to have link removals affect
-                // preference page even when not managing external links,
-
-                if (m_manageExternalLinks and deviceChanged) {
-                    if (ports.connectedDevices.empty()) {
-                        m_pSoundManager->updatePathDevice(input, SoundDeviceId{}, true);
-                        ports.active.store(false);
-                        m_pSoundManager->unconfigureInput(input);
-                    } else {
-                        m_pSoundManager->updatePathDevice(input,
-                                m_soundDevices.at(ports.activeDevice)
-                                        ->getDeviceId(),
-                                true);
-                    }
-                }
-
-                if (m_manageExternalLinks and ports.activeDevice) {
-                    const Node& activeDeviceNode = m_nodes.at(ports.activeDevice);
-                    m_pSoundManager->updatePathChannel(input,
-                            ports.inputChannel(activeDeviceNode.outputs),
-                            true);
-                }
-                break;
-            }
-        }
-
         if (outputPort.node == m_filterId) {
             for (auto& [output, ports] : m_outputs) {
-                bool deviceChanged;
                 if (ports.left.id == link.output) {
-                    deviceChanged = ports.removePort(inputPort.node, link.input, true);
+                    Port& rightPort = m_ports.at(ports.right.id);
+                    if (outputPort.links.empty() && rightPort.links.empty()) {
+                        ports.active.store(false);
+                        // close the device if device is disconnected externally
+                        ports.activeDevice = 0;
+                        m_pSoundManager->unconfigureOutput(output);
+                    }
                 } else if (ports.right.id == link.output) {
-                    deviceChanged = ports.removePort(inputPort.node, link.input, false);
+                    Port& leftPort = m_ports.at(ports.left.id);
+                    if (outputPort.links.empty() && leftPort.links.empty()) {
+                        ports.active.store(false);
+                        // close the device if device is disconnected externally
+                        ports.activeDevice = 0;
+                        m_pSoundManager->unconfigureOutput(output);
+                    }
                 } else {
                     continue;
                 }
-
-                if (m_manageExternalLinks and deviceChanged) {
-                    if (ports.connectedDevices.empty()) {
-                        m_pSoundManager->updatePathDevice(output, SoundDeviceId{}, false);
-                        ports.active.store(false);
-                        m_pSoundManager->unconfigureOutput(output);
-                    } else {
-                        m_pSoundManager->updatePathDevice(output,
-                                m_soundDevices.at(ports.activeDevice)
-                                        ->getDeviceId(),
-                                false);
-                    }
-                }
-                if (m_manageExternalLinks and ports.activeDevice) {
-                    m_pSoundManager->updatePathChannel(output,
-                            ports.outputChannel(
-                                    m_nodes.at(ports.activeDevice).inputs),
-                            false);
-                }
-                break;
             }
         }
+
+        if (inputPort.node == m_filterId) {
+            for (auto& [input, ports] : m_inputs) {
+                if (ports.left.id == link.input) {
+                    Port& rightPort = m_ports.at(ports.right.id);
+                    if (inputPort.links.empty() && rightPort.links.empty()) {
+                        // close the device if device is disconnected externally
+                        ports.activeDevice = 0;
+                        ports.active.store(false);
+                        m_pSoundManager->unconfigureInput(input);
+                    }
+                } else if (ports.right.id == link.input) {
+                    Port& leftPort = m_ports.at(ports.left.id);
+                    if (inputPort.links.empty() && leftPort.links.empty()) {
+                        // close the device if device is disconnected externally
+                        ports.activeDevice = 0;
+                        ports.active.store(false);
+                        m_pSoundManager->unconfigureInput(input);
+                    }
+                } else {
+                    continue;
+                }
+            }
+        }
+
+        if (!m_manageExternalLinks) {
+            QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::invalidateConfig);
+        }
+
         m_links.erase(id);
     }
 }
@@ -624,14 +580,17 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
         return "PipewireEnumerator uninitialized";
     }
 
+    qDebug() << "PipewireEnumerator::openDeviceInput" << m_manageExternalLinks;
+    if (m_manageExternalLinks) {
+        return {};
+    }
+
     if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
         updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
     PortPair& ports = m_inputs.at(input);
-    if (!m_manageExternalLinks) {
-        ports.activeDevice = deviceId;
-    }
+    ports.activeDevice = deviceId;
 
     ChannelGroup channelGroup = input.getChannelGroup();
     unsigned char channelBase = channelGroup.getChannelBase();
@@ -643,20 +602,12 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
     if (channelCount == 1) {
         result += createLink(deviceId, portIds[channelBase], m_filterId, ports.left.id);
         result += createLink(deviceId, portIds[channelBase], m_filterId, ports.right.id);
-        if (!m_manageExternalLinks) {
-            ports.addPort(deviceId, portIds[channelBase], true);
-            ports.addPort(deviceId, portIds[channelBase], false);
-        }
     } else {
         result += createLink(deviceId, portIds[channelBase], m_filterId, ports.left.id);
         result += createLink(deviceId,
                 portIds[channelBase + 1],
                 m_filterId,
                 ports.right.id);
-        if (!m_manageExternalLinks) {
-            ports.addPort(deviceId, portIds[channelBase], true);
-            ports.addPort(deviceId, portIds[channelBase + 1], false);
-        }
     }
 
     pw_thread_loop_unlock(m_pPwThreadLoop);
@@ -674,14 +625,17 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId,
         return "PipewireEnumerator uninitialized";
     }
 
+    qDebug() << "PipewireEnumerator::openDeviceInput" << m_manageExternalLinks;
+    if (m_manageExternalLinks) {
+        return {};
+    }
+
     if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
         updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
     PortPair& ports = m_outputs.at(output);
-    if (!m_manageExternalLinks) {
-        ports.activeDevice = deviceId;
-    }
+    ports.activeDevice = deviceId;
 
     ChannelGroup channelGroup = output.getChannelGroup();
     unsigned char channelBase = channelGroup.getChannelBase();
@@ -694,68 +648,35 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId,
     if (channelCount == 1) {
         uint32_t filterPort = channelBase % 2 ? ports.right.id : ports.left.id;
         result += createLink(m_filterId, filterPort, deviceId, portIds[channelBase]);
-        if (!m_manageExternalLinks) {
-            ports.addPort(deviceId, portIds[channelBase], !(channelBase % 2));
-        }
     } else {
         result += createLink(m_filterId, ports.left.id, deviceId, portIds[channelBase]);
         result += createLink(m_filterId,
                 ports.right.id,
                 deviceId,
                 portIds[channelBase + 1]);
-        if (!m_manageExternalLinks) {
-            ports.addPort(deviceId, portIds[channelBase], true);
-            ports.addPort(deviceId, portIds[channelBase + 1], false);
-        }
     }
 
     pw_thread_loop_unlock(m_pPwThreadLoop);
     return result;
 }
 
-void PipewireEnumerator::closePorts(PortPair& ports, bool isInput) {
+void PipewireEnumerator::closePorts(PortPair& ports) {
     const Port& left = m_ports.at(ports.left.id);
     const Port& right = m_ports.at(ports.right.id);
 
-    if (m_manageExternalLinks) {
-        // we handle all links to/from Mixxx, and destroy all links
-        // connected to Mixxx path
-        for (uint32_t link : left.links) {
-            destroyLink(link);
-            qDebug() << "PipewireEnumerator::closePath left" << link;
-        }
-
-        for (uint32_t link : right.links) {
-            destroyLink(link);
-            qDebug() << "PipewireEnumerator::closePath right" << link;
-        }
-    } else {
-        const PortPair::ConnectedDevice& device = ports.connectedDevices.at(ports.activeDevice);
-
-        for (uint32_t linkId : left.links) {
-            const Link& link = m_links.at(linkId);
-            auto it = std::ranges::find(device.leftPorts, isInput ? link.output : link.input);
-            if (it != device.leftPorts.end()) {
-                destroyLink(linkId);
-            }
-            qDebug() << "PipewireEnumerator::closePath" << isInput
-                     << ports.left.id << link.input << link.output;
-        }
-
-        for (uint32_t linkId : right.links) {
-            const Link& link = m_links.at(linkId);
-            auto it = std::ranges::find(device.rightPorts, isInput ? link.output : link.input);
-            if (it != device.rightPorts.end()) {
-                destroyLink(linkId);
-            }
-
-            qDebug() << "PipewireEnumerator::closePath" << isInput
-                     << ports.right.id << link.input << link.output;
-        }
+    for (uint32_t link : left.links) {
+        destroyLink(link);
+        qDebug() << "PipewireEnumerator::closePath left" << link;
     }
+
+    for (uint32_t link : right.links) {
+        destroyLink(link);
+        qDebug() << "PipewireEnumerator::closePath right" << link;
+    }
+    ports.activeDevice = 0;
 }
 
-void PipewireEnumerator::closeDevice(uint32_t deviceId) {
+void PipewireEnumerator::closeDeviceInput(uint32_t deviceId, const AudioInput& input) {
     qDebug() << "PipewireEnumerator::closeDevice" << deviceId;
     VERIFY_OR_DEBUG_ASSERT(m_initialized) {
         qDebug() << "PipewireEnumerator::closePath called when "
@@ -763,17 +684,20 @@ void PipewireEnumerator::closeDevice(uint32_t deviceId) {
         return;
     }
 
-    for (auto& [input, ports] : m_inputs) {
-        if (ports.activeDevice == deviceId) {
-            closePorts(ports, true);
-        }
+    PortPair& ports = m_inputs.at(input);
+    closePorts(ports);
+}
+
+void PipewireEnumerator::closeDeviceOutput(uint32_t deviceId, const AudioOutput& output) {
+    qDebug() << "PipewireEnumerator::closeDevice" << deviceId;
+    VERIFY_OR_DEBUG_ASSERT(m_initialized) {
+        qDebug() << "PipewireEnumerator::closePath called when "
+                    "uninitialized, this should not happen";
+        return;
     }
 
-    for (auto& [output, ports] : m_outputs) {
-        if (ports.activeDevice == deviceId) {
-            closePorts(ports, false);
-        }
-    }
+    PortPair& ports = m_outputs.at(output);
+    closePorts(ports);
 }
 
 void PipewireEnumerator::callback(const spa_io_position* pos) {
@@ -1057,37 +981,10 @@ void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int frames
     ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
 }
 
-bool PipewireEnumerator::portsEmpty() {
-    for (auto& portPair : std::views::values(m_outputs)) {
-        if (portPair.active.load()) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-void PipewireEnumerator::patchbayWaitTimer() {
-    pw_loop* loop = pw_thread_loop_get_loop(m_pPwThreadLoop);
-    pw_loop_destroy_source(loop, m_patchbayWaitTimer);
-    m_patchbayWaitTimer = nullptr;
-    if (portsEmpty()) {
-        // patchbay didn't connect any ports, load config
-        QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::devicesEnumerated);
-    }
-}
-
 void PipewireEnumerator::coreEventDone(uint32_t id, int seq) {
     qDebug() << "PipewireEnumerator::coreEventDone" << id << seq << m_coreSyncSeq;
     if (id == 0 && seq == m_coreSyncSeq) {
-        if (portsEmpty()) {
-            // No device open till now, wait for 2 seconds for any external
-            // patchbay to open devices, and then check again
-            pw_loop* loop = pw_thread_loop_get_loop(m_pPwThreadLoop);
-            m_patchbayWaitTimer = pw_loop_add_timer(loop, patchbayWaitTimer, this);
-            struct timespec when = {.tv_sec = kPatchbayWaitTime, .tv_nsec = 0};
-            pw_loop_update_timer(loop, m_patchbayWaitTimer, &when, nullptr, false);
-        }
+        QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::devicesEnumerated);
     }
 }
 
@@ -1145,213 +1042,4 @@ bool PipewireEnumerator::nodeHasPorts(const Node& node) {
     }
 
     return false;
-}
-
-bool PipewireEnumerator::PortPair::addPort(uint32_t deviceId, uint32_t portId, bool isLeft) {
-    qDebug() << "PortPair::addPort" << deviceId << portId << activeDevice;
-    for (const auto& [id, device] : connectedDevices) {
-        qDebug() << "connectedDevices" << id;
-        QDebug dbg = qDebug();
-        for (uint32_t port : device.leftPorts) {
-            dbg << port;
-        }
-
-        dbg = qDebug();
-        for (uint32_t port : device.rightPorts) {
-            dbg << port;
-        }
-    }
-
-    auto [it, didEmplace] = connectedDevices.try_emplace(deviceId);
-
-    if (isLeft) {
-        it->second.leftPorts.push_back(portId);
-    } else {
-        it->second.rightPorts.push_back(portId);
-    }
-
-    if (didEmplace and connectedDevices.size() == 1) {
-        // check separately since we preemptively set deviceId when
-        // manually opening it
-        if (!activeDevice) {
-            activeDevice = deviceId;
-        }
-        return true;
-    }
-
-    return false;
-}
-
-bool PipewireEnumerator::PortPair::removePort(uint32_t deviceId, uint32_t portId, bool isLeft) {
-    qDebug() << "PortPair::removePort" << deviceId << portId << activeDevice;
-    for (const auto& [id, device] : connectedDevices) {
-        qDebug() << "connectedDevices" << id;
-        QDebug dbg = qDebug();
-        for (uint32_t port : device.leftPorts) {
-            dbg << port;
-        }
-
-        dbg = qDebug();
-        for (uint32_t port : device.rightPorts) {
-            dbg << port;
-        }
-    }
-
-    VERIFY_OR_DEBUG_ASSERT(connectedDevices.contains(deviceId)) {
-        return false;
-    }
-
-    ConnectedDevice& device = connectedDevices.at(deviceId);
-
-    if (isLeft) {
-        std::erase(device.leftPorts, portId);
-    } else {
-        std::erase(device.rightPorts, portId);
-    }
-
-    if (device.leftPorts.empty() and device.rightPorts.empty()) {
-        connectedDevices.erase(deviceId);
-        if (activeDevice == deviceId) {
-            if (connectedDevices.empty()) {
-                activeDevice = 0;
-            } else {
-                activeDevice = connectedDevices.cbegin()->first;
-            }
-        }
-        // return connectedDevices.size() <= 1;
-        return true;
-    }
-
-    return false;
-}
-
-ChannelGroup PipewireEnumerator::PortPair::inputChannel(std::span<const uint32_t> ports) {
-    // qDebug() << "inputChannelGroup" << left.devicePort << right.devicePort;
-    for (const auto& [id, device] : connectedDevices) {
-        qDebug() << "outputChannelGroup" << id;
-        QDebug dbg = qDebug();
-        for (uint32_t port : device.leftPorts) {
-            dbg << port;
-        }
-
-        dbg = qDebug();
-        for (uint32_t port : device.rightPorts) {
-            dbg << port;
-        }
-    }
-
-    for (uint32_t port : ports) {
-        fprintf(stderr, "%u ", port);
-    }
-    fprintf(stderr, "\n");
-    if (connectedDevices.size() != 1) {
-        qDebug() << "inputChannel connectedDevices.size() != 1";
-        return {0, mixxx::audio::ChannelCount()};
-    }
-
-    const ConnectedDevice& device = connectedDevices.cbegin()->second;
-
-    if (device.leftPorts.size() != 1 or device.rightPorts.size() != 1) {
-        qDebug() << "inputChannel device.leftPorts.size() != 1 or device.rightPorts.size() != 1";
-        return {0, mixxx::audio::ChannelCount()};
-    }
-
-    uint32_t leftPort = device.leftPorts.back();
-    uint32_t rightPort = device.rightPorts.back();
-
-    const auto leftChannel = std::ranges::find(ports, leftPort);
-    if (leftChannel != ports.end()) {
-        // PipeWire supports channel count > UINT8_MAX, although unlikely,
-        // to prevent errors need to either change this mechanism or ChannelGroup
-        unsigned char channelBase = std::distance(ports.begin(), leftChannel);
-        if (leftPort == rightPort) {
-            qDebug() << "inputChannel leftPort == rightPort";
-            return {channelBase, mixxx::audio::ChannelCount::mono()};
-        } else {
-            const auto rightChannel = leftChannel + 1;
-            if (rightChannel != ports.end() and *rightChannel == rightPort) {
-                qDebug() << "inputChannel rightChannel != ports.end() and "
-                            "*rightChannel == rightPort";
-                return {channelBase, mixxx::audio::ChannelCount::stereo()};
-            }
-        }
-    }
-
-    return {0, mixxx::audio::ChannelCount()};
-}
-
-ChannelGroup PipewireEnumerator::PortPair::outputChannel(std::span<const uint32_t> ports) {
-    // qDebug() << "outputChannelGroup" << left.devicePort << right.devicePort;
-    for (const auto& [id, device] : connectedDevices) {
-        qDebug() << "outputChannel" << id;
-        QDebug dbg = qDebug();
-        for (uint32_t port : device.leftPorts) {
-            dbg << port;
-        }
-
-        dbg = qDebug();
-        for (uint32_t port : device.rightPorts) {
-            dbg << port;
-        }
-    }
-
-    for (uint32_t port : ports) {
-        fprintf(stderr, "%u ", port);
-    }
-    fprintf(stderr, "\n");
-
-    if (connectedDevices.size() != 1) {
-        qDebug() << "outputChannel connectedDevices.size() != 1";
-        return {0, mixxx::audio::ChannelCount()};
-    }
-
-    const ConnectedDevice& device = connectedDevices.cbegin()->second;
-
-    if (device.leftPorts.size() > 1 or device.rightPorts.size() > 1) {
-        qDebug() << "outputChannel " << device.leftPorts.size() << " > 1 or "
-                 << device.rightPorts.size() << " > 1";
-        return {0, mixxx::audio::ChannelCount()};
-    }
-
-    bool hasLeftPort = !device.leftPorts.empty();
-    bool hasRightPort = !device.rightPorts.empty();
-
-    if (!hasLeftPort and !hasRightPort) {
-        qDebug() << "outputChannel !hasLeftPort and !hasRightPort";
-        return {0, mixxx::audio::ChannelCount()};
-    }
-
-    if (!hasLeftPort) {
-        auto it = std::ranges::find(ports, device.rightPorts.back());
-        unsigned char channelBase = std::distance(ports.begin(), it);
-        // hacky way to get if Mixxx right port is connected to device right port
-        if (it != ports.end() and channelBase % 2) {
-            qDebug() << "outputChannel it != ports.end() and" << channelBase % 2;
-            return {channelBase, mixxx::audio::ChannelCount::mono()};
-        }
-    } else if (!hasRightPort) {
-        auto it = std::ranges::find(ports, device.leftPorts.back());
-        unsigned char channelBase = std::distance(ports.begin(), it);
-        // hacky way to get if Mixxx left port is connected to device left port
-        if (it != ports.end() and !(channelBase % 2)) {
-            qDebug() << "outputChannel it != ports.end() and" << channelBase % 2;
-            return {channelBase, mixxx::audio::ChannelCount::mono()};
-        }
-    } else {
-        const auto leftChannel = std::ranges::find(ports, device.leftPorts.back());
-        unsigned char channelBase = std::distance(ports.begin(), leftChannel);
-        if (leftChannel != ports.end() and !(channelBase % 2)) {
-            // PipeWire supports channel count > UINT8_MAX, although unlikely,
-            // to prevent errors need to change this mechanism or ChannelGroup
-            const auto rightChannel = leftChannel + 1;
-            if (rightChannel != ports.end() and *rightChannel == device.rightPorts.back()) {
-                qDebug() << "outputChannel rightChannel != ports.end() and "
-                         << *rightChannel << " == " << device.rightPorts.back()
-                         << "";
-                return {channelBase, mixxx::audio::ChannelCount::stereo()};
-            }
-        }
-    }
-
-    return {0, mixxx::audio::ChannelCount()};
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -28,6 +28,7 @@
 namespace {
 
 constexpr int kCpuUsageUpdateRate = 30; // in 1/s, fits to display frame rate
+constexpr int kPatchbayWaitTime = 3;    // wait for patchbay to connect inputs
 const QString kAppGroup = QStringLiteral("[App]");
 
 static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
@@ -1054,10 +1055,37 @@ void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int frames
     ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
 }
 
+bool PipewireEnumerator::portsEmpty() {
+    for (auto& portPair : std::views::values(m_outputs)) {
+        if (portPair.active.load()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void PipewireEnumerator::patchbayWaitTimer() {
+    pw_loop* loop = pw_thread_loop_get_loop(m_pPwThreadLoop);
+    pw_loop_destroy_source(loop, m_patchbayWaitTimer);
+    m_patchbayWaitTimer = nullptr;
+    if (portsEmpty()) {
+        // patchbay didn't connect any ports, load config
+        QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::devicesEnumerated);
+    }
+}
+
 void PipewireEnumerator::coreEventDone(uint32_t id, int seq) {
     qDebug() << "PipewireEnumerator::coreEventDone" << id << seq << m_coreSyncSeq;
     if (id == 0 && seq == m_coreSyncSeq) {
-        QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::devicesEnumerated);
+        if (portsEmpty()) {
+            // No device open till now, wait for 2 seconds for any external
+            // patchbay to open devices, and then check again
+            pw_loop* loop = pw_thread_loop_get_loop(m_pPwThreadLoop);
+            m_patchbayWaitTimer = pw_loop_add_timer(loop, patchbayWaitTimer, this);
+            struct timespec when = {.tv_sec = kPatchbayWaitTime, .tv_nsec = 0};
+            pw_loop_update_timer(loop, m_patchbayWaitTimer, &when, nullptr, false);
+        }
     }
 }
 

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -19,6 +19,7 @@
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
 #include "util/assert.h"
+#include "util/defs.h"
 #include "util/sample.h"
 #include "util/trace.h"
 #include "util/types.h"
@@ -461,7 +462,7 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
     }
 
     if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        setLatency(sampleRate, framesPerBuffer);
+        updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
     int deviceId = device.getDeviceId().deviceIndex;
@@ -807,10 +808,13 @@ std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createOutputPorts(const Audi
     return createPorts(outputName, SPA_DIRECTION_OUTPUT);
 }
 
-void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qWarning() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
-    std::string rateStr = "1/" + std::to_string(sampleRate);
-    std::string latencyStr = std::to_string(framesPerBuffer) + "/" + std::to_string(sampleRate);
+void PipewireEnumerator::updateFilterLatency(
+        unsigned int sampleRate, unsigned int framesPerBuffer) {
+    qWarning() << "PipewireEnumerator::updateFilterLatency" << sampleRate << framesPerBuffer;
+    std::string rate = std::to_string(sampleRate);
+    std::string rateStr = "1/" + rate;
+    std::string quantumStr = std::to_string(framesPerBuffer);
+    std::string latencyStr = quantumStr + "/" + std::to_string(sampleRate);
 
     spa_dict_item items[] = {
             SPA_DICT_ITEM_INIT(PW_KEY_NODE_RATE, rateStr.c_str()),
@@ -826,21 +830,24 @@ void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int frames
     int res = pw_filter_update_properties(m_pPwFilter, nullptr, &properties);
 
     pw_thread_loop_unlock(m_pPwThreadLoop);
-
     if (res >= 0) {
-        m_sampleRate = sampleRate;
-        m_framesPerBuffer = framesPerBuffer;
-        ControlObject::set(
-                ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
-                m_framesPerBuffer * 1000 / m_sampleRate);
-        ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
-
+        setLatency(sampleRate, framesPerBuffer);
     } else {
         qWarning() << "PipewireEnumerator::setLatency "
                       "pw_filter_update_properties failed:"
                    << spa_strerror(res);
         qWarning() << "Unable to set requested samplerate";
     }
+}
+
+void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
+    qWarning() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
+    m_sampleRate = sampleRate;
+    m_framesPerBuffer = framesPerBuffer;
+    ControlObject::set(
+            ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
+            m_framesPerBuffer * 1000 / m_sampleRate);
+    ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
 }
 
 void PipewireEnumerator::coreEventError(uint32_t id, int seq, int res, const char* message) {

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -9,6 +9,7 @@
 #include <QMessageBox>
 #include <QSharedPointer>
 #include <QStringView>
+#include <ranges>
 #include <string>
 
 #include "audio/types.h"
@@ -161,16 +162,21 @@ void PipewireEnumerator::initialize() {
                     "Mixxx",
                     PW_KEY_NODE_NICK,
                     "Mixxx",
+                    // we need to limit the maximum quantum pipewire will give us
+                    // since the callback can run before we configure any quantum
+                    // from preference page (by using external patchbay)
+                    PW_KEY_NODE_MAX_LATENCY,
+                    "4096/44100",
                     nullptr));
 
     pw_filter_add_listener(m_pPwFilter, &m_pwFilterListener, &filter_events, this);
 
-    for (auto it = m_inputs.begin(); it != m_inputs.end(); ++it) {
-        it.value() = createInputPorts(it.key());
+    for (auto& [input, ports] : m_inputs) {
+        createInputPorts(input, ports);
     }
 
-    for (auto it = m_outputs.begin(); it != m_outputs.end(); ++it) {
-        it.value() = createOutputPorts(it.key());
+    for (auto& [output, ports] : m_outputs) {
+        createOutputPorts(output, ports);
     }
 
     int res = pw_filter_connect(m_pPwFilter,
@@ -294,6 +300,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         Node& node = m_nodes.at(node_id);
         Port port{};
         port.id = id;
+        port.node = node_id;
         port.channel = channel ? channel : (portName ? portName : std::to_string(id).c_str());
         port.isInput = isInput;
 
@@ -323,28 +330,28 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
             QString name(spa_dict_lookup(pProps, PW_KEY_PORT_NAME));
             QStringList list = name.split(':');
             if (isInput) {
-                QList<AudioInput> keys = m_inputs.keys();
+                auto keys = std::views::keys(m_inputs);
                 auto it = std::ranges::find(keys, list.at(0), &AudioPath::getString);
                 VERIFY_OR_DEBUG_ASSERT(it != keys.end()) {
                     return;
                 }
 
                 if (list.at(1) == "FL") {
-                    *m_inputs.value(*it).first = id;
+                    m_inputs[*it].left.id = id;
                 } else {
-                    *m_inputs.value(*it).second = id;
+                    m_inputs[*it].right.id = id;
                 }
             } else {
-                QList<AudioOutput> keys = m_outputs.keys();
+                auto keys = std::views::keys(m_outputs);
                 auto it = std::ranges::find(keys, list.at(0), &AudioPath::getString);
                 VERIFY_OR_DEBUG_ASSERT(it != keys.end()) {
                     return;
                 }
 
                 if (list.at(1) == "FL") {
-                    *m_outputs.value(*it).first = id;
+                    m_outputs.at(*it).left.id = id;
                 } else {
-                    *m_outputs.value(*it).second = id;
+                    m_outputs.at(*it).right.id = id;
                 }
             }
         }
@@ -362,13 +369,40 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         Port& outputPort = m_ports.at(out_port);
 
         if (in_node == m_filterId) {
-            m_links.insert_or_assign(id, Link(in_port, out_port));
+            m_links.insert_or_assign(id, Link{in_port, out_port});
+
+            const Node& deviceNode = m_nodes.at(out_node);
+            if (!nodeHasPorts(deviceNode)) {
+                m_openedDevices.push_back(out_node);
+            }
             inputPort.links.push_back(id);
             outputPort.links.push_back(id);
+
+            for (auto& [input, ports] : m_inputs) {
+                if (ports.left.id == in_port or ports.right.id == in_port) {
+                    if (!ports.active.load()) {
+                        ports.active.store(true);
+                        m_pSoundManager->configureInput(input);
+                    }
+                }
+            }
         } else if (out_node == m_filterId) {
-            m_links.insert_or_assign(id, Link(in_port, out_port));
+            m_links.insert_or_assign(id, Link{in_port, out_port});
+
+            const Node& deviceNode = m_nodes.at(out_node);
+            if (!nodeHasPorts(deviceNode)) {
+                m_openedDevices.push_back(out_node);
+            }
             inputPort.links.push_back(id);
             outputPort.links.push_back(id);
+            for (auto& [output, ports] : m_outputs) {
+                if (ports.left.id == out_port or ports.right.id == out_port) {
+                    if (!ports.active.load()) {
+                        ports.active.store(true);
+                        m_pSoundManager->configureOutput(output);
+                    }
+                }
+            }
         }
     }
 }
@@ -408,10 +442,62 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
         m_ports.erase(id);
     } else if (m_links.contains(id)) {
         const Link& link = m_links.at(id);
-        Port& input = m_ports.at(link.input);
-        Port& output = m_ports.at(link.output);
-        std::erase(input.links, id);
-        std::erase(output.links, id);
+        Port& inputPort = m_ports.at(link.input);
+        Port& outputPort = m_ports.at(link.output);
+        std::erase(inputPort.links, id);
+        std::erase(outputPort.links, id);
+
+        // check if we can close any PortPair
+        if (inputPort.node == m_filterId) {
+            if (inputPort.links.empty()) {
+                for (auto& [input, ports] : m_inputs) {
+                    if (ports.left.id == link.input) {
+                        const Port& right = m_ports.at(ports.right.id);
+                        if (right.links.empty()) {
+                            ports.active.store(false);
+                            m_pSoundManager->unconfigureInput(input);
+                        }
+                        break;
+                    } else if (ports.right.id == link.input) {
+                        const Port& left = m_ports.at(ports.left.id);
+                        if (left.links.empty()) {
+                            ports.active.store(false);
+                            m_pSoundManager->unconfigureInput(input);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            const Node& deviceNode = m_nodes.at(outputPort.node);
+            if (!nodeHasPorts(deviceNode)) {
+                std::erase(m_openedDevices, outputPort.node);
+            }
+        } else if (outputPort.node == m_filterId) {
+            if (outputPort.links.empty()) {
+                for (auto& [output, ports] : m_outputs) {
+                    if (ports.left.id == link.output) {
+                        const Port& right = m_ports.at(ports.right.id);
+                        if (right.links.empty()) {
+                            ports.active.store(false);
+                            m_pSoundManager->unconfigureOutput(output);
+                        }
+                        break;
+                    } else if (ports.right.id == link.output) {
+                        const Port& left = m_ports.at(ports.left.id);
+                        if (left.links.empty()) {
+                            ports.active.store(false);
+                            m_pSoundManager->unconfigureOutput(output);
+                        }
+                        break;
+                    }
+                }
+            }
+            const Node& deviceNode = m_nodes.at(outputPort.node);
+            if (!nodeHasPorts(deviceNode)) {
+                std::erase(m_openedDevices, outputPort.node);
+            }
+        }
         m_links.erase(id);
     }
 }
@@ -476,7 +562,7 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
     pw_thread_loop_lock(m_pPwThreadLoop);
 
     // device.inputs() corresponds to output ports of device node
-    QList<AudioInput> inKeys = m_inputs.keys();
+    auto inKeys = std::views::keys(m_inputs);
     for (const AudioInputBuffer& input : device.inputs()) {
         auto it = std::ranges::find_if(inKeys, [input](const AudioPath& path) {
             return path.getType() == input.getType() && path.getIndex() == input.getIndex();
@@ -486,26 +572,26 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
             continue;
         }
 
-        std::pair<uint32_t*, uint32_t*> filterPorts = m_inputs.value(*it);
+        const PortPair& filterPorts = m_inputs.at(*it);
         ChannelGroup channelGroup = input.getChannelGroup();
         unsigned char channelBase = channelGroup.getChannelBase();
         unsigned char channelCount = channelGroup.getChannelCount().value();
         std::span<const uint32_t> ports = deviceNode.outputs;
 
         if (channelCount == 1) {
-            result += createLink(deviceId, ports[channelBase], m_filterId, *filterPorts.first);
-            result += createLink(deviceId, ports[channelBase], m_filterId, *filterPorts.second);
+            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.left.id);
+            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.right.id);
         } else {
-            result += createLink(deviceId, ports[channelBase], m_filterId, *filterPorts.first);
+            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.left.id);
             result += createLink(deviceId,
                     ports[channelBase + 1],
                     m_filterId,
-                    *filterPorts.second);
+                    filterPorts.right.id);
         }
     }
 
     // device.outputs() corresponds to input ports of device node
-    QList<AudioOutput> outKeys = m_outputs.keys();
+    auto outKeys = std::views::keys(m_outputs);
     for (const AudioOutputBuffer& output : device.outputs()) {
         auto it = std::ranges::find_if(outKeys, [output](const AudioPath& path) {
             return path.getType() == output.getType() && path.getIndex() == output.getIndex();
@@ -515,19 +601,19 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
             continue;
         }
 
-        std::pair<uint32_t*, uint32_t*> filterPorts = m_outputs.value(*it);
+        const PortPair& filterPorts = m_outputs.at(*it);
         ChannelGroup channelGroup = output.getChannelGroup();
         unsigned char channelBase = channelGroup.getChannelBase();
         unsigned char channelCount = channelGroup.getChannelCount().value();
         std::span<const uint32_t> ports = deviceNode.inputs;
 
         if (channelCount == 1) {
-            uint32_t filterPort = channelBase % 2 ? *filterPorts.second : *filterPorts.first;
+            uint32_t filterPort = channelBase % 2 ? filterPorts.right.id : filterPorts.left.id;
             result += createLink(m_filterId, filterPort, deviceId, ports[channelBase]);
         } else {
-            result += createLink(m_filterId, *filterPorts.first, deviceId, ports[channelBase]);
+            result += createLink(m_filterId, filterPorts.left.id, deviceId, ports[channelBase]);
             result += createLink(m_filterId,
-                    *filterPorts.second,
+                    filterPorts.right.id,
                     deviceId,
                     ports[channelBase + 1]);
         }
@@ -551,6 +637,16 @@ void PipewireEnumerator::closeDevice(uint32_t id) {
         return;
     }
 
+    auto pDevice = m_soundDevices.at(*deviceId);
+
+    for (const AudioInputBuffer& input : pDevice->inputs()) {
+        m_inputs.at(input).active.store(false);
+    }
+
+    for (const AudioOutputBuffer& output : pDevice->outputs()) {
+        m_outputs.at(output).active.store(false);
+    }
+
     const Node& node = m_nodes.at(*deviceId);
 
     for (uint32_t portId : node.inputs) {
@@ -572,7 +668,7 @@ void PipewireEnumerator::closeDevice(uint32_t id) {
 
 void PipewireEnumerator::callback(const spa_io_position* pos) {
     // This must be the very first call, else timeInfo becomes invalid
-    m_clkRefTimer.restart().toDoubleSeconds();
+    m_clkRefTimer.restart();
     VisualPlayPosition::setCallbackEntryToDacSecs(
             pos->clock.delay / pos->clock.rate.denom, m_clkRefTimer);
 
@@ -600,64 +696,68 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
     qDebug() << "PipewireEnumerator::callback" << sampleRate << framesPerBuffer;
     m_pSoundManager->processUnderflowHappened(framesPerBuffer);
 
-    for (uint32_t deviceId : m_openedDevices) {
-        QSharedPointer<SoundDevicePipewire> device = m_soundDevices.at(deviceId);
-        QList<AudioInputBuffer> deviceInputs = device->inputs();
-        for (const AudioInputBuffer& input : deviceInputs) {
-            CSAMPLE* pInputBuffer = input.getBuffer();
+    for (const auto& [input, ports] : m_inputs) {
+        if (!ports.active.load()) {
+            continue;
+        }
+        CSAMPLE* pInputBuffer = m_pSoundManager->getInputBuffer(input);
+        VERIFY_OR_DEBUG_ASSERT(pInputBuffer) {
+            return;
+        }
 
-            std::pair<uint32_t*, uint32_t*> ports = m_inputs.value(input);
+        const float* bufferFL = static_cast<const float*>(
+                pw_filter_get_dsp_buffer(ports.left.data, framesPerBuffer));
 
-            const float* bufferFL = static_cast<const float*>(
-                    pw_filter_get_dsp_buffer(ports.first, framesPerBuffer));
-            if (bufferFL) {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    pInputBuffer[i * 2] = bufferFL[i];
-                }
-            } else {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    pInputBuffer[i * 2] = 0;
-                }
+        if (bufferFL) {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                pInputBuffer[i * 2] = bufferFL[i];
             }
-
-            const float* bufferFR = static_cast<const float*>(
-                    pw_filter_get_dsp_buffer(ports.second, framesPerBuffer));
-            if (bufferFR) {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    pInputBuffer[i * 2 + 1] = bufferFR[i];
-                }
-            } else {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    pInputBuffer[i * 2 + 1] = 0;
-                }
+        } else {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                pInputBuffer[i * 2] = 0;
             }
         }
-        m_pSoundManager->pushInputBuffers(deviceInputs, framesPerBuffer);
+
+        const float* bufferFR = static_cast<const float*>(
+                pw_filter_get_dsp_buffer(ports.right.data, framesPerBuffer));
+        if (bufferFR) {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                pInputBuffer[i * 2 + 1] = bufferFR[i];
+            }
+        } else {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                pInputBuffer[i * 2 + 1] = 0;
+            }
+        }
+        m_pSoundManager->pushInputBuffer(input, framesPerBuffer);
     }
 
     m_pSoundManager->onDeviceOutputCallback(framesPerBuffer);
 
-    for (uint32_t deviceId : m_openedDevices) {
-        QSharedPointer<SoundDevicePipewire> device = m_soundDevices.at(deviceId);
-        for (const AudioOutputBuffer& output : device->outputs()) {
-            const CSAMPLE* pOutputBuffer = output.getBuffer();
+    for (const auto& [output, ports] : m_outputs) {
+        if (!ports.active.load()) {
+            continue;
+        }
 
-            std::pair<uint32_t*, uint32_t*> ports = m_outputs.value(output);
+        const CSAMPLE* pOutputBuffer = m_pSoundManager->getOutputBuffer(output);
 
-            float* bufferFL = static_cast<float*>(
-                    pw_filter_get_dsp_buffer(ports.first, framesPerBuffer));
-            if (bufferFL) {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    bufferFL[i] = pOutputBuffer[i * 2];
-                }
+        VERIFY_OR_DEBUG_ASSERT(pOutputBuffer) {
+            return;
+        }
+
+        float* bufferFL = static_cast<float*>(
+                pw_filter_get_dsp_buffer(ports.left.data, framesPerBuffer));
+        if (bufferFL) {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                bufferFL[i] = pOutputBuffer[i * 2];
             }
+        }
 
-            float* bufferFR = static_cast<float*>(
-                    pw_filter_get_dsp_buffer(ports.second, framesPerBuffer));
-            if (bufferFR) {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    bufferFR[i] = pOutputBuffer[i * 2 + 1];
-                }
+        float* bufferFR = static_cast<float*>(
+                pw_filter_get_dsp_buffer(ports.right.data, framesPerBuffer));
+        if (bufferFR) {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                bufferFR[i] = pOutputBuffer[i * 2 + 1];
             }
         }
     }
@@ -725,17 +825,16 @@ std::string PipewireEnumerator::createLink(uint32_t outNodeId,
 }
 
 void PipewireEnumerator::registerInput(const AudioInput& input, AudioDestination*) {
-    if (m_inputs.contains(input) or input.isHidden()) {
-        // duplicate VinylControl signal
+    if (input.isHidden()) {
         return;
     }
 
-    if (m_initialized) {
+    auto [it, isInserted] = m_inputs.try_emplace(input);
+
+    if (m_initialized and isInserted) {
         pw_thread_loop_lock(m_pPwThreadLoop);
-        m_inputs.insert(input, createInputPorts(input));
+        createInputPorts(input, it->second);
         pw_thread_loop_unlock(m_pPwThreadLoop);
-    } else {
-        m_inputs.insert(input, {});
     }
 }
 
@@ -744,18 +843,17 @@ void PipewireEnumerator::registerOutput(const AudioOutput& output, AudioSource*)
         return;
     }
 
-    if (m_initialized) {
+    auto [it, isInserted] = m_outputs.try_emplace(output);
+    if (m_initialized and isInserted) {
         pw_thread_loop_lock(m_pPwThreadLoop);
-        m_outputs.insert(output, createOutputPorts(output));
+        createOutputPorts(output, it->second);
         pw_thread_loop_unlock(m_pPwThreadLoop);
-    } else {
-        m_outputs.insert(output, {});
     }
 }
 
 // need to pw_thread_loop_lock before calling this
-std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createPorts(
-        std::string_view name, spa_direction direction) {
+void PipewireEnumerator::createPorts(
+        PortPair& ports, std::string_view name, spa_direction direction) {
     pw_properties* props = pw_properties_new(
             // see pipewire/keys.h header
             PW_KEY_FORMAT_DSP,
@@ -767,10 +865,10 @@ std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createPorts(
     // PipewireEnumerator::registryEventGlobal
     pw_properties_setf(props, PW_KEY_PORT_NAME, "%s:FL", name.data());
 
-    void* leftPort = pw_filter_add_port(m_pPwFilter,
+    ports.left.data = pw_filter_add_port(m_pPwFilter,
             direction,
             PW_FILTER_PORT_FLAG_MAP_BUFFERS,
-            sizeof(uint32_t),
+            0,
             props,
             nullptr,
             0);
@@ -786,26 +884,25 @@ std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createPorts(
     // PipewireEnumerator::registryEventGlobal
     pw_properties_setf(props, PW_KEY_PORT_NAME, "%s:FR", name.data());
 
-    void* rightPort = pw_filter_add_port(m_pPwFilter,
+    ports.right.data = pw_filter_add_port(m_pPwFilter,
             direction,
             PW_FILTER_PORT_FLAG_MAP_BUFFERS,
-            sizeof(uint32_t),
+            0,
             props,
             nullptr,
             0);
-    return std::pair{static_cast<uint32_t*>(leftPort), static_cast<uint32_t*>(rightPort)};
 }
 
 // need to pw_thread_loop_lock before calling this
-std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createInputPorts(const AudioInput& input) {
+void PipewireEnumerator::createInputPorts(const AudioInput& input, PortPair& ports) {
     std::string inputName = input.getString().toStdString();
-    return createPorts(inputName, SPA_DIRECTION_INPUT);
+    createPorts(ports, inputName, SPA_DIRECTION_INPUT);
 }
 
 // need to pw_thread_loop_lock before calling this
-std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createOutputPorts(const AudioOutput& output) {
+void PipewireEnumerator::createOutputPorts(const AudioOutput& output, PortPair& ports) {
     std::string outputName = output.getString().toStdString();
-    return createPorts(outputName, SPA_DIRECTION_OUTPUT);
+    createPorts(ports, outputName, SPA_DIRECTION_OUTPUT);
 }
 
 void PipewireEnumerator::updateFilterLatency(
@@ -888,4 +985,20 @@ QString PipewireEnumerator::getChannelString(
         }
     }
     return QString::fromStdString(channelString);
+}
+
+bool PipewireEnumerator::nodeHasPorts(const Node& node) {
+    for (uint32_t portId : node.inputs) {
+        if (!m_ports.at(portId).links.empty()) {
+            return true;
+        }
+    }
+
+    for (uint32_t portId : node.outputs) {
+        if (!m_ports.at(portId).links.empty()) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -74,7 +74,8 @@ static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
 }
 } // namespace
 
-PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManager)
+PipewireEnumerator::PipewireEnumerator(
+        UserSettingsPointer pConfig, SoundManager* pManager)
         : m_pSoundManager(pManager),
           m_pPwThreadLoop(nullptr),
           m_pPwContext(nullptr),
@@ -86,7 +87,9 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
           m_COmanageExternalLinks(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay"))),
           m_framesPerBuffer(0),
-          m_manageExternalLinks(false) {
+          m_manageExternalLinks(static_cast<bool>(pConfig->getValue(
+                  ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay")),
+                  false))) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -414,8 +417,9 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
 
                 break;
             }
+        }
 
-        } else if (out_node == m_filterId) {
+        if (out_node == m_filterId) {
             // device input, mixxx output
             for (auto& [output, ports] : m_outputs) {
                 if (ports.left.id != out_port and ports.right.id != out_port) {
@@ -517,7 +521,9 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
                 }
                 break;
             }
-        } else if (outputPort.node == m_filterId) {
+        }
+
+        if (outputPort.node == m_filterId) {
             for (auto& [output, ports] : m_outputs) {
                 bool deviceChanged;
                 if (ports.left.id == link.output) {
@@ -1113,20 +1119,7 @@ bool PipewireEnumerator::PortPair::addPort(uint32_t deviceId, uint32_t portId, b
         }
     }
 
-    if (connectedDevices.contains(deviceId)) {
-        if (isLeft) {
-            connectedDevices.at(deviceId).leftPorts.push_back(portId);
-        } else {
-            connectedDevices.at(deviceId).rightPorts.push_back(portId);
-        }
-
-        return false;
-    }
-
     auto [it, didEmplace] = connectedDevices.try_emplace(deviceId);
-    if (!didEmplace) {
-        return false;
-    }
 
     if (isLeft) {
         it->second.leftPorts.push_back(portId);
@@ -1134,7 +1127,7 @@ bool PipewireEnumerator::PortPair::addPort(uint32_t deviceId, uint32_t portId, b
         it->second.rightPorts.push_back(portId);
     }
 
-    if (connectedDevices.size() == 1) {
+    if (didEmplace and connectedDevices.size() == 1) {
         // check separately since we preemptively set deviceId when
         // manually opening it
         if (!activeDevice) {

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -453,8 +453,8 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
         auto ports = device.getOutPorts();
 
         if (channelCount == 1) {
-            uint32_t filterPort = channelBase % 2 ? *filterPorts.second : *filterPorts.first;
-            result += createLink(deviceId, ports[channelBase].id, m_filterId, filterPort);
+            result += createLink(deviceId, ports[channelBase].id, m_filterId, *filterPorts.first);
+            result += createLink(deviceId, ports[channelBase].id, m_filterId, *filterPorts.second);
         } else {
             result += createLink(deviceId, ports[channelBase].id, m_filterId, *filterPorts.first);
             result += createLink(deviceId,
@@ -559,48 +559,31 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
         QSharedPointer<SoundDevicePipewire> device = m_soundDevices.at(deviceId);
         QList<AudioInputBuffer> deviceInputs = device->inputs();
         for (const AudioInputBuffer& input : deviceInputs) {
-            ChannelGroup channelGroup = input.getChannelGroup();
-            const int iChannelCount = channelGroup.getChannelCount();
-            const int iChannelBase = channelGroup.getChannelBase();
             CSAMPLE* pInputBuffer = input.getBuffer();
 
             std::pair<uint32_t*, uint32_t*> ports = m_inputs.value(input);
 
-            if (iChannelCount == 1) {
-                void* portData = iChannelBase % 2 ? ports.second : ports.first;
-                const float* buffer = static_cast<const float*>(
-                        pw_filter_get_dsp_buffer(portData, framesPerBuffer));
-                if (buffer) {
-                    for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                        pInputBuffer[i * 2] = buffer[i];
-                        pInputBuffer[i * 2 + 1] = buffer[i];
-                    }
-                } else {
-                    SampleUtil::fill(pInputBuffer, 0, framesPerBuffer * 2);
+            const float* bufferFL = static_cast<const float*>(
+                    pw_filter_get_dsp_buffer(ports.first, framesPerBuffer));
+            if (bufferFL) {
+                for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                    pInputBuffer[i * 2] = bufferFL[i];
                 }
             } else {
-                const float* bufferFL = static_cast<const float*>(
-                        pw_filter_get_dsp_buffer(ports.first, framesPerBuffer));
-                if (bufferFL) {
-                    for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                        pInputBuffer[iChannelBase + i * 2] = bufferFL[i];
-                    }
-                } else {
-                    for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                        pInputBuffer[iChannelBase + i * 2] = 0;
-                    }
+                for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                    pInputBuffer[i * 2] = 0;
                 }
+            }
 
-                const float* bufferFR = static_cast<const float*>(
-                        pw_filter_get_dsp_buffer(ports.second, framesPerBuffer));
-                if (bufferFR) {
-                    for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                        pInputBuffer[iChannelBase + 1 + i * 2] = bufferFR[i];
-                    }
-                } else {
-                    for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                        pInputBuffer[iChannelBase + 1 + i * 2] = 0;
-                    }
+            const float* bufferFR = static_cast<const float*>(
+                    pw_filter_get_dsp_buffer(ports.second, framesPerBuffer));
+            if (bufferFR) {
+                for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                    pInputBuffer[i * 2 + 1] = bufferFR[i];
+                }
+            } else {
+                for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                    pInputBuffer[i * 2 + 1] = 0;
                 }
             }
         }
@@ -612,37 +595,23 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
     for (uint32_t deviceId : m_openedDevices) {
         QSharedPointer<SoundDevicePipewire> device = m_soundDevices.at(deviceId);
         for (const AudioOutputBuffer& output : device->outputs()) {
-            ChannelGroup chanGroup = output.getChannelGroup();
-            const int iChannelCount = chanGroup.getChannelCount();
-            const int iChannelBase = chanGroup.getChannelBase();
             const CSAMPLE* pOutputBuffer = output.getBuffer();
 
             std::pair<uint32_t*, uint32_t*> ports = m_outputs.value(output);
 
-            if (iChannelCount == 1) {
-                void* portData = iChannelBase % 2 ? ports.second : ports.first;
-                float* buffer = static_cast<float*>(
-                        pw_filter_get_dsp_buffer(portData, framesPerBuffer));
-                if (buffer) {
-                    for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                        buffer[i] = pOutputBuffer[iChannelBase + i * 2];
-                    }
+            float* bufferFL = static_cast<float*>(
+                    pw_filter_get_dsp_buffer(ports.first, framesPerBuffer));
+            if (bufferFL) {
+                for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                    bufferFL[i] = pOutputBuffer[i * 2];
                 }
-            } else {
-                float* bufferFL = static_cast<float*>(
-                        pw_filter_get_dsp_buffer(ports.first, framesPerBuffer));
-                if (bufferFL) {
-                    for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                        bufferFL[i] = pOutputBuffer[iChannelBase + i * 2];
-                    }
-                }
+            }
 
-                float* bufferFR = static_cast<float*>(
-                        pw_filter_get_dsp_buffer(ports.second, framesPerBuffer));
-                if (bufferFR) {
-                    for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                        bufferFR[i] = pOutputBuffer[iChannelBase + 1 + i * 2];
-                    }
+            float* bufferFR = static_cast<float*>(
+                    pw_filter_get_dsp_buffer(ports.second, framesPerBuffer));
+            if (bufferFR) {
+                for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                    bufferFR[i] = pOutputBuffer[i * 2 + 1];
                 }
             }
         }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -283,17 +283,45 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
             return;
         }
 
-        m_ports.insert_or_assign(id, Port(node_id));
-        QSharedPointer<SoundDevicePipewire> pSoundDevice = m_soundDevices.at(node_id);
-        pSoundDevice->registerPort(id, pProps);
-        m_pSoundManager->updateDeviceChannels(pSoundDevice);
-
+        const char* portName = spa_dict_lookup(pProps, PW_KEY_PORT_NAME);
+        const char* channel = spa_dict_lookup(pProps, PW_KEY_AUDIO_CHANNEL);
         const char* direction = spa_dict_lookup(pProps, PW_KEY_PORT_DIRECTION);
+        const bool isInput = std::strcmp(direction, "in") == 0;
+
+        QSharedPointer<SoundDevicePipewire> pSoundDevice = m_soundDevices.at(node_id);
+        m_pSoundManager->updateDeviceChannels(pSoundDevice);
+        Node& node = m_nodes.at(node_id);
+        Port port{};
+        port.id = id;
+        port.channel = channel ? channel : (portName ? portName : std::to_string(id).c_str());
+        port.isInput = isInput;
+
+        if (portName && channel) {
+            std::string_view name = portName;
+            const size_t last = name.find_last_of("_:-");
+            const bool nameContainsChannel = last != std::string_view::npos and
+                    port.channel == name.substr(last + 1);
+            port.name = nameContainsChannel ? name.substr(0, last) : portName;
+            port.name += ':';
+        }
+
+        // m_numInputChannels, m_numOutputChannels, m_audioInputs, m_audioOutputs
+        // are with respect to Mixxx and not the SoundDevice
+        if (isInput) {
+            node.inputs.push_back(id);
+            pSoundDevice->setNumOutputs(node.inputs.size());
+        } else {
+            node.outputs.push_back(id);
+            pSoundDevice->setNumInputs(node.outputs.size());
+        }
+
+        m_ports.insert_or_assign(id, std::move(port));
+        m_pSoundManager->updateDeviceChannels(pSoundDevice);
 
         if (node_id == m_filterId) {
             QString name(spa_dict_lookup(pProps, PW_KEY_PORT_NAME));
             QStringList list = name.split(':');
-            if (strcmp(direction, "in") == 0) {
+            if (isInput) {
                 QList<AudioInput> keys = m_inputs.keys();
                 auto it = std::ranges::find(keys, list.at(0), &AudioPath::getString);
                 VERIFY_OR_DEBUG_ASSERT(it != keys.end()) {
@@ -329,12 +357,17 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         const uint32_t out_port = pw_properties_parse_int(
                 spa_dict_lookup(pProps, PW_KEY_LINK_OUTPUT_PORT));
 
+        Port& inputPort = m_ports.at(in_port);
+        Port& outputPort = m_ports.at(out_port);
+
         if (in_node == m_filterId) {
             m_links.insert_or_assign(id, Link(in_port, out_port));
-            m_soundDevices.at(out_node)->registerLink(id, SPA_DIRECTION_OUTPUT);
+            inputPort.links.push_back(id);
+            outputPort.links.push_back(id);
         } else if (out_node == m_filterId) {
             m_links.insert_or_assign(id, Link(in_port, out_port));
-            m_soundDevices.at(in_node)->registerLink(id, SPA_DIRECTION_INPUT);
+            inputPort.links.push_back(id);
+            outputPort.links.push_back(id);
         }
     }
 }
@@ -354,25 +387,30 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
         emit deviceRemoved(pDevice);
         m_nodes.erase(id);
     } else if (m_ports.contains(id)) {
-        Port& port = m_ports.at(id);
+        const Port& port = m_ports.at(id);
         VERIFY_OR_DEBUG_ASSERT(m_soundDevices.contains(port.node)) {
             return;
         }
 
         QSharedPointer<SoundDevicePipewire> pSoundDevice = m_soundDevices.at(port.node);
-        pSoundDevice->unregisterPort(id);
+        Node& node = m_nodes.at(port.node);
+
+        if (port.isInput) {
+            std::erase(node.inputs, id);
+            pSoundDevice->setNumOutputs(node.inputs.size());
+        } else {
+            std::erase(node.outputs, id);
+            pSoundDevice->setNumInputs(node.outputs.size());
+        }
+
         m_pSoundManager->updateDeviceChannels(pSoundDevice);
         m_ports.erase(id);
     } else if (m_links.contains(id)) {
-        Link& link = m_links.at(id);
-        Port input = m_ports.at(link.input);
-        Port output = m_ports.at(link.output);
-
-        if (input.node == m_filterId) {
-            m_soundDevices.at(output.node)->unregisterLink(id, SPA_DIRECTION_OUTPUT);
-        } else if (output.node == m_filterId) {
-            m_soundDevices.at(input.node)->unregisterLink(id, SPA_DIRECTION_INPUT);
-        }
+        const Link& link = m_links.at(id);
+        Port& input = m_ports.at(link.input);
+        Port& output = m_ports.at(link.output);
+        std::erase(input.links, id);
+        std::erase(output.links, id);
         m_links.erase(id);
     }
 }
@@ -427,6 +465,7 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
     }
 
     int deviceId = device.getDeviceId().deviceIndex;
+    const Node& deviceNode = m_nodes.at(deviceId);
 
     VERIFY_OR_DEBUG_ASSERT(std::ranges::find(m_openedDevices, deviceId) == m_openedDevices.end()) {
         qWarning() << "SoundDevicePipewire:" << deviceId << "already open";
@@ -450,15 +489,15 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
         ChannelGroup channelGroup = input.getChannelGroup();
         unsigned char channelBase = channelGroup.getChannelBase();
         unsigned char channelCount = channelGroup.getChannelCount().value();
-        auto ports = device.getOutPorts();
+        std::span<const uint32_t> ports = deviceNode.outputs;
 
         if (channelCount == 1) {
-            result += createLink(deviceId, ports[channelBase].id, m_filterId, *filterPorts.first);
-            result += createLink(deviceId, ports[channelBase].id, m_filterId, *filterPorts.second);
+            result += createLink(deviceId, ports[channelBase], m_filterId, *filterPorts.first);
+            result += createLink(deviceId, ports[channelBase], m_filterId, *filterPorts.second);
         } else {
-            result += createLink(deviceId, ports[channelBase].id, m_filterId, *filterPorts.first);
+            result += createLink(deviceId, ports[channelBase], m_filterId, *filterPorts.first);
             result += createLink(deviceId,
-                    ports[channelBase + 1].id,
+                    ports[channelBase + 1],
                     m_filterId,
                     *filterPorts.second);
         }
@@ -479,17 +518,17 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
         ChannelGroup channelGroup = output.getChannelGroup();
         unsigned char channelBase = channelGroup.getChannelBase();
         unsigned char channelCount = channelGroup.getChannelCount().value();
-        auto ports = device.getInPorts();
+        std::span<const uint32_t> ports = deviceNode.inputs;
 
         if (channelCount == 1) {
             uint32_t filterPort = channelBase % 2 ? *filterPorts.second : *filterPorts.first;
-            result += createLink(m_filterId, filterPort, deviceId, ports[channelBase].id);
+            result += createLink(m_filterId, filterPort, deviceId, ports[channelBase]);
         } else {
-            result += createLink(m_filterId, *filterPorts.first, deviceId, ports[channelBase].id);
+            result += createLink(m_filterId, *filterPorts.first, deviceId, ports[channelBase]);
             result += createLink(m_filterId,
                     *filterPorts.second,
                     deviceId,
-                    ports[channelBase + 1].id);
+                    ports[channelBase + 1]);
         }
     }
     pw_thread_loop_unlock(m_pPwThreadLoop);
@@ -511,15 +550,20 @@ void PipewireEnumerator::closeDevice(uint32_t id) {
         return;
     }
 
-    QSharedPointer<SoundDevicePipewire> pDevice = m_soundDevices.at(*deviceId);
+    const Node& node = m_nodes.at(*deviceId);
 
-    // device m_inLinks and m_outLinks are cleared by link registryEventGlobalRemove
-    for (uint32_t link : pDevice->getInLinks()) {
-        destroyLink(link);
+    for (uint32_t portId : node.inputs) {
+        const Port& port = m_ports.at(portId);
+        for (uint32_t linkId : port.links) {
+            destroyLink(linkId);
+        }
     }
 
-    for (uint32_t link : pDevice->getOutLinks()) {
-        destroyLink(link);
+    for (uint32_t portId : node.outputs) {
+        const Port& port = m_ports.at(portId);
+        for (uint32_t linkId : port.links) {
+            destroyLink(linkId);
+        }
     }
 
     m_openedDevices.erase(deviceId);
@@ -810,4 +854,31 @@ void PipewireEnumerator::coreEventError(uint32_t id, int seq, int res, const cha
             deinitialize();
         }
     }
+}
+
+QString PipewireEnumerator::getChannelString(
+        uint32_t id, ChannelGroup channelGroup, bool input) const {
+    unsigned char base = channelGroup.getChannelBase();
+    mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
+
+    const Node& node = m_nodes.at(id);
+
+    std::span<const uint32_t> ports = input ? node.outputs : node.inputs;
+    std::span<const uint32_t> subspan = ports.subspan(base + 1, count - 1);
+
+    // without this 1st port will always take else branch, inserting unnecessary ' '
+    const Port& firstPort = m_ports.at(ports[base]);
+    std::string_view currentCommonSubstr = firstPort.name;
+    std::string channelString = firstPort.name + firstPort.channel;
+
+    for (uint32_t portId : subspan) {
+        const Port& port = m_ports.at(portId);
+        if (!port.name.empty() and port.name == currentCommonSubstr) {
+            channelString = channelString + '/' + port.channel;
+        } else {
+            channelString = channelString + ' ' + port.name + port.channel;
+            currentCommonSubstr = port.name;
+        }
+    }
+    return QString::fromStdString(channelString);
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -7,6 +7,7 @@
 
 #include <QList>
 #include <QMessageBox>
+#include <QMetaObject>
 #include <QSharedPointer>
 #include <QStringView>
 #include <ranges>
@@ -200,6 +201,9 @@ void PipewireEnumerator::initialize() {
                  << spa_strerror(res);
     }
 
+    // queue an event when device enumeration is complete
+    // so we can compare from Mixxx config and configure the devices
+    m_coreSyncSeq = pw_core_sync(m_pPwCore, PW_ID_CORE, 0);
     pw_thread_loop_start(m_pPwThreadLoop);
 
     m_initialized = true;
@@ -1046,6 +1050,13 @@ void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int frames
             ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
             m_framesPerBuffer * 1000 / m_sampleRate);
     ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
+}
+
+void PipewireEnumerator::coreEventDone(uint32_t id, int seq) {
+    qDebug() << "PipewireEnumerator::coreEventDone" << id << seq << m_coreSyncSeq;
+    if (id == 0 && seq == m_coreSyncSeq) {
+        QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::devicesEnumerated);
+    }
 }
 
 void PipewireEnumerator::coreEventError(uint32_t id, int seq, int res, const char* message) {

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -592,6 +592,10 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
     PortPair& ports = m_inputs.at(input);
     ports.activeDevice = deviceId;
 
+    if (ports.active.load()) {
+        closePorts(ports);
+    }
+
     ChannelGroup channelGroup = input.getChannelGroup();
     unsigned char channelBase = channelGroup.getChannelBase();
     unsigned char channelCount = channelGroup.getChannelCount().value();
@@ -637,6 +641,10 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId,
     PortPair& ports = m_outputs.at(output);
     ports.activeDevice = deviceId;
 
+    if (ports.active.load()) {
+        closePorts(ports);
+    }
+
     ChannelGroup channelGroup = output.getChannelGroup();
     unsigned char channelBase = channelGroup.getChannelBase();
     unsigned char channelCount = channelGroup.getChannelCount().value();
@@ -664,40 +672,34 @@ void PipewireEnumerator::closePorts(PortPair& ports) {
     const Port& left = m_ports.at(ports.left.id);
     const Port& right = m_ports.at(ports.right.id);
 
+    qDebug() << "PipewireEnumerator::closePorts" << left.links.size() << right.links.size();
+
     for (uint32_t link : left.links) {
         destroyLink(link);
-        qDebug() << "PipewireEnumerator::closePath left" << link;
+        qDebug() << "PipewireEnumerator::closePorts" << link;
     }
 
     for (uint32_t link : right.links) {
         destroyLink(link);
-        qDebug() << "PipewireEnumerator::closePath right" << link;
+        qDebug() << "PipewireEnumerator::closePorts" << link;
     }
     ports.activeDevice = 0;
 }
 
-void PipewireEnumerator::closeDeviceInput(uint32_t deviceId, const AudioInput& input) {
-    qDebug() << "PipewireEnumerator::closeDevice" << deviceId;
-    VERIFY_OR_DEBUG_ASSERT(m_initialized) {
-        qDebug() << "PipewireEnumerator::closePath called when "
-                    "uninitialized, this should not happen";
-        return;
+void PipewireEnumerator::closeDevices() {
+    for (auto& [path, ports] : m_inputs) {
+        if (ports.active.load()) {
+            qDebug() << "PipewireEnumerator::closeDevices" << path.getString();
+            closePorts(ports);
+        }
     }
 
-    PortPair& ports = m_inputs.at(input);
-    closePorts(ports);
-}
-
-void PipewireEnumerator::closeDeviceOutput(uint32_t deviceId, const AudioOutput& output) {
-    qDebug() << "PipewireEnumerator::closeDevice" << deviceId;
-    VERIFY_OR_DEBUG_ASSERT(m_initialized) {
-        qDebug() << "PipewireEnumerator::closePath called when "
-                    "uninitialized, this should not happen";
-        return;
+    for (auto& [path, ports] : m_outputs) {
+        if (ports.active.load()) {
+            qDebug() << "PipewireEnumerator::closeDevices" << path.getString();
+            closePorts(ports);
+        }
     }
-
-    PortPair& ports = m_outputs.at(output);
-    closePorts(ports);
 }
 
 void PipewireEnumerator::callback(const spa_io_position* pos) {

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -197,7 +197,9 @@ void PipewireEnumerator::deinitialize() {
     // clear everything we get through registry
     m_openedDevices.clear();
     m_soundDevices.clear();
-    m_objects.clear();
+    m_nodes.clear();
+    m_ports.clear();
+    m_links.clear();
 
     // or is it better to m_pSoundManager->removeDevice(device) for every device?
     emit m_pSoundManager->devicesUpdated();
@@ -260,7 +262,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
 
         std::string name = find_node_name(id, pProps);
 
-        m_objects.insert_or_assign(id, Object{Node{}});
+        m_nodes.insert_or_assign(id, Node{});
         auto pDevice = QSharedPointer<SoundDevicePipewire>::create(
                 m_pConfig, m_pSoundManager, this, id, name);
         emit deviceAdded(pDevice);
@@ -281,7 +283,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
             return;
         }
 
-        m_objects.insert_or_assign(id, Object{Port(node_id)});
+        m_ports.insert_or_assign(id, Port(node_id));
         QSharedPointer<SoundDevicePipewire> pSoundDevice = m_soundDevices.at(node_id);
         pSoundDevice->registerPort(id, pProps);
         m_pSoundManager->updateDeviceChannels(pSoundDevice);
@@ -328,24 +330,17 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
                 spa_dict_lookup(pProps, PW_KEY_LINK_OUTPUT_PORT));
 
         if (in_node == m_filterId) {
-            m_objects.insert_or_assign(id, Object{Link(in_port, out_port)});
+            m_links.insert_or_assign(id, Link(in_port, out_port));
             m_soundDevices.at(out_node)->registerLink(id, SPA_DIRECTION_OUTPUT);
         } else if (out_node == m_filterId) {
-            m_objects.insert_or_assign(id, Object{Link(in_port, out_port)});
+            m_links.insert_or_assign(id, Link(in_port, out_port));
             m_soundDevices.at(in_node)->registerLink(id, SPA_DIRECTION_INPUT);
         }
     }
 }
 
 void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
-    if (!m_objects.contains(id)) {
-        return;
-    }
-
-    auto pair = m_objects.extract(id);
-    Object& object = pair.mapped();
-
-    if (std::get_if<Node>(&object)) {
+    if (m_nodes.contains(id)) {
         if (!m_soundDevices.contains(id)) {
             return;
         }
@@ -357,24 +352,28 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
 
         m_soundDevices.erase(id);
         emit deviceRemoved(pDevice);
-        // m_pSoundManager->removeDevice(device);
-    } else if (Port* port = std::get_if<Port>(&object)) {
-        VERIFY_OR_DEBUG_ASSERT(m_soundDevices.contains(port->node)) {
+        m_nodes.erase(id);
+    } else if (m_ports.contains(id)) {
+        Port& port = m_ports.at(id);
+        VERIFY_OR_DEBUG_ASSERT(m_soundDevices.contains(port.node)) {
             return;
         }
 
-        QSharedPointer<SoundDevicePipewire> pSoundDevice = m_soundDevices.at(port->node);
+        QSharedPointer<SoundDevicePipewire> pSoundDevice = m_soundDevices.at(port.node);
         pSoundDevice->unregisterPort(id);
         m_pSoundManager->updateDeviceChannels(pSoundDevice);
-    } else if (Link* link = std::get_if<Link>(&object)) {
-        Port input = std::get<Port>(m_objects.at(link->input));
-        Port output = std::get<Port>(m_objects.at(link->output));
+        m_ports.erase(id);
+    } else if (m_links.contains(id)) {
+        Link& link = m_links.at(id);
+        Port input = m_ports.at(link.input);
+        Port output = m_ports.at(link.output);
 
         if (input.node == m_filterId) {
             m_soundDevices.at(output.node)->unregisterLink(id, SPA_DIRECTION_OUTPUT);
         } else if (output.node == m_filterId) {
             m_soundDevices.at(input.node)->unregisterLink(id, SPA_DIRECTION_INPUT);
         }
+        m_links.erase(id);
     }
 }
 

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -87,6 +87,7 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
           m_sampleRate(48000),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
           m_coPipewirePatchbaySync(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
+          m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
           m_framesPerBuffer(0) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
@@ -560,9 +561,7 @@ bool PipewireEnumerator::isOpen(uint32_t id) {
 }
 
 std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
-        const AudioInput& input,
-        mixxx::audio::SampleRate sampleRate,
-        SINT framesPerBuffer) {
+        const AudioInput& input) {
     std::string result;
     VERIFY_OR_DEBUG_ASSERT(m_initialized) {
         qDebug() << "PipewireEnumerator::openDevice called when "
@@ -572,10 +571,6 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
 
     if (static_cast<bool>(m_coPipewirePatchbaySync.get())) {
         return {};
-    }
-
-    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
     PortPair& ports = m_inputs.at(input);
@@ -607,10 +602,7 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
     return result;
 }
 
-std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId,
-        const AudioOutput& output,
-        mixxx::audio::SampleRate sampleRate,
-        SINT framesPerBuffer) {
+std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId, const AudioOutput& output) {
     std::string result;
     VERIFY_OR_DEBUG_ASSERT(m_initialized) {
         qDebug() << "PipewireEnumerator::openDevice called when "
@@ -620,10 +612,6 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId,
 
     if (static_cast<bool>(m_coPipewirePatchbaySync.get())) {
         return {};
-    }
-
-    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
     PortPair& ports = m_outputs.at(output);
@@ -1032,4 +1020,12 @@ bool PipewireEnumerator::nodeHasPorts(const Node& node) {
     }
 
     return false;
+}
+
+void PipewireEnumerator::setLatencyParams(
+        mixxx::audio::SampleRate sampleRate, SINT framesPerBuffer) {
+    qDebug() << "PipewireEnumerator::setLatencyParams" << sampleRate << framesPerBuffer;
+    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
+        updateFilterLatency(sampleRate, framesPerBuffer);
+    }
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -20,8 +20,6 @@
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
 #include "util/assert.h"
-#include "util/defs.h"
-#include "util/sample.h"
 #include "util/trace.h"
 #include "util/types.h"
 #include "waveform/visualplayposition.h"
@@ -86,7 +84,9 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
           m_pPwFilter(nullptr),
           m_sampleRate(48000),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
-          m_framesPerBuffer(0) {
+          m_COmanageExternalLinks(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay"))),
+          m_framesPerBuffer(0),
+          m_manageExternalLinks(false) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -98,6 +98,10 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
 
     connect(this, &PipewireEnumerator::deviceAdded, m_pSoundManager, &SoundManager::addDevice);
     connect(this, &PipewireEnumerator::deviceRemoved, m_pSoundManager, &SoundManager::removeDevice);
+    connect(&m_COmanageExternalLinks, &ControlObject::valueChanged, this, [this](double value) {
+        // TODO(pri-yan-shu) cleanup any invalid state here, or make the toggle startup only
+        m_manageExternalLinks = static_cast<bool>(value);
+    });
 
     pw_init(nullptr, nullptr);
 
@@ -124,9 +128,9 @@ void PipewireEnumerator::initialize() {
     if (!m_pPwContext) {
         m_pPwContext = pw_context_new(pw_thread_loop_get_loop(m_pPwThreadLoop), nullptr, 0);
         if (!m_pPwContext) {
-            qWarning() << "PipewireEnumerator::initialize pw_context_new "
-                          "failed with error:"
-                       << spa_strerror(errno);
+            qDebug() << "PipewireEnumerator::initialize pw_context_new "
+                        "failed with error:"
+                     << spa_strerror(errno);
             return;
         }
     }
@@ -134,9 +138,9 @@ void PipewireEnumerator::initialize() {
     m_pPwCore = pw_context_connect(m_pPwContext, nullptr, 0);
 
     if (!m_pPwCore) {
-        qWarning() << "PipewireEnumerator::initialize pw_context_connect "
-                      "failed with error:"
-                   << spa_strerror(errno);
+        qDebug() << "PipewireEnumerator::initialize pw_context_connect "
+                    "failed with error:"
+                 << spa_strerror(errno);
         return;
     }
     pw_core_add_listener(m_pPwCore, &m_pwCoreListener, &coreEvents, this);
@@ -189,8 +193,8 @@ void PipewireEnumerator::initialize() {
             0);
 
     VERIFY_OR_DEBUG_ASSERT(res >= 0) {
-        qWarning() << "PipewireEnumerator::initialize pw_filter_connect error:"
-                   << spa_strerror(res);
+        qDebug() << "PipewireEnumerator::initialize pw_filter_connect error:"
+                 << spa_strerror(res);
     }
 
     pw_thread_loop_start(m_pPwThreadLoop);
@@ -206,7 +210,6 @@ void PipewireEnumerator::deinitialize() {
     pw_thread_loop_stop(m_pPwThreadLoop);
 
     // clear everything we get through registry
-    m_openedDevices.clear();
     m_soundDevices.clear();
     m_nodes.clear();
     m_ports.clear();
@@ -289,7 +292,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         }
     } else if (strcmp(pType, PW_TYPE_INTERFACE_Port) == 0) {
         const uint32_t node_id = pw_properties_parse_int(spa_dict_lookup(pProps, PW_KEY_NODE_ID));
-        if (!m_soundDevices.contains(node_id)) {
+        if (!m_nodes.contains(node_id)) {
             // most likely midi or video node
             return;
         }
@@ -303,7 +306,6 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         m_pSoundManager->updateDeviceChannels(pSoundDevice);
         Node& node = m_nodes.at(node_id);
         Port port{};
-        port.id = id;
         port.node = node_id;
         port.channel = channel ? channel : (portName ? portName : std::to_string(id).c_str());
         port.isInput = isInput;
@@ -369,43 +371,94 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         const uint32_t out_port = pw_properties_parse_int(
                 spa_dict_lookup(pProps, PW_KEY_LINK_OUTPUT_PORT));
 
+        if (in_node != m_filterId and out_node != m_filterId) {
+            return;
+        }
+
         Port& inputPort = m_ports.at(in_port);
         Port& outputPort = m_ports.at(out_port);
 
+        m_links.insert_or_assign(id, Link{in_port, out_port});
+        inputPort.links.push_back(id);
+        outputPort.links.push_back(id);
+
         if (in_node == m_filterId) {
-            m_links.insert_or_assign(id, Link{in_port, out_port});
-
-            const Node& deviceNode = m_nodes.at(out_node);
-            if (!nodeHasPorts(deviceNode)) {
-                m_openedDevices.push_back(out_node);
-            }
-            inputPort.links.push_back(id);
-            outputPort.links.push_back(id);
-
+            bool deviceChanged;
+            // device output, mixxx input
             for (auto& [input, ports] : m_inputs) {
-                if (ports.left.id == in_port or ports.right.id == in_port) {
-                    if (!ports.active.load()) {
-                        ports.active.store(true);
-                        m_pSoundManager->configureInput(input);
+                if (ports.left.id == in_port) {
+                    if (m_manageExternalLinks) {
+                        deviceChanged = ports.addPort(out_node, out_port, true);
                     }
+                } else if (ports.right.id == in_port) {
+                    if (m_manageExternalLinks) {
+                        deviceChanged = ports.addPort(out_node, out_port, false);
+                    }
+                } else {
+                    continue;
                 }
-            }
-        } else if (out_node == m_filterId) {
-            m_links.insert_or_assign(id, Link{in_port, out_port});
 
-            const Node& deviceNode = m_nodes.at(out_node);
-            if (!nodeHasPorts(deviceNode)) {
-                m_openedDevices.push_back(out_node);
-            }
-            inputPort.links.push_back(id);
-            outputPort.links.push_back(id);
-            for (auto& [output, ports] : m_outputs) {
-                if (ports.left.id == out_port or ports.right.id == out_port) {
-                    if (!ports.active.load()) {
-                        ports.active.store(true);
-                        m_pSoundManager->configureOutput(output);
-                    }
+                const bool portsActive = ports.active.load();
+                if (!portsActive) {
+                    ports.active.store(true);
+                    m_pSoundManager->configureInput(input);
+                    // if (!deviceChanged) {
+                    // qDebug() << "portsActive == false but device not changed, this is bad";
+                    // }
                 }
+
+                if (m_manageExternalLinks) {
+                    const SoundDeviceId& deviceId =
+                            m_soundDevices.at(ports.activeDevice)
+                                    ->getDeviceId();
+                    if (deviceChanged) {
+                        m_pSoundManager->updatePathDevice(input, deviceId);
+                    }
+                    const Node& deviceNode = m_nodes.at(ports.activeDevice);
+                    m_pSoundManager->updatePathChannel(
+                            input, ports.inputChannel(deviceNode.outputs));
+                }
+
+                break;
+            }
+
+        } else if (out_node == m_filterId) {
+            bool deviceChanged;
+            // device input, mixxx output
+            for (auto& [output, ports] : m_outputs) {
+                if (ports.left.id == out_port) {
+                    if (m_manageExternalLinks) {
+                        deviceChanged = ports.addPort(in_node, in_port, true);
+                    }
+                } else if (ports.right.id == out_port) {
+                    if (m_manageExternalLinks) {
+                        deviceChanged = ports.addPort(in_node, in_port, false);
+                    }
+                } else {
+                    continue;
+                }
+
+                const bool portsActive = ports.active.load();
+                if (!portsActive) {
+                    ports.active.store(true);
+                    m_pSoundManager->configureOutput(output);
+                    // if (!deviceChanged) {
+                    // qDebug() << "portsActive == false but device not changed, this is bad";
+                    // }
+                }
+
+                if (m_manageExternalLinks) {
+                    if (deviceChanged) {
+                        const SoundDeviceId& deviceId =
+                                m_soundDevices.at(ports.activeDevice)
+                                        ->getDeviceId();
+                        m_pSoundManager->updatePathDevice(output, deviceId);
+                    }
+                    const Node& deviceNode = m_nodes.at(ports.activeDevice);
+                    m_pSoundManager->updatePathChannel(
+                            output, ports.outputChannel(deviceNode.inputs));
+                }
+                break;
             }
         }
     }
@@ -413,18 +466,13 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
 
 void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
     if (m_nodes.contains(id)) {
-        if (!m_soundDevices.contains(id)) {
+        m_nodes.erase(id);
+        VERIFY_OR_DEBUG_ASSERT(m_soundDevices.contains(id)) {
             return;
         }
 
-        QSharedPointer<SoundDevicePipewire> pDevice = m_soundDevices.at(id);
-        if (pDevice->isOpen()) {
-            pDevice->close();
-        }
-
+        emit deviceRemoved(m_soundDevices.at(id));
         m_soundDevices.erase(id);
-        emit deviceRemoved(pDevice);
-        m_nodes.erase(id);
     } else if (m_ports.contains(id)) {
         const Port& port = m_ports.at(id);
         VERIFY_OR_DEBUG_ASSERT(m_soundDevices.contains(port.node)) {
@@ -451,55 +499,67 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
         std::erase(inputPort.links, id);
         std::erase(outputPort.links, id);
 
-        // check if we can close any PortPair
         if (inputPort.node == m_filterId) {
-            if (inputPort.links.empty()) {
-                for (auto& [input, ports] : m_inputs) {
-                    if (ports.left.id == link.input) {
-                        const Port& right = m_ports.at(ports.right.id);
-                        if (right.links.empty()) {
-                            ports.active.store(false);
-                            m_pSoundManager->unconfigureInput(input);
-                        }
-                        break;
-                    } else if (ports.right.id == link.input) {
-                        const Port& left = m_ports.at(ports.left.id);
-                        if (left.links.empty()) {
-                            ports.active.store(false);
-                            m_pSoundManager->unconfigureInput(input);
-                        }
-                        break;
+            for (auto& [input, ports] : m_inputs) {
+                bool deviceChanged;
+                if (ports.left.id == link.input) {
+                    deviceChanged = ports.removePort(outputPort.node, link.output, true);
+                } else if (ports.right.id == link.input) {
+                    deviceChanged = ports.removePort(outputPort.node, link.output, false);
+                } else {
+                    continue;
+                }
+
+                // TODO(pri-yan-shu) It would be nice to have link removals affect
+                // preference page even when not managing external links,
+
+                if (m_manageExternalLinks and deviceChanged) {
+                    if (ports.connectedDevices.empty()) {
+                        m_pSoundManager->updatePathDevice(input, SoundDeviceId{});
+                        ports.active.store(false);
+                        m_pSoundManager->unconfigureInput(input);
+                    } else {
+                        m_pSoundManager->updatePathDevice(input,
+                                m_soundDevices.at(ports.activeDevice)
+                                        ->getDeviceId());
                     }
                 }
-            }
 
-            const Node& deviceNode = m_nodes.at(outputPort.node);
-            if (!nodeHasPorts(deviceNode)) {
-                std::erase(m_openedDevices, outputPort.node);
+                if (m_manageExternalLinks and ports.activeDevice) {
+                    const Node& activeDeviceNode = m_nodes.at(ports.activeDevice);
+                    m_pSoundManager->updatePathChannel(input,
+                            ports.inputChannel(activeDeviceNode.outputs));
+                }
+                break;
             }
         } else if (outputPort.node == m_filterId) {
-            if (outputPort.links.empty()) {
-                for (auto& [output, ports] : m_outputs) {
-                    if (ports.left.id == link.output) {
-                        const Port& right = m_ports.at(ports.right.id);
-                        if (right.links.empty()) {
-                            ports.active.store(false);
-                            m_pSoundManager->unconfigureOutput(output);
-                        }
-                        break;
-                    } else if (ports.right.id == link.output) {
-                        const Port& left = m_ports.at(ports.left.id);
-                        if (left.links.empty()) {
-                            ports.active.store(false);
-                            m_pSoundManager->unconfigureOutput(output);
-                        }
-                        break;
+            for (auto& [output, ports] : m_outputs) {
+                bool deviceChanged;
+                if (ports.left.id == link.output) {
+                    deviceChanged = ports.removePort(inputPort.node, link.input, true);
+                } else if (ports.right.id == link.output) {
+                    deviceChanged = ports.removePort(inputPort.node, link.input, false);
+                } else {
+                    continue;
+                }
+
+                if (m_manageExternalLinks and deviceChanged) {
+                    if (ports.connectedDevices.empty()) {
+                        m_pSoundManager->updatePathDevice(output, SoundDeviceId{});
+                        ports.active.store(false);
+                        m_pSoundManager->unconfigureOutput(output);
+                    } else {
+                        m_pSoundManager->updatePathDevice(output,
+                                m_soundDevices.at(ports.activeDevice)
+                                        ->getDeviceId());
                     }
                 }
-            }
-            const Node& deviceNode = m_nodes.at(outputPort.node);
-            if (!nodeHasPorts(deviceNode)) {
-                std::erase(m_openedDevices, outputPort.node);
+                if (m_manageExternalLinks and ports.activeDevice) {
+                    m_pSoundManager->updatePathChannel(output,
+                            ports.outputChannel(
+                                    m_nodes.at(ports.activeDevice).inputs));
+                }
+                break;
             }
         }
         m_links.erase(id);
@@ -538,16 +598,29 @@ int PipewireEnumerator::metadataProperty(
 }
 
 bool PipewireEnumerator::isOpen(uint32_t id) {
-    return std::ranges::find(m_openedDevices, id) != m_openedDevices.end();
+    for (const auto& ports : std::views::values(m_inputs)) {
+        if (ports.activeDevice == id) {
+            return true;
+        }
+    }
+
+    for (const auto& ports : std::views::values(m_outputs)) {
+        if (ports.activeDevice == id) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
-std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
+std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
+        const AudioInput& input,
         mixxx::audio::SampleRate sampleRate,
         SINT framesPerBuffer) {
     std::string result;
     VERIFY_OR_DEBUG_ASSERT(m_initialized) {
-        qWarning() << "PipewireEnumerator::openDevice called when "
-                      "uninitialized, this should not happen";
+        qDebug() << "PipewireEnumerator::openDevice called when "
+                    "uninitialized, this should not happen";
         return "PipewireEnumerator uninitialized";
     }
 
@@ -555,119 +628,152 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
         updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
-    int deviceId = device.getDeviceId().deviceIndex;
-    const Node& deviceNode = m_nodes.at(deviceId);
-
-    VERIFY_OR_DEBUG_ASSERT(std::ranges::find(m_openedDevices, deviceId) == m_openedDevices.end()) {
-        qWarning() << "SoundDevicePipewire:" << deviceId << "already open";
-        return "Device already open";
+    PortPair& ports = m_inputs.at(input);
+    if (!m_manageExternalLinks) {
+        ports.activeDevice = deviceId;
     }
+
+    ChannelGroup channelGroup = input.getChannelGroup();
+    unsigned char channelBase = channelGroup.getChannelBase();
+    unsigned char channelCount = channelGroup.getChannelCount().value();
+    std::span<const uint32_t> portIds = m_nodes.at(deviceId).outputs;
 
     pw_thread_loop_lock(m_pPwThreadLoop);
 
-    // device.inputs() corresponds to output ports of device node
-    auto inKeys = std::views::keys(m_inputs);
-    for (const AudioInputBuffer& input : device.inputs()) {
-        auto it = std::ranges::find_if(inKeys, [input](const AudioPath& path) {
-            return path.getType() == input.getType() && path.getIndex() == input.getIndex();
-        });
-
-        VERIFY_OR_DEBUG_ASSERT(it != inKeys.end()) {
-            continue;
+    if (channelCount == 1) {
+        result += createLink(deviceId, portIds[channelBase], m_filterId, ports.left.id);
+        result += createLink(deviceId, portIds[channelBase], m_filterId, ports.right.id);
+        if (!m_manageExternalLinks) {
+            ports.addPort(deviceId, portIds[channelBase], true);
+            ports.addPort(deviceId, portIds[channelBase], false);
         }
-
-        const PortPair& filterPorts = m_inputs.at(*it);
-        ChannelGroup channelGroup = input.getChannelGroup();
-        unsigned char channelBase = channelGroup.getChannelBase();
-        unsigned char channelCount = channelGroup.getChannelCount().value();
-        std::span<const uint32_t> ports = deviceNode.outputs;
-
-        if (channelCount == 1) {
-            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.left.id);
-            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.right.id);
-        } else {
-            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.left.id);
-            result += createLink(deviceId,
-                    ports[channelBase + 1],
-                    m_filterId,
-                    filterPorts.right.id);
+    } else {
+        result += createLink(deviceId, portIds[channelBase], m_filterId, ports.left.id);
+        result += createLink(deviceId,
+                portIds[channelBase + 1],
+                m_filterId,
+                ports.right.id);
+        if (!m_manageExternalLinks) {
+            ports.addPort(deviceId, portIds[channelBase], true);
+            ports.addPort(deviceId, portIds[channelBase + 1], false);
         }
     }
 
-    // device.outputs() corresponds to input ports of device node
-    auto outKeys = std::views::keys(m_outputs);
-    for (const AudioOutputBuffer& output : device.outputs()) {
-        auto it = std::ranges::find_if(outKeys, [output](const AudioPath& path) {
-            return path.getType() == output.getType() && path.getIndex() == output.getIndex();
-        });
-
-        VERIFY_OR_DEBUG_ASSERT(it != outKeys.end()) {
-            continue;
-        }
-
-        const PortPair& filterPorts = m_outputs.at(*it);
-        ChannelGroup channelGroup = output.getChannelGroup();
-        unsigned char channelBase = channelGroup.getChannelBase();
-        unsigned char channelCount = channelGroup.getChannelCount().value();
-        std::span<const uint32_t> ports = deviceNode.inputs;
-
-        if (channelCount == 1) {
-            uint32_t filterPort = channelBase % 2 ? filterPorts.right.id : filterPorts.left.id;
-            result += createLink(m_filterId, filterPort, deviceId, ports[channelBase]);
-        } else {
-            result += createLink(m_filterId, filterPorts.left.id, deviceId, ports[channelBase]);
-            result += createLink(m_filterId,
-                    filterPorts.right.id,
-                    deviceId,
-                    ports[channelBase + 1]);
-        }
-    }
     pw_thread_loop_unlock(m_pPwThreadLoop);
-    m_openedDevices.push_back(deviceId);
     return result;
 }
 
-void PipewireEnumerator::closeDevice(uint32_t id) {
+std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId,
+        const AudioOutput& output,
+        mixxx::audio::SampleRate sampleRate,
+        SINT framesPerBuffer) {
+    std::string result;
     VERIFY_OR_DEBUG_ASSERT(m_initialized) {
-        qWarning() << "PipewireEnumerator::closeDevice called when "
-                      "uninitialized, this should not happen";
-        return;
+        qDebug() << "PipewireEnumerator::openDevice called when "
+                    "uninitialized, this should not happen";
+        return "PipewireEnumerator uninitialized";
     }
 
-    auto deviceId = std::ranges::find(m_openedDevices, id);
-
-    VERIFY_OR_DEBUG_ASSERT(deviceId != m_openedDevices.end()) {
-        qWarning() << "device:" << id << "not opened";
-        return;
+    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
+        updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
-    auto pDevice = m_soundDevices.at(*deviceId);
-
-    for (const AudioInputBuffer& input : pDevice->inputs()) {
-        m_inputs.at(input).active.store(false);
+    PortPair& ports = m_outputs.at(output);
+    if (!m_manageExternalLinks) {
+        ports.activeDevice = deviceId;
     }
 
-    for (const AudioOutputBuffer& output : pDevice->outputs()) {
-        m_outputs.at(output).active.store(false);
-    }
+    ChannelGroup channelGroup = output.getChannelGroup();
+    unsigned char channelBase = channelGroup.getChannelBase();
+    unsigned char channelCount = channelGroup.getChannelCount().value();
 
-    const Node& node = m_nodes.at(*deviceId);
+    std::span<const uint32_t> portIds = m_nodes.at(deviceId).inputs;
 
-    for (uint32_t portId : node.inputs) {
-        const Port& port = m_ports.at(portId);
-        for (uint32_t linkId : port.links) {
-            destroyLink(linkId);
+    pw_thread_loop_lock(m_pPwThreadLoop);
+
+    if (channelCount == 1) {
+        uint32_t filterPort = channelBase % 2 ? ports.right.id : ports.left.id;
+        result += createLink(m_filterId, filterPort, deviceId, portIds[channelBase]);
+        if (!m_manageExternalLinks) {
+            ports.addPort(deviceId, portIds[channelBase], !(channelBase % 2));
+        }
+    } else {
+        result += createLink(m_filterId, ports.left.id, deviceId, portIds[channelBase]);
+        result += createLink(m_filterId,
+                ports.right.id,
+                deviceId,
+                portIds[channelBase + 1]);
+        if (!m_manageExternalLinks) {
+            ports.addPort(deviceId, portIds[channelBase], true);
+            ports.addPort(deviceId, portIds[channelBase + 1], false);
         }
     }
 
-    for (uint32_t portId : node.outputs) {
-        const Port& port = m_ports.at(portId);
-        for (uint32_t linkId : port.links) {
-            destroyLink(linkId);
+    pw_thread_loop_unlock(m_pPwThreadLoop);
+    return result;
+}
+
+void PipewireEnumerator::closePorts(PortPair& ports, bool isInput) {
+    const Port& left = m_ports.at(ports.left.id);
+    const Port& right = m_ports.at(ports.right.id);
+
+    if (m_manageExternalLinks) {
+        // we handle all links to/from Mixxx, and destroy all links
+        // connected to Mixxx path
+        for (uint32_t link : left.links) {
+            destroyLink(link);
+            qDebug() << "PipewireEnumerator::closePath left" << link;
+        }
+
+        for (uint32_t link : right.links) {
+            destroyLink(link);
+            qDebug() << "PipewireEnumerator::closePath right" << link;
+        }
+    } else {
+        const PortPair::ConnectedDevice& device = ports.connectedDevices.at(ports.activeDevice);
+
+        for (uint32_t linkId : left.links) {
+            const Link& link = m_links.at(linkId);
+            auto it = std::ranges::find(device.leftPorts, isInput ? link.output : link.input);
+            if (it != device.leftPorts.end()) {
+                destroyLink(linkId);
+            }
+            qDebug() << "PipewireEnumerator::closePath" << isInput
+                     << ports.left.id << link.input << link.output;
+        }
+
+        for (uint32_t linkId : right.links) {
+            const Link& link = m_links.at(linkId);
+            auto it = std::ranges::find(device.rightPorts, isInput ? link.output : link.input);
+            if (it != device.rightPorts.end()) {
+                destroyLink(linkId);
+            }
+
+            qDebug() << "PipewireEnumerator::closePath" << isInput
+                     << ports.right.id << link.input << link.output;
+        }
+    }
+}
+
+void PipewireEnumerator::closeDevice(uint32_t deviceId) {
+    qDebug() << "PipewireEnumerator::closeDevice" << deviceId;
+    VERIFY_OR_DEBUG_ASSERT(m_initialized) {
+        qDebug() << "PipewireEnumerator::closePath called when "
+                    "uninitialized, this should not happen";
+        return;
+    }
+
+    for (auto& [input, ports] : m_inputs) {
+        if (ports.activeDevice == deviceId) {
+            closePorts(ports, true);
         }
     }
 
-    m_openedDevices.erase(deviceId);
+    for (auto& [output, ports] : m_outputs) {
+        if (ports.activeDevice == deviceId) {
+            closePorts(ports, false);
+        }
+    }
 }
 
 void PipewireEnumerator::callback(const spa_io_position* pos) {
@@ -689,15 +795,15 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
     const uint64_t framesPerBuffer = pos->clock.duration;
 
     if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        qWarning() << "PipewireEnumerator::callback"
-                      "requested"
-                   << m_framesPerBuffer << "samples at" << m_sampleRate << "hz,"
-                                                                           "provided"
-                   << framesPerBuffer << "samples at" << sampleRate << "hz";
+        qDebug() << "PipewireEnumerator::callback"
+                    "requested"
+                 << m_framesPerBuffer << "samples at" << m_sampleRate << "hz,"
+                                                                         "provided"
+                 << framesPerBuffer << "samples at" << sampleRate << "hz";
         setLatency(sampleRate, framesPerBuffer);
     }
 
-    qDebug() << "PipewireEnumerator::callback" << sampleRate << framesPerBuffer;
+    // qDebug() << "PipewireEnumerator::callback" << sampleRate << framesPerBuffer;
     m_pSoundManager->processUnderflowHappened(framesPerBuffer);
 
     for (const auto& [input, ports] : m_inputs) {
@@ -911,7 +1017,7 @@ void PipewireEnumerator::createOutputPorts(const AudioOutput& output, PortPair& 
 
 void PipewireEnumerator::updateFilterLatency(
         unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qWarning() << "PipewireEnumerator::updateFilterLatency" << sampleRate << framesPerBuffer;
+    qDebug() << "PipewireEnumerator::updateFilterLatency" << sampleRate << framesPerBuffer;
     std::string rate = std::to_string(sampleRate);
     std::string rateStr = "1/" + rate;
     std::string quantumStr = std::to_string(framesPerBuffer);
@@ -934,15 +1040,15 @@ void PipewireEnumerator::updateFilterLatency(
     if (res >= 0) {
         setLatency(sampleRate, framesPerBuffer);
     } else {
-        qWarning() << "PipewireEnumerator::setLatency "
-                      "pw_filter_update_properties failed:"
-                   << spa_strerror(res);
-        qWarning() << "Unable to set requested samplerate";
+        qDebug() << "PipewireEnumerator::setLatency "
+                    "pw_filter_update_properties failed:"
+                 << spa_strerror(res);
+        qDebug() << "Unable to set requested samplerate";
     }
 }
 
 void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qWarning() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
+    qDebug() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
     m_sampleRate = sampleRate;
     m_framesPerBuffer = framesPerBuffer;
     ControlObject::set(
@@ -952,10 +1058,10 @@ void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int frames
 }
 
 void PipewireEnumerator::coreEventError(uint32_t id, int seq, int res, const char* message) {
-    qWarning() << "PipewireEnumerator::coreEventError" << id << seq << res << message;
+    qDebug() << "PipewireEnumerator::coreEventError" << id << seq << res << message;
     if (id == 0) {
         if (res == -EPIPE) {
-            qWarning() << "Deinitializing PipeWire due to server disconnect";
+            qDebug() << "Deinitializing PipeWire due to server disconnect";
             QMessageBox::information(nullptr,
                     tr("Information"),
                     tr("PipeWire server disconnected, query devices to reconnect."));
@@ -1005,4 +1111,226 @@ bool PipewireEnumerator::nodeHasPorts(const Node& node) {
     }
 
     return false;
+}
+
+bool PipewireEnumerator::PortPair::addPort(uint32_t deviceId, uint32_t portId, bool isLeft) {
+    qDebug() << "PortPair::addPort" << deviceId << portId << activeDevice;
+    for (const auto& [id, device] : connectedDevices) {
+        qDebug() << "connectedDevices" << id;
+        QDebug dbg = qDebug();
+        for (uint32_t port : device.leftPorts) {
+            dbg << port;
+        }
+
+        dbg = qDebug();
+        for (uint32_t port : device.rightPorts) {
+            dbg << port;
+        }
+    }
+
+    if (connectedDevices.contains(deviceId)) {
+        if (isLeft) {
+            connectedDevices.at(deviceId).leftPorts.push_back(portId);
+        } else {
+            connectedDevices.at(deviceId).rightPorts.push_back(portId);
+        }
+
+        return false;
+    }
+
+    auto [it, didEmplace] = connectedDevices.try_emplace(deviceId);
+    if (!didEmplace) {
+        return false;
+    }
+
+    if (isLeft) {
+        it->second.leftPorts.push_back(portId);
+    } else {
+        it->second.rightPorts.push_back(portId);
+    }
+
+    if (connectedDevices.size() == 1) {
+        // check separately since we preemptively set deviceId when
+        // manually opening it
+        if (!activeDevice) {
+            activeDevice = deviceId;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+bool PipewireEnumerator::PortPair::removePort(uint32_t deviceId, uint32_t portId, bool isLeft) {
+    qDebug() << "PortPair::removePort" << deviceId << portId << activeDevice;
+    for (const auto& [id, device] : connectedDevices) {
+        qDebug() << "connectedDevices" << id;
+        QDebug dbg = qDebug();
+        for (uint32_t port : device.leftPorts) {
+            dbg << port;
+        }
+
+        dbg = qDebug();
+        for (uint32_t port : device.rightPorts) {
+            dbg << port;
+        }
+    }
+
+    VERIFY_OR_DEBUG_ASSERT(connectedDevices.contains(deviceId)) {
+        return false;
+    }
+
+    ConnectedDevice& device = connectedDevices.at(deviceId);
+
+    if (isLeft) {
+        std::erase(device.leftPorts, portId);
+    } else {
+        std::erase(device.rightPorts, portId);
+    }
+
+    if (device.leftPorts.empty() and device.rightPorts.empty()) {
+        connectedDevices.erase(deviceId);
+        if (activeDevice == deviceId) {
+            if (connectedDevices.empty()) {
+                activeDevice = 0;
+            } else {
+                activeDevice = connectedDevices.cbegin()->first;
+            }
+        }
+        // return connectedDevices.size() <= 1;
+        return true;
+    }
+
+    return false;
+}
+
+ChannelGroup PipewireEnumerator::PortPair::inputChannel(std::span<const uint32_t> ports) {
+    // qDebug() << "inputChannelGroup" << left.devicePort << right.devicePort;
+    for (const auto& [id, device] : connectedDevices) {
+        qDebug() << "outputChannelGroup" << id;
+        QDebug dbg = qDebug();
+        for (uint32_t port : device.leftPorts) {
+            dbg << port;
+        }
+
+        dbg = qDebug();
+        for (uint32_t port : device.rightPorts) {
+            dbg << port;
+        }
+    }
+
+    for (uint32_t port : ports) {
+        fprintf(stderr, "%u ", port);
+    }
+    fprintf(stderr, "\n");
+    if (connectedDevices.size() != 1) {
+        qDebug() << "inputChannel connectedDevices.size() != 1";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    const ConnectedDevice& device = connectedDevices.cbegin()->second;
+
+    if (device.leftPorts.size() != 1 or device.rightPorts.size() != 1) {
+        qDebug() << "inputChannel device.leftPorts.size() != 1 or device.rightPorts.size() != 1";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    uint32_t leftPort = device.leftPorts.back();
+    uint32_t rightPort = device.rightPorts.back();
+
+    const auto leftChannel = std::ranges::find(ports, leftPort);
+    if (leftChannel != ports.end()) {
+        // PipeWire supports channel count > UINT8_MAX, although unlikely,
+        // to prevent errors need to either change this mechanism or ChannelGroup
+        unsigned char channelBase = std::distance(ports.begin(), leftChannel);
+        if (leftPort == rightPort) {
+            qDebug() << "inputChannel leftPort == rightPort";
+            return {channelBase, mixxx::audio::ChannelCount::mono()};
+        } else {
+            const auto rightChannel = leftChannel + 1;
+            if (rightChannel != ports.end() and *rightChannel == rightPort) {
+                qDebug() << "inputChannel rightChannel != ports.end() and "
+                            "*rightChannel == rightPort";
+                return {channelBase, mixxx::audio::ChannelCount::stereo()};
+            }
+        }
+    }
+
+    return {0, mixxx::audio::ChannelCount()};
+}
+
+ChannelGroup PipewireEnumerator::PortPair::outputChannel(std::span<const uint32_t> ports) {
+    // qDebug() << "outputChannelGroup" << left.devicePort << right.devicePort;
+    for (const auto& [id, device] : connectedDevices) {
+        qDebug() << "outputChannel" << id;
+        QDebug dbg = qDebug();
+        for (uint32_t port : device.leftPorts) {
+            dbg << port;
+        }
+
+        dbg = qDebug();
+        for (uint32_t port : device.rightPorts) {
+            dbg << port;
+        }
+    }
+
+    for (uint32_t port : ports) {
+        fprintf(stderr, "%u ", port);
+    }
+    fprintf(stderr, "\n");
+
+    if (connectedDevices.size() != 1) {
+        qDebug() << "outputChannel connectedDevices.size() != 1";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    const ConnectedDevice& device = connectedDevices.cbegin()->second;
+
+    if (device.leftPorts.size() > 1 or device.rightPorts.size() > 1) {
+        qDebug() << "outputChannel " << device.leftPorts.size() << " > 1 or "
+                 << device.rightPorts.size() << " > 1";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    bool hasLeftPort = !device.leftPorts.empty();
+    bool hasRightPort = !device.rightPorts.empty();
+
+    if (!hasLeftPort and !hasRightPort) {
+        qDebug() << "outputChannel !hasLeftPort and !hasRightPort";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    if (!hasLeftPort) {
+        auto it = std::ranges::find(ports, device.rightPorts.back());
+        unsigned char channelBase = std::distance(ports.begin(), it);
+        // hacky way to get if Mixxx right port is connected to device right port
+        if (it != ports.end() and channelBase % 2) {
+            qDebug() << "outputChannel it != ports.end() and" << channelBase % 2;
+            return {channelBase, mixxx::audio::ChannelCount::mono()};
+        }
+    } else if (!hasRightPort) {
+        auto it = std::ranges::find(ports, device.leftPorts.back());
+        unsigned char channelBase = std::distance(ports.begin(), it);
+        // hacky way to get if Mixxx left port is connected to device left port
+        if (it != ports.end() and !(channelBase % 2)) {
+            qDebug() << "outputChannel it != ports.end() and" << channelBase % 2;
+            return {channelBase, mixxx::audio::ChannelCount::mono()};
+        }
+    } else {
+        const auto leftChannel = std::ranges::find(ports, device.leftPorts.back());
+        unsigned char channelBase = std::distance(ports.begin(), leftChannel);
+        if (leftChannel != ports.end() and !(channelBase % 2)) {
+            // PipeWire supports channel count > UINT8_MAX, although unlikely,
+            // to prevent errors need to change this mechanism or ChannelGroup
+            const auto rightChannel = leftChannel + 1;
+            if (rightChannel != ports.end() and *rightChannel == device.rightPorts.back()) {
+                qDebug() << "outputChannel rightChannel != ports.end() and "
+                         << *rightChannel << " == " << device.rightPorts.back()
+                         << "";
+                return {channelBase, mixxx::audio::ChannelCount::stereo()};
+            }
+        }
+    }
+
+    return {0, mixxx::audio::ChannelCount()};
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -20,8 +20,6 @@
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
 #include "util/assert.h"
-#include "util/defs.h"
-#include "util/sample.h"
 #include "util/trace.h"
 #include "util/types.h"
 #include "waveform/visualplayposition.h"
@@ -76,7 +74,8 @@ static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
 }
 } // namespace
 
-PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManager)
+PipewireEnumerator::PipewireEnumerator(
+        UserSettingsPointer pConfig, SoundManager* pManager)
         : m_pSoundManager(pManager),
           m_pPwThreadLoop(nullptr),
           m_pPwContext(nullptr),
@@ -86,7 +85,11 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
           m_pPwFilter(nullptr),
           m_sampleRate(48000),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
-          m_framesPerBuffer(0) {
+          m_COmanageExternalLinks(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay"))),
+          m_framesPerBuffer(0),
+          m_manageExternalLinks(static_cast<bool>(pConfig->getValue(
+                  ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay")),
+                  false))) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -98,6 +101,10 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
 
     connect(this, &PipewireEnumerator::deviceAdded, m_pSoundManager, &SoundManager::addDevice);
     connect(this, &PipewireEnumerator::deviceRemoved, m_pSoundManager, &SoundManager::removeDevice);
+    connect(&m_COmanageExternalLinks, &ControlObject::valueChanged, this, [this](double value) {
+        // TODO(pri-yan-shu) cleanup any invalid state here, or make the toggle startup only
+        m_manageExternalLinks = static_cast<bool>(value);
+    });
 
     pw_init(nullptr, nullptr);
 
@@ -124,9 +131,9 @@ void PipewireEnumerator::initialize() {
     if (!m_pPwContext) {
         m_pPwContext = pw_context_new(pw_thread_loop_get_loop(m_pPwThreadLoop), nullptr, 0);
         if (!m_pPwContext) {
-            qWarning() << "PipewireEnumerator::initialize pw_context_new "
-                          "failed with error:"
-                       << spa_strerror(errno);
+            qDebug() << "PipewireEnumerator::initialize pw_context_new "
+                        "failed with error:"
+                     << spa_strerror(errno);
             return;
         }
     }
@@ -134,9 +141,9 @@ void PipewireEnumerator::initialize() {
     m_pPwCore = pw_context_connect(m_pPwContext, nullptr, 0);
 
     if (!m_pPwCore) {
-        qWarning() << "PipewireEnumerator::initialize pw_context_connect "
-                      "failed with error:"
-                   << spa_strerror(errno);
+        qDebug() << "PipewireEnumerator::initialize pw_context_connect "
+                    "failed with error:"
+                 << spa_strerror(errno);
         return;
     }
     pw_core_add_listener(m_pPwCore, &m_pwCoreListener, &coreEvents, this);
@@ -189,8 +196,8 @@ void PipewireEnumerator::initialize() {
             0);
 
     VERIFY_OR_DEBUG_ASSERT(res >= 0) {
-        qWarning() << "PipewireEnumerator::initialize pw_filter_connect error:"
-                   << spa_strerror(res);
+        qDebug() << "PipewireEnumerator::initialize pw_filter_connect error:"
+                 << spa_strerror(res);
     }
 
     pw_thread_loop_start(m_pPwThreadLoop);
@@ -206,7 +213,6 @@ void PipewireEnumerator::deinitialize() {
     pw_thread_loop_stop(m_pPwThreadLoop);
 
     // clear everything we get through registry
-    m_openedDevices.clear();
     m_soundDevices.clear();
     m_nodes.clear();
     m_ports.clear();
@@ -289,7 +295,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         }
     } else if (strcmp(pType, PW_TYPE_INTERFACE_Port) == 0) {
         const uint32_t node_id = pw_properties_parse_int(spa_dict_lookup(pProps, PW_KEY_NODE_ID));
-        if (!m_soundDevices.contains(node_id)) {
+        if (!m_nodes.contains(node_id)) {
             // most likely midi or video node
             return;
         }
@@ -303,7 +309,6 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         m_pSoundManager->updateDeviceChannels(pSoundDevice);
         Node& node = m_nodes.at(node_id);
         Port port{};
-        port.id = id;
         port.node = node_id;
         port.channel = channel ? channel : (portName ? portName : std::to_string(id).c_str());
         port.isInput = isInput;
@@ -369,43 +374,80 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         const uint32_t out_port = pw_properties_parse_int(
                 spa_dict_lookup(pProps, PW_KEY_LINK_OUTPUT_PORT));
 
+        if (in_node != m_filterId and out_node != m_filterId) {
+            return;
+        }
+
         Port& inputPort = m_ports.at(in_port);
         Port& outputPort = m_ports.at(out_port);
 
+        m_links.insert_or_assign(id, Link{in_port, out_port});
+        inputPort.links.push_back(id);
+        outputPort.links.push_back(id);
+
         if (in_node == m_filterId) {
-            m_links.insert_or_assign(id, Link{in_port, out_port});
-
-            const Node& deviceNode = m_nodes.at(out_node);
-            if (!nodeHasPorts(deviceNode)) {
-                m_openedDevices.push_back(out_node);
-            }
-            inputPort.links.push_back(id);
-            outputPort.links.push_back(id);
-
+            // device output, mixxx input
             for (auto& [input, ports] : m_inputs) {
-                if (ports.left.id == in_port or ports.right.id == in_port) {
-                    if (!ports.active.load()) {
-                        ports.active.store(true);
-                        m_pSoundManager->configureInput(input);
-                    }
+                if (ports.left.id != in_port and ports.right.id != in_port) {
+                    continue;
                 }
-            }
-        } else if (out_node == m_filterId) {
-            m_links.insert_or_assign(id, Link{in_port, out_port});
 
-            const Node& deviceNode = m_nodes.at(out_node);
-            if (!nodeHasPorts(deviceNode)) {
-                m_openedDevices.push_back(out_node);
-            }
-            inputPort.links.push_back(id);
-            outputPort.links.push_back(id);
-            for (auto& [output, ports] : m_outputs) {
-                if (ports.left.id == out_port or ports.right.id == out_port) {
-                    if (!ports.active.load()) {
-                        ports.active.store(true);
-                        m_pSoundManager->configureOutput(output);
-                    }
+                const bool portsActive = ports.active.load();
+                if (!portsActive) {
+                    ports.active.store(true);
+                    m_pSoundManager->configureInput(input);
+                    // if (!deviceChanged) {
+                    // qDebug() << "portsActive == false but device not changed, this is bad";
+                    // }
                 }
+
+                if (m_manageExternalLinks) {
+                    bool deviceChanged = ports.addPort(
+                            out_node, out_port, ports.left.id == in_port);
+                    if (deviceChanged) {
+                        const SoundDeviceId& deviceId =
+                                m_soundDevices.at(ports.activeDevice)
+                                        ->getDeviceId();
+                        m_pSoundManager->updatePathDevice(input, deviceId);
+                    }
+                    const Node& deviceNode = m_nodes.at(ports.activeDevice);
+                    m_pSoundManager->updatePathChannel(
+                            input, ports.inputChannel(deviceNode.outputs));
+                }
+
+                break;
+            }
+        }
+
+        if (out_node == m_filterId) {
+            // device input, mixxx output
+            for (auto& [output, ports] : m_outputs) {
+                if (ports.left.id != out_port and ports.right.id != out_port) {
+                    continue;
+                }
+
+                const bool portsActive = ports.active.load();
+                if (!portsActive) {
+                    ports.active.store(true);
+                    m_pSoundManager->configureOutput(output);
+                    // if (!deviceChanged) {
+                    // qDebug() << "portsActive == false but device not changed, this is bad";
+                    // }
+                }
+
+                if (m_manageExternalLinks) {
+                    bool deviceChanged = ports.addPort(in_node, in_port, ports.left.id == out_port);
+                    if (deviceChanged) {
+                        const SoundDeviceId& deviceId =
+                                m_soundDevices.at(ports.activeDevice)
+                                        ->getDeviceId();
+                        m_pSoundManager->updatePathDevice(output, deviceId);
+                    }
+                    const Node& deviceNode = m_nodes.at(ports.activeDevice);
+                    m_pSoundManager->updatePathChannel(
+                            output, ports.outputChannel(deviceNode.inputs));
+                }
+                break;
             }
         }
     }
@@ -413,18 +455,13 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
 
 void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
     if (m_nodes.contains(id)) {
-        if (!m_soundDevices.contains(id)) {
+        m_nodes.erase(id);
+        VERIFY_OR_DEBUG_ASSERT(m_soundDevices.contains(id)) {
             return;
         }
 
-        QSharedPointer<SoundDevicePipewire> pDevice = m_soundDevices.at(id);
-        if (pDevice->isOpen()) {
-            pDevice->close();
-        }
-
+        emit deviceRemoved(m_soundDevices.at(id));
         m_soundDevices.erase(id);
-        emit deviceRemoved(pDevice);
-        m_nodes.erase(id);
     } else if (m_ports.contains(id)) {
         const Port& port = m_ports.at(id);
         VERIFY_OR_DEBUG_ASSERT(m_soundDevices.contains(port.node)) {
@@ -451,55 +488,69 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
         std::erase(inputPort.links, id);
         std::erase(outputPort.links, id);
 
-        // check if we can close any PortPair
         if (inputPort.node == m_filterId) {
-            if (inputPort.links.empty()) {
-                for (auto& [input, ports] : m_inputs) {
-                    if (ports.left.id == link.input) {
-                        const Port& right = m_ports.at(ports.right.id);
-                        if (right.links.empty()) {
-                            ports.active.store(false);
-                            m_pSoundManager->unconfigureInput(input);
-                        }
-                        break;
-                    } else if (ports.right.id == link.input) {
-                        const Port& left = m_ports.at(ports.left.id);
-                        if (left.links.empty()) {
-                            ports.active.store(false);
-                            m_pSoundManager->unconfigureInput(input);
-                        }
-                        break;
-                    }
+            for (auto& [input, ports] : m_inputs) {
+                bool deviceChanged;
+                if (ports.left.id == link.input) {
+                    deviceChanged = ports.removePort(outputPort.node, link.output, true);
+                } else if (ports.right.id == link.input) {
+                    deviceChanged = ports.removePort(outputPort.node, link.output, false);
+                } else {
+                    continue;
                 }
-            }
 
-            const Node& deviceNode = m_nodes.at(outputPort.node);
-            if (!nodeHasPorts(deviceNode)) {
-                std::erase(m_openedDevices, outputPort.node);
-            }
-        } else if (outputPort.node == m_filterId) {
-            if (outputPort.links.empty()) {
-                for (auto& [output, ports] : m_outputs) {
-                    if (ports.left.id == link.output) {
-                        const Port& right = m_ports.at(ports.right.id);
-                        if (right.links.empty()) {
-                            ports.active.store(false);
-                            m_pSoundManager->unconfigureOutput(output);
-                        }
-                        break;
-                    } else if (ports.right.id == link.output) {
-                        const Port& left = m_ports.at(ports.left.id);
-                        if (left.links.empty()) {
-                            ports.active.store(false);
-                            m_pSoundManager->unconfigureOutput(output);
-                        }
-                        break;
+                // TODO(pri-yan-shu) It would be nice to have link removals affect
+                // preference page even when not managing external links,
+
+                if (m_manageExternalLinks and deviceChanged) {
+                    if (ports.connectedDevices.empty()) {
+                        m_pSoundManager->updatePathDevice(input, SoundDeviceId{});
+                        ports.active.store(false);
+                        m_pSoundManager->unconfigureInput(input);
+                    } else {
+                        m_pSoundManager->updatePathDevice(input,
+                                m_soundDevices.at(ports.activeDevice)
+                                        ->getDeviceId());
                     }
                 }
+
+                if (m_manageExternalLinks and ports.activeDevice) {
+                    const Node& activeDeviceNode = m_nodes.at(ports.activeDevice);
+                    m_pSoundManager->updatePathChannel(input,
+                            ports.inputChannel(activeDeviceNode.outputs));
+                }
+                break;
             }
-            const Node& deviceNode = m_nodes.at(outputPort.node);
-            if (!nodeHasPorts(deviceNode)) {
-                std::erase(m_openedDevices, outputPort.node);
+        }
+
+        if (outputPort.node == m_filterId) {
+            for (auto& [output, ports] : m_outputs) {
+                bool deviceChanged;
+                if (ports.left.id == link.output) {
+                    deviceChanged = ports.removePort(inputPort.node, link.input, true);
+                } else if (ports.right.id == link.output) {
+                    deviceChanged = ports.removePort(inputPort.node, link.input, false);
+                } else {
+                    continue;
+                }
+
+                if (m_manageExternalLinks and deviceChanged) {
+                    if (ports.connectedDevices.empty()) {
+                        m_pSoundManager->updatePathDevice(output, SoundDeviceId{});
+                        ports.active.store(false);
+                        m_pSoundManager->unconfigureOutput(output);
+                    } else {
+                        m_pSoundManager->updatePathDevice(output,
+                                m_soundDevices.at(ports.activeDevice)
+                                        ->getDeviceId());
+                    }
+                }
+                if (m_manageExternalLinks and ports.activeDevice) {
+                    m_pSoundManager->updatePathChannel(output,
+                            ports.outputChannel(
+                                    m_nodes.at(ports.activeDevice).inputs));
+                }
+                break;
             }
         }
         m_links.erase(id);
@@ -538,16 +589,29 @@ int PipewireEnumerator::metadataProperty(
 }
 
 bool PipewireEnumerator::isOpen(uint32_t id) {
-    return std::ranges::find(m_openedDevices, id) != m_openedDevices.end();
+    for (const auto& ports : std::views::values(m_inputs)) {
+        if (ports.activeDevice == id) {
+            return true;
+        }
+    }
+
+    for (const auto& ports : std::views::values(m_outputs)) {
+        if (ports.activeDevice == id) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
-std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
+std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
+        const AudioInput& input,
         mixxx::audio::SampleRate sampleRate,
         SINT framesPerBuffer) {
     std::string result;
     VERIFY_OR_DEBUG_ASSERT(m_initialized) {
-        qWarning() << "PipewireEnumerator::openDevice called when "
-                      "uninitialized, this should not happen";
+        qDebug() << "PipewireEnumerator::openDevice called when "
+                    "uninitialized, this should not happen";
         return "PipewireEnumerator uninitialized";
     }
 
@@ -555,119 +619,152 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
         updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
-    int deviceId = device.getDeviceId().deviceIndex;
-    const Node& deviceNode = m_nodes.at(deviceId);
-
-    VERIFY_OR_DEBUG_ASSERT(std::ranges::find(m_openedDevices, deviceId) == m_openedDevices.end()) {
-        qWarning() << "SoundDevicePipewire:" << deviceId << "already open";
-        return "Device already open";
+    PortPair& ports = m_inputs.at(input);
+    if (!m_manageExternalLinks) {
+        ports.activeDevice = deviceId;
     }
+
+    ChannelGroup channelGroup = input.getChannelGroup();
+    unsigned char channelBase = channelGroup.getChannelBase();
+    unsigned char channelCount = channelGroup.getChannelCount().value();
+    std::span<const uint32_t> portIds = m_nodes.at(deviceId).outputs;
 
     pw_thread_loop_lock(m_pPwThreadLoop);
 
-    // device.inputs() corresponds to output ports of device node
-    auto inKeys = std::views::keys(m_inputs);
-    for (const AudioInputBuffer& input : device.inputs()) {
-        auto it = std::ranges::find_if(inKeys, [input](const AudioPath& path) {
-            return path.getType() == input.getType() && path.getIndex() == input.getIndex();
-        });
-
-        VERIFY_OR_DEBUG_ASSERT(it != inKeys.end()) {
-            continue;
+    if (channelCount == 1) {
+        result += createLink(deviceId, portIds[channelBase], m_filterId, ports.left.id);
+        result += createLink(deviceId, portIds[channelBase], m_filterId, ports.right.id);
+        if (!m_manageExternalLinks) {
+            ports.addPort(deviceId, portIds[channelBase], true);
+            ports.addPort(deviceId, portIds[channelBase], false);
         }
-
-        const PortPair& filterPorts = m_inputs.at(*it);
-        ChannelGroup channelGroup = input.getChannelGroup();
-        unsigned char channelBase = channelGroup.getChannelBase();
-        unsigned char channelCount = channelGroup.getChannelCount().value();
-        std::span<const uint32_t> ports = deviceNode.outputs;
-
-        if (channelCount == 1) {
-            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.left.id);
-            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.right.id);
-        } else {
-            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.left.id);
-            result += createLink(deviceId,
-                    ports[channelBase + 1],
-                    m_filterId,
-                    filterPorts.right.id);
+    } else {
+        result += createLink(deviceId, portIds[channelBase], m_filterId, ports.left.id);
+        result += createLink(deviceId,
+                portIds[channelBase + 1],
+                m_filterId,
+                ports.right.id);
+        if (!m_manageExternalLinks) {
+            ports.addPort(deviceId, portIds[channelBase], true);
+            ports.addPort(deviceId, portIds[channelBase + 1], false);
         }
     }
 
-    // device.outputs() corresponds to input ports of device node
-    auto outKeys = std::views::keys(m_outputs);
-    for (const AudioOutputBuffer& output : device.outputs()) {
-        auto it = std::ranges::find_if(outKeys, [output](const AudioPath& path) {
-            return path.getType() == output.getType() && path.getIndex() == output.getIndex();
-        });
-
-        VERIFY_OR_DEBUG_ASSERT(it != outKeys.end()) {
-            continue;
-        }
-
-        const PortPair& filterPorts = m_outputs.at(*it);
-        ChannelGroup channelGroup = output.getChannelGroup();
-        unsigned char channelBase = channelGroup.getChannelBase();
-        unsigned char channelCount = channelGroup.getChannelCount().value();
-        std::span<const uint32_t> ports = deviceNode.inputs;
-
-        if (channelCount == 1) {
-            uint32_t filterPort = channelBase % 2 ? filterPorts.right.id : filterPorts.left.id;
-            result += createLink(m_filterId, filterPort, deviceId, ports[channelBase]);
-        } else {
-            result += createLink(m_filterId, filterPorts.left.id, deviceId, ports[channelBase]);
-            result += createLink(m_filterId,
-                    filterPorts.right.id,
-                    deviceId,
-                    ports[channelBase + 1]);
-        }
-    }
     pw_thread_loop_unlock(m_pPwThreadLoop);
-    m_openedDevices.push_back(deviceId);
     return result;
 }
 
-void PipewireEnumerator::closeDevice(uint32_t id) {
+std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId,
+        const AudioOutput& output,
+        mixxx::audio::SampleRate sampleRate,
+        SINT framesPerBuffer) {
+    std::string result;
     VERIFY_OR_DEBUG_ASSERT(m_initialized) {
-        qWarning() << "PipewireEnumerator::closeDevice called when "
-                      "uninitialized, this should not happen";
-        return;
+        qDebug() << "PipewireEnumerator::openDevice called when "
+                    "uninitialized, this should not happen";
+        return "PipewireEnumerator uninitialized";
     }
 
-    auto deviceId = std::ranges::find(m_openedDevices, id);
-
-    VERIFY_OR_DEBUG_ASSERT(deviceId != m_openedDevices.end()) {
-        qWarning() << "device:" << id << "not opened";
-        return;
+    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
+        updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
-    auto pDevice = m_soundDevices.at(*deviceId);
-
-    for (const AudioInputBuffer& input : pDevice->inputs()) {
-        m_inputs.at(input).active.store(false);
+    PortPair& ports = m_outputs.at(output);
+    if (!m_manageExternalLinks) {
+        ports.activeDevice = deviceId;
     }
 
-    for (const AudioOutputBuffer& output : pDevice->outputs()) {
-        m_outputs.at(output).active.store(false);
-    }
+    ChannelGroup channelGroup = output.getChannelGroup();
+    unsigned char channelBase = channelGroup.getChannelBase();
+    unsigned char channelCount = channelGroup.getChannelCount().value();
 
-    const Node& node = m_nodes.at(*deviceId);
+    std::span<const uint32_t> portIds = m_nodes.at(deviceId).inputs;
 
-    for (uint32_t portId : node.inputs) {
-        const Port& port = m_ports.at(portId);
-        for (uint32_t linkId : port.links) {
-            destroyLink(linkId);
+    pw_thread_loop_lock(m_pPwThreadLoop);
+
+    if (channelCount == 1) {
+        uint32_t filterPort = channelBase % 2 ? ports.right.id : ports.left.id;
+        result += createLink(m_filterId, filterPort, deviceId, portIds[channelBase]);
+        if (!m_manageExternalLinks) {
+            ports.addPort(deviceId, portIds[channelBase], !(channelBase % 2));
+        }
+    } else {
+        result += createLink(m_filterId, ports.left.id, deviceId, portIds[channelBase]);
+        result += createLink(m_filterId,
+                ports.right.id,
+                deviceId,
+                portIds[channelBase + 1]);
+        if (!m_manageExternalLinks) {
+            ports.addPort(deviceId, portIds[channelBase], true);
+            ports.addPort(deviceId, portIds[channelBase + 1], false);
         }
     }
 
-    for (uint32_t portId : node.outputs) {
-        const Port& port = m_ports.at(portId);
-        for (uint32_t linkId : port.links) {
-            destroyLink(linkId);
+    pw_thread_loop_unlock(m_pPwThreadLoop);
+    return result;
+}
+
+void PipewireEnumerator::closePorts(PortPair& ports, bool isInput) {
+    const Port& left = m_ports.at(ports.left.id);
+    const Port& right = m_ports.at(ports.right.id);
+
+    if (m_manageExternalLinks) {
+        // we handle all links to/from Mixxx, and destroy all links
+        // connected to Mixxx path
+        for (uint32_t link : left.links) {
+            destroyLink(link);
+            qDebug() << "PipewireEnumerator::closePath left" << link;
+        }
+
+        for (uint32_t link : right.links) {
+            destroyLink(link);
+            qDebug() << "PipewireEnumerator::closePath right" << link;
+        }
+    } else {
+        const PortPair::ConnectedDevice& device = ports.connectedDevices.at(ports.activeDevice);
+
+        for (uint32_t linkId : left.links) {
+            const Link& link = m_links.at(linkId);
+            auto it = std::ranges::find(device.leftPorts, isInput ? link.output : link.input);
+            if (it != device.leftPorts.end()) {
+                destroyLink(linkId);
+            }
+            qDebug() << "PipewireEnumerator::closePath" << isInput
+                     << ports.left.id << link.input << link.output;
+        }
+
+        for (uint32_t linkId : right.links) {
+            const Link& link = m_links.at(linkId);
+            auto it = std::ranges::find(device.rightPorts, isInput ? link.output : link.input);
+            if (it != device.rightPorts.end()) {
+                destroyLink(linkId);
+            }
+
+            qDebug() << "PipewireEnumerator::closePath" << isInput
+                     << ports.right.id << link.input << link.output;
+        }
+    }
+}
+
+void PipewireEnumerator::closeDevice(uint32_t deviceId) {
+    qDebug() << "PipewireEnumerator::closeDevice" << deviceId;
+    VERIFY_OR_DEBUG_ASSERT(m_initialized) {
+        qDebug() << "PipewireEnumerator::closePath called when "
+                    "uninitialized, this should not happen";
+        return;
+    }
+
+    for (auto& [input, ports] : m_inputs) {
+        if (ports.activeDevice == deviceId) {
+            closePorts(ports, true);
         }
     }
 
-    m_openedDevices.erase(deviceId);
+    for (auto& [output, ports] : m_outputs) {
+        if (ports.activeDevice == deviceId) {
+            closePorts(ports, false);
+        }
+    }
 }
 
 void PipewireEnumerator::callback(const spa_io_position* pos) {
@@ -689,15 +786,15 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
     const uint64_t framesPerBuffer = pos->clock.duration;
 
     if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        qWarning() << "PipewireEnumerator::callback"
-                      "requested"
-                   << m_framesPerBuffer << "samples at" << m_sampleRate << "hz,"
-                                                                           "provided"
-                   << framesPerBuffer << "samples at" << sampleRate << "hz";
+        qDebug() << "PipewireEnumerator::callback"
+                    "requested"
+                 << m_framesPerBuffer << "samples at" << m_sampleRate << "hz,"
+                                                                         "provided"
+                 << framesPerBuffer << "samples at" << sampleRate << "hz";
         setLatency(sampleRate, framesPerBuffer);
     }
 
-    qDebug() << "PipewireEnumerator::callback" << sampleRate << framesPerBuffer;
+    // qDebug() << "PipewireEnumerator::callback" << sampleRate << framesPerBuffer;
     m_pSoundManager->processUnderflowHappened(framesPerBuffer);
 
     for (const auto& [input, ports] : m_inputs) {
@@ -911,7 +1008,7 @@ void PipewireEnumerator::createOutputPorts(const AudioOutput& output, PortPair& 
 
 void PipewireEnumerator::updateFilterLatency(
         unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qWarning() << "PipewireEnumerator::updateFilterLatency" << sampleRate << framesPerBuffer;
+    qDebug() << "PipewireEnumerator::updateFilterLatency" << sampleRate << framesPerBuffer;
     std::string rate = std::to_string(sampleRate);
     std::string rateStr = "1/" + rate;
     std::string quantumStr = std::to_string(framesPerBuffer);
@@ -934,15 +1031,15 @@ void PipewireEnumerator::updateFilterLatency(
     if (res >= 0) {
         setLatency(sampleRate, framesPerBuffer);
     } else {
-        qWarning() << "PipewireEnumerator::setLatency "
-                      "pw_filter_update_properties failed:"
-                   << spa_strerror(res);
-        qWarning() << "Unable to set requested samplerate";
+        qDebug() << "PipewireEnumerator::setLatency "
+                    "pw_filter_update_properties failed:"
+                 << spa_strerror(res);
+        qDebug() << "Unable to set requested samplerate";
     }
 }
 
 void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qWarning() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
+    qDebug() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
     m_sampleRate = sampleRate;
     m_framesPerBuffer = framesPerBuffer;
     ControlObject::set(
@@ -952,10 +1049,10 @@ void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int frames
 }
 
 void PipewireEnumerator::coreEventError(uint32_t id, int seq, int res, const char* message) {
-    qWarning() << "PipewireEnumerator::coreEventError" << id << seq << res << message;
+    qDebug() << "PipewireEnumerator::coreEventError" << id << seq << res << message;
     if (id == 0) {
         if (res == -EPIPE) {
-            qWarning() << "Deinitializing PipeWire due to server disconnect";
+            qDebug() << "Deinitializing PipeWire due to server disconnect";
             QMessageBox::information(nullptr,
                     tr("Information"),
                     tr("PipeWire server disconnected, query devices to reconnect."));
@@ -1005,4 +1102,213 @@ bool PipewireEnumerator::nodeHasPorts(const Node& node) {
     }
 
     return false;
+}
+
+bool PipewireEnumerator::PortPair::addPort(uint32_t deviceId, uint32_t portId, bool isLeft) {
+    qDebug() << "PortPair::addPort" << deviceId << portId << activeDevice;
+    for (const auto& [id, device] : connectedDevices) {
+        qDebug() << "connectedDevices" << id;
+        QDebug dbg = qDebug();
+        for (uint32_t port : device.leftPorts) {
+            dbg << port;
+        }
+
+        dbg = qDebug();
+        for (uint32_t port : device.rightPorts) {
+            dbg << port;
+        }
+    }
+
+    auto [it, didEmplace] = connectedDevices.try_emplace(deviceId);
+
+    if (isLeft) {
+        it->second.leftPorts.push_back(portId);
+    } else {
+        it->second.rightPorts.push_back(portId);
+    }
+
+    if (didEmplace and connectedDevices.size() == 1) {
+        // check separately since we preemptively set deviceId when
+        // manually opening it
+        if (!activeDevice) {
+            activeDevice = deviceId;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+bool PipewireEnumerator::PortPair::removePort(uint32_t deviceId, uint32_t portId, bool isLeft) {
+    qDebug() << "PortPair::removePort" << deviceId << portId << activeDevice;
+    for (const auto& [id, device] : connectedDevices) {
+        qDebug() << "connectedDevices" << id;
+        QDebug dbg = qDebug();
+        for (uint32_t port : device.leftPorts) {
+            dbg << port;
+        }
+
+        dbg = qDebug();
+        for (uint32_t port : device.rightPorts) {
+            dbg << port;
+        }
+    }
+
+    VERIFY_OR_DEBUG_ASSERT(connectedDevices.contains(deviceId)) {
+        return false;
+    }
+
+    ConnectedDevice& device = connectedDevices.at(deviceId);
+
+    if (isLeft) {
+        std::erase(device.leftPorts, portId);
+    } else {
+        std::erase(device.rightPorts, portId);
+    }
+
+    if (device.leftPorts.empty() and device.rightPorts.empty()) {
+        connectedDevices.erase(deviceId);
+        if (activeDevice == deviceId) {
+            if (connectedDevices.empty()) {
+                activeDevice = 0;
+            } else {
+                activeDevice = connectedDevices.cbegin()->first;
+            }
+        }
+        // return connectedDevices.size() <= 1;
+        return true;
+    }
+
+    return false;
+}
+
+ChannelGroup PipewireEnumerator::PortPair::inputChannel(std::span<const uint32_t> ports) {
+    // qDebug() << "inputChannelGroup" << left.devicePort << right.devicePort;
+    for (const auto& [id, device] : connectedDevices) {
+        qDebug() << "outputChannelGroup" << id;
+        QDebug dbg = qDebug();
+        for (uint32_t port : device.leftPorts) {
+            dbg << port;
+        }
+
+        dbg = qDebug();
+        for (uint32_t port : device.rightPorts) {
+            dbg << port;
+        }
+    }
+
+    for (uint32_t port : ports) {
+        fprintf(stderr, "%u ", port);
+    }
+    fprintf(stderr, "\n");
+    if (connectedDevices.size() != 1) {
+        qDebug() << "inputChannel connectedDevices.size() != 1";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    const ConnectedDevice& device = connectedDevices.cbegin()->second;
+
+    if (device.leftPorts.size() != 1 or device.rightPorts.size() != 1) {
+        qDebug() << "inputChannel device.leftPorts.size() != 1 or device.rightPorts.size() != 1";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    uint32_t leftPort = device.leftPorts.back();
+    uint32_t rightPort = device.rightPorts.back();
+
+    const auto leftChannel = std::ranges::find(ports, leftPort);
+    if (leftChannel != ports.end()) {
+        // PipeWire supports channel count > UINT8_MAX, although unlikely,
+        // to prevent errors need to either change this mechanism or ChannelGroup
+        unsigned char channelBase = std::distance(ports.begin(), leftChannel);
+        if (leftPort == rightPort) {
+            qDebug() << "inputChannel leftPort == rightPort";
+            return {channelBase, mixxx::audio::ChannelCount::mono()};
+        } else {
+            const auto rightChannel = leftChannel + 1;
+            if (rightChannel != ports.end() and *rightChannel == rightPort) {
+                qDebug() << "inputChannel rightChannel != ports.end() and "
+                            "*rightChannel == rightPort";
+                return {channelBase, mixxx::audio::ChannelCount::stereo()};
+            }
+        }
+    }
+
+    return {0, mixxx::audio::ChannelCount()};
+}
+
+ChannelGroup PipewireEnumerator::PortPair::outputChannel(std::span<const uint32_t> ports) {
+    // qDebug() << "outputChannelGroup" << left.devicePort << right.devicePort;
+    for (const auto& [id, device] : connectedDevices) {
+        qDebug() << "outputChannel" << id;
+        QDebug dbg = qDebug();
+        for (uint32_t port : device.leftPorts) {
+            dbg << port;
+        }
+
+        dbg = qDebug();
+        for (uint32_t port : device.rightPorts) {
+            dbg << port;
+        }
+    }
+
+    for (uint32_t port : ports) {
+        fprintf(stderr, "%u ", port);
+    }
+    fprintf(stderr, "\n");
+
+    if (connectedDevices.size() != 1) {
+        qDebug() << "outputChannel connectedDevices.size() != 1";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    const ConnectedDevice& device = connectedDevices.cbegin()->second;
+
+    if (device.leftPorts.size() > 1 or device.rightPorts.size() > 1) {
+        qDebug() << "outputChannel " << device.leftPorts.size() << " > 1 or "
+                 << device.rightPorts.size() << " > 1";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    bool hasLeftPort = !device.leftPorts.empty();
+    bool hasRightPort = !device.rightPorts.empty();
+
+    if (!hasLeftPort and !hasRightPort) {
+        qDebug() << "outputChannel !hasLeftPort and !hasRightPort";
+        return {0, mixxx::audio::ChannelCount()};
+    }
+
+    if (!hasLeftPort) {
+        auto it = std::ranges::find(ports, device.rightPorts.back());
+        unsigned char channelBase = std::distance(ports.begin(), it);
+        // hacky way to get if Mixxx right port is connected to device right port
+        if (it != ports.end() and channelBase % 2) {
+            qDebug() << "outputChannel it != ports.end() and" << channelBase % 2;
+            return {channelBase, mixxx::audio::ChannelCount::mono()};
+        }
+    } else if (!hasRightPort) {
+        auto it = std::ranges::find(ports, device.leftPorts.back());
+        unsigned char channelBase = std::distance(ports.begin(), it);
+        // hacky way to get if Mixxx left port is connected to device left port
+        if (it != ports.end() and !(channelBase % 2)) {
+            qDebug() << "outputChannel it != ports.end() and" << channelBase % 2;
+            return {channelBase, mixxx::audio::ChannelCount::mono()};
+        }
+    } else {
+        const auto leftChannel = std::ranges::find(ports, device.leftPorts.back());
+        unsigned char channelBase = std::distance(ports.begin(), leftChannel);
+        if (leftChannel != ports.end() and !(channelBase % 2)) {
+            // PipeWire supports channel count > UINT8_MAX, although unlikely,
+            // to prevent errors need to change this mechanism or ChannelGroup
+            const auto rightChannel = leftChannel + 1;
+            if (rightChannel != ports.end() and *rightChannel == device.rightPorts.back()) {
+                qDebug() << "outputChannel rightChannel != ports.end() and "
+                         << *rightChannel << " == " << device.rightPorts.back()
+                         << "";
+                return {channelBase, mixxx::audio::ChannelCount::stereo()};
+            }
+        }
+    }
+
+    return {0, mixxx::audio::ChannelCount()};
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -167,6 +167,10 @@ void PipewireEnumerator::initialize() {
                     // from preference page (by using external patchbay)
                     PW_KEY_NODE_MAX_LATENCY,
                     "4096/44100",
+                    // this ensures that audio callback runs even when no link is
+                    // connected, so we don't use network clock unless forced
+                    PW_KEY_NODE_ALWAYS_PROCESS,
+                    "true",
                     nullptr));
 
     pw_filter_add_listener(m_pPwFilter, &m_pwFilterListener, &filter_events, this);

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -9,6 +9,7 @@
 #include <QMessageBox>
 #include <QSharedPointer>
 #include <QStringView>
+#include <ranges>
 #include <string>
 
 #include "audio/types.h"
@@ -161,16 +162,21 @@ void PipewireEnumerator::initialize() {
                     "Mixxx",
                     PW_KEY_NODE_NICK,
                     "Mixxx",
+                    // we need to limit the maximum quantum pipewire will give us
+                    // since the callback can run before we configure any quantum
+                    // from preference page (by using external patchbay)
+                    PW_KEY_NODE_MAX_LATENCY,
+                    "4096/44100",
                     nullptr));
 
     pw_filter_add_listener(m_pPwFilter, &m_pwFilterListener, &filter_events, this);
 
     for (auto it = m_inputs.begin(); it != m_inputs.end(); ++it) {
-        it.value() = createInputPorts(it.key());
+        createInputPorts(it->first, it->second);
     }
 
     for (auto it = m_outputs.begin(); it != m_outputs.end(); ++it) {
-        it.value() = createOutputPorts(it.key());
+        createOutputPorts(it->first, it->second);
     }
 
     int res = pw_filter_connect(m_pPwFilter,
@@ -294,6 +300,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         Node& node = m_nodes.at(node_id);
         Port port{};
         port.id = id;
+        port.node = node_id;
         port.channel = channel ? channel : (portName ? portName : std::to_string(id).c_str());
         port.isInput = isInput;
 
@@ -323,28 +330,28 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
             QString name(spa_dict_lookup(pProps, PW_KEY_PORT_NAME));
             QStringList list = name.split(':');
             if (isInput) {
-                QList<AudioInput> keys = m_inputs.keys();
+                auto keys = std::views::keys(m_inputs);
                 auto it = std::ranges::find(keys, list.at(0), &AudioPath::getString);
                 VERIFY_OR_DEBUG_ASSERT(it != keys.end()) {
                     return;
                 }
 
                 if (list.at(1) == "FL") {
-                    *m_inputs.value(*it).first = id;
+                    m_inputs[*it].left.id = id;
                 } else {
-                    *m_inputs.value(*it).second = id;
+                    m_inputs[*it].right.id = id;
                 }
             } else {
-                QList<AudioOutput> keys = m_outputs.keys();
+                auto keys = std::views::keys(m_outputs);
                 auto it = std::ranges::find(keys, list.at(0), &AudioPath::getString);
                 VERIFY_OR_DEBUG_ASSERT(it != keys.end()) {
                     return;
                 }
 
                 if (list.at(1) == "FL") {
-                    *m_outputs.value(*it).first = id;
+                    m_outputs.at(*it).left.id = id;
                 } else {
-                    *m_outputs.value(*it).second = id;
+                    m_outputs.at(*it).right.id = id;
                 }
             }
         }
@@ -362,13 +369,40 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         Port& outputPort = m_ports.at(out_port);
 
         if (in_node == m_filterId) {
-            m_links.insert_or_assign(id, Link(in_port, out_port));
+            m_links.insert_or_assign(id, Link{in_port, out_port});
+
+            const Node& deviceNode = m_nodes.at(out_node);
+            if (!nodeHasPorts(deviceNode)) {
+                m_openedDevices.push_back(out_node);
+            }
             inputPort.links.push_back(id);
             outputPort.links.push_back(id);
+
+            for (auto& [input, ports] : m_inputs) {
+                if (ports.left.id == in_port or ports.right.id == in_port) {
+                    if (!ports.active.load()) {
+                        ports.active.store(true);
+                        m_pSoundManager->configureInput(input);
+                    }
+                }
+            }
         } else if (out_node == m_filterId) {
-            m_links.insert_or_assign(id, Link(in_port, out_port));
+            m_links.insert_or_assign(id, Link{in_port, out_port});
+
+            const Node& deviceNode = m_nodes.at(out_node);
+            if (!nodeHasPorts(deviceNode)) {
+                m_openedDevices.push_back(out_node);
+            }
             inputPort.links.push_back(id);
             outputPort.links.push_back(id);
+            for (auto& [output, ports] : m_outputs) {
+                if (ports.left.id == out_port or ports.right.id == out_port) {
+                    if (!ports.active.load()) {
+                        ports.active.store(true);
+                        m_pSoundManager->configureOutput(output);
+                    }
+                }
+            }
         }
     }
 }
@@ -408,10 +442,62 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
         m_ports.erase(id);
     } else if (m_links.contains(id)) {
         const Link& link = m_links.at(id);
-        Port& input = m_ports.at(link.input);
-        Port& output = m_ports.at(link.output);
-        std::erase(input.links, id);
-        std::erase(output.links, id);
+        Port& inputPort = m_ports.at(link.input);
+        Port& outputPort = m_ports.at(link.output);
+        std::erase(inputPort.links, id);
+        std::erase(outputPort.links, id);
+
+        // check if we can close any PortPair
+        if (inputPort.node == m_filterId) {
+            if (inputPort.links.empty()) {
+                for (auto& [input, ports] : m_inputs) {
+                    if (ports.left.id == link.input) {
+                        const Port& right = m_ports.at(ports.right.id);
+                        if (right.links.empty()) {
+                            ports.active.store(false);
+                            m_pSoundManager->unconfigureInput(input);
+                        }
+                        break;
+                    } else if (ports.right.id == link.input) {
+                        const Port& left = m_ports.at(ports.left.id);
+                        if (left.links.empty()) {
+                            ports.active.store(false);
+                            m_pSoundManager->unconfigureInput(input);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            const Node& deviceNode = m_nodes.at(outputPort.node);
+            if (!nodeHasPorts(deviceNode)) {
+                std::erase(m_openedDevices, outputPort.node);
+            }
+        } else if (outputPort.node == m_filterId) {
+            if (outputPort.links.empty()) {
+                for (auto& [output, ports] : m_outputs) {
+                    if (ports.left.id == link.output) {
+                        const Port& right = m_ports.at(ports.right.id);
+                        if (right.links.empty()) {
+                            ports.active.store(false);
+                            m_pSoundManager->unconfigureOutput(output);
+                        }
+                        break;
+                    } else if (ports.right.id == link.output) {
+                        const Port& left = m_ports.at(ports.left.id);
+                        if (left.links.empty()) {
+                            ports.active.store(false);
+                            m_pSoundManager->unconfigureOutput(output);
+                        }
+                        break;
+                    }
+                }
+            }
+            const Node& deviceNode = m_nodes.at(outputPort.node);
+            if (!nodeHasPorts(deviceNode)) {
+                std::erase(m_openedDevices, outputPort.node);
+            }
+        }
         m_links.erase(id);
     }
 }
@@ -476,7 +562,7 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
     pw_thread_loop_lock(m_pPwThreadLoop);
 
     // device.inputs() corresponds to output ports of device node
-    QList<AudioInput> inKeys = m_inputs.keys();
+    auto inKeys = std::views::keys(m_inputs);
     for (const AudioInputBuffer& input : device.inputs()) {
         auto it = std::ranges::find_if(inKeys, [input](const AudioPath& path) {
             return path.getType() == input.getType() && path.getIndex() == input.getIndex();
@@ -486,26 +572,26 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
             continue;
         }
 
-        std::pair<uint32_t*, uint32_t*> filterPorts = m_inputs.value(*it);
+        const PortPair& filterPorts = m_inputs.at(*it);
         ChannelGroup channelGroup = input.getChannelGroup();
         unsigned char channelBase = channelGroup.getChannelBase();
         unsigned char channelCount = channelGroup.getChannelCount().value();
         std::span<const uint32_t> ports = deviceNode.outputs;
 
         if (channelCount == 1) {
-            result += createLink(deviceId, ports[channelBase], m_filterId, *filterPorts.first);
-            result += createLink(deviceId, ports[channelBase], m_filterId, *filterPorts.second);
+            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.left.id);
+            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.right.id);
         } else {
-            result += createLink(deviceId, ports[channelBase], m_filterId, *filterPorts.first);
+            result += createLink(deviceId, ports[channelBase], m_filterId, filterPorts.left.id);
             result += createLink(deviceId,
                     ports[channelBase + 1],
                     m_filterId,
-                    *filterPorts.second);
+                    filterPorts.right.id);
         }
     }
 
     // device.outputs() corresponds to input ports of device node
-    QList<AudioOutput> outKeys = m_outputs.keys();
+    auto outKeys = std::views::keys(m_outputs);
     for (const AudioOutputBuffer& output : device.outputs()) {
         auto it = std::ranges::find_if(outKeys, [output](const AudioPath& path) {
             return path.getType() == output.getType() && path.getIndex() == output.getIndex();
@@ -515,19 +601,19 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
             continue;
         }
 
-        std::pair<uint32_t*, uint32_t*> filterPorts = m_outputs.value(*it);
+        const PortPair& filterPorts = m_outputs.at(*it);
         ChannelGroup channelGroup = output.getChannelGroup();
         unsigned char channelBase = channelGroup.getChannelBase();
         unsigned char channelCount = channelGroup.getChannelCount().value();
         std::span<const uint32_t> ports = deviceNode.inputs;
 
         if (channelCount == 1) {
-            uint32_t filterPort = channelBase % 2 ? *filterPorts.second : *filterPorts.first;
+            uint32_t filterPort = channelBase % 2 ? filterPorts.right.id : filterPorts.left.id;
             result += createLink(m_filterId, filterPort, deviceId, ports[channelBase]);
         } else {
-            result += createLink(m_filterId, *filterPorts.first, deviceId, ports[channelBase]);
+            result += createLink(m_filterId, filterPorts.left.id, deviceId, ports[channelBase]);
             result += createLink(m_filterId,
-                    *filterPorts.second,
+                    filterPorts.right.id,
                     deviceId,
                     ports[channelBase + 1]);
         }
@@ -551,6 +637,16 @@ void PipewireEnumerator::closeDevice(uint32_t id) {
         return;
     }
 
+    auto pDevice = m_soundDevices.at(*deviceId);
+
+    for (const AudioInputBuffer& input : pDevice->inputs()) {
+        m_inputs.at(input).active.store(false);
+    }
+
+    for (const AudioOutputBuffer& output : pDevice->outputs()) {
+        m_outputs.at(output).active.store(false);
+    }
+
     const Node& node = m_nodes.at(*deviceId);
 
     for (uint32_t portId : node.inputs) {
@@ -572,7 +668,7 @@ void PipewireEnumerator::closeDevice(uint32_t id) {
 
 void PipewireEnumerator::callback(const spa_io_position* pos) {
     // This must be the very first call, else timeInfo becomes invalid
-    m_clkRefTimer.restart().toDoubleSeconds();
+    m_clkRefTimer.restart();
     VisualPlayPosition::setCallbackEntryToDacSecs(
             pos->clock.delay / pos->clock.rate.denom, m_clkRefTimer);
 
@@ -600,64 +696,68 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
     qDebug() << "PipewireEnumerator::callback" << sampleRate << framesPerBuffer;
     m_pSoundManager->processUnderflowHappened(framesPerBuffer);
 
-    for (uint32_t deviceId : m_openedDevices) {
-        QSharedPointer<SoundDevicePipewire> device = m_soundDevices.at(deviceId);
-        QList<AudioInputBuffer> deviceInputs = device->inputs();
-        for (const AudioInputBuffer& input : deviceInputs) {
-            CSAMPLE* pInputBuffer = input.getBuffer();
+    for (const auto& [input, ports] : m_inputs) {
+        if (!ports.active.load()) {
+            continue;
+        }
+        CSAMPLE* pInputBuffer = m_pSoundManager->getInputBuffer(input);
+        VERIFY_OR_DEBUG_ASSERT(pInputBuffer) {
+            return;
+        }
 
-            std::pair<uint32_t*, uint32_t*> ports = m_inputs.value(input);
+        const float* bufferFL = static_cast<const float*>(
+                pw_filter_get_dsp_buffer(ports.left.data, framesPerBuffer));
 
-            const float* bufferFL = static_cast<const float*>(
-                    pw_filter_get_dsp_buffer(ports.first, framesPerBuffer));
-            if (bufferFL) {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    pInputBuffer[i * 2] = bufferFL[i];
-                }
-            } else {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    pInputBuffer[i * 2] = 0;
-                }
+        if (bufferFL) {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                pInputBuffer[i * 2] = bufferFL[i];
             }
-
-            const float* bufferFR = static_cast<const float*>(
-                    pw_filter_get_dsp_buffer(ports.second, framesPerBuffer));
-            if (bufferFR) {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    pInputBuffer[i * 2 + 1] = bufferFR[i];
-                }
-            } else {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    pInputBuffer[i * 2 + 1] = 0;
-                }
+        } else {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                pInputBuffer[i * 2] = 0;
             }
         }
-        m_pSoundManager->pushInputBuffers(deviceInputs, framesPerBuffer);
+
+        const float* bufferFR = static_cast<const float*>(
+                pw_filter_get_dsp_buffer(ports.right.data, framesPerBuffer));
+        if (bufferFR) {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                pInputBuffer[i * 2 + 1] = bufferFR[i];
+            }
+        } else {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                pInputBuffer[i * 2 + 1] = 0;
+            }
+        }
+        m_pSoundManager->pushInputBuffer(input, framesPerBuffer);
     }
 
     m_pSoundManager->onDeviceOutputCallback(framesPerBuffer);
 
-    for (uint32_t deviceId : m_openedDevices) {
-        QSharedPointer<SoundDevicePipewire> device = m_soundDevices.at(deviceId);
-        for (const AudioOutputBuffer& output : device->outputs()) {
-            const CSAMPLE* pOutputBuffer = output.getBuffer();
+    for (const auto& [output, ports] : m_outputs) {
+        if (!ports.active.load()) {
+            continue;
+        }
 
-            std::pair<uint32_t*, uint32_t*> ports = m_outputs.value(output);
+        const CSAMPLE* pOutputBuffer = m_pSoundManager->getOutputBuffer(output);
 
-            float* bufferFL = static_cast<float*>(
-                    pw_filter_get_dsp_buffer(ports.first, framesPerBuffer));
-            if (bufferFL) {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    bufferFL[i] = pOutputBuffer[i * 2];
-                }
+        VERIFY_OR_DEBUG_ASSERT(pOutputBuffer) {
+            return;
+        }
+
+        float* bufferFL = static_cast<float*>(
+                pw_filter_get_dsp_buffer(ports.left.data, framesPerBuffer));
+        if (bufferFL) {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                bufferFL[i] = pOutputBuffer[i * 2];
             }
+        }
 
-            float* bufferFR = static_cast<float*>(
-                    pw_filter_get_dsp_buffer(ports.second, framesPerBuffer));
-            if (bufferFR) {
-                for (uint64_t i = 0; i < framesPerBuffer; i++) {
-                    bufferFR[i] = pOutputBuffer[i * 2 + 1];
-                }
+        float* bufferFR = static_cast<float*>(
+                pw_filter_get_dsp_buffer(ports.right.data, framesPerBuffer));
+        if (bufferFR) {
+            for (uint64_t i = 0; i < framesPerBuffer; i++) {
+                bufferFR[i] = pOutputBuffer[i * 2 + 1];
             }
         }
     }
@@ -725,17 +825,16 @@ std::string PipewireEnumerator::createLink(uint32_t outNodeId,
 }
 
 void PipewireEnumerator::registerInput(const AudioInput& input, AudioDestination*) {
-    if (m_inputs.contains(input) or input.isHidden()) {
-        // duplicate VinylControl signal
+    if (input.isHidden()) {
         return;
     }
 
-    if (m_initialized) {
+    auto [it, isInserted] = m_inputs.try_emplace(input);
+
+    if (m_initialized and isInserted) {
         pw_thread_loop_lock(m_pPwThreadLoop);
-        m_inputs.insert(input, createInputPorts(input));
+        createInputPorts(input, it->second);
         pw_thread_loop_unlock(m_pPwThreadLoop);
-    } else {
-        m_inputs.insert(input, {});
     }
 }
 
@@ -744,18 +843,17 @@ void PipewireEnumerator::registerOutput(const AudioOutput& output, AudioSource*)
         return;
     }
 
-    if (m_initialized) {
+    auto [it, isInserted] = m_outputs.try_emplace(output);
+    if (m_initialized and isInserted) {
         pw_thread_loop_lock(m_pPwThreadLoop);
-        m_outputs.insert(output, createOutputPorts(output));
+        createOutputPorts(output, it->second);
         pw_thread_loop_unlock(m_pPwThreadLoop);
-    } else {
-        m_outputs.insert(output, {});
     }
 }
 
 // need to pw_thread_loop_lock before calling this
-std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createPorts(
-        std::string_view name, spa_direction direction) {
+void PipewireEnumerator::createPorts(
+        PortPair& ports, std::string_view name, spa_direction direction) {
     pw_properties* props = pw_properties_new(
             // see pipewire/keys.h header
             PW_KEY_FORMAT_DSP,
@@ -767,10 +865,10 @@ std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createPorts(
     // PipewireEnumerator::registryEventGlobal
     pw_properties_setf(props, PW_KEY_PORT_NAME, "%s:FL", name.data());
 
-    void* leftPort = pw_filter_add_port(m_pPwFilter,
+    ports.left.data = pw_filter_add_port(m_pPwFilter,
             direction,
             PW_FILTER_PORT_FLAG_MAP_BUFFERS,
-            sizeof(uint32_t),
+            0,
             props,
             nullptr,
             0);
@@ -786,26 +884,25 @@ std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createPorts(
     // PipewireEnumerator::registryEventGlobal
     pw_properties_setf(props, PW_KEY_PORT_NAME, "%s:FR", name.data());
 
-    void* rightPort = pw_filter_add_port(m_pPwFilter,
+    ports.right.data = pw_filter_add_port(m_pPwFilter,
             direction,
             PW_FILTER_PORT_FLAG_MAP_BUFFERS,
-            sizeof(uint32_t),
+            0,
             props,
             nullptr,
             0);
-    return std::pair{static_cast<uint32_t*>(leftPort), static_cast<uint32_t*>(rightPort)};
 }
 
 // need to pw_thread_loop_lock before calling this
-std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createInputPorts(const AudioInput& input) {
+void PipewireEnumerator::createInputPorts(const AudioInput& input, PortPair& ports) {
     std::string inputName = input.getString().toStdString();
-    return createPorts(inputName, SPA_DIRECTION_INPUT);
+    createPorts(ports, inputName, SPA_DIRECTION_INPUT);
 }
 
 // need to pw_thread_loop_lock before calling this
-std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createOutputPorts(const AudioOutput& output) {
+void PipewireEnumerator::createOutputPorts(const AudioOutput& output, PortPair& ports) {
     std::string outputName = output.getString().toStdString();
-    return createPorts(outputName, SPA_DIRECTION_OUTPUT);
+    createPorts(ports, outputName, SPA_DIRECTION_OUTPUT);
 }
 
 void PipewireEnumerator::updateFilterLatency(
@@ -888,4 +985,20 @@ QString PipewireEnumerator::getChannelString(
         }
     }
     return QString::fromStdString(channelString);
+}
+
+bool PipewireEnumerator::nodeHasPorts(const Node& node) {
+    for (uint32_t portId : node.inputs) {
+        if (!m_ports.at(portId).links.empty()) {
+            return true;
+        }
+    }
+
+    for (uint32_t portId : node.outputs) {
+        if (!m_ports.at(portId).links.empty()) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -76,8 +76,7 @@ static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
 }
 } // namespace
 
-PipewireEnumerator::PipewireEnumerator(
-        UserSettingsPointer pConfig, SoundManager* pManager)
+PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManager)
         : m_pSoundManager(pManager),
           m_pPwThreadLoop(nullptr),
           m_pPwContext(nullptr),
@@ -87,12 +86,8 @@ PipewireEnumerator::PipewireEnumerator(
           m_pPwFilter(nullptr),
           m_sampleRate(48000),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
-          m_COmanageExternalLinks(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
-          m_framesPerBuffer(0),
-          m_manageExternalLinks(pConfig->getValue(
-                  ConfigKey(
-                          kAppGroup, QStringLiteral("pipewire_patchbay_sync")),
-                  false)) {
+          m_coPipewirePatchbaySync(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
+          m_framesPerBuffer(0) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -104,11 +99,6 @@ PipewireEnumerator::PipewireEnumerator(
 
     connect(this, &PipewireEnumerator::deviceAdded, m_pSoundManager, &SoundManager::addDevice);
     connect(this, &PipewireEnumerator::deviceRemoved, m_pSoundManager, &SoundManager::removeDevice);
-    connect(&m_COmanageExternalLinks, &ControlObject::valueChanged, this, [this](double value) {
-        pw_thread_loop_lock(m_pPwThreadLoop);
-        m_manageExternalLinks = static_cast<bool>(value);
-        pw_thread_loop_unlock(m_pPwThreadLoop);
-    });
 
     pw_init(nullptr, nullptr);
 
@@ -425,7 +415,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
             }
         }
 
-        if (!m_manageExternalLinks) {
+        if (!static_cast<bool>(m_coPipewirePatchbaySync.get())) {
             QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::invalidateConfig);
         }
     }
@@ -514,7 +504,7 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
             }
         }
 
-        if (!m_manageExternalLinks) {
+        if (!static_cast<bool>(m_coPipewirePatchbaySync.get())) {
             QMetaObject::invokeMethod(m_pSoundManager, &SoundManager::invalidateConfig);
         }
 
@@ -580,8 +570,7 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
         return "PipewireEnumerator uninitialized";
     }
 
-    qDebug() << "PipewireEnumerator::openDeviceInput" << m_manageExternalLinks;
-    if (m_manageExternalLinks) {
+    if (static_cast<bool>(m_coPipewirePatchbaySync.get())) {
         return {};
     }
 
@@ -629,8 +618,7 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId,
         return "PipewireEnumerator uninitialized";
     }
 
-    qDebug() << "PipewireEnumerator::openDeviceInput" << m_manageExternalLinks;
-    if (m_manageExternalLinks) {
+    if (static_cast<bool>(m_coPipewirePatchbaySync.get())) {
         return {};
     }
 

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -410,11 +410,11 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
                         const SoundDeviceId& deviceId =
                                 m_soundDevices.at(ports.activeDevice)
                                         ->getDeviceId();
-                        m_pSoundManager->updatePathDevice(input, deviceId);
+                        m_pSoundManager->updatePathDevice(input, deviceId, true);
                     }
                     const Node& deviceNode = m_nodes.at(ports.activeDevice);
                     m_pSoundManager->updatePathChannel(
-                            input, ports.inputChannel(deviceNode.outputs));
+                            input, ports.inputChannel(deviceNode.outputs), true);
                 }
 
                 break;
@@ -443,11 +443,11 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
                         const SoundDeviceId& deviceId =
                                 m_soundDevices.at(ports.activeDevice)
                                         ->getDeviceId();
-                        m_pSoundManager->updatePathDevice(output, deviceId);
+                        m_pSoundManager->updatePathDevice(output, deviceId, false);
                     }
                     const Node& deviceNode = m_nodes.at(ports.activeDevice);
                     m_pSoundManager->updatePathChannel(
-                            output, ports.outputChannel(deviceNode.inputs));
+                            output, ports.outputChannel(deviceNode.inputs), false);
                 }
                 break;
             }
@@ -506,20 +506,22 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
 
                 if (m_manageExternalLinks and deviceChanged) {
                     if (ports.connectedDevices.empty()) {
-                        m_pSoundManager->updatePathDevice(input, SoundDeviceId{});
+                        m_pSoundManager->updatePathDevice(input, SoundDeviceId{}, true);
                         ports.active.store(false);
                         m_pSoundManager->unconfigureInput(input);
                     } else {
                         m_pSoundManager->updatePathDevice(input,
                                 m_soundDevices.at(ports.activeDevice)
-                                        ->getDeviceId());
+                                        ->getDeviceId(),
+                                true);
                     }
                 }
 
                 if (m_manageExternalLinks and ports.activeDevice) {
                     const Node& activeDeviceNode = m_nodes.at(ports.activeDevice);
                     m_pSoundManager->updatePathChannel(input,
-                            ports.inputChannel(activeDeviceNode.outputs));
+                            ports.inputChannel(activeDeviceNode.outputs),
+                            true);
                 }
                 break;
             }
@@ -538,19 +540,21 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
 
                 if (m_manageExternalLinks and deviceChanged) {
                     if (ports.connectedDevices.empty()) {
-                        m_pSoundManager->updatePathDevice(output, SoundDeviceId{});
+                        m_pSoundManager->updatePathDevice(output, SoundDeviceId{}, false);
                         ports.active.store(false);
                         m_pSoundManager->unconfigureOutput(output);
                     } else {
                         m_pSoundManager->updatePathDevice(output,
                                 m_soundDevices.at(ports.activeDevice)
-                                        ->getDeviceId());
+                                        ->getDeviceId(),
+                                false);
                     }
                 }
                 if (m_manageExternalLinks and ports.activeDevice) {
                     m_pSoundManager->updatePathChannel(output,
                             ports.outputChannel(
-                                    m_nodes.at(ports.activeDevice).inputs));
+                                    m_nodes.at(ports.activeDevice).inputs),
+                            false);
                 }
                 break;
             }

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -158,9 +158,10 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     };
 
     struct Node {};
-    using Object = std::variant<Node, Port, Link>;
 
-    std::unordered_map<uint32_t, Object> m_objects;
+    std::unordered_map<uint32_t, Node> m_nodes;
+    std::unordered_map<uint32_t, Port> m_ports;
+    std::unordered_map<uint32_t, Link> m_links;
     QList<mixxx::audio::SampleRate> m_samplerates;
 
     SoundManager* m_pSoundManager;

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -54,6 +54,9 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     }
 
     QString getChannelString(uint32_t id, ChannelGroup channelGroup, bool input) const;
+    static void patchbayWaitTimer(void* data, [[maybe_unused]] uint64_t expirations) {
+        static_cast<PipewireEnumerator*>(data)->patchbayWaitTimer();
+    }
 
   signals:
     void deviceAdded(SoundDevicePointer pDevice);
@@ -64,6 +67,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void registerOutput(const AudioOutput& output, AudioSource* src);
 
   private:
+    void patchbayWaitTimer();
     struct Link {
         uint32_t input;
         uint32_t output;
@@ -233,6 +237,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     void updateFilterLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
     bool nodeHasPorts(const Node& node);
+    bool portsEmpty();
 
     std::unordered_map<uint32_t, Node> m_nodes;
     std::unordered_map<uint32_t, Port> m_ports;
@@ -278,4 +283,5 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     // the ones made with external patchbay
     bool m_manageExternalLinks;
     int m_coreSyncSeq;
+    spa_source* m_patchbayWaitTimer;
 };

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -5,14 +5,17 @@
 #include <spa/utils/defs.h>
 
 #include <QObject>
+#include <cstdint>
 
 #include "audio/types.h"
+#include "control/controlobject.h"
 #include "preferences/usersettings.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddeviceenumerator.h"
 #include "soundio/sounddevicepipewire.h"
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerconfig.h"
+#include "soundio/soundmanagerutil.h"
 
 class PipewireEnumerator : public SoundDeviceEnumerator {
     Q_OBJECT
@@ -32,7 +35,12 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void deinitialize() override;
 
     bool isOpen(uint32_t id);
-    std::string openDevice(const SoundDevicePipewire& device,
+    std::string openDeviceInput(uint32_t id,
+            const AudioInput& input,
+            mixxx::audio::SampleRate sampleRate,
+            SINT framesPerBuffer);
+    std::string openDeviceOutput(uint32_t id,
+            const AudioOutput& output,
             mixxx::audio::SampleRate sampleRate,
             SINT framesPerBuffer);
     void closeDevice(uint32_t id);
@@ -56,17 +64,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void registerOutput(const AudioOutput& output, AudioSource* src);
 
   private:
-    struct PortPair {
-        struct Port {
-            void* data;
-            uint32_t id;
-        };
-
-        Port left;
-        Port right;
-        std::atomic<bool> active = false;
-    };
-
     struct Link {
         uint32_t input;
         uint32_t output;
@@ -81,7 +78,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
             return name + channel;
         }
 
-        uint32_t id;
         // this is port.name after stripping out channel and delimiter,
         // and appending a ':' to simplify logic
         std::string name;
@@ -93,6 +89,45 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     struct Node {
         std::vector<uint32_t> inputs;
         std::vector<uint32_t> outputs;
+    };
+
+    struct PortPair {
+        struct Port {
+            void* data;
+            uint32_t id;
+        };
+
+        struct ConnectedDevice {
+            std::vector<uint32_t> leftPorts;
+            std::vector<uint32_t> rightPorts;
+        };
+
+        // Registry for all connections to a PortPair, including devices which
+        // are not shown on Preference page, but might become "visible" after
+        // the visible device is removed
+        std::unordered_map<uint32_t, ConnectedDevice> connectedDevices;
+        // the visible device of the registry, what is shown on deviceComboBox
+        uint32_t activeDevice = 0;
+
+        Port left;
+        Port right;
+        std::atomic<bool> active = false;
+
+        // add/remove port and return if visible device might have changed
+        bool addPort(uint32_t deviceId, uint32_t portId, bool isLeft);
+        bool removePort(uint32_t deviceId, uint32_t portId, bool isLeft);
+
+        // Compute if current connections have a presentable device/channel representation
+        // Blank channelComboBox represents non presentable config (non contiguous connections
+        // or multiple devices).
+
+        // These are separate functions because we consider different conditions
+        // for mono connections. For inputs, mono connection is one device output
+        // port connected to both left and right input ports, while for outputs,
+        // mono connection is one L/R output port connected to same L/R input
+        // device port
+        ChannelGroup inputChannel(std::span<const uint32_t> ports);
+        ChannelGroup outputChannel(std::span<const uint32_t> ports);
     };
 
     static void coreEventError(void* data, uint32_t id, int seq, int res, const char* message) {
@@ -189,6 +224,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void createInputPorts(const AudioInput& path, PortPair& ports);
     void createOutputPorts(const AudioOutput& path, PortPair& ports);
     void createPorts(PortPair& ports, std::string_view name, spa_direction direction);
+    void closePorts(PortPair& ports, bool isInput);
 
     void updateFilterLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
     bool nodeHasPorts(const Node& node);
@@ -213,7 +249,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     spa_hook m_pwMetadataListener;
 
     std::unordered_map<uint32_t, QSharedPointer<SoundDevicePipewire>> m_soundDevices;
-    std::vector<uint32_t> m_openedDevices;
 
     uint64_t xrun_duration;
     int m_invalidTimeInfoCount;
@@ -226,9 +261,15 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     std::unordered_map<AudioOutput, PortPair> m_outputs;
 
     PollingControlProxy m_audioLatencyUsage;
+    ControlObject m_COmanageExternalLinks;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     uint32_t m_filterId;
     uint32_t m_framesPerBuffer;
+    // Handle all connections made to/from Mixxx node
+    // If we do not, then we only track connections made in the
+    // preference page, and leave the external patchbay connections
+    // If we do, then all connections to Mixxx will be affected, even
+    // the ones made with external patchbay
     bool m_manageExternalLinks;
 };

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -43,7 +43,8 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
             const AudioOutput& output,
             mixxx::audio::SampleRate sampleRate,
             SINT framesPerBuffer);
-    void closeDevice(uint32_t id);
+    void closeDeviceInput(uint32_t id, const AudioInput& input);
+    void closeDeviceOutput(uint32_t id, const AudioOutput& output);
 
     mixxx::audio::SampleRate getDefaultSampleRate() const {
         return m_defaultSampleRate;
@@ -54,9 +55,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     }
 
     QString getChannelString(uint32_t id, ChannelGroup channelGroup, bool input) const;
-    static void patchbayWaitTimer(void* data, [[maybe_unused]] uint64_t expirations) {
-        static_cast<PipewireEnumerator*>(data)->patchbayWaitTimer();
-    }
 
   signals:
     void deviceAdded(SoundDevicePointer pDevice);
@@ -67,7 +65,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void registerOutput(const AudioOutput& output, AudioSource* src);
 
   private:
-    void patchbayWaitTimer();
     struct Link {
         uint32_t input;
         uint32_t output;
@@ -101,37 +98,10 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
             uint32_t id;
         };
 
-        struct ConnectedDevice {
-            std::vector<uint32_t> leftPorts;
-            std::vector<uint32_t> rightPorts;
-        };
-
-        // Registry for all connections to a PortPair, including devices which
-        // are not shown on Preference page, but might become "visible" after
-        // the visible device is removed
-        std::unordered_map<uint32_t, ConnectedDevice> connectedDevices;
-        // the visible device of the registry, what is shown on deviceComboBox
-        uint32_t activeDevice = 0;
-
         Port left;
         Port right;
+        uint32_t activeDevice = 0;
         std::atomic<bool> active = false;
-
-        // add/remove port and return if visible device might have changed
-        bool addPort(uint32_t deviceId, uint32_t portId, bool isLeft);
-        bool removePort(uint32_t deviceId, uint32_t portId, bool isLeft);
-
-        // Compute if current connections have a presentable device/channel representation
-        // Blank channelComboBox represents non presentable config (non contiguous connections
-        // or multiple devices).
-
-        // These are separate functions because we consider different conditions
-        // for mono connections. For inputs, mono connection is one device output
-        // port connected to both left and right input ports, while for outputs,
-        // mono connection is one L/R output port connected to same L/R input
-        // device port
-        ChannelGroup inputChannel(std::span<const uint32_t> ports);
-        ChannelGroup outputChannel(std::span<const uint32_t> ports);
     };
 
     static void coreEventDone(void* data, uint32_t id, int seq) {
@@ -233,11 +203,10 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void createInputPorts(const AudioInput& path, PortPair& ports);
     void createOutputPorts(const AudioOutput& path, PortPair& ports);
     void createPorts(PortPair& ports, std::string_view name, spa_direction direction);
-    void closePorts(PortPair& ports, bool isInput);
+    void closePorts(PortPair& ports);
 
     void updateFilterLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
     bool nodeHasPorts(const Node& node);
-    bool portsEmpty();
 
     std::unordered_map<uint32_t, Node> m_nodes;
     std::unordered_map<uint32_t, Port> m_ports;
@@ -283,5 +252,4 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     // the ones made with external patchbay
     bool m_manageExternalLinks;
     int m_coreSyncSeq;
-    spa_source* m_patchbayWaitTimer;
 };

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -150,6 +150,8 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     std::pair<uint32_t*, uint32_t*> createOutputPorts(const AudioOutput& path);
     std::pair<uint32_t*, uint32_t*> createPorts(std::string_view name, spa_direction direction);
 
+    void updateFilterLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
+
     struct Link {
         uint32_t input;
         uint32_t output;

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -239,7 +239,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     std::unordered_map<AudioOutput, PortPair> m_outputs;
 
     PollingControlProxy m_audioLatencyUsage;
-    ControlObject m_COmanageExternalLinks;
+    ControlObject m_coPipewirePatchbaySync;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     uint32_t m_filterId;
@@ -249,6 +249,5 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     // preference page, and leave the external patchbay connections
     // If we do, then all connections to Mixxx will be affected, even
     // the ones made with external patchbay
-    bool m_manageExternalLinks;
     int m_coreSyncSeq;
 };

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -43,8 +43,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
             const AudioOutput& output,
             mixxx::audio::SampleRate sampleRate,
             SINT framesPerBuffer);
-    void closeDeviceInput(uint32_t id, const AudioInput& input);
-    void closeDeviceOutput(uint32_t id, const AudioOutput& output);
+    void closeDevices();
 
     mixxx::audio::SampleRate getDefaultSampleRate() const {
         return m_defaultSampleRate;

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -9,6 +9,7 @@
 
 #include "audio/types.h"
 #include "control/controlobject.h"
+#include "control/controlproxy.h"
 #include "preferences/usersettings.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddeviceenumerator.h"
@@ -35,15 +36,11 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void deinitialize() override;
 
     bool isOpen(uint32_t id);
-    std::string openDeviceInput(uint32_t id,
-            const AudioInput& input,
-            mixxx::audio::SampleRate sampleRate,
-            SINT framesPerBuffer);
-    std::string openDeviceOutput(uint32_t id,
-            const AudioOutput& output,
-            mixxx::audio::SampleRate sampleRate,
-            SINT framesPerBuffer);
+    std::string openDeviceInput(uint32_t id, const AudioInput& input);
+    std::string openDeviceOutput(uint32_t id, const AudioOutput& output);
     void closeDevices();
+
+    void setLatencyParams(mixxx::audio::SampleRate sampleRate, SINT framesPerBuffer) override;
 
     mixxx::audio::SampleRate getDefaultSampleRate() const {
         return m_defaultSampleRate;
@@ -240,6 +237,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     PollingControlProxy m_audioLatencyUsage;
     ControlObject m_coPipewirePatchbaySync;
+    ControlProxy m_coOutputLatencyMs;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     uint32_t m_filterId;

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -130,6 +130,10 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
         ChannelGroup outputChannel(std::span<const uint32_t> ports);
     };
 
+    static void coreEventDone(void* data, uint32_t id, int seq) {
+        static_cast<PipewireEnumerator*>(data)->coreEventDone(id, seq);
+    }
+
     static void coreEventError(void* data, uint32_t id, int seq, int res, const char* message) {
         static_cast<PipewireEnumerator*>(data)->coreEventError(id, seq, res, message);
     }
@@ -137,7 +141,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     static constexpr pw_core_events coreEvents = {
             .version = PW_VERSION_CORE_EVENTS,
             .info = nullptr,
-            .done = nullptr,
+            .done = coreEventDone,
             .ping = nullptr,
             .error = coreEventError,
             .remove_id = nullptr,
@@ -149,6 +153,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 #endif
     };
 
+    void coreEventDone(uint32_t id, int seq);
     void coreEventError(uint32_t id, int seq, int res, const char* message);
 
     static void registryEventGlobalOuter(void* data,
@@ -272,4 +277,5 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     // If we do, then all connections to Mixxx will be affected, even
     // the ones made with external patchbay
     bool m_manageExternalLinks;
+    int m_coreSyncSeq;
 };

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -45,6 +45,8 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
         return {SoundManagerConfig::kAPIPipewire};
     }
 
+    QString getChannelString(uint32_t id, ChannelGroup channelGroup, bool input) const;
+
   signals:
     void deviceAdded(SoundDevicePointer pDevice);
     void deviceRemoved(SoundDevicePointer pDevice);
@@ -155,9 +157,26 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     struct Port {
         uint32_t node;
+        bool isInput;
+        std::vector<uint32_t> links;
+
+        std::string getDisplayName() const {
+            return name + channel;
+        }
+
+        uint32_t id;
+        // this is port.name after stripping out channel and delimiter,
+        // and appending a ':' to simplify logic
+        std::string name;
+        // in case port had no recognizable channel, entire name is put
+        // here so SoundDevicePipewire::getChannelString logic works fine
+        std::string channel;
     };
 
-    struct Node {};
+    struct Node {
+        std::vector<uint32_t> inputs;
+        std::vector<uint32_t> outputs;
+    };
 
     std::unordered_map<uint32_t, Node> m_nodes;
     std::unordered_map<uint32_t, Port> m_ports;

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -56,6 +56,45 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void registerOutput(const AudioOutput& output, AudioSource* src);
 
   private:
+    struct PortPair {
+        struct Port {
+            void* data;
+            uint32_t id;
+        };
+
+        Port left;
+        Port right;
+        std::atomic<bool> active = false;
+    };
+
+    struct Link {
+        uint32_t input;
+        uint32_t output;
+    };
+
+    struct Port {
+        uint32_t node;
+        bool isInput;
+        std::vector<uint32_t> links;
+
+        std::string getDisplayName() const {
+            return name + channel;
+        }
+
+        uint32_t id;
+        // this is port.name after stripping out channel and delimiter,
+        // and appending a ':' to simplify logic
+        std::string name;
+        // in case port had no recognizable channel, entire name is put
+        // here so SoundDevicePipewire::getChannelString logic works fine
+        std::string channel;
+    };
+
+    struct Node {
+        std::vector<uint32_t> inputs;
+        std::vector<uint32_t> outputs;
+    };
+
     static void coreEventError(void* data, uint32_t id, int seq, int res, const char* message) {
         static_cast<PipewireEnumerator*>(data)->coreEventError(id, seq, res, message);
     }
@@ -146,39 +185,13 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     void updateAudioLatencyUsage(const SINT framesPerBuffer);
     void setLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
-    std::pair<uint32_t*, uint32_t*> createInputPorts(const AudioInput& path);
-    std::pair<uint32_t*, uint32_t*> createOutputPorts(const AudioOutput& path);
-    std::pair<uint32_t*, uint32_t*> createPorts(std::string_view name, spa_direction direction);
+
+    void createInputPorts(const AudioInput& path, PortPair& ports);
+    void createOutputPorts(const AudioOutput& path, PortPair& ports);
+    void createPorts(PortPair& ports, std::string_view name, spa_direction direction);
 
     void updateFilterLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
-
-    struct Link {
-        uint32_t input;
-        uint32_t output;
-    };
-
-    struct Port {
-        uint32_t node;
-        bool isInput;
-        std::vector<uint32_t> links;
-
-        std::string getDisplayName() const {
-            return name + channel;
-        }
-
-        uint32_t id;
-        // this is port.name after stripping out channel and delimiter,
-        // and appending a ':' to simplify logic
-        std::string name;
-        // in case port had no recognizable channel, entire name is put
-        // here so SoundDevicePipewire::getChannelString logic works fine
-        std::string channel;
-    };
-
-    struct Node {
-        std::vector<uint32_t> inputs;
-        std::vector<uint32_t> outputs;
-    };
+    bool nodeHasPorts(const Node& node);
 
     std::unordered_map<uint32_t, Node> m_nodes;
     std::unordered_map<uint32_t, Port> m_ports;
@@ -209,12 +222,13 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     mixxx::audio::SampleRate m_sampleRate;
     mixxx::audio::SampleRate m_defaultSampleRate;
 
-    QHash<AudioInput, std::pair<uint32_t*, uint32_t*>> m_inputs;
-    QHash<AudioOutput, std::pair<uint32_t*, uint32_t*>> m_outputs;
+    std::unordered_map<AudioInput, PortPair> m_inputs;
+    std::unordered_map<AudioOutput, PortPair> m_outputs;
 
     PollingControlProxy m_audioLatencyUsage;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     uint32_t m_filterId;
     uint32_t m_framesPerBuffer;
+    bool m_manageExternalLinks;
 };

--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -225,7 +225,7 @@ void SoundDevice::clearInputBuffer(const SINT framesToPush,
     }
 }
 
-QString SoundDevice::getChannelString(ChannelGroup channelGroup, bool) {
+QString SoundDevice::getChannelString(ChannelGroup channelGroup, bool) const {
     mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
     unsigned char channelBase = channelGroup.getChannelBase();
     if (count == 1) {

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -38,7 +38,7 @@ class SoundDevice {
     virtual void writeProcess(SINT framesPerBuffer) = 0;
     virtual QString getError() const = 0;
     virtual mixxx::audio::SampleRate getDefaultSampleRate() const = 0;
-    virtual QString getChannelString(ChannelGroup channelGroup, bool input);
+    virtual QString getChannelString(ChannelGroup channelGroup, bool input) const;
     mixxx::audio::ChannelCount getNumOutputChannels() const;
     mixxx::audio::ChannelCount getNumInputChannels() const;
     SoundDeviceStatus addOutput(const AudioOutputBuffer& out);

--- a/src/soundio/sounddeviceenumerator.h
+++ b/src/soundio/sounddeviceenumerator.h
@@ -15,6 +15,9 @@ class SoundDeviceEnumerator : public QObject {
     virtual QList<QString> getAPIs() const = 0;
     virtual void initialize() = 0;
     virtual void deinitialize() = 0;
+    virtual void setLatencyParams(
+            [[maybe_unused]] mixxx::audio::SampleRate sampleRate,
+            [[maybe_unused]] SINT framesPerBuffer) {};
 
     bool initialized() const {
         return m_initialized;

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -64,7 +64,13 @@ bool SoundDevicePipewire::isOpen() const {
 }
 
 SoundDeviceStatus SoundDevicePipewire::close() {
-    m_pEnumerator->closeDevice(m_deviceId.deviceIndex);
+    for (auto& input : m_audioInputs) {
+        m_pEnumerator->closeDeviceInput(m_deviceId.deviceIndex, input);
+    }
+
+    for (auto& output : m_audioOutputs) {
+        m_pEnumerator->closeDeviceOutput(m_deviceId.deviceIndex, output);
+    }
     return SoundDeviceStatus::Ok;
 }
 

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -36,12 +36,27 @@ SoundDevicePipewire::~SoundDevicePipewire() {
 }
 
 SoundDeviceStatus SoundDevicePipewire::open(bool, int) {
-    m_error = m_pEnumerator->openDevice(*this, m_sampleRate, m_configFramesPerBuffer);
-    if (m_error.empty()) {
-        return SoundDeviceStatus::Ok;
-    } else {
-        return SoundDeviceStatus::Error;
+    std::string error;
+    for (auto& input : m_audioInputs) {
+        error += m_pEnumerator->openDeviceInput(m_deviceId.deviceIndex,
+                input,
+                m_sampleRate,
+                m_configFramesPerBuffer);
     }
+
+    for (auto& output : m_audioOutputs) {
+        error += m_pEnumerator->openDeviceOutput(m_deviceId.deviceIndex,
+                output,
+                m_sampleRate,
+                m_configFramesPerBuffer);
+    }
+
+    if (error.empty()) {
+        return SoundDeviceStatus::Ok;
+    }
+
+    m_error = error;
+    return SoundDeviceStatus::Error;
 }
 
 bool SoundDevicePipewire::isOpen() const {

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -38,17 +38,11 @@ SoundDevicePipewire::~SoundDevicePipewire() {
 SoundDeviceStatus SoundDevicePipewire::open(bool, int) {
     std::string error;
     for (auto& input : m_audioInputs) {
-        error += m_pEnumerator->openDeviceInput(m_deviceId.deviceIndex,
-                input,
-                m_sampleRate,
-                m_configFramesPerBuffer);
+        error += m_pEnumerator->openDeviceInput(m_deviceId.deviceIndex, input);
     }
 
     for (auto& output : m_audioOutputs) {
-        error += m_pEnumerator->openDeviceOutput(m_deviceId.deviceIndex,
-                output,
-                m_sampleRate,
-                m_configFramesPerBuffer);
+        error += m_pEnumerator->openDeviceOutput(m_deviceId.deviceIndex, output);
     }
 
     if (error.empty()) {

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -64,13 +64,7 @@ bool SoundDevicePipewire::isOpen() const {
 }
 
 SoundDeviceStatus SoundDevicePipewire::close() {
-    for (auto& input : m_audioInputs) {
-        m_pEnumerator->closeDeviceInput(m_deviceId.deviceIndex, input);
-    }
-
-    for (auto& output : m_audioOutputs) {
-        m_pEnumerator->closeDeviceOutput(m_deviceId.deviceIndex, output);
-    }
+    m_pEnumerator->closeDevices();
     return SoundDeviceStatus::Ok;
 }
 

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -50,8 +50,6 @@ bool SoundDevicePipewire::isOpen() const {
 
 SoundDeviceStatus SoundDevicePipewire::close() {
     m_pEnumerator->closeDevice(m_deviceId.deviceIndex);
-    m_inPorts.clear();
-    m_outPorts.clear();
     return SoundDeviceStatus::Ok;
 }
 
@@ -117,51 +115,6 @@ void SoundDevicePipewire::writeInput(
     }
 }
 
-void SoundDevicePipewire::registerPort(uint32_t id, const struct spa_dict* props) {
-    const char* portName = spa_dict_lookup(props, PW_KEY_PORT_NAME);
-    const char* channel = spa_dict_lookup(props, PW_KEY_AUDIO_CHANNEL);
-    const char* direction = spa_dict_lookup(props, PW_KEY_PORT_DIRECTION);
-    const char* portId = spa_dict_lookup(props, PW_KEY_PORT_ID);
-
-    Port port{};
-    port.id = id;
-    port.channel = channel ? channel : (portName ? portName : portId);
-
-    if (portName && channel) {
-        std::string_view name = portName;
-        const size_t last = name.find_last_of("_:-");
-        const bool nameContainsChannel = last != std::string_view::npos and
-                port.channel == name.substr(last + 1);
-        port.name = nameContainsChannel ? name.substr(0, last) : portName;
-        port.name += ':';
-    }
-
-    // m_numInputChannels, m_numOutputChannels, m_audioInputs, m_audioOutputs
-    // are with respect to Mixxx and not the SoundDevice
-    if (strcmp(direction, "in") == 0) {
-        m_inPorts.push_back(std::move(port));
-        m_numOutputChannels = mixxx::audio::ChannelCount::fromInt(m_inPorts.size());
-    } else if (strcmp(direction, "out") == 0) {
-        m_outPorts.push_back(std::move(port));
-        m_numInputChannels = mixxx::audio::ChannelCount::fromInt(m_outPorts.size());
-    }
-}
-
-void SoundDevicePipewire::unregisterPort(uint32_t id) {
-    for (auto it = m_inPorts.begin(); it != m_inPorts.end(); it++) {
-        if (it->id == id) {
-            m_inPorts.erase(it);
-            return;
-        }
-    }
-    for (auto it = m_outPorts.begin(); it != m_outPorts.end(); it++) {
-        if (it->id == id) {
-            m_outPorts.erase(it);
-            return;
-        }
-    }
-}
-
 mixxx::audio::SampleRate SoundDevicePipewire::getDefaultSampleRate() const {
     auto defaultSampleRate = m_pEnumerator->getDefaultSampleRate();
     if (defaultSampleRate.isValid()) {
@@ -171,47 +124,6 @@ mixxx::audio::SampleRate SoundDevicePipewire::getDefaultSampleRate() const {
     return SoundManagerConfig::kMixxxDefaultSampleRate;
 }
 
-void SoundDevicePipewire::registerLink(uint32_t id, spa_direction direction) {
-    if (direction == SPA_DIRECTION_INPUT) {
-        m_inLinks.push_back(id);
-    } else {
-        m_outLinks.push_back(id);
-    }
-}
-
-void SoundDevicePipewire::unregisterLink(uint32_t id, spa_direction direction) {
-    if (direction == SPA_DIRECTION_INPUT) {
-        auto it = std::ranges::find(m_inLinks, id);
-        if (it != m_inLinks.end()) {
-            m_inLinks.erase(it);
-        }
-    } else {
-        auto it = std::ranges::find(m_outLinks, id);
-        if (it != m_outLinks.end()) {
-            m_outLinks.erase(it);
-        }
-    }
-}
-
-QString SoundDevicePipewire::getChannelString(ChannelGroup channelGroup, bool input) {
-    unsigned char base = channelGroup.getChannelBase();
-    mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
-
-    std::span<Port> ports = input ? m_outPorts : m_inPorts;
-    std::span<Port> subspan = ports.subspan(base + 1, count - 1);
-
-    // without this 1st port will always take else branch, inserting unnecessary ' '
-    Port& firstPort = ports[base];
-    std::string_view currentCommonSubstr = firstPort.name;
-    std::string channelString = firstPort.name + firstPort.channel;
-
-    for (Port& port : subspan) {
-        if (!port.name.empty() and port.name == currentCommonSubstr) {
-            channelString = channelString + '/' + port.channel;
-        } else {
-            channelString = channelString + ' ' + port.name + port.channel;
-            currentCommonSubstr = port.name;
-        }
-    }
-    return QString::fromStdString(channelString);
+QString SoundDevicePipewire::getChannelString(ChannelGroup channelGroup, bool input) const {
+    return m_pEnumerator->getChannelString(m_deviceId.deviceIndex, channelGroup, input);
 }

--- a/src/soundio/sounddevicepipewire.h
+++ b/src/soundio/sounddevicepipewire.h
@@ -2,6 +2,7 @@
 
 #include <spa/utils/defs.h>
 
+#include "audio/types.h"
 #include "sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
 #include "soundio/soundmanagerutil.h"
@@ -30,7 +31,7 @@ class SoundDevicePipewire : public SoundDevice {
         return m_error.c_str();
     }
 
-    QString getChannelString(ChannelGroup channelGroup, bool input) override;
+    QString getChannelString(ChannelGroup channelGroup, bool input) const override;
     mixxx::audio::SampleRate getDefaultSampleRate() const override;
 
     void writeOutput(float* output, int channel, int framesPerBuffer, int offset = 0);
@@ -40,47 +41,16 @@ class SoundDevicePipewire : public SoundDevice {
             uint32_t outPortId,
             uint32_t inNodeId,
             uint32_t inPortId);
-    void registerPort(uint32_t id, const struct spa_dict* props);
-    void unregisterPort(uint32_t id);
-    void registerLink(uint32_t id, spa_direction direction);
-    void unregisterLink(uint32_t id, spa_direction direction);
 
-    std::span<const uint32_t> getInLinks() const {
-        return m_inLinks;
+    void setNumInputs(SINT count) {
+        m_numInputChannels = mixxx::audio::ChannelCount::fromInt(count);
     }
 
-    std::span<const uint32_t> getOutLinks() const {
-        return m_outLinks;
-    }
-
-    struct Port {
-        std::string getDisplayName() const {
-            return name + channel;
-        }
-
-        uint32_t id;
-        // this is port.name after stripping out channel and delimiter,
-        // and appending a ':' to simplify logic
-        std::string name;
-        // in case port had no recognizable channel, entire name is put
-        // here so SoundDevicePipewire::getChannelString logic works fine
-        std::string channel;
-    };
-
-    std::span<const Port> getInPorts() const {
-        return m_inPorts;
-    }
-
-    std::span<const Port> getOutPorts() const {
-        return m_outPorts;
+    void setNumOutputs(SINT count) {
+        m_numOutputChannels = mixxx::audio::ChannelCount::fromInt(count);
     }
 
   private:
     PipewireEnumerator* m_pEnumerator;
-    std::vector<Port> m_inPorts;
-    std::vector<Port> m_outPorts;
-
-    std::vector<uint32_t> m_inLinks;
-    std::vector<uint32_t> m_outLinks;
     std::string m_error;
 };

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -62,7 +62,9 @@ SoundManager::SoundManager(
                   kAppGroup, QStringLiteral("audio_latency_overload")),
           m_pNetworkStream(QSharedPointer<EngineNetworkStream>::create(2, 0)),
           m_pNetworkDevice(QSharedPointer<SoundDeviceNetwork>::create(
-                  pConfig, this, m_pNetworkStream)) {
+                  pConfig, this, m_pNetworkStream)),
+          m_pipewireEnabled(m_pConfig->getValue(
+                  ConfigKey(kAppGroup, QStringLiteral("pipewire")), false)) {
     // TODO(xxx) some of these ControlObject are not needed by soundmanager, or are unused here.
     // It is possible to take them out?
     m_pControlObjectSoundStatusCO = new ControlObject(

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -12,7 +12,6 @@
 #include "engine/enginemixer.h"
 #include "moc_soundmanager.cpp"
 #include "preferences/configobject.h"
-#include "soundio/pipewireenumerator.h"
 #include "soundio/portaudioenumerator.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddeviceenumerator.h"
@@ -210,12 +209,18 @@ void SoundManager::completeDevicesClosing() {
         for (const auto& in : pDevice->inputs()) {
             // Need to tell all registered AudioDestinations for this AudioInput
             // that the input was disconnected.
-            unconfigureInput(in);
+            if (!isPipewireSelected()) {
+                // PipeWire manages input/output configuration itself
+                unconfigureInput(in);
+            }
         }
         for (const auto& out: pDevice->outputs()) {
             // Need to tell all registered AudioSources for this AudioOutput
             // that the output was disconnected.
-            unconfigureOutput(out);
+            if (!isPipewireSelected()) {
+                // PipeWire manages input/output configuration itself
+                unconfigureOutput(out);
+            }
         }
     }
 
@@ -337,7 +342,10 @@ SoundDeviceStatus SoundManager::setupDevices() {
                 goto closeAndError;
             }
 
-            configureInput(in);
+            if (!isPipewireSelected()) {
+                // PipeWire manages input/output configuration itself
+                configureInput(in);
+            }
         }
         QList<AudioOutput> outputs =
                 m_config.getOutputs().values(pDevice->getDeviceId());
@@ -383,7 +391,10 @@ SoundDeviceStatus SoundManager::setupDevices() {
                 }
             }
 
-            configureOutput(out);
+            if (!isPipewireSelected()) {
+                // PipeWire manages input/output configuration itself
+                configureOutput(out);
+            }
         }
 
         if (mode.isInput || mode.isOutput) {
@@ -506,6 +517,11 @@ void SoundManager::closeActiveConfig(bool async) {
     closeDevices(sleepAfterClosing, async);
 }
 
+void SoundManager::updateConfig(const SoundManagerConfig& config) {
+    m_config = config;
+    checkConfig();
+}
+
 SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& config) {
     SoundDeviceStatus status = SoundDeviceStatus::Ok;
     m_config = config;
@@ -561,7 +577,7 @@ void SoundManager::pushInputBuffers(const QList<AudioInputBuffer>& inputs,
                 ++it) {
             it.value()->receiveBuffer(in, pInputBuffer, iFramesPerBuffer);
         }
-    }
+   }
 }
 
 void SoundManager::writeProcess(SINT framesPerBuffer) const {
@@ -654,6 +670,18 @@ void SoundManager::removeDevice(SoundDevicePointer pDevice) {
 
 void SoundManager::updateDeviceChannels(SoundDevicePointer pDevice) {
     emit deviceChannelsUpdated(pDevice);
+}
+
+void SoundManager::updatePathChannel(const AudioPath& path, ChannelGroup group) {
+    qWarning() << "SoundManager::updatePathChannel" << path.getString()
+               << group.getChannelBase() << group.getChannelCount();
+    emit pathChannelUpdated(&path, group);
+}
+
+void SoundManager::updatePathDevice(const AudioPath& path, const SoundDeviceId& deviceId) {
+    qWarning() << "SoundManager::updatePathDevice" << path.getString()
+               << deviceId.deviceIndex << deviceId.name;
+    emit pathDeviceUpdated(&path, deviceId);
 }
 
 void SoundManager::configureInput(const AudioInput& input) {

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -206,12 +206,18 @@ void SoundManager::completeDevicesClosing() {
         for (const auto& in : pDevice->inputs()) {
             // Need to tell all registered AudioDestinations for this AudioInput
             // that the input was disconnected.
-            unconfigureInput(in);
+            if (!isPipewireSelected()) {
+                // PipeWire manages input/output configuration itself
+                unconfigureInput(in);
+            }
         }
         for (const auto& out: pDevice->outputs()) {
             // Need to tell all registered AudioSources for this AudioOutput
             // that the output was disconnected.
-            unconfigureOutput(out);
+            if (!isPipewireSelected()) {
+                // PipeWire manages input/output configuration itself
+                unconfigureOutput(out);
+            }
         }
     }
 
@@ -333,7 +339,10 @@ SoundDeviceStatus SoundManager::setupDevices() {
                 goto closeAndError;
             }
 
-            configureInput(in);
+            if (!isPipewireSelected()) {
+                // PipeWire manages input/output configuration itself
+                configureInput(in);
+            }
         }
         QList<AudioOutput> outputs =
                 m_config.getOutputs().values(pDevice->getDeviceId());
@@ -379,7 +388,10 @@ SoundDeviceStatus SoundManager::setupDevices() {
                 }
             }
 
-            configureOutput(out);
+            if (!isPipewireSelected()) {
+                // PipeWire manages input/output configuration itself
+                configureOutput(out);
+            }
         }
 
         if (mode.isInput || mode.isOutput) {
@@ -502,6 +514,11 @@ void SoundManager::closeActiveConfig(bool async) {
     closeDevices(sleepAfterClosing, async);
 }
 
+void SoundManager::updateConfig(const SoundManagerConfig& config) {
+    m_config = config;
+    checkConfig();
+}
+
 SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& config) {
     SoundDeviceStatus status = SoundDeviceStatus::Ok;
     m_config = config;
@@ -557,7 +574,7 @@ void SoundManager::pushInputBuffers(const QList<AudioInputBuffer>& inputs,
                 ++it) {
             it.value()->receiveBuffer(in, pInputBuffer, iFramesPerBuffer);
         }
-    }
+   }
 }
 
 void SoundManager::writeProcess(SINT framesPerBuffer) const {
@@ -650,6 +667,18 @@ void SoundManager::removeDevice(SoundDevicePointer pDevice) {
 
 void SoundManager::updateDeviceChannels(SoundDevicePointer pDevice) {
     emit deviceChannelsUpdated(pDevice);
+}
+
+void SoundManager::updatePathChannel(const AudioPath& path, ChannelGroup group) {
+    qWarning() << "SoundManager::updatePathChannel" << path.getString()
+               << group.getChannelBase() << group.getChannelCount();
+    emit pathChannelUpdated(&path, group);
+}
+
+void SoundManager::updatePathDevice(const AudioPath& path, const SoundDeviceId& deviceId) {
+    qWarning() << "SoundManager::updatePathDevice" << path.getString()
+               << deviceId.deviceIndex << deviceId.name;
+    emit pathDeviceUpdated(&path, deviceId);
 }
 
 void SoundManager::configureInput(const AudioInput& input) {

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -91,6 +91,8 @@ SoundManager::SoundManager(
         devicesEnumerated();
     }
 
+    checkConfig();
+
     // Don't write config to disk, yet -- it may be reset to defaults in case
     // previously configured devices were not found.
     // Write new config after MixxxMainWindow::noOutputDlg where the user has
@@ -466,7 +468,7 @@ SoundDeviceStatus SoundManager::setupDevices() {
                     SOUNDMANAGER_CONNECTED : SOUNDMANAGER_DISCONNECTED);
 
     // returns OK if we were able to open all the devices the user wanted
-    if (devicesNotFound.isEmpty()) {
+    if (devicesNotFound.isEmpty() || pipewireSkipConfig()) {
         emit devicesSetup();
         return SoundDeviceStatus::Ok;
     }
@@ -522,11 +524,6 @@ void SoundManager::closeActiveConfig(bool async) {
     // SoundDevices are closed. closeDevices() blocks and can take a while.
     const bool sleepAfterClosing = true;
     closeDevices(sleepAfterClosing, async);
-}
-
-void SoundManager::updateConfig(const SoundManagerConfig& config) {
-    m_config = config;
-    checkConfig();
 }
 
 SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& config) {
@@ -618,7 +615,10 @@ void SoundManager::registerInput(const AudioInput& input, AudioDestination* dest
     // passthrough, each with different outputs. So unlike outputs, do not assert
     // that the input has not been registered yet.
     m_registeredDestinations.insert(input, dest);
-    m_inputBuffers.insert(input, SampleUtil::alloc(kMaxEngineSamples));
+
+    if (!m_inputBuffers.contains(input)) {
+        m_inputBuffers.insert(input, SampleUtil::alloc(kMaxEngineSamples));
+    }
 
     emit inputRegistered(input, dest);
 }
@@ -679,84 +679,6 @@ void SoundManager::updateDeviceChannels(SoundDevicePointer pDevice) {
     emit deviceChannelsUpdated(pDevice);
 }
 
-void SoundManager::updatePathChannel(const AudioPath& path, ChannelGroup group, bool isInput) {
-    qWarning() << "SoundManager::updatePathChannel" << path.getString()
-               << group.getChannelBase() << group.getChannelCount();
-
-    if (isInput) {
-        QMultiHash<SoundDeviceId, AudioInput>& inputs = m_config.getInputsRef();
-        for (auto it = inputs.begin(); it != inputs.end(); ++it) {
-            if (it.value() == path) {
-                it.value() = AudioInput(path.getType(),
-                        group.getChannelBase(),
-                        group.getChannelCount(),
-                        path.getIndex());
-                break;
-            }
-        }
-    } else {
-        QMultiHash<SoundDeviceId, AudioOutput>& outputs = m_config.getOutputsRef();
-        for (auto it = outputs.begin(); it != outputs.end(); ++it) {
-            if (it.value() == path) {
-                it.value() = AudioOutput(path.getType(),
-                        group.getChannelBase(),
-                        group.getChannelCount(),
-                        path.getIndex());
-                break;
-            }
-        }
-    }
-
-    m_config.writeToDisk();
-    emit pathChannelUpdated(&path, group);
-}
-
-// this sets the given device to open on an AudioPath with null ChannelGroup
-// ChannelGroup will be updated in subsequent calls to SoundManager::updatePathChannel
-// therefore we don't write config here
-void SoundManager::updatePathDevice(
-        const AudioPath& path, const SoundDeviceId& deviceId, bool isInput) {
-    qWarning() << "SoundManager::updatePathDevice" << path.getString()
-               << deviceId.deviceIndex << deviceId.name;
-
-    if (isInput) {
-        auto& inputs = m_config.getInputsRef();
-        for (auto it = inputs.begin(); it != inputs.end(); ++it) {
-            if (it.value() == path) {
-                inputs.erase(it);
-                break;
-            }
-        }
-        if (deviceId != SoundDeviceId{}) {
-            // AudioInput will be updated in subsequent call to updatePathChannel
-            // but we still try to keep somewhat valid state
-            const AudioInput input(path.getType(),
-                    0,
-                    mixxx::audio::ChannelCount(),
-                    path.getIndex());
-            inputs.insert(deviceId, input);
-        }
-    } else {
-        auto& outputs = m_config.getOutputsRef();
-        for (auto it = outputs.begin(); it != outputs.end(); ++it) {
-            if (it.value() == path) {
-                outputs.erase(it);
-                break;
-            }
-        }
-        if (deviceId != SoundDeviceId{}) {
-            // AudioOutput will be updated in subsequent call to updatePathChannel
-            // but we still try to keep somewhat valid state
-            const AudioOutput output(path.getType(),
-                    0,
-                    mixxx::audio::ChannelCount(),
-                    path.getIndex());
-            outputs.insert(deviceId, output);
-        }
-    }
-    emit pathDeviceUpdated(&path, deviceId);
-}
-
 void SoundManager::configureInput(const AudioInput& input) {
     // Check if any AudioDestination is registered for this AudioInput
     // and call the onInputConnected method.
@@ -802,4 +724,9 @@ void SoundManager::devicesEnumerated() {
         qDebug() << "!m_config.validateDevices()";
         m_config.loadDefaults(this, SoundManagerConfig::DEVICES);
     }
+}
+
+void SoundManager::invalidateConfig() {
+    qDebug() << "SoundManager::invalidateConfig";
+    emit configInvalidated();
 }

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -71,9 +71,12 @@ SoundManager::SoundManager(
     m_pControlObjectVinylControlGainCO = new ControlObject(
             ConfigKey(VINYL_PREF_KEY, "gain"));
 
+#ifdef __PIPEWIRE__
     if (isPipewireSelected()) {
         m_pEnumerator = std::make_unique<PipewireEnumerator>(m_pConfig, this);
-    } else {
+    } else
+#endif
+    {
         m_pEnumerator = std::make_unique<PortAudioEnumerator>(m_pConfig, this);
     }
 

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -335,6 +335,9 @@ SoundDeviceStatus SoundManager::setupDevices() {
     // loop over all available devices
 
     std::vector<SoundDevicePointer> devices = m_pEnumerator->queryDevices();
+
+    m_pEnumerator->setLatencyParams(m_config.getSampleRate(), m_config.getFramesPerBuffer());
+
     // here some network device conditions can be separated, currently simply
     // add it to the list of other devices
     devices.push_back(m_pNetworkDevice);

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -12,7 +12,6 @@
 #include "engine/enginemixer.h"
 #include "moc_soundmanager.cpp"
 #include "preferences/configobject.h"
-#include "soundio/pipewireenumerator.h"
 #include "soundio/portaudioenumerator.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddeviceenumerator.h"

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -12,6 +12,7 @@
 #include "engine/enginemixer.h"
 #include "moc_soundmanager.cpp"
 #include "preferences/configobject.h"
+#include "soundio/pipewireenumerator.h"
 #include "soundio/portaudioenumerator.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddeviceenumerator.h"
@@ -33,9 +34,6 @@
 namespace {
 
 const QString kAppGroup = QStringLiteral("[App]");
-#ifdef __PIPEWIRE__
-const ConfigKey kPipeWire = ConfigKey(kAppGroup, QStringLiteral("pipewire"));
-#endif
 
 #define CPU_OVERLOAD_DURATION 500 // in ms
 
@@ -399,10 +397,15 @@ SoundDeviceStatus SoundManager::setupDevices() {
         SoundDevicePointer pDevice = mode.pDevice;
         m_pErrorDevice = pDevice;
 
+        // Don't use network clock unless forced with PipeWire
+        // as PipeWire callbacks run even without any devices configured
+        const bool isNetworkDevice = pDevice->getDeviceId().name == kNetworkDeviceInternalName;
+        const bool deviceAllowedClockReference = isPipewireSelected() != isNetworkDevice;
+
         // If we have not yet set a clock source then we use the first
         // output pDevice
         if (pNewMainClockRef.isNull() &&
-                (!haveOutput || mode.isOutput)) {
+                (!haveOutput || mode.isOutput) && deviceAllowedClockReference) {
             pNewMainClockRef = pDevice;
             qWarning() << "Output sound device clock reference not set! Using"
                        << pDevice->getDisplayName();
@@ -652,12 +655,6 @@ void SoundManager::removeDevice(SoundDevicePointer pDevice) {
 void SoundManager::updateDeviceChannels(SoundDevicePointer pDevice) {
     emit deviceChannelsUpdated(pDevice);
 }
-
-#ifdef __PIPEWIRE__
-bool SoundManager::isPipewireSelected() {
-    return CmdlineArgs::Instance().getDeveloper() && m_pConfig->getValue(kPipeWire, false);
-}
-#endif
 
 void SoundManager::configureInput(const AudioInput& input) {
     // Check if any AudioDestination is registered for this AudioInput

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -1,5 +1,7 @@
 #include "soundio/soundmanager.h"
 
+#include <qlogging.h>
+
 #include <QLibrary>
 #include <QThread>
 #include <QtGlobal>
@@ -103,6 +105,15 @@ SoundManager::~SoundManager() {
 
     delete m_pControlObjectSoundStatusCO;
     delete m_pControlObjectVinylControlGainCO;
+
+    const QList<CSAMPLE*> buffers = m_inputBuffers.values();
+    for (CSAMPLE* pBuffer : buffers) {
+        if (pBuffer != nullptr) {
+            SampleUtil::free(pBuffer);
+        }
+    }
+
+    m_inputBuffers.clear();
 }
 
 QList<SoundDevicePointer> SoundManager::getDeviceList(
@@ -201,29 +212,14 @@ void SoundManager::completeDevicesClosing() {
         for (const auto& in : pDevice->inputs()) {
             // Need to tell all registered AudioDestinations for this AudioInput
             // that the input was disconnected.
-            for (auto it = m_registeredDestinations.constFind(in);
-                 it != m_registeredDestinations.constEnd() && it.key() == in; ++it) {
-                it.value()->onInputUnconfigured(in);
-                m_pEngineMixer->onInputDisconnected(in);
-            }
+            unconfigureInput(in);
         }
         for (const auto& out: pDevice->outputs()) {
             // Need to tell all registered AudioSources for this AudioOutput
             // that the output was disconnected.
-            for (auto it = m_registeredSources.constFind(out);
-                 it != m_registeredSources.constEnd() && it.key() == out; ++it) {
-                it.value()->onOutputDisconnected(out);
-            }
+            unconfigureOutput(out);
         }
     }
-
-    while (!m_inputBuffers.isEmpty()) {
-        CSAMPLE* pBuffer = m_inputBuffers.takeLast();
-        if (pBuffer != nullptr) {
-            SampleUtil::free(pBuffer);
-        }
-    }
-    m_inputBuffers.clear();
 
     // Indicate to the rest of Mixxx that sound is disconnected.
     m_pControlObjectSoundStatusCO->set(SOUNDMANAGER_DISCONNECTED);
@@ -338,23 +334,12 @@ SoundDeviceStatus SoundManager::setupDevices() {
             mode.isInput = true;
             // TODO(bkgood) look into allocating this with the frames per
             // buffer value from SMConfig
-            AudioInputBuffer aib(in, SampleUtil::alloc(kMaxEngineSamples));
-            status = pDevice->addInput(aib);
+            status = pDevice->addInput(AudioInputBuffer{in, m_inputBuffers.value(in)});
             if (status != SoundDeviceStatus::Ok) {
-                SampleUtil::free(aib.getBuffer());
                 goto closeAndError;
             }
 
-            m_inputBuffers.append(aib.getBuffer());
-
-            // Check if any AudioDestination is registered for this AudioInput
-            // and call the onInputConnected method.
-            for (auto it = m_registeredDestinations.find(in);
-                    it != m_registeredDestinations.end() && it.key() == in;
-                    ++it) {
-                it.value()->onInputConfigured(in);
-                m_pEngineMixer->onInputConnected(in);
-            }
+            configureInput(in);
         }
         QList<AudioOutput> outputs =
                 m_config.getOutputs().values(pDevice->getDeviceId());
@@ -400,13 +385,7 @@ SoundDeviceStatus SoundManager::setupDevices() {
                 }
             }
 
-            // Check if any AudioSource is registered for this AudioOutput and
-            // call the onOutputConnected method.
-            for (auto it = m_registeredSources.find(out);
-                    it != m_registeredSources.end() && it.key() == out;
-                    ++it) {
-                it.value()->onOutputConnected(out);
-            }
+            configureOutput(out);
         }
 
         if (mode.isInput || mode.isOutput) {
@@ -560,6 +539,14 @@ void SoundManager::onDeviceOutputCallback(const SINT iFramesPerBuffer) {
     m_pEngineMixer->process(iFramesPerBuffer * 2);
 }
 
+void SoundManager::pushInputBuffer(const AudioInput& input, const SINT iFramesPerBuffer) {
+    CSAMPLE* pInputBuffer = m_inputBuffers.value(input);
+    for (auto it = m_registeredDestinations.constFind(input);
+            it != m_registeredDestinations.constEnd() && it.key() == input;
+            ++it) {
+        it.value()->receiveBuffer(input, pInputBuffer, iFramesPerBuffer);
+    }
+}
 void SoundManager::pushInputBuffers(const QList<AudioInputBuffer>& inputs,
                                     const SINT iFramesPerBuffer) {
    for (QList<AudioInputBuffer>::ConstIterator i = inputs.begin(),
@@ -605,6 +592,7 @@ void SoundManager::registerInput(const AudioInput& input, AudioDestination* dest
     // passthrough, each with different outputs. So unlike outputs, do not assert
     // that the input has not been registered yet.
     m_registeredDestinations.insert(input, dest);
+    m_inputBuffers.insert(input, SampleUtil::alloc(kMaxEngineSamples));
 
     emit inputRegistered(input, dest);
 }
@@ -670,3 +658,36 @@ bool SoundManager::isPipewireSelected() {
     return CmdlineArgs::Instance().getDeveloper() && m_pConfig->getValue(kPipeWire, false);
 }
 #endif
+
+void SoundManager::configureInput(const AudioInput& input) {
+    // Check if any AudioDestination is registered for this AudioInput
+    // and call the onInputConnected method.
+    qWarning() << "SoundManager::configureInput";
+    auto [first, last] = m_registeredDestinations.equal_range(input);
+
+    for (auto it = first; it != last; ++it) {
+        it.value()->onInputConfigured(input);
+        m_pEngineMixer->onInputConnected(input);
+    }
+}
+
+void SoundManager::unconfigureInput(const AudioInput& input) {
+    qWarning() << "SoundManager::unconfigureInput";
+    auto [first, last] = m_registeredDestinations.equal_range(input);
+    for (auto it = first; it != last; ++it) {
+        it.value()->onInputUnconfigured(input);
+        m_pEngineMixer->onInputDisconnected(input);
+    }
+}
+
+void SoundManager::configureOutput(const AudioOutput& output) {
+    // Check if any AudioSource is registered for this AudioOutput and
+    // call the onOutputConnected method.
+    qWarning() << "SoundManager::configureOutput";
+    m_registeredSources.value(output)->onOutputConnected(output);
+}
+
+void SoundManager::unconfigureOutput(const AudioOutput& output) {
+    qWarning() << "SoundManager::unconfigureOutput";
+    m_registeredSources.value(output)->onOutputDisconnected(output);
+}

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -12,6 +12,7 @@
 #include "engine/enginemixer.h"
 #include "moc_soundmanager.cpp"
 #include "preferences/configobject.h"
+#include "soundio/pipewireenumerator.h"
 #include "soundio/portaudioenumerator.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddeviceenumerator.h"

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -8,6 +8,7 @@
 #include <cstring> // for memcpy and strcmp
 #include <memory>
 
+#include "audio/types.h"
 #include "control/controlobject.h"
 #include "engine/enginemixer.h"
 #include "moc_soundmanager.cpp"
@@ -678,15 +679,81 @@ void SoundManager::updateDeviceChannels(SoundDevicePointer pDevice) {
     emit deviceChannelsUpdated(pDevice);
 }
 
-void SoundManager::updatePathChannel(const AudioPath& path, ChannelGroup group) {
+void SoundManager::updatePathChannel(const AudioPath& path, ChannelGroup group, bool isInput) {
     qWarning() << "SoundManager::updatePathChannel" << path.getString()
                << group.getChannelBase() << group.getChannelCount();
+
+    if (isInput) {
+        QMultiHash<SoundDeviceId, AudioInput>& inputs = m_config.getInputsRef();
+        for (auto it = inputs.begin(); it != inputs.end(); ++it) {
+            if (it.value() == path) {
+                it.value() = AudioInput(path.getType(),
+                        group.getChannelBase(),
+                        group.getChannelCount(),
+                        path.getIndex());
+                break;
+            }
+        }
+    } else {
+        QMultiHash<SoundDeviceId, AudioOutput>& outputs = m_config.getOutputsRef();
+        for (auto it = outputs.begin(); it != outputs.end(); ++it) {
+            if (it.value() == path) {
+                it.value() = AudioOutput(path.getType(),
+                        group.getChannelBase(),
+                        group.getChannelCount(),
+                        path.getIndex());
+                break;
+            }
+        }
+    }
+
+    m_config.writeToDisk();
     emit pathChannelUpdated(&path, group);
 }
 
-void SoundManager::updatePathDevice(const AudioPath& path, const SoundDeviceId& deviceId) {
+// this sets the given device to open on an AudioPath with null ChannelGroup
+// ChannelGroup will be updated in subsequent calls to SoundManager::updatePathChannel
+// therefore we don't write config here
+void SoundManager::updatePathDevice(
+        const AudioPath& path, const SoundDeviceId& deviceId, bool isInput) {
     qWarning() << "SoundManager::updatePathDevice" << path.getString()
                << deviceId.deviceIndex << deviceId.name;
+
+    if (isInput) {
+        auto& inputs = m_config.getInputsRef();
+        for (auto it = inputs.begin(); it != inputs.end(); ++it) {
+            if (it.value() == path) {
+                inputs.erase(it);
+                break;
+            }
+        }
+        if (deviceId != SoundDeviceId{}) {
+            // AudioInput will be updated in subsequent call to updatePathChannel
+            // but we still try to keep somewhat valid state
+            const AudioInput input(path.getType(),
+                    0,
+                    mixxx::audio::ChannelCount(),
+                    path.getIndex());
+            inputs.insert(deviceId, input);
+        }
+    } else {
+        auto& outputs = m_config.getOutputsRef();
+        for (auto it = outputs.begin(); it != outputs.end(); ++it) {
+            if (it.value() == path) {
+                outputs.erase(it);
+                break;
+            }
+        }
+        if (deviceId != SoundDeviceId{}) {
+            // AudioOutput will be updated in subsequent call to updatePathChannel
+            // but we still try to keep somewhat valid state
+            const AudioOutput output(path.getType(),
+                    0,
+                    mixxx::audio::ChannelCount(),
+                    path.getIndex());
+            outputs.insert(deviceId, output);
+        }
+    }
     emit pathDeviceUpdated(&path, deviceId);
 }
 

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -33,9 +33,6 @@
 namespace {
 
 const QString kAppGroup = QStringLiteral("[App]");
-#ifdef __PIPEWIRE__
-const ConfigKey kPipeWire = ConfigKey(kAppGroup, QStringLiteral("pipewire"));
-#endif
 
 #define CPU_OVERLOAD_DURATION 500 // in ms
 
@@ -74,12 +71,9 @@ SoundManager::SoundManager(
     m_pControlObjectVinylControlGainCO = new ControlObject(
             ConfigKey(VINYL_PREF_KEY, "gain"));
 
-#ifdef __PIPEWIRE__
     if (isPipewireSelected()) {
         m_pEnumerator = std::make_unique<PipewireEnumerator>(m_pConfig, this);
-    } else
-#endif
-    {
+    } else {
         m_pEnumerator = std::make_unique<PortAudioEnumerator>(m_pConfig, this);
     }
 
@@ -399,10 +393,15 @@ SoundDeviceStatus SoundManager::setupDevices() {
         SoundDevicePointer pDevice = mode.pDevice;
         m_pErrorDevice = pDevice;
 
+        // Don't use network clock unless forced with PipeWire
+        // as PipeWire callbacks run even without any devices configured
+        const bool isNetworkDevice = pDevice->getDeviceId().name == kNetworkDeviceInternalName;
+        const bool deviceAllowedClockReference = isPipewireSelected() != isNetworkDevice;
+
         // If we have not yet set a clock source then we use the first
         // output pDevice
         if (pNewMainClockRef.isNull() &&
-                (!haveOutput || mode.isOutput)) {
+                (!haveOutput || mode.isOutput) && deviceAllowedClockReference) {
             pNewMainClockRef = pDevice;
             qWarning() << "Output sound device clock reference not set! Using"
                        << pDevice->getDisplayName();
@@ -652,12 +651,6 @@ void SoundManager::removeDevice(SoundDevicePointer pDevice) {
 void SoundManager::updateDeviceChannels(SoundDevicePointer pDevice) {
     emit deviceChannelsUpdated(pDevice);
 }
-
-#ifdef __PIPEWIRE__
-bool SoundManager::isPipewireSelected() {
-    return CmdlineArgs::Instance().getDeveloper() && m_pConfig->getValue(kPipeWire, false);
-}
-#endif
 
 void SoundManager::configureInput(const AudioInput& input) {
     // Check if any AudioDestination is registered for this AudioInput

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -83,9 +83,13 @@ SoundManager::SoundManager(
     queryDevices();
 
     if (!m_config.readFromDisk()) {
-        m_config.loadDefaults(this, SoundManagerConfig::ALL);
+        m_config.loadDefaults(this, SoundManagerConfig::API | SoundManagerConfig::OTHER);
     }
-    checkConfig();
+
+    if (!isPipewireSelected()) {
+        devicesEnumerated();
+    }
+
     // Don't write config to disk, yet -- it may be reset to defaults in case
     // previously configured devices were not found.
     // Write new config after MixxxMainWindow::noOutputDlg where the user has
@@ -269,7 +273,9 @@ void SoundManager::queryDevices() {
     qDebug() << "SoundManager::queryDevices()";
     m_pEnumerator->initialize();
     // now tell the prefs that we updated the device list -- bkgood
+#ifndef __PIPEWIRE__
     emit devicesUpdated();
+#endif
 }
 
 void SoundManager::clearAndQueryDevices() {
@@ -715,4 +721,18 @@ void SoundManager::configureOutput(const AudioOutput& output) {
 void SoundManager::unconfigureOutput(const AudioOutput& output) {
     qWarning() << "SoundManager::unconfigureOutput";
     m_registeredSources.value(output)->onOutputDisconnected(output);
+}
+
+void SoundManager::devicesEnumerated() {
+    qDebug() << "SoundManager::devicesEnumerated";
+    for (const auto& device : m_pEnumerator->queryDevices()) {
+        qDebug() << device->getDisplayName();
+    }
+
+    // currently PipeWire has no sane default device options, we need to obtain
+    // it from metadata, and select it in SoundManagerConfig::loadDefaults
+    if (!m_config.validateDevices() && !isPipewireSelected()) {
+        qDebug() << "!m_config.validateDevices()";
+        m_config.loadDefaults(this, SoundManagerConfig::DEVICES);
+    }
 }

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -83,9 +83,13 @@ SoundManager::SoundManager(
     queryDevices();
 
     if (!m_config.readFromDisk()) {
-        m_config.loadDefaults(this, SoundManagerConfig::ALL);
+        m_config.loadDefaults(this, SoundManagerConfig::API | SoundManagerConfig::OTHER);
     }
-    checkConfig();
+
+#ifndef __PIPEWIRE__
+    devicesEnumerated();
+#endif
+
     // Don't write config to disk, yet -- it may be reset to defaults in case
     // previously configured devices were not found.
     // Write new config after MixxxMainWindow::noOutputDlg where the user has
@@ -269,7 +273,9 @@ void SoundManager::queryDevices() {
     qDebug() << "SoundManager::queryDevices()";
     m_pEnumerator->initialize();
     // now tell the prefs that we updated the device list -- bkgood
+#ifndef __PIPEWIRE__
     emit devicesUpdated();
+#endif
 }
 
 void SoundManager::clearAndQueryDevices() {
@@ -715,4 +721,16 @@ void SoundManager::configureOutput(const AudioOutput& output) {
 void SoundManager::unconfigureOutput(const AudioOutput& output) {
     qWarning() << "SoundManager::unconfigureOutput";
     m_registeredSources.value(output)->onOutputDisconnected(output);
+}
+
+void SoundManager::devicesEnumerated() {
+    qDebug() << "SoundManager::devicesEnumerated";
+    for (const auto& device : m_pEnumerator->queryDevices()) {
+        qDebug() << device->getDisplayName();
+    }
+
+    if (!m_config.validateDevices()) {
+        qDebug() << "!m_config.validateDevices()";
+        m_config.loadDefaults(this, SoundManagerConfig::DEVICES);
+    }
 }

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -17,6 +17,7 @@
 #include "soundio/sounddevicenetwork.h"
 #include "soundio/sounddevicestatus.h"
 #include "soundio/soundmanagerconfig.h"
+#include "soundio/soundmanagerutil.h"
 #include "util/cmdlineargs.h"
 #include "util/types.h"
 
@@ -66,6 +67,7 @@ class SoundManager : public QObject {
     // Get a list of host APIs supported by PortAudio.
     QList<QString> getHostAPIList() const;
     SoundManagerConfig getConfig() const;
+    void updateConfig(const SoundManagerConfig& config);
     SoundDeviceStatus setConfig(const SoundManagerConfig& config);
     // Due to a bug in in PulseAudio, we must give at least 5 seconds of cool
     // down before performing further audio related operation. This sleep
@@ -115,6 +117,8 @@ class SoundManager : public QObject {
     }
 
     void updateDeviceChannels(SoundDevicePointer pDevice);
+    void updatePathChannel(const AudioPath& path, ChannelGroup group);
+    void updatePathDevice(const AudioPath& path, const SoundDeviceId& pDevice);
     bool isPipewireSelected() {
 #ifdef __PIPEWIRE__
         return CmdlineArgs::Instance().getDeveloper() and
@@ -150,6 +154,8 @@ class SoundManager : public QObject {
     void deviceAdded(SoundDevicePointer pDevice);
     void deviceRemoved(SoundDevicePointer pDevice);
     void deviceChannelsUpdated(SoundDevicePointer pDevice);
+    void pathChannelUpdated(const AudioPath* path, ChannelGroup channelGroup);
+    void pathDeviceUpdated(const AudioPath* path, const SoundDeviceId& deviceId);
     void deviceConnected(const SoundDeviceId& pDevice, const AudioPath* pPath);
     void deviceDisconnected(const AudioPath* pPath);
 

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -114,18 +114,21 @@ class SoundManager : public QObject {
         m_audioLatencyOverloadCount.set(0);
     }
 
-    // currently only used by pipewire
     void updateDeviceChannels(SoundDevicePointer pDevice);
+    bool isPipewireSelected() {
 #ifdef __PIPEWIRE__
-    bool isPipewireSelected();
+        return CmdlineArgs::Instance().getDeveloper() and
+                m_pConfig->getValue(ConfigKey(QStringLiteral("[App]"),
+                                            QStringLiteral("pipewire")),
+                        false);
+#else
+        return false;
 #endif
+    }
 
     CSAMPLE* getInputBuffer(const AudioInput& input) {
         if (!m_inputBuffers.contains(input)) {
             qWarning() << "getInputBuffer does not have" << input.getString();
-            for (const auto& [input, buffer] : m_inputBuffers.asKeyValueRange()) {
-                qWarning() << "getInputBuffer" << input.getString() << buffer;
-            }
         }
         return m_inputBuffers.value(input);
     }

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -133,9 +133,6 @@ class SoundManager : public QObject {
     CSAMPLE* getInputBuffer(const AudioInput& input) {
         if (!m_inputBuffers.contains(input)) {
             qWarning() << "getInputBuffer does not have" << input.getString();
-            for (const auto& [input, buffer] : m_inputBuffers.asKeyValueRange()) {
-                qWarning() << "getInputBuffer" << input.getString() << buffer;
-            }
         }
         return m_inputBuffers.value(input);
     }

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -17,6 +17,7 @@
 #include "soundio/sounddevicenetwork.h"
 #include "soundio/sounddevicestatus.h"
 #include "soundio/soundmanagerconfig.h"
+#include "soundio/soundmanagerutil.h"
 #include "util/cmdlineargs.h"
 #include "util/types.h"
 
@@ -66,6 +67,7 @@ class SoundManager : public QObject {
     // Get a list of host APIs supported by PortAudio.
     QList<QString> getHostAPIList() const;
     SoundManagerConfig getConfig() const;
+    void updateConfig(const SoundManagerConfig& config);
     SoundDeviceStatus setConfig(const SoundManagerConfig& config);
     // Due to a bug in in PulseAudio, we must give at least 5 seconds of cool
     // down before performing further audio related operation. This sleep
@@ -115,6 +117,8 @@ class SoundManager : public QObject {
     }
 
     void updateDeviceChannels(SoundDevicePointer pDevice);
+    void updatePathChannel(const AudioPath& path, ChannelGroup group);
+    void updatePathDevice(const AudioPath& path, const SoundDeviceId& pDevice);
     bool isPipewireSelected() {
 #ifdef __PIPEWIRE__
         return CmdlineArgs::Instance().getDeveloper() and
@@ -153,6 +157,8 @@ class SoundManager : public QObject {
     void deviceAdded(SoundDevicePointer pDevice);
     void deviceRemoved(SoundDevicePointer pDevice);
     void deviceChannelsUpdated(SoundDevicePointer pDevice);
+    void pathChannelUpdated(const AudioPath* path, ChannelGroup channelGroup);
+    void pathDeviceUpdated(const AudioPath* path, const SoundDeviceId& deviceId);
     void deviceConnected(const SoundDeviceId& pDevice, const AudioPath* pPath);
     void deviceDisconnected(const AudioPath* pPath);
 

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -114,11 +114,17 @@ class SoundManager : public QObject {
         m_audioLatencyOverloadCount.set(0);
     }
 
-    // currently only used by pipewire
     void updateDeviceChannels(SoundDevicePointer pDevice);
+    bool isPipewireSelected() {
 #ifdef __PIPEWIRE__
-    bool isPipewireSelected();
+        return CmdlineArgs::Instance().getDeveloper() and
+                m_pConfig->getValue(ConfigKey(QStringLiteral("[App]"),
+                                            QStringLiteral("pipewire")),
+                        false);
+#else
+        return false;
 #endif
+    }
 
     CSAMPLE* getInputBuffer(const AudioInput& input) {
         if (!m_inputBuffers.contains(input)) {

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -150,6 +150,7 @@ class SoundManager : public QObject {
     void configureOutput(const AudioOutput& output);
     void unconfigureOutput(const AudioOutput& output);
 
+    void loadConfig();
   signals:
     void deviceAdded(SoundDevicePointer pDevice);
     void deviceRemoved(SoundDevicePointer pDevice);
@@ -171,6 +172,7 @@ class SoundManager : public QObject {
   public slots:
     void addDevice(SoundDevicePointer pDevice);
     void removeDevice(SoundDevicePointer pDevice);
+    void devicesEnumerated();
 
   private:
     // Closes all the devices and empties the list of devices we have.

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -117,10 +117,7 @@ class SoundManager : public QObject {
     void updateDeviceChannels(SoundDevicePointer pDevice);
     bool isPipewireSelected() {
 #ifdef __PIPEWIRE__
-        return CmdlineArgs::Instance().getDeveloper() and
-                m_pConfig->getValue(ConfigKey(QStringLiteral("[App]"),
-                                            QStringLiteral("pipewire")),
-                        false);
+        return CmdlineArgs::Instance().getDeveloper() && m_pipewireEnabled;
 #else
         return false;
 #endif
@@ -213,4 +210,5 @@ class SoundManager : public QObject {
 
     QSharedPointer<EngineNetworkStream> m_pNetworkStream;
     QSharedPointer<SoundDeviceNetwork> m_pNetworkDevice;
+    bool m_pipewireEnabled;
 };

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -79,6 +79,7 @@ class SoundManager : public QObject {
 
     // Used by SoundDevices to "push" any audio from their inputs that they have
     // into the mixing engine.
+    void pushInputBuffer(const AudioInput& input, const SINT iFramesPerBuffer);
     void pushInputBuffers(const QList<AudioInputBuffer>& inputs,
                           const SINT iFramesPerBuffer);
 
@@ -119,6 +120,29 @@ class SoundManager : public QObject {
     bool isPipewireSelected();
 #endif
 
+    CSAMPLE* getInputBuffer(const AudioInput& input) {
+        if (!m_inputBuffers.contains(input)) {
+            qWarning() << "getInputBuffer does not have" << input.getString();
+            for (const auto& [input, buffer] : m_inputBuffers.asKeyValueRange()) {
+                qWarning() << "getInputBuffer" << input.getString() << buffer;
+            }
+        }
+        return m_inputBuffers.value(input);
+    }
+
+    const CSAMPLE* getOutputBuffer(const AudioOutput& output) {
+        const float* buffer = m_registeredSources.value(output)->buffer(output).data();
+        if (!buffer) {
+            qWarning() << "getOutputBuffer does not have" << output.getString();
+        }
+        return buffer;
+    }
+
+    void configureInput(const AudioInput& input);
+    void unconfigureInput(const AudioInput& input);
+    void configureOutput(const AudioOutput& output);
+    void unconfigureOutput(const AudioOutput& output);
+
   signals:
     void deviceAdded(SoundDevicePointer pDevice);
     void deviceRemoved(SoundDevicePointer pDevice);
@@ -156,7 +180,7 @@ class SoundManager : public QObject {
     EngineMixer* m_pEngineMixer;
     UserSettingsPointer m_pConfig;
     QList<SoundDevicePointer> m_devices;
-    QList<CSAMPLE*> m_inputBuffers;
+    QHash<AudioInput, CSAMPLE*> m_inputBuffers;
 
     SoundManagerConfig m_config;
     SoundDevicePointer m_pErrorDevice;

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -117,8 +117,8 @@ class SoundManager : public QObject {
     }
 
     void updateDeviceChannels(SoundDevicePointer pDevice);
-    void updatePathChannel(const AudioPath& path, ChannelGroup group);
-    void updatePathDevice(const AudioPath& path, const SoundDeviceId& pDevice);
+    void updatePathChannel(const AudioPath& path, ChannelGroup group, bool isInput);
+    void updatePathDevice(const AudioPath& path, const SoundDeviceId& pDevice, bool isInput);
     bool isPipewireSelected() {
 #ifdef __PIPEWIRE__
         return CmdlineArgs::Instance().getDeveloper() and

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -17,7 +17,6 @@
 #include "soundio/sounddevicenetwork.h"
 #include "soundio/sounddevicestatus.h"
 #include "soundio/soundmanagerconfig.h"
-#include "soundio/soundmanagerutil.h"
 #include "util/cmdlineargs.h"
 #include "util/types.h"
 
@@ -67,7 +66,6 @@ class SoundManager : public QObject {
     // Get a list of host APIs supported by PortAudio.
     QList<QString> getHostAPIList() const;
     SoundManagerConfig getConfig() const;
-    void updateConfig(const SoundManagerConfig& config);
     SoundDeviceStatus setConfig(const SoundManagerConfig& config);
     // Due to a bug in in PulseAudio, we must give at least 5 seconds of cool
     // down before performing further audio related operation. This sleep
@@ -117,8 +115,6 @@ class SoundManager : public QObject {
     }
 
     void updateDeviceChannels(SoundDevicePointer pDevice);
-    void updatePathChannel(const AudioPath& path, ChannelGroup group, bool isInput);
-    void updatePathDevice(const AudioPath& path, const SoundDeviceId& pDevice, bool isInput);
     bool isPipewireSelected() {
 #ifdef __PIPEWIRE__
         return CmdlineArgs::Instance().getDeveloper() and
@@ -128,6 +124,14 @@ class SoundManager : public QObject {
 #else
         return false;
 #endif
+    }
+
+    bool pipewireSkipConfig() {
+        return isPipewireSelected() &&
+                m_pConfig->getValue(
+                        ConfigKey("[App]",
+                                QStringLiteral("pipewire_patchbay_sync")),
+                        false);
     }
 
     CSAMPLE* getInputBuffer(const AudioInput& input) {
@@ -151,12 +155,11 @@ class SoundManager : public QObject {
     void unconfigureOutput(const AudioOutput& output);
 
     void loadConfig();
+    void invalidateConfig();
   signals:
     void deviceAdded(SoundDevicePointer pDevice);
     void deviceRemoved(SoundDevicePointer pDevice);
     void deviceChannelsUpdated(SoundDevicePointer pDevice);
-    void pathChannelUpdated(const AudioPath* path, ChannelGroup channelGroup);
-    void pathDeviceUpdated(const AudioPath* path, const SoundDeviceId& deviceId);
     void deviceConnected(const SoundDeviceId& pDevice, const AudioPath* pPath);
     void deviceDisconnected(const AudioPath* pPath);
 
@@ -165,6 +168,7 @@ class SoundManager : public QObject {
     void devicesClosed(); // emitted when the sound devices have been closed and resources freed
     void outputRegistered(const AudioOutput& output, AudioSource* src);
     void inputRegistered(const AudioInput& input, AudioDestination* dest);
+    void configInvalidated();
 
   private slots:
     void completeDevicesClosing();

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -70,17 +70,16 @@ SoundManagerConfig::SoundManagerConfig(SoundManager* pSoundManager)
  */
 bool SoundManagerConfig::readFromDisk() {
     QFile file(m_configFile.absoluteFilePath());
-    QDomDocument doc;
     QDomElement rootElement;
     if (!file.open(QIODevice::ReadOnly)) {
         return false;
     }
-    if (!doc.setContent(&file)) {
+    if (!m_doc.setContent(&file)) {
         file.close();
         return false;
     }
     file.close();
-    rootElement = doc.documentElement();
+    rootElement = m_doc.documentElement();
 
     setAPI(rootElement.attribute(xmlAttributeApi));
 
@@ -99,13 +98,25 @@ bool SoundManagerConfig::readFromDisk() {
     setDeckCount(rootElement.attribute(xmlAttributeDeckCount,
                                     QString::number(kDefaultDeckCount))
                          .toUInt());
+
+    return true;
+}
+
+bool SoundManagerConfig::validateDevices() {
     clearOutputs();
     clearInputs();
-    QDomNodeList devElements(rootElement.elementsByTagName(xmlElementSoundDevice));
+
+    if (m_doc.isNull()) {
+        return false;
+    }
 
     VERIFY_OR_DEBUG_ASSERT(m_pSoundManager != nullptr) {
         return false;
     }
+
+    QDomElement rootElement = m_doc.documentElement();
+    QDomNodeList devElements(rootElement.elementsByTagName(xmlElementSoundDevice));
+
     const QList<SoundDevicePointer> soundDevices =
             m_pSoundManager->getDeviceList(m_api, true, true);
 

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -84,12 +84,10 @@ bool SoundManagerConfig::readFromDisk() {
 
     setAPI(rootElement.attribute(xmlAttributeApi));
 
-#ifdef __PIPEWIRE__
     if (m_pSoundManager->isPipewireSelected() and m_api != SoundManagerConfig::kAPIPipewire) {
         // PipeWire check box just changed, current config is useless
         return false;
     }
-#endif
 
     setSampleRate(mixxx::audio::SampleRate(
             rootElement.attribute(xmlAttributeSampleRate, "0").toUInt()));
@@ -501,17 +499,14 @@ void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int f
         if (!apiList.isEmpty()) {
 #ifdef __LINUX__
             // Check if PipeWire checkbox selected
-#ifdef __PIPEWIRE__
             if (m_pSoundManager->isPipewireSelected()) {
                 m_api = SoundManagerConfig::kAPIPipewire;
-            } else
-#endif
                 // Check for JACK and use that if it's available, otherwise use ALSA
-                if (apiList.contains(SoundManagerConfig::kAPIJack)) {
-                    m_api = SoundManagerConfig::kAPIJack;
-                } else {
-                    m_api = SoundManagerConfig::kAPIAlsa;
-                }
+            } else if (apiList.contains(SoundManagerConfig::kAPIJack)) {
+                m_api = SoundManagerConfig::kAPIJack;
+            } else {
+                m_api = SoundManagerConfig::kAPIAlsa;
+            }
 #endif
 #ifdef __WINDOWS__
             //Existence of ASIO doesn't necessarily mean you've got ASIO devices

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -479,6 +479,14 @@ QMultiHash<SoundDeviceId, AudioInput> SoundManagerConfig::getInputs() const {
     return m_inputs;
 }
 
+QMultiHash<SoundDeviceId, AudioOutput>& SoundManagerConfig::getOutputsRef() {
+    return m_outputs;
+}
+
+QMultiHash<SoundDeviceId, AudioInput>& SoundManagerConfig::getInputsRef() {
+    return m_inputs;
+}
+
 void SoundManagerConfig::clearOutputs() {
     m_outputs.clear();
 }

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -85,6 +85,7 @@ bool SoundManagerConfig::readFromDisk() {
 
     if (m_pSoundManager->isPipewireSelected() and m_api != SoundManagerConfig::kAPIPipewire) {
         // PipeWire check box just changed, current config is useless
+        m_doc.clear();
         return false;
     }
 

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -72,6 +72,11 @@ class SoundManagerConfig {
     static const int kDefaultSyncBuffers;
 
     bool readFromDisk();
+    // NOTE(pri-yan-shu) separate config reading and device validation, to allow
+    // asynchronous API's like PipeWire to validate the devices
+    // after they are enumerated, while keeping the logic which expects
+    // other parts of the config to already be loaded.
+    bool validateDevices();
     bool writeToDisk() const;
     QString getAPI() const;
     void setAPI(const QString& api);
@@ -123,4 +128,5 @@ class SoundManagerConfig {
     int m_iNumMicInputs;
     bool m_bExternalRecordBroadcastConnected;
     SoundManager* m_pSoundManager;
+    QDomDocument m_doc;
 };

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -103,6 +103,8 @@ class SoundManagerConfig {
     void addInput(const SoundDeviceId& device, const AudioInput& in);
     QMultiHash<SoundDeviceId, AudioOutput> getOutputs() const;
     QMultiHash<SoundDeviceId, AudioInput> getInputs() const;
+    QMultiHash<SoundDeviceId, AudioOutput>& getOutputsRef();
+    QMultiHash<SoundDeviceId, AudioInput>& getInputsRef();
     void clearOutputs();
     void clearInputs();
     bool hasMicInputs();

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -206,6 +206,37 @@ class AudioInputBuffer : public AudioInput {
     CSAMPLE* m_pBuffer;
 };
 
+namespace std {
+
+template<>
+struct hash<AudioInput> {
+    size_t operator()(const AudioInput& b) const noexcept {
+        return b.hashValue();
+    }
+};
+
+template<>
+struct hash<AudioOutput> {
+    size_t operator()(const AudioOutput& b) const noexcept {
+        return b.hashValue();
+    }
+};
+
+template<>
+struct hash<AudioInputBuffer> {
+    size_t operator()(const AudioInputBuffer& b) const noexcept {
+        return b.hashValue();
+    }
+};
+
+template<>
+struct hash<AudioOutputBuffer> {
+    size_t operator()(const AudioOutputBuffer& b) const noexcept {
+        return b.hashValue();
+    }
+};
+
+} // namespace std
 
 class AudioSource {
   public:


### PR DESCRIPTION
Preemptively allocate all input buffers, and detect link connections and configure/unconfigure AudioSource/AudioDestination appropriately.