### PR TITLE
DlgPrefLibrary: add option to reset missing tags on import

### DIFF
--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -269,6 +269,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     spinbox_history_min_tracks_to_keep->setValue(1);
     checkBox_sync_track_metadata->setChecked(false);
     checkBox_serato_metadata_export->setChecked(false);
+    checkBox_reset_missing_tag_metadata->setChecked(false);
     checkBox_use_relative_path->setChecked(false);
     checkBox_edit_metadata_selected_clicked->setChecked(kEditMetadataSelectedClickDefault);
     radioButton_dbclick_deck->setChecked(true);
@@ -327,6 +328,8 @@ void DlgPrefLibrary::slotUpdate() {
     checkBox_serato_metadata_export->setChecked(
             m_pConfig->getValue(kSyncSeratoMetadataConfigKey, false));
     setSeratoMetadataEnabled(checkBox_sync_track_metadata->isChecked());
+    checkBox_reset_missing_tag_metadata->setChecked(
+            m_pConfig->getValue(kResetMissingTagMetadataOnImportConfigKey, false));
     checkBox_use_relative_path->setChecked(m_pConfig->getValue(
             kUseRelativePathOnExportConfigKey, false));
 
@@ -610,6 +613,9 @@ void DlgPrefLibrary::slotApply() {
     m_pConfig->set(
             kSyncSeratoMetadataConfigKey,
             ConfigValue{checkBox_serato_metadata_export->isChecked()});
+    m_pConfig->set(
+            kResetMissingTagMetadataOnImportConfigKey,
+            ConfigValue{checkBox_reset_missing_tag_metadata->isChecked()});
 
     m_pConfig->set(kUseRelativePathOnExportConfigKey,
             ConfigValue((int)checkBox_use_relative_path->isChecked()));

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -784,6 +784,7 @@
   <tabstop>checkBox_library_scan_summary</tabstop>
   <tabstop>checkBox_sync_track_metadata</tabstop>
   <tabstop>checkBox_serato_metadata_export</tabstop>
+  <tabstop>checkBox_reset_missing_tag_metadata</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>
   <tabstop>checkBox_edit_metadata_selected_clicked</tabstop>
   <tabstop>radioButton_dbclick_deck</tabstop>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -156,6 +156,17 @@
       </item>
 
       <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkBox_reset_missing_tag_metadata">
+        <property name="toolTip">
+         <string>When reimporting track metadata from file tags, clear library fields that are empty or missing in the file tags instead of keeping the existing value.</string>
+        </property>
+        <property name="text">
+         <string>Reset missing metadata fields when reimporting from file tags</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_use_relative_path">
         <property name="text">
          <string>Use relative paths for playlist export if possible</string>


### PR DESCRIPTION
## Summary

Resolves mixxxdj/mixxx#11241.

The `ResetMissingTagMetadataOnImport` behavior already exists in the backend — `DlgTrackInfo::slotImportMetadataFromFile()` reads `kResetMissingTagMetadataOnImportConfigKey` directly — but there was no UI to enable it. As reported, this meant **"Import From File Tags" would not clear** a library field such as *Album Artist* after it had been emptied in another tag editor.

Per @uklotzde in the issue thread, the only missing piece was *"a UI option for `kResetMissingTagMetadataOnImportConfigKey`"* — this PR adds exactly that.

## Approach

Add a standalone checkbox **"Reset missing metadata fields when reimporting from file tags"** to Library preferences → *Track Metadata Synchronization*, bound to the existing config key:

- loaded in `slotUpdate()`
- saved in `slotApply()`
- reset in `slotResetToDefaults()`

The manual import path reads the key directly and is **not** gated on `kSyncTrackMetadataConfigKey`, so this is an independent option rather than a sub-option of "Synchronize library track metadata".

## Changes

- `src/preferences/dialog/dlgpreflibrarydlg.ui` — new checkbox in the metadata group.
- `src/preferences/dialog/dlgpreflibrary.cpp` — load/save/default wiring.

## Screenshots

**Before** — sync / Serato / relative paths:

![before](https://raw.githubusercontent.com/gary-gdbsystems/mixxx/pr-screenshots/11241-before.png)

**After** — adds “Reset missing metadata fields when reimporting from file tags”:

![after](https://raw.githubusercontent.com/gary-gdbsystems/mixxx/pr-screenshots/11241-after.png)

## Testing

- Builds cleanly (incl. `uic` regeneration of the dialog).
- clang-format and the other pre-commit hooks pass.
- Verified the new checkbox renders in the correct position within the metadata group.
