### PR TITLE
CueControl: reject hotcue position writes when unset

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2638,10 +2638,6 @@ HotcueControl::HotcueControl(const QString& group, int hotcueIndex)
             &HotcueControl::slotHotcuePositionChanged,
             Qt::DirectConnection);
     m_hotcuePosition->set(Cue::kNoPosition);
-    // The position may only be moved by dragging an existing hotcue, so route
-    // write requests through a handler that rejects them unless the hotcue is
-    // set. This also makes the control confirm-required, so engine-side updates
-    // must use setAndConfirm() (see HotcueControl::setPosition()).
     m_hotcuePosition->connectValueChangeRequest(
             this,
             &HotcueControl::slotHotcuePositionChangeRequest,
@@ -2655,6 +2651,10 @@ HotcueControl::HotcueControl(const QString& group, int hotcueIndex)
             &HotcueControl::slotHotcueEndPositionChanged,
             Qt::DirectConnection);
     m_hotcueEndPosition->set(Cue::kNoPosition);
+    m_hotcueEndPosition->connectValueChangeRequest(
+            this,
+            &HotcueControl::slotHotcueEndPositionChangeRequest,
+            Qt::DirectConnection);
 
     m_pHotcueStatus = std::make_unique<ControlObject>(keyForControl(QStringLiteral("status")));
     m_pHotcueStatus->setReadOnly();
@@ -2846,18 +2846,22 @@ void HotcueControl::slotHotcuePositionChanged(double newPosition) {
 }
 
 void HotcueControl::slotHotcuePositionChangeRequest(double newPosition) {
-    // Reject the change if no hotcue is set: the position can only be moved by
-    // dragging an existing hotcue, not to create one (see issue #10409).
+    // Reject the change if no hotcue is set
     if (!m_pCue) {
         return;
     }
-    // Delegate to CueControl::hotcuePositionChanged(), which validates the
-    // position and moves the cue. The resulting cue change syncs the position
-    // control back to the confirmed value via loadCuesFromTrack().
     emit hotcuePositionChanged(this, newPosition);
 }
 
 void HotcueControl::slotHotcueEndPositionChanged(double newEndPosition) {
+    emit hotcueEndPositionChanged(this, newEndPosition);
+}
+
+void HotcueControl::slotHotcueEndPositionChangeRequest(double newEndPosition) {
+    // Reject the change if no hotcue is set
+    if (!m_pCue) {
+        return;
+    }
     emit hotcueEndPositionChanged(this, newEndPosition);
 }
 
@@ -2925,14 +2929,13 @@ void HotcueControl::resetCue() {
 }
 
 void HotcueControl::setPosition(mixxx::audio::FramePos position) {
-    // Use setAndConfirm() because m_hotcuePosition is confirm-required: a plain
-    // set() would be intercepted as a change request instead of updating the
-    // engine-authoritative value.
+    // setAndConfirm() because m_hotcuePosition is confirm-required.
     m_hotcuePosition->setAndConfirm(position.toEngineSamplePosMaybeInvalid());
 }
 
 void HotcueControl::setEndPosition(mixxx::audio::FramePos endPosition) {
-    m_hotcueEndPosition->set(endPosition.toEngineSamplePosMaybeInvalid());
+    // setAndConfirm() because m_hotcueEndPosition is confirm-required.
+    m_hotcueEndPosition->setAndConfirm(endPosition.toEngineSamplePosMaybeInvalid());
 }
 
 mixxx::CueType HotcueControl::getType() const {

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2638,6 +2638,14 @@ HotcueControl::HotcueControl(const QString& group, int hotcueIndex)
             &HotcueControl::slotHotcuePositionChanged,
             Qt::DirectConnection);
     m_hotcuePosition->set(Cue::kNoPosition);
+    // The position may only be moved by dragging an existing hotcue, so route
+    // write requests through a handler that rejects them unless the hotcue is
+    // set. This also makes the control confirm-required, so engine-side updates
+    // must use setAndConfirm() (see HotcueControl::setPosition()).
+    m_hotcuePosition->connectValueChangeRequest(
+            this,
+            &HotcueControl::slotHotcuePositionChangeRequest,
+            Qt::DirectConnection);
 
     m_hotcueEndPosition = std::make_unique<ControlObject>(
             keyForControl(QStringLiteral("endposition")));
@@ -2837,6 +2845,18 @@ void HotcueControl::slotHotcuePositionChanged(double newPosition) {
     emit hotcuePositionChanged(this, newPosition);
 }
 
+void HotcueControl::slotHotcuePositionChangeRequest(double newPosition) {
+    // Reject the change if no hotcue is set: the position can only be moved by
+    // dragging an existing hotcue, not to create one (see issue #10409).
+    if (!m_pCue) {
+        return;
+    }
+    // Delegate to CueControl::hotcuePositionChanged(), which validates the
+    // position and moves the cue. The resulting cue change syncs the position
+    // control back to the confirmed value via loadCuesFromTrack().
+    emit hotcuePositionChanged(this, newPosition);
+}
+
 void HotcueControl::slotHotcueEndPositionChanged(double newEndPosition) {
     emit hotcueEndPositionChanged(this, newEndPosition);
 }
@@ -2905,7 +2925,10 @@ void HotcueControl::resetCue() {
 }
 
 void HotcueControl::setPosition(mixxx::audio::FramePos position) {
-    m_hotcuePosition->set(position.toEngineSamplePosMaybeInvalid());
+    // Use setAndConfirm() because m_hotcuePosition is confirm-required: a plain
+    // set() would be intercepted as a change request instead of updating the
+    // engine-authoritative value.
+    m_hotcuePosition->setAndConfirm(position.toEngineSamplePosMaybeInvalid());
 }
 
 void HotcueControl::setEndPosition(mixxx::audio::FramePos endPosition) {

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -138,6 +138,7 @@ class HotcueControl : public QObject {
     void slotHotcueSwap(double v);
     void slotHotcueEndPositionChanged(double newPosition);
     void slotHotcuePositionChanged(double newPosition);
+    void slotHotcuePositionChangeRequest(double newPosition);
     void slotHotcueColorChangeRequest(double newColor);
 
   signals:

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -139,6 +139,7 @@ class HotcueControl : public QObject {
     void slotHotcueEndPositionChanged(double newPosition);
     void slotHotcuePositionChanged(double newPosition);
     void slotHotcuePositionChangeRequest(double newPosition);
+    void slotHotcueEndPositionChangeRequest(double newEndPosition);
     void slotHotcueColorChangeRequest(double newColor);
 
   signals:

--- a/src/test/hotcuecontrol_test.cpp
+++ b/src/test/hotcuecontrol_test.cpp
@@ -281,6 +281,74 @@ TEST_F(HotcueControlTest, PositionChangeRequestRejectedWhenUnset) {
             m_pHotcue1Status->get());
 }
 
+TEST_F(HotcueControlTest, EndPositionChangeRequestRejectedWhenUnset) {
+    createAndLoadFakeTrack();
+
+    // With no hotcue set the end position control must reject write requests and
+    // stay unset instead of storing a bogus value (issue #10409).
+    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+            m_pHotcue1EndPosition->get())
+                    .isValid());
+
+    m_pHotcue1EndPosition->set(mixxx::audio::FramePos(200).toEngineSamplePos());
+    ProcessBuffer();
+
+    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+            m_pHotcue1EndPosition->get())
+                    .isValid());
+    EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty),
+            m_pHotcue1Status->get());
+}
+
+TEST_F(HotcueControlTest, EndPositionChangeRequestMovesSetLoop) {
+    createAndLoadFakeTrack();
+
+    // Create a saved loop hotcue at [100, 200].
+    constexpr mixxx::audio::FramePos loopStartPosition(100);
+    constexpr mixxx::audio::FramePos loopEndPosition(200);
+    m_pChannel1->getEngineBuffer()->setLoop(
+            loopStartPosition, loopEndPosition, true);
+    m_pHotcue1Set->set(1);
+    m_pHotcue1Set->set(0);
+    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+
+    // Writing the end position control of a set loop hotcue must still move the
+    // loop end (the confirm-required guard only rejects writes when unset).
+    constexpr mixxx::audio::FramePos newEndPosition(300);
+    m_pHotcue1EndPosition->set(newEndPosition.toEngineSamplePos());
+    ProcessBuffer();
+
+    EXPECT_FRAMEPOS_EQ_CONTROL(newEndPosition, m_pHotcue1EndPosition);
+}
+
+TEST_F(HotcueControlTest, EndPositionChangeRequestClearsSetLoop) {
+    createAndLoadFakeTrack();
+
+    // Create a saved loop hotcue at [100, 200].
+    constexpr mixxx::audio::FramePos loopStartPosition(100);
+    constexpr mixxx::audio::FramePos loopEndPosition(200);
+    m_pChannel1->getEngineBuffer()->setLoop(
+            loopStartPosition, loopEndPosition, true);
+    m_pHotcue1Set->set(1);
+    m_pHotcue1Set->set(0);
+    EXPECT_FRAMEPOS_EQ_CONTROL(loopEndPosition, m_pHotcue1EndPosition);
+
+    // Writing Cue::kNoPosition to the end position of a set loop hotcue clears
+    // the end and converts the loop back into a plain hotcue. This still routes
+    // through the confirm-required handler because the hotcue is set.
+    ControlProxy hotcueType(m_sGroup1, QStringLiteral("hotcue_1_type"));
+    m_pHotcue1EndPosition->set(Cue::kNoPosition);
+    ProcessBuffer();
+
+    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+            m_pHotcue1EndPosition->get())
+                    .isValid());
+    EXPECT_DOUBLE_EQ(static_cast<double>(mixxx::CueType::HotCue),
+            hotcueType.get());
+    // The hotcue itself remains at its start position.
+    EXPECT_FRAMEPOS_EQ_CONTROL(loopStartPosition, m_pHotcue1Position);
+}
+
 TEST_F(HotcueControlTest, PositionChangeRequestMovesSetHotcue) {
     createAndLoadFakeTrack();
 

--- a/src/test/hotcuecontrol_test.cpp
+++ b/src/test/hotcuecontrol_test.cpp
@@ -262,6 +262,48 @@ TEST_F(HotcueControlTest, SetCueManual) {
                          .isValid());
 }
 
+TEST_F(HotcueControlTest, PositionChangeRequestRejectedWhenUnset) {
+    createAndLoadFakeTrack();
+
+    // With no hotcue set the position control must reject write requests and
+    // stay unset instead of storing a bogus value (issue #10409).
+    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+            m_pHotcue1Position->get())
+                    .isValid());
+
+    m_pHotcue1Position->set(mixxx::audio::FramePos(100).toEngineSamplePos());
+    ProcessBuffer();
+
+    EXPECT_FALSE(mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+            m_pHotcue1Position->get())
+                    .isValid());
+    EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Empty),
+            m_pHotcue1Status->get());
+}
+
+TEST_F(HotcueControlTest, PositionChangeRequestMovesSetHotcue) {
+    createAndLoadFakeTrack();
+
+    constexpr mixxx::audio::FramePos hotcuePosition(100);
+    constexpr mixxx::audio::FramePos movedPosition(200);
+
+    m_pQuantizeEnabled->set(0);
+    setCurrentFramePosition(hotcuePosition);
+    m_pHotcue1SetCue->set(1);
+    m_pHotcue1SetCue->set(0);
+    EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set),
+            m_pHotcue1Status->get());
+    EXPECT_FRAMEPOS_EQ_CONTROL(hotcuePosition, m_pHotcue1Position);
+
+    // Writing to the position control of a set hotcue moves it.
+    m_pHotcue1Position->set(movedPosition.toEngineSamplePos());
+    ProcessBuffer();
+
+    EXPECT_FRAMEPOS_EQ_CONTROL(movedPosition, m_pHotcue1Position);
+    EXPECT_DOUBLE_EQ(static_cast<double>(HotcueControl::Status::Set),
+            m_pHotcue1Status->get());
+}
+
 TEST_F(HotcueControlTest, SetLoopAutoNoRedundantLoopCue) {
     createAndLoadFakeTrack();
 


### PR DESCRIPTION
## Summary

Fixes mixxxdj/mixxx#10409.

`hotcue_X_position` was a plain writable `ControlObject`, so a script or controller could write to it even when **no hotcue was set**. The underlying cue never moved — `CueControl::hotcuePositionChanged()` already rejects a null cue — but the raw `set()` still stored a bogus value in the control, which was then reported back on read.

## Approach

Route external writes through `connectValueChangeRequest`, mirroring the existing `hotcue_X_color` pattern:

- The new `slotHotcuePositionChangeRequest()` **rejects the request unless a hotcue is set** (guards on the `m_pCue` pointer).
- Otherwise it delegates to the existing validated move path (`CueControl::hotcuePositionChanged`), so moving an existing hotcue still works; the resulting cue change syncs the control back to the cue's actual (validated) position via `loadCuesFromTrack()`.
- Because the control is now confirm-required, the engine-side sync in `HotcueControl::setPosition()` uses `setAndConfirm()`.

This supersedes the earlier stalled attempt in #13446. It intentionally does **not** call `setReadOnly()` (which, combined with a request handler, would log a spurious `is read-only. Ignoring` warning on every legitimate hotcue move) and guards on `m_pCue` rather than the control value (the old `!m_hotcuePosition->get()` check misfires at position 0).

## Changes

- `src/engine/controls/cuecontrol.cpp` — wire the change-request handler, add `slotHotcuePositionChangeRequest()`, use `setAndConfirm()` in `setPosition()`.
- `src/engine/controls/cuecontrol.h` — slot declaration.
- `src/test/hotcuecontrol_test.cpp` — two tests: a write is rejected when no hotcue is set; a write moves a set hotcue.

## Testing

- `HotcueControlTest` (32 tests) and all cue/loop suites (113 tests) pass.
- clang-format, clang-tidy, and the other pre-commit hooks are clean.
