### PR TITLE
ControllerScriptInterfaceLegacy: add engine.getPlaypositionSamples()

### DIFF
--- a/res/controllers/engine-api.d.ts
+++ b/res/controllers/engine-api.d.ts
@@ -153,6 +153,17 @@ declare namespace engine {
     function getValue<TGroup extends MixxxControls.Group>(group: TGroup, name: MixxxControls.Ctrl<TGroup>): number;
 
     /**
+     * Gets the current play position of a deck in samples
+     *
+     * This is a convenience helper equivalent to multiplying the relative
+     * "playposition" control by the "track_samples" control.
+     *
+     * @param group Group of the deck e.g. "[Channel1]"
+     * @returns The absolute play position in samples, or 0 if the deck has no track loaded
+     */
+    function getPlaypositionSamples<TGroup extends MixxxControls.Group>(group: TGroup): number;
+
+    /**
      * Sets a control value
      *
      * @param group Group of the control e.g. "[Channel1]"

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -151,6 +151,15 @@ double ControllerScriptInterfaceLegacy::getValue(const QString& group, const QSt
     return coScript->get();
 }
 
+double ControllerScriptInterfaceLegacy::getPlaypositionSamples(const QString& group) {
+    // "playposition" is a relative control (0.0 = track start, 1.0 = track end).
+    // Multiplying by "track_samples" yields the absolute sample position, matching
+    // the sample-based position controls (e.g. "loop_end_position"). This spares
+    // mappings from computing the product themselves.
+    return getValue(group, QStringLiteral("playposition")) *
+            getValue(group, QStringLiteral("track_samples"));
+}
+
 void ControllerScriptInterfaceLegacy::setValue(
         const QString& group, const QString& name, double newValue) {
     if (util_isnan(newValue)) {

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -58,6 +58,7 @@ class ControllerScriptInterfaceLegacy : public QObject {
     Q_INVOKABLE QJSValue getSetting(const QString& name);
     Q_INVOKABLE QObject* getPlayer(const QString& group);
     Q_INVOKABLE double getValue(const QString& group, const QString& name);
+    Q_INVOKABLE double getPlaypositionSamples(const QString& group);
     Q_INVOKABLE void setValue(const QString& group, const QString& name, double newValue);
     Q_INVOKABLE double getParameter(const QString& group, const QString& name);
     Q_INVOKABLE void setParameter(const QString& group, const QString& name, double newValue);

--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -258,6 +258,21 @@ TEST_F(ControllerScriptEngineLegacyTest, getValue_InvalidControl) {
     EXPECT_TRUE(evaluateAndAssert("engine.getValue('[Nothing]', 'nothing');"));
 }
 
+TEST_F(ControllerScriptEngineLegacyTest, getPlaypositionSamples) {
+    auto playposition = std::make_unique<ControlObject>(ConfigKey("[Test]", "playposition"));
+    auto trackSamples = std::make_unique<ControlObject>(ConfigKey("[Test]", "track_samples"));
+    playposition->set(0.25);
+    trackSamples->set(2000.0);
+    EXPECT_DOUBLE_EQ(500.0, evaluate("engine.getPlaypositionSamples('[Test]');").toNumber());
+}
+
+TEST_F(ControllerScriptEngineLegacyTest, getPlaypositionSamples_NoTrackLoaded) {
+    // With no track loaded, track_samples is 0, so the position is 0 too.
+    auto playposition = std::make_unique<ControlObject>(ConfigKey("[Test]", "playposition"));
+    auto trackSamples = std::make_unique<ControlObject>(ConfigKey("[Test]", "track_samples"));
+    EXPECT_DOUBLE_EQ(0.0, evaluate("engine.getPlaypositionSamples('[Test]');").toNumber());
+}
+
 TEST_F(ControllerScriptEngineLegacyTest, setValue_IgnoresNaN) {
     auto co = std::make_unique<ControlObject>(ConfigKey("[Test]", "co"));
     co->set(10.0);


### PR DESCRIPTION
## Summary

Adds a `engine.getPlaypositionSamples(group)` scripting helper that returns a deck's absolute play position in samples, i.e. the relative `"playposition"` control multiplied by `"track_samples"`. This spares controller mappings from computing the product by hand and gives a value in the same units as the other sample-based position controls (e.g. `"loop_end_position"`).

Resolves #12950.

## Approach

Per the discussion in #12950, the maintainers explicitly chose a **script helper** over adding another sample-based `ControlObject` (to avoid growing the sample-based CO surface while the engine moves toward frame-based controls). This implements exactly that: a small helper on the `engine` object (`ControllerScriptInterfaceLegacy`), reusing `getValue()` so error handling stays consistent.

## Changes

- `controllerscriptinterfacelegacy.{h,cpp}`: add `getPlaypositionSamples()`
- `res/controllers/engine-api.d.ts`: TypeScript declaration + JSDoc for mapping-dev autocompletion
- `controllerscriptenginelegacy_test.cpp`: unit tests (normal case and no-track-loaded)

## Testing

- `ctest -R ControllerScriptEngineLegacy` → 51/51 pass, including the 2 new tests
- pre-commit (clang-format 19.1.3, prettier 3.1.0, eslint, codespell, …) and clang-tidy pass on the changed files

This is my first contribution to Mixxx — feedback very welcome.