### PR TITLE
Ableton Push 2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1941,8 +1941,11 @@ else()
     PRIVATE
       # The following source depends of QML being available but aren't part of the new QML UI
       src/controllers/rendering/controllerrenderingengine.cpp
+      src/controllers/rendering/controllerrenderingengine.h
       src/controllers/controllerenginethreadcontrol.cpp
+      src/controllers/controllerenginethreadcontrol.h
       src/controllers/controllerscreenpreview.cpp
+      src/controllers/controllerscreenpreview.h
   )
 endif()
 if(QOPENGL)
@@ -3153,6 +3156,12 @@ if(ENGINEPRIME)
         APPEND
         DJINTEROP_EXTRA_CMAKE_ARGS
         -DCMAKE_CXX_FLAGS=-Wno-error=deprecated-literal-operator
+      )
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      list(
+        APPEND
+        DJINTEROP_EXTRA_CMAKE_ARGS
+        -DCMAKE_CXX_FLAGS=-Wno-error=stringop-overflow
       )
     endif()
 

--- a/res/controllers/Ableton Push 2 Display.bulk.xml
+++ b/res/controllers/Ableton Push 2 Display.bulk.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MixxxControllerPreset mixxxVersion="2.6.0+" schemaVersion="1">
+    <info>
+        <name>Ableton Push 2 Display</name>
+        <author>OpenAI Codex</author>
+        <description>Renders scrolling waveforms for decks 1 and 2 on the Ableton Push 2 display.</description>
+        <devices>
+            <product
+                protocol="bulk"
+                vendor_id="0x2982"
+                product_id="0x1967"
+                in_epaddr="0x81"
+                out_epaddr="0x01"
+                interface_number="0x00" />
+        </devices>
+    </info>
+    <controller id="Ableton Push 2 Display" direction="out">
+        <screens>
+            <!--
+              Push 2 expects BGR565, little endian. Mixxx's reversed RGB565
+              output produces that channel order. The included Mixxx source
+              patch adds the Push-specific XOR mask and line padding, then
+              sends the frame header as a separate USB transfer.
+            -->
+            <screen
+                identifier="main"
+                width="960"
+                height="160"
+                targetFps="60"
+                msaa="1"
+                pixelType="RGB565"
+                endian="little"
+                reversed="true"
+                raw="false" />
+        </screens>
+        <scriptfiles>
+            <file filename="Ableton-Push-2-Display.qml" identifier="main" />
+        </scriptfiles>
+    </controller>
+</MixxxControllerPreset>

--- a/res/controllers/Ableton Push 2.midi.xml
+++ b/res/controllers/Ableton Push 2.midi.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MixxxControllerPreset mixxxVersion="2.6.0+" schemaVersion="1">
+    <info>
+        <name>Ableton Push 2</name>
+        <author>OpenAI Codex</author>
+        <description>Two-deck Push 2 mapping designed to accompany the Push 2 dual-waveform display mapping.</description>
+    </info>
+    <controller id="Ableton Push 2">
+        <scriptfiles>
+            <file functionprefix="Push2" filename="Ableton-Push-2-scripts.js" />
+        </scriptfiles>
+        <controls>
+            <!-- Eight buttons below the display: transport and PFL. -->
+            <control>
+                <group>[Channel1]</group>
+                <key>Push2.transport</key>
+                <status>0xB0</status>
+                <midino>0x14</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>Push2.transport</key>
+                <status>0xB0</status>
+                <midino>0x15</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>Push2.transport</key>
+                <status>0xB0</status>
+                <midino>0x16</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>Push2.transport</key>
+                <status>0xB0</status>
+                <midino>0x17</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>Push2.transport</key>
+                <status>0xB0</status>
+                <midino>0x18</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>Push2.transport</key>
+                <status>0xB0</status>
+                <midino>0x19</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>Push2.transport</key>
+                <status>0xB0</status>
+                <midino>0x1A</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>Push2.transport</key>
+                <status>0xB0</status>
+                <midino>0x1B</midino>
+                <options><script-binding /></options>
+            </control>
+
+            <!-- Shift enables hotcue deletion. -->
+            <control>
+                <group>[Controls]</group>
+                <key>Push2.shift</key>
+                <status>0xB0</status>
+                <midino>0x31</midino>
+                <options><script-binding /></options>
+            </control>
+
+            <!-- Browse arrows: left/right load decks; up/down move selection. -->
+            <control>
+                <group>[Library]</group>
+                <key>Push2.browse</key>
+                <status>0xB0</status>
+                <midino>0x2C</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>Push2.browse</key>
+                <status>0xB0</status>
+                <midino>0x2D</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>Push2.browse</key>
+                <status>0xB0</status>
+                <midino>0x2E</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>Push2.browse</key>
+                <status>0xB0</status>
+                <midino>0x2F</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>Push2.loadTrack</key>
+                <status>0xB0</status>
+                <midino>0x66</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>Push2.loadTrack</key>
+                <status>0xB0</status>
+                <midino>0x6D</midino>
+                <options><script-binding /></options>
+            </control>
+
+            <!-- Track encoders: high/mid/low/filter for deck 1, then deck 2. -->
+            <control>
+                <group>[Channel1]</group>
+                <key>Push2.deckEncoder</key>
+                <status>0xB0</status>
+                <midino>0x47</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>Push2.deckEncoder</key>
+                <status>0xB0</status>
+                <midino>0x48</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>Push2.deckEncoder</key>
+                <status>0xB0</status>
+                <midino>0x49</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>Push2.deckEncoder</key>
+                <status>0xB0</status>
+                <midino>0x4A</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>Push2.deckEncoder</key>
+                <status>0xB0</status>
+                <midino>0x4B</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>Push2.deckEncoder</key>
+                <status>0xB0</status>
+                <midino>0x4C</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>Push2.deckEncoder</key>
+                <status>0xB0</status>
+                <midino>0x4D</midino>
+                <options><script-binding /></options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>Push2.deckEncoder</key>
+                <status>0xB0</status>
+                <midino>0x4E</midino>
+                <options><script-binding /></options>
+            </control>
+
+            <!-- Tempo encoder browses the focused library list. -->
+            <control>
+                <group>[Library]</group>
+                <key>Push2.browseEncoder</key>
+                <status>0xB0</status>
+                <midino>0x0E</midino>
+                <options><script-binding /></options>
+            </control>
+
+            <!-- Touching the Tempo encoder momentarily opens the library view. -->
+            <control>
+                <group>[Controls]</group>
+                <key>Push2.tempoEncoderTouch</key>
+                <status>0x90</status>
+                <midino>0x0A</midino>
+                <options><script-binding /></options>
+            </control>
+
+            <!-- The adjacent Swing encoder zooms both deck waveforms. -->
+            <control>
+                <group>[Controls]</group>
+                <key>Push2.waveformZoomEncoder</key>
+                <status>0xB0</status>
+                <midino>0x0F</midino>
+                <options><script-binding /></options>
+            </control>
+
+            <!-- Bottom pad row: deck 1 hotcues 1-8. -->
+            <control><group>[Channel1]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x24</midino><options><script-binding /></options></control>
+            <control><group>[Channel1]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x25</midino><options><script-binding /></options></control>
+            <control><group>[Channel1]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x26</midino><options><script-binding /></options></control>
+            <control><group>[Channel1]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x27</midino><options><script-binding /></options></control>
+            <control><group>[Channel1]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x28</midino><options><script-binding /></options></control>
+            <control><group>[Channel1]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x29</midino><options><script-binding /></options></control>
+            <control><group>[Channel1]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x2A</midino><options><script-binding /></options></control>
+            <control><group>[Channel1]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x2B</midino><options><script-binding /></options></control>
+
+            <!-- Second pad row: deck 2 hotcues 1-8. -->
+            <control><group>[Channel2]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x2C</midino><options><script-binding /></options></control>
+            <control><group>[Channel2]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x2D</midino><options><script-binding /></options></control>
+            <control><group>[Channel2]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x2E</midino><options><script-binding /></options></control>
+            <control><group>[Channel2]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x2F</midino><options><script-binding /></options></control>
+            <control><group>[Channel2]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x30</midino><options><script-binding /></options></control>
+            <control><group>[Channel2]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x31</midino><options><script-binding /></options></control>
+            <control><group>[Channel2]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x32</midino><options><script-binding /></options></control>
+            <control><group>[Channel2]</group><key>Push2.hotcuePad</key><status>0x90</status><midino>0x33</midino><options><script-binding /></options></control>
+        </controls>
+    </controller>
+</MixxxControllerPreset>

--- a/res/controllers/Ableton-Push-2-Display.qml
+++ b/res/controllers/Ableton-Push-2-Display.qml
@@ -1,0 +1,309 @@
+import QtQuick 2.15
+
+import Mixxx 1.0 as Mixxx
+import Mixxx.Controls 1.0 as MixxxControls
+
+Mixxx.ControllerScreen {
+    id: root
+
+    required property string screenId
+
+    Mixxx.ControlProxy {
+        id: tempoEncoderTouch
+        group: "[Controls]"
+        key: "touch_shift"
+    }
+
+    Component {
+        id: deckWaveformComponent
+
+        Item {
+            id: deck
+
+            property string group: parent.deckGroup
+            property string deckName: parent.deckLabel
+            property color accentColor: parent.deckAccent
+
+            property var player: Mixxx.PlayerManager.getPlayer(group)
+
+        Mixxx.ControlProxy {
+            id: trackLoaded
+            group: deck.group
+            key: "track_loaded"
+
+            onValueChanged: {
+                deck.player = Mixxx.PlayerManager.getPlayer(deck.group);
+            }
+        }
+
+        Mixxx.ControlProxy {
+            id: waveformZoom
+            group: deck.group
+            key: "waveform_zoom"
+        }
+
+        Mixxx.ControlProxy {
+            id: bpm
+            group: deck.group
+            key: "bpm"
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: "#05070a"
+        }
+
+        MixxxControls.WaveformDisplay {
+            anchors.fill: parent
+            group: deck.group
+            // Show roughly 17 beats where the standard waveform zoom shows 9.
+            zoom: Math.min(10, Math.max(1, waveformZoom.value * 1.9))
+            backgroundColor: "#05070a"
+
+            Mixxx.WaveformRendererEndOfTrack {
+                color: "#802020"
+                endOfTrackWarningTime: 30
+            }
+
+            Mixxx.WaveformRendererPreroll {
+                color: "#554433"
+            }
+
+            Mixxx.WaveformRendererMarkRange {
+                Mixxx.WaveformMarkRange {
+                    startControl: "loop_start_position"
+                    endControl: "loop_end_position"
+                    enabledControl: "loop_enabled"
+                    color: deck.accentColor
+                    opacity: 0.32
+                    disabledColor: "#808080"
+                    disabledOpacity: 0.18
+                }
+            }
+
+            Mixxx.WaveformRendererRGB {
+                axesColor: "#60ffffff"
+                lowColor: deck.deckName === "DECK 1" ? "#e84a5f" : "#36b9e8"
+                midColor: deck.deckName === "DECK 1" ? "#ffd166" : "#63e6be"
+                highColor: "#f5f7fa"
+                gainAll: 1.0
+                gainLow: 1.0
+                gainMid: 1.0
+                gainHigh: 1.0
+            }
+
+            Mixxx.WaveformRendererBeat {
+                color: "#70ffffff"
+            }
+
+            Mixxx.WaveformRendererMark {
+                playMarkerColor: deck.accentColor
+                playMarkerBackground: "#50000000"
+                defaultMark: Mixxx.WaveformMark {
+                    align: "bottom|center"
+                    color: deck.accentColor
+                    textColor: "#ffffff"
+                    text: " %1 "
+                }
+
+                untilMark.showTime: false
+                untilMark.showBeats: true
+                untilMark.align: Qt.AlignCenter
+                untilMark.textSize: 12
+            }
+        }
+
+        Rectangle {
+            x: parent.width / 2
+            width: 2
+            height: parent.height
+            color: deck.accentColor
+            opacity: 0.9
+        }
+
+        Rectangle {
+            x: 5
+            y: 4
+            width: labelRow.width + 10
+            height: 22
+            radius: 3
+            color: "#b0000000"
+
+            Row {
+                id: labelRow
+                anchors.centerIn: parent
+                spacing: 8
+
+                Text {
+                    text: deck.deckName
+                    color: deck.accentColor
+                    font.family: "Noto Sans"
+                    font.pixelSize: 13
+                    font.bold: true
+                }
+
+                Text {
+                    text: deck.player && deck.player.isLoaded ? (deck.player.artist.length > 0 ? deck.player.artist + " — " + deck.player.title : deck.player.title) : "NO TRACK"
+                    color: "#f2f2f2"
+                    font.family: "Noto Sans"
+                    font.pixelSize: 12
+                    elide: Text.ElideRight
+                    width: Math.min(520, implicitWidth)
+                }
+            }
+        }
+
+        Rectangle {
+            anchors.right: parent.right
+            anchors.rightMargin: 5
+            y: 4
+            width: bpmText.width + 10
+            height: 22
+            radius: 3
+            color: "#b0000000"
+
+            Text {
+                id: bpmText
+                anchors.centerIn: parent
+                text: bpm.value > 0 ? Number(bpm.value).toFixed(1) + " BPM" : "--.- BPM"
+                color: "#f2f2f2"
+                font.family: "Noto Sans"
+                font.pixelSize: 12
+                font.bold: true
+            }
+        }
+        }
+    }
+
+    init: function (controllerName, isDebug) {
+        console.log("Starting Push 2 dual-deck waveform screen for " + controllerName);
+    }
+
+    shutdown: function () {
+        console.log("Stopping Push 2 dual-deck waveform screen");
+    }
+
+    transformFrame: function (input, timestamp) {
+        // The patched C++ USB backend performs the Push-specific XOR and
+        // line padding without a per-byte JavaScript loop.
+        return input;
+    }
+
+    Rectangle {
+        id: waveformView
+        anchors.fill: parent
+        color: "black"
+        visible: tempoEncoderTouch.value <= 0
+
+        Loader {
+            id: deck1
+            property string deckGroup: "[Channel1]"
+            property string deckLabel: "DECK 1"
+            property color deckAccent: "#ff6b6b"
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            height: 79
+            sourceComponent: deckWaveformComponent
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            y: 79
+            height: 2
+            color: "#d0d5db"
+        }
+
+        Loader {
+            id: deck2
+            property string deckGroup: "[Channel2]"
+            property string deckLabel: "DECK 2"
+            property color deckAccent: "#4dabf7"
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            y: 81
+            height: 79
+            sourceComponent: deckWaveformComponent
+        }
+    }
+
+    Rectangle {
+        id: libraryView
+        anchors.fill: parent
+        color: "#05070a"
+        visible: tempoEncoderTouch.value > 0
+        z: 10
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            height: 28
+            color: "#18202a"
+
+            Text {
+                anchors.centerIn: parent
+                text: "LIBRARY  ·  TEMPO: BROWSE  ·  \u2190 DECK 1  ·  DECK 2 \u2192"
+                color: "#f2f2f2"
+                font.family: "Noto Sans"
+                font.pixelSize: 13
+                font.bold: true
+            }
+        }
+
+        Item {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.topMargin: 30
+            anchors.bottom: parent.bottom
+
+            Text {
+                anchors.left: parent.left
+                anchors.leftMargin: 24
+                anchors.right: parent.right
+                anchors.rightMargin: 24
+                y: 12
+                text: Mixxx.Library.selectedTitle.length > 0
+                        ? Mixxx.Library.selectedTitle
+                        : "Turn Tempo to select a track"
+                color: "#ffffff"
+                font.family: "Noto Sans"
+                font.pixelSize: 28
+                font.bold: true
+                horizontalAlignment: Text.AlignHCenter
+                elide: Text.ElideRight
+            }
+
+            Text {
+                anchors.left: parent.left
+                anchors.leftMargin: 24
+                anchors.right: parent.right
+                anchors.rightMargin: 24
+                y: 52
+                text: Mixxx.Library.selectedArtist
+                color: "#62c5ff"
+                font.family: "Noto Sans"
+                font.pixelSize: 20
+                horizontalAlignment: Text.AlignHCenter
+                elide: Text.ElideRight
+            }
+
+            Text {
+                anchors.left: parent.left
+                anchors.leftMargin: 24
+                anchors.right: parent.right
+                anchors.rightMargin: 24
+                y: 84
+                text: Mixxx.Library.selectedAlbum
+                color: "#aeb8c3"
+                font.family: "Noto Sans"
+                font.pixelSize: 14
+                horizontalAlignment: Text.AlignHCenter
+                elide: Text.ElideRight
+            }
+        }
+    }
+}

--- a/res/controllers/Ableton-Push-2-scripts.js
+++ b/res/controllers/Ableton-Push-2-scripts.js
@@ -1,0 +1,224 @@
+// Ableton Push 2 MIDI mapping for Mixxx 2.6.
+//
+// Use the Push 2 User MIDI port. The separate "Ableton Push 2 Display"
+// USB-bulk mapping drives the screen.
+
+// eslint-disable-next-line no-var
+var Push2 = {
+    shiftPressed: false,
+    connections: [],
+
+    transportControls: {
+        20: {group: "[Channel1]", key: "play", kind: "toggle"},
+        21: {
+            group: "[Channel1]",
+            key: "cue_default",
+            ledKey: "cue_indicator",
+            kind: "momentary"
+        },
+        22: {group: "[Channel1]", key: "sync_enabled", kind: "toggle"},
+        23: {group: "[Channel1]", key: "pfl", kind: "toggle"},
+        24: {group: "[Channel2]", key: "play", kind: "toggle"},
+        25: {
+            group: "[Channel2]",
+            key: "cue_default",
+            ledKey: "cue_indicator",
+            kind: "momentary"
+        },
+        26: {group: "[Channel2]", key: "sync_enabled", kind: "toggle"},
+        27: {group: "[Channel2]", key: "pfl", kind: "toggle"}
+    },
+
+    // Default Push 2 palette: 126 is green, 127 is red, 125 is blue.
+    colors: {
+        off: 0,
+        deck1: 127,
+        deck2: 125,
+        active: 126
+    }
+};
+
+Push2.init = function() {
+    // User mode makes Push send control events to the User MIDI port.
+    midi.sendSysexMsg(
+        [0xF0, 0x00, 0x21, 0x1D, 0x01, 0x01, 0x0A, 0x01, 0xF7],
+        9);
+
+    Push2.connectTransportLEDs();
+    Push2.connectHotcueLEDs();
+    Push2.refreshLEDs();
+};
+
+Push2.shutdown = function() {
+    for (let control = 20; control <= 27; ++control) {
+        midi.sendShortMsg(0xB0, control, 0);
+    }
+    for (let note = 36; note <= 51; ++note) {
+        midi.sendShortMsg(0x90, note, 0);
+    }
+    for (const connection of Push2.connections) {
+        connection.disconnect();
+    }
+    Push2.connections = [];
+};
+
+Push2.relativeDelta = function(value) {
+    return value < 64 ? value : value - 128;
+};
+
+Push2.transport = function(channel, control, value) {
+    const mapping = Push2.transportControls[control];
+    if (!mapping) {
+        return;
+    }
+
+    if (mapping.kind === "momentary") {
+        engine.setValue(mapping.group, mapping.key, value > 0 ? 1 : 0);
+    } else if (value > 0) {
+        script.toggleControl(mapping.group, mapping.key);
+    }
+};
+
+Push2.shift = function(channel, control, value) {
+    Push2.shiftPressed = value > 0;
+};
+
+Push2.browse = function(channel, control, value) {
+    if (value === 0) {
+        return;
+    }
+    if (control === 44) {
+        script.triggerControl("[Channel1]", "LoadSelectedTrack");
+    } else if (control === 45) {
+        script.triggerControl("[Channel2]", "LoadSelectedTrack");
+    } else if (control === 46) {
+        script.triggerControl("[Library]", "MoveUp");
+    } else if (control === 47) {
+        script.triggerControl("[Library]", "MoveDown");
+    }
+};
+
+Push2.browseEncoder = function(channel, control, value) {
+    const delta = Push2.relativeDelta(value);
+    const key = delta > 0 ? "MoveDown" : "MoveUp";
+    for (let step = 0; step < Math.abs(delta); ++step) {
+        script.triggerControl("[Library]", key);
+    }
+};
+
+Push2.tempoEncoderTouch = function(channel, control, value) {
+    // Reuse Mixxx's momentary touch control to communicate with the separate
+    // QML display mapping. Touch sends a nonzero velocity; release sends zero.
+    engine.setValue("[Controls]", "touch_shift", value > 0 ? 1 : 0);
+};
+
+Push2.waveformZoomEncoder = function(channel, control, value) {
+    const delta = Push2.relativeDelta(value);
+    if (delta === 0) {
+        return;
+    }
+
+    // Keep the two Push waveforms at the same zoom. A higher Mixxx waveform
+    // zoom value shows a longer section of the track.
+    const currentZoom = engine.getValue("[Channel1]", "waveform_zoom");
+    const nextZoom = Math.max(1, Math.min(10, currentZoom + delta * 0.25));
+    for (let deck = 1; deck <= 2; ++deck) {
+        engine.setValue("[Channel" + deck + "]", "waveform_zoom", nextZoom);
+    }
+};
+
+Push2.loadTrack = function(channel, control, value, status, group) {
+    if (value > 0) {
+        script.triggerControl(group, "LoadSelectedTrack");
+    }
+};
+
+Push2.deckEncoder = function(channel, control, value, status, group) {
+    const encoderIndex = (control - 71) % 4;
+    const delta = Push2.relativeDelta(value) * 0.01;
+    let targetGroup;
+    let targetKey;
+
+    if (encoderIndex < 3) {
+        const deck = script.deckFromGroup(group);
+        targetGroup = "[EqualizerRack1_[Channel" + deck + "]_Effect1]";
+        // Encoders are physically ordered high, mid, low.
+        targetKey = "parameter" + (3 - encoderIndex);
+    } else {
+        targetGroup = "[QuickEffectRack1_" + group + "]";
+        targetKey = "super1";
+    }
+
+    const nextValue = Math.max(
+        0,
+        Math.min(1, engine.getParameter(targetGroup, targetKey) + delta));
+    engine.setParameter(targetGroup, targetKey, nextValue);
+};
+
+Push2.hotcuePad = function(channel, control, value, status, group) {
+    if (value === 0) {
+        return;
+    }
+
+    const hotcue = group === "[Channel1]" ? control - 35 : control - 43;
+    const action = Push2.shiftPressed ? "clear" : "activate";
+    script.triggerControl(group, "hotcue_" + hotcue + "_" + action);
+};
+
+Push2.connectTransportLEDs = function() {
+    Object.keys(Push2.transportControls).forEach(function(controlString) {
+        const control = Number(controlString);
+        const mapping = Push2.transportControls[control];
+        const connection = engine.makeConnection(
+            mapping.group,
+            mapping.ledKey || mapping.key,
+            function(value) {
+                const color = mapping.group === "[Channel1]"
+                    ? Push2.colors.deck1
+                    : Push2.colors.deck2;
+                midi.sendShortMsg(0xB0, control, value > 0 ? color : 0);
+            });
+        Push2.connections.push(connection);
+    });
+};
+
+Push2.connectHotcueLEDs = function() {
+    for (let deck = 1; deck <= 2; ++deck) {
+        const group = "[Channel" + deck + "]";
+        const firstNote = deck === 1 ? 36 : 44;
+        const color = deck === 1 ? Push2.colors.deck1 : Push2.colors.deck2;
+
+        for (let hotcue = 1; hotcue <= 8; ++hotcue) {
+            const note = firstNote + hotcue - 1;
+            const connection = engine.makeConnection(
+                group,
+                "hotcue_" + hotcue + "_enabled",
+                function(value) {
+                    midi.sendShortMsg(0x90, note, value > 0 ? color : 0);
+                });
+            Push2.connections.push(connection);
+        }
+    }
+};
+
+Push2.refreshLEDs = function() {
+    Object.keys(Push2.transportControls).forEach(function(controlString) {
+        const control = Number(controlString);
+        const mapping = Push2.transportControls[control];
+        const value = engine.getValue(mapping.group, mapping.ledKey || mapping.key);
+        const color = mapping.group === "[Channel1]"
+            ? Push2.colors.deck1
+            : Push2.colors.deck2;
+        midi.sendShortMsg(0xB0, control, value > 0 ? color : 0);
+    });
+
+    for (let deck = 1; deck <= 2; ++deck) {
+        const group = "[Channel" + deck + "]";
+        const firstNote = deck === 1 ? 36 : 44;
+        const color = deck === 1 ? Push2.colors.deck1 : Push2.colors.deck2;
+        for (let hotcue = 1; hotcue <= 8; ++hotcue) {
+            const enabled = engine.getValue(group, "hotcue_" + hotcue + "_enabled");
+            midi.sendShortMsg(0x90, firstNote + hotcue - 1, enabled > 0 ? color : 0);
+        }
+    }
+};

--- a/res/linux/mixxx-usb-uaccess.rules
+++ b/res/linux/mixxx-usb-uaccess.rules
@@ -54,5 +54,8 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="0582", TAG+="uaccess"
 # Sony Corp.
 KERNEL=="hidraw*", ATTRS{idVendor}=="054c", TAG+="uaccess"
 
+# Ableton AG (Push 2 display)
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="2982", TAG+="uaccess"
+
 # Missing:
 # - American Musical Supply (AMS/Mixars)

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -54,6 +54,7 @@
     <modalias>usb:v200Cp*</modalias>
     <modalias>usb:v0582p*</modalias>
     <modalias>usb:v054Cp*</modalias>
+    <modalias>usb:v2982p*</modalias>
   </provides>
   <screenshots>
     <screenshot type="default">

--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -299,11 +299,67 @@ bool BulkController::sendBytes(const QByteArray& data) {
     int ret;
     int transferred;
 
+    QByteArray pushFrame;
+    const QByteArray* pDataToSend = &data;
+
+    // Mixxx renders the Push 2 display as tightly packed 960 x 160 RGB565.
+    // Convert it here instead of in QML JavaScript: Push expects every
+    // 1920-byte pixel row to be XOR-masked and padded to 2048 bytes.
+    if (m_vendorId == 0x2982 &&
+            m_productId == 0x1967 &&
+            data.size() == 960 * 160 * 2) {
+        constexpr int kSourceLineBytes = 960 * 2;
+        constexpr int kTargetLineBytes = 2048;
+        constexpr int kDisplayHeight = 160;
+        constexpr unsigned char kXorPattern[] = {0xe7, 0xf3, 0xe7, 0xff};
+
+        pushFrame.resize(kTargetLineBytes * kDisplayHeight);
+        for (int y = 0; y < kDisplayHeight; ++y) {
+            const int sourceOffset = y * kSourceLineBytes;
+            const int targetOffset = y * kTargetLineBytes;
+            for (int x = 0; x < kSourceLineBytes; ++x) {
+                pushFrame[targetOffset + x] =
+                        data[sourceOffset + x] ^ kXorPattern[x & 3];
+            }
+            for (int x = kSourceLineBytes; x < kTargetLineBytes; ++x) {
+                pushFrame[targetOffset + x] = kXorPattern[x & 3];
+            }
+        }
+        pDataToSend = &pushFrame;
+    }
+
+    // Push 2 requires its 16-byte frame header to be a separate USB bulk
+    // transfer before the 160 * 2048 bytes of pixel-line data.
+    if (m_vendorId == 0x2982 &&
+            m_productId == 0x1967 &&
+            pDataToSend->size() == 160 * 2048) {
+        unsigned char frameHeader[16] = {
+                0xff, 0xcc, 0xaa, 0x88,
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00};
+        int headerTransferred;
+        ret = libusb_bulk_transfer(m_phandle,
+                m_outEndpointAddr,
+                frameHeader,
+                sizeof(frameHeader),
+                &headerTransferred,
+                5000);
+        if (ret < 0 ||
+                headerTransferred != static_cast<int>(sizeof(frameHeader))) {
+            qCWarning(m_logOutput)
+                    << "Unable to send Push 2 display frame header to"
+                    << getName() << "-" << libusb_error_name(ret);
+            return false;
+        }
+    }
+
     // XXX: don't get drunk again.
     ret = libusb_bulk_transfer(m_phandle,
             m_outEndpointAddr,
-            (unsigned char*)data.constData(),
-            data.size(),
+            reinterpret_cast<unsigned char*>(
+                    const_cast<char*>(pDataToSend->constData())),
+            pDataToSend->size(),
             &transferred,
             5000 // Send timeout in milliseconds
     );

--- a/src/controllers/bulk/bulksupported.h
+++ b/src/controllers/bulk/bulksupported.h
@@ -28,4 +28,5 @@ constexpr static bulk_support_lookup bulk_supported[] = {
         {{0x06f8, 0xb107}, {0x83, 0x03, std::nullopt}}, // Hercules Mk4
         {{0x06f8, 0xb100}, {0x86, 0x06, std::nullopt}}, // Hercules Mk2
         {{0x06f8, 0xb120}, {0x82, 0x03, std::nullopt}}, // Hercules MP3 LE / Glow
+        {{0x2982, 0x1967}, {0x81, 0x01, 0x00}},         // Ableton Push 2 display
 };

--- a/src/qml/qmllibraryproxy.cpp
+++ b/src/qml/qmllibraryproxy.cpp
@@ -4,14 +4,33 @@
 
 #include "library/library.h"
 #include "moc_qmllibraryproxy.cpp"
+#include "track/track.h"
 
 namespace mixxx {
 namespace qml {
 
 QmlLibraryProxy::QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent)
         : QObject(parent),
-          m_pLibrary(pLibrary),
-          m_pModelProperty(new QmlLibraryTrackListModel(m_pLibrary->trackTableModel(), this)) {
+          m_pLibrary(pLibrary) {
+    connect(m_pLibrary.get(),
+            &Library::trackSelected,
+            this,
+            &QmlLibraryProxy::slotTrackSelected);
+}
+
+QmlLibraryTrackListModel* QmlLibraryProxy::model() {
+    if (!m_pModelProperty) {
+        m_pModelProperty = new QmlLibraryTrackListModel(
+                m_pLibrary->trackTableModel(), this);
+    }
+    return m_pModelProperty;
+}
+
+void QmlLibraryProxy::slotTrackSelected(TrackPointer pTrack) {
+    m_selectedTitle = pTrack ? pTrack->getTitle() : QString{};
+    m_selectedArtist = pTrack ? pTrack->getArtist() : QString{};
+    m_selectedAlbum = pTrack ? pTrack->getAlbum() : QString{};
+    emit selectedTrackChanged();
 }
 
 // static

--- a/src/qml/qmllibraryproxy.h
+++ b/src/qml/qmllibraryproxy.h
@@ -1,9 +1,11 @@
 #pragma once
 #include <QObject>
 #include <QQmlEngine>
+#include <QString>
 #include <memory>
 
 #include "qml/qmllibrarytracklistmodel.h"
+#include "track/track_decl.h"
 #include "util/parented_ptr.h"
 
 class Library;
@@ -15,25 +17,47 @@ class QmlLibraryTrackListModel;
 
 class QmlLibraryProxy : public QObject {
     Q_OBJECT
-    Q_PROPERTY(mixxx::qml::QmlLibraryTrackListModel* model MEMBER m_pModelProperty CONSTANT)
+    Q_PROPERTY(mixxx::qml::QmlLibraryTrackListModel* model READ model CONSTANT)
+    Q_PROPERTY(QString selectedTitle READ selectedTitle NOTIFY selectedTrackChanged)
+    Q_PROPERTY(QString selectedArtist READ selectedArtist NOTIFY selectedTrackChanged)
+    Q_PROPERTY(QString selectedAlbum READ selectedAlbum NOTIFY selectedTrackChanged)
     QML_NAMED_ELEMENT(Library)
     QML_SINGLETON
 
   public:
     explicit QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent = nullptr);
 
+    QmlLibraryTrackListModel* model();
+    const QString& selectedTitle() const {
+        return m_selectedTitle;
+    }
+    const QString& selectedArtist() const {
+        return m_selectedArtist;
+    }
+    const QString& selectedAlbum() const {
+        return m_selectedAlbum;
+    }
+
     static QmlLibraryProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
     static void registerLibrary(std::shared_ptr<Library> pLibrary) {
         s_pLibrary = std::move(pLibrary);
     }
+
+  signals:
+    void selectedTrackChanged();
+
+  private slots:
+    void slotTrackSelected(TrackPointer pTrack);
 
   private:
     static inline std::shared_ptr<Library> s_pLibrary;
 
     std::shared_ptr<Library> m_pLibrary;
 
-    /// This needs to be a plain pointer because it's used as a `Q_PROPERTY` member variable.
-    QmlLibraryTrackListModel* m_pModelProperty;
+    QmlLibraryTrackListModel* m_pModelProperty{};
+    QString m_selectedTitle;
+    QString m_selectedArtist;
+    QString m_selectedAlbum;
 };
 
 } // namespace qml

--- a/src/qml/qmlwaveformrenderer.cpp
+++ b/src/qml/qmlwaveformrenderer.cpp
@@ -165,8 +165,8 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererMark::create(
     pRenderer->setPlayMarkerForegroundColor(m_playMarkerColor);
     pRenderer->setPlayMarkerBackgroundColor(m_playMarkerBackground);
 
-    pRenderer->setUntilMarkShowBeats(m_untilMark->showTime());
-    pRenderer->setUntilMarkShowTime(m_untilMark->showBeats());
+    pRenderer->setUntilMarkShowBeats(m_untilMark->showBeats());
+    pRenderer->setUntilMarkShowTime(m_untilMark->showTime());
     pRenderer->setUntilMarkAlign(m_untilMark->align());
     pRenderer->setUntilMarkTextSize(m_untilMark->textSize());
     pRenderer->setUntilMarkTextHeightLimit(m_untilMark->textHeightLimit());

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -227,6 +227,8 @@ void allshader::WaveformRenderMark::setup(const QDomNode& node, const SkinContex
 bool allshader::WaveformRenderMark::init() {
     m_pTimeRemainingControl = std::make_unique<ControlProxy>(
             m_waveformRenderer->getGroup(), "time_remaining");
+    m_pPlayPositionControl = std::make_unique<ControlProxy>(
+            m_waveformRenderer->getGroup(), "playposition");
     ::WaveformRenderMarkBase::init();
     return true;
 }
@@ -304,7 +306,20 @@ void allshader::WaveformRenderMark::update() {
     // (Will create textures so requires OpenGL context)
     updateMarkImages();
 
-    const double playPosition = m_waveformRenderer->getTruePosSample(positionType);
+    double playPosition = m_waveformRenderer->getTruePosSample(positionType);
+    if (!m_isSlipRenderer) {
+        // Controller screens have their own VSync provider. Its interpolated
+        // transport snapshot may occasionally be unavailable or stale, which
+        // used to freeze the beats-until-next-cue counter. The audio engine's
+        // normalized playposition is updated independently and is reliable
+        // enough for an integer beat count.
+        const double normalizedPlayPosition = m_pPlayPositionControl->get();
+        const double trackSamples = m_waveformRenderer->getTrackSamples();
+        if (normalizedPlayPosition >= 0.0 && normalizedPlayPosition <= 1.0 &&
+                trackSamples > 0.0) {
+            playPosition = normalizedPlayPosition * trackSamples;
+        }
+    }
     double nextMarkPosition = std::numeric_limits<double>::max();
 
     GeometryNode* pRangeChild = static_cast<GeometryNode*>(m_pRangeNodesParent->firstChild());

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -83,6 +83,7 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
     double m_currentBeatPosition;
     double m_nextBeatPosition;
     std::unique_ptr<ControlProxy> m_pTimeRemainingControl;
+    std::unique_ptr<ControlProxy> m_pPlayPositionControl;
 
     bool m_isSlipRenderer;
 


### PR DESCRIPTION
Added support for the Ableton  Push 2.
Controller bindings are still really basic and could be improved.
The display works (waveform + library browser).

required udev rules added under /res/linux

