### PR TITLE
fix(pre-commit): update lxml dependency to 6.0.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -185,7 +185,7 @@ repos:
         language: python
         additional_dependencies:
           - beautifulsoup4==4.12.3
-          - lxml==5.3.0
+          - lxml==6.0.2
           - Markdown==3.7
         types: [text]
         files: ^(CHANGELOG\.md|res/linux/org\.mixxx\.Mixxx\.metainfo.xml)$
@@ -196,7 +196,7 @@ repos:
         require_serial: true
         language: python
         additional_dependencies:
-          - lxml==5.3.0
+          - lxml==6.0.2
         files: ^(res/translations/.*\.ts)$
       - id: check-ui-buddies
         name: check-ui-buddies


### PR DESCRIPTION
Update lxml version from 5.3.0 to 6.0.2 for metainfo and ts-source-copy hooks to match system-installed version.

Should let pre-commit works, without `SKIP=`...
before:
`SKIP=metainfo,ts-source-copy git commit`
after:
`git commit`