### PR TITLE
Alternative fix for #16306 / Overview playpos drag / Wayland

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -531,11 +531,7 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
             return;
         }
 
-        if (m_orientation == Qt::Horizontal) {
-            m_iPickupPos = math_clamp(e->pos().x(), 0, width() - 1);
-        } else {
-            m_iPickupPos = math_clamp(e->pos().y(), 0, height() - 1);
-        }
+        m_iPickupPos = clampedPickupPos(e->pos());
     }
 
     // Do not activate cue hovering while right click is held down and the
@@ -564,30 +560,33 @@ void WOverview::mouseReleaseEvent(QMouseEvent* e) {
         unsetCursor();
         return;
     }
-    //qDebug() << "WOverview::mouseReleaseEvent" << e->pos() << m_iPos << ">>" << dValue;
+    // qDebug() << "WOverview::mouseReleaseEvent" << e->pos() << m_iPickupPos << ">>" << positionToValue(m_iPickupPos);
 
     if (e->button() == Qt::LeftButton) {
         if (m_bLeftClickDragging) {
             unsetCursor();
-            if (isPosInAllowedPosDragZone(e->pos())) {
-                m_iPlayPos = m_iPickupPos;
-                double dValue = positionToValue(m_iPickupPos);
-                setControlParameterUp(dValue);
-                m_bLeftClickDragging = false;
-            } else {
+            if (!isPosInAllowedPosDragZone(e->pos())) {
                 // Abort dragging if we are way outside the widget.
                 m_iPickupPos = m_iPlayPos;
-                m_bLeftClickDragging = false;
-                m_bTimeRulerActive = false;
-                return;
+            } else {
+                leftMouseDragRelease(e->pos());
             }
         }
+        m_bLeftClickDragging = false;
         m_bTimeRulerActive = false;
     } else if (e->button() == Qt::RightButton) {
         // Do not seek when releasing a right click. This is important to
         // prevent accidental seeking when trying to right click a hotcue.
         m_bTimeRulerActive = false;
     }
+}
+
+void WOverview::leftMouseDragRelease(QPoint pos) {
+    m_iPickupPos = clampedPickupPos(pos);
+    m_iPlayPos = m_iPickupPos;
+    double dValue = positionToValue(m_iPlayPos);
+    // Do the seek.
+    setControlParameterUp(dValue);
 }
 
 void WOverview::mousePressEvent(QMouseEvent* e) {
@@ -603,11 +602,7 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
         return;
     }
     if (e->button() == Qt::LeftButton) {
-        if (m_orientation == Qt::Horizontal) {
-            m_iPickupPos = math_clamp(e->pos().x(), 0, width() - 1);
-        } else {
-            m_iPickupPos = math_clamp(e->pos().y(), 0, height() - 1);
-        }
+        m_iPickupPos = clampedPickupPos(e->pos());
 
         if (m_pHoveredMark != nullptr) {
             double dValue = m_pHoveredMark->getSamplePosition() / trackSamples;
@@ -680,7 +675,7 @@ void WOverview::leaveEvent(QEvent* pEvent) {
     // Note: casting to QMouseEvent works, but buttons are not reported correctly,
     // QGuiApplication::mouseButtons() is the way to go here.
     if (QGuiApplication::mouseButtons() & Qt::LeftButton) {
-        return;
+        leftMouseDragRelease(mapFromGlobal(QCursor::pos()));
     }
     if (!m_pCueMenuPopup->isVisible()) {
         m_pHoveredMark.clear();

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -570,6 +570,7 @@ void WOverview::mouseReleaseEvent(QMouseEvent* e) {
 
 void WOverview::leftMouseDragRelease(QPoint pos) {
     unsetCursor();
+    m_bLeftClickDragging = false;
     if (!isPosInAllowedPosDragZone(pos)) {
         // Abort dragging if we are way outside the widget.
         m_iPickupPos = m_iPlayPos;
@@ -581,7 +582,6 @@ void WOverview::leftMouseDragRelease(QPoint pos) {
     double dValue = positionToValue(m_iPlayPos);
     // Do the seek.
     setControlParameterUp(dValue);
-    m_bLeftClickDragging = false;
 }
 
 void WOverview::mousePressEvent(QMouseEvent* e) {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -564,7 +564,6 @@ void WOverview::mouseReleaseEvent(QMouseEvent* e) {
 
     if (e->button() == Qt::LeftButton && m_bLeftClickDragging) {
         leftMouseDragRelease(e->pos());
-        m_bLeftClickDragging = false;
     }
     m_bTimeRulerActive = false;
 }
@@ -582,6 +581,7 @@ void WOverview::leftMouseDragRelease(QPoint pos) {
     double dValue = positionToValue(m_iPlayPos);
     // Do the seek.
     setControlParameterUp(dValue);
+    m_bLeftClickDragging = false;
 }
 
 void WOverview::mousePressEvent(QMouseEvent* e) {
@@ -669,7 +669,7 @@ void WOverview::leaveEvent(QEvent* pEvent) {
     // We still get another leave event when we release outside WOverview.
     // Note: casting to QMouseEvent works, but buttons are not reported correctly,
     // QGuiApplication::mouseButtons() is the way to go here.
-    if (QGuiApplication::mouseButtons() & Qt::LeftButton) {
+    if ((QGuiApplication::mouseButtons() & Qt::LeftButton) && m_bLeftClickDragging) {
         leftMouseDragRelease(mapFromGlobal(QCursor::pos()));
     }
     if (!m_pCueMenuPopup->isVisible()) {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -562,26 +562,21 @@ void WOverview::mouseReleaseEvent(QMouseEvent* e) {
     }
     // qDebug() << "WOverview::mouseReleaseEvent" << e->pos() << m_iPickupPos << ">>" << positionToValue(m_iPickupPos);
 
-    if (e->button() == Qt::LeftButton) {
-        if (m_bLeftClickDragging) {
-            unsetCursor();
-            if (!isPosInAllowedPosDragZone(e->pos())) {
-                // Abort dragging if we are way outside the widget.
-                m_iPickupPos = m_iPlayPos;
-            } else {
-                leftMouseDragRelease(e->pos());
-            }
-        }
+    if (e->button() == Qt::LeftButton && m_bLeftClickDragging) {
+        leftMouseDragRelease(e->pos());
         m_bLeftClickDragging = false;
-        m_bTimeRulerActive = false;
-    } else if (e->button() == Qt::RightButton) {
-        // Do not seek when releasing a right click. This is important to
-        // prevent accidental seeking when trying to right click a hotcue.
-        m_bTimeRulerActive = false;
     }
+    m_bTimeRulerActive = false;
 }
 
 void WOverview::leftMouseDragRelease(QPoint pos) {
+    unsetCursor();
+    if (!isPosInAllowedPosDragZone(pos)) {
+        // Abort dragging if we are way outside the widget.
+        m_iPickupPos = m_iPlayPos;
+        return;
+    }
+
     m_iPickupPos = clampedPickupPos(pos);
     m_iPlayPos = m_iPickupPos;
     double dValue = positionToValue(m_iPlayPos);

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -72,6 +72,14 @@ class WOverview : public WWidget, public TrackDropTarget {
     void slotScalingChanged();
 
   private:
+    inline int clampedPickupPos(QPoint pos) {
+        if (m_orientation == Qt::Horizontal) {
+            return math_clamp(pos.x(), 0, width() - 1);
+        }
+        return math_clamp(pos.y(), 0, height() - 1);
+    }
+    // Performs a seek associated with releasing the left mouse button. Clamps position value.
+    void leftMouseDragRelease(QPoint pos);
     // Append the waveform overview pixmap according to available data
     // in waveform
     bool drawNextPixmapPart();

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -74,9 +74,9 @@ class WOverview : public WWidget, public TrackDropTarget {
   private:
     inline int clampedPickupPos(QPoint pos) {
         if (m_orientation == Qt::Horizontal) {
-            return math_clamp(pos.x(), 0, width() - 1);
+            return math_clamp(pos.x(), 0, math_max(0, width() - 1));
         }
-        return math_clamp(pos.y(), 0, height() - 1);
+        return math_clamp(pos.y(), 0, math_max(0, height() - 1));
     }
     // Performs a seek associated with releasing the left mouse button. Clamps position value.
     void leftMouseDragRelease(QPoint pos);


### PR DESCRIPTION
Interpret leave events as a mouse release. Also refactor some code to make it cleaner.
