### PR TITLE
DlgPrefMixer: add option to reset EQ kill switches on track load

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -722,8 +722,14 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         m_pKey->set(m_pLoadedTrack->getKey());
         slotSetTrackColor(m_pLoadedTrack->getColor());
 
-        if(m_pConfig->getValue(
-                ConfigKey("[Mixer Profile]", "EqAutoReset"), false)) {
+        const bool eqAutoReset = m_pConfig->getValue(
+                ConfigKey("[Mixer Profile]", "EqAutoReset"), false);
+        // Resetting the EQ knobs always resets the kill switches too, so the
+        // kill switches are additionally reset on their own when requested.
+        const bool eqKillAutoReset = eqAutoReset ||
+                m_pConfig->getValue(
+                        ConfigKey("[Mixer Profile]", "EqKillAutoReset"), false);
+        if (eqAutoReset) {
             if (m_pLowFilter) {
                 m_pLowFilter->set(1.0);
             }
@@ -733,6 +739,8 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
             if (m_pHighFilter) {
                 m_pHighFilter->set(1.0);
             }
+        }
+        if (eqKillAutoReset) {
             if (m_pLowFilterKill) {
                 m_pLowFilterKill->set(0.0);
             }

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -28,6 +28,8 @@ const ConfigKey kEnableEqsKey = ConfigKey(kMixerProfile, QStringLiteral("EnableE
 const ConfigKey kEqsOnlyKey = ConfigKey(kMixerProfile, QStringLiteral("EQsOnly"));
 const ConfigKey kSingleEqKey = ConfigKey(kMixerProfile, QStringLiteral("SingleEQEffect"));
 const ConfigKey kEqAutoResetKey = ConfigKey(kMixerProfile, QStringLiteral("EqAutoReset"));
+const ConfigKey kEqKillAutoResetKey =
+        ConfigKey(kMixerProfile, QStringLiteral("EqKillAutoReset"));
 const ConfigKey kGainAutoResetKey = ConfigKey(kMixerProfile, QStringLiteral("GainAutoReset"));
 #ifdef __STEM__
 const ConfigKey kStemAutoResetKey = ConfigKey(kMixerProfile, QStringLiteral("stem_auto_reset"));
@@ -94,6 +96,7 @@ DlgPrefMixer::DlgPrefMixer(
           m_singleEq(true),
           m_eqEffectsOnly(true),
           m_eqAutoReset(false),
+          m_eqKillAutoReset(false),
           m_gainAutoReset(false),
 #ifdef __STEM__
           m_stemAutoReset(true),
@@ -155,6 +158,14 @@ DlgPrefMixer::DlgPrefMixer(
 #endif
             this,
             &DlgPrefMixer::slotEqAutoResetToggled);
+    connect(CheckBoxEqKillAutoReset,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
+            &QCheckBox::stateChanged,
+#endif
+            this,
+            &DlgPrefMixer::slotEqKillAutoResetToggled);
     connect(CheckBoxGainAutoReset,
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
             &QCheckBox::checkStateChanged,
@@ -520,6 +531,7 @@ void DlgPrefMixer::slotResetToDefaults() {
     CheckBoxEqOnly->setChecked(true);
     CheckBoxSingleEqEffect->setChecked(true);
     CheckBoxEqAutoReset->setChecked(false);
+    CheckBoxEqKillAutoReset->setChecked(false);
     CheckBoxGainAutoReset->setChecked(false);
 #ifdef __STEM__
     CheckBoxStemAutoReset->setChecked(true);
@@ -734,6 +746,7 @@ void DlgPrefMixer::slotApply() {
     m_pConfig->set(kSingleEqKey, ConfigValue(m_singleEq ? 1 : 0));
     m_pConfig->set(kEqsOnlyKey, ConfigValue(m_eqEffectsOnly ? 1 : 0));
     m_pConfig->set(kEqAutoResetKey, ConfigValue(m_eqAutoReset ? 1 : 0));
+    m_pConfig->set(kEqKillAutoResetKey, ConfigValue(m_eqKillAutoReset ? 1 : 0));
     m_pConfig->set(kGainAutoResetKey, ConfigValue(m_gainAutoReset ? 1 : 0));
 #ifdef __STEM__
     m_pConfig->set(kStemAutoResetKey, ConfigValue(m_stemAutoReset ? 1 : 0));
@@ -788,7 +801,9 @@ void DlgPrefMixer::slotUpdate() {
     }
 
     m_eqAutoReset = m_pConfig->getValue<bool>(kEqAutoResetKey, false);
+    m_eqKillAutoReset = m_pConfig->getValue<bool>(kEqKillAutoResetKey, false);
     CheckBoxEqAutoReset->setChecked(m_eqAutoReset);
+    updateEqKillAutoResetState();
 
     m_gainAutoReset = m_pConfig->getValue<bool>(kGainAutoResetKey, false);
     CheckBoxGainAutoReset->setChecked(m_gainAutoReset);
@@ -1048,6 +1063,22 @@ void DlgPrefMixer::slotXFaderReverseControlChanged(double v) {
 
 void DlgPrefMixer::slotEqAutoResetToggled(bool checked) {
     m_eqAutoReset = checked;
+    updateEqKillAutoResetState();
+}
+
+void DlgPrefMixer::slotEqKillAutoResetToggled(bool checked) {
+    // Ignore programmatic changes made while the checkbox is disabled (i.e.
+    // forced on by the equalizer reset option), so the user's own preference
+    // is preserved and restored once equalizer reset is turned off again.
+    if (CheckBoxEqKillAutoReset->isEnabled()) {
+        m_eqKillAutoReset = checked;
+    }
+}
+
+void DlgPrefMixer::updateEqKillAutoResetState() {
+    const bool eqReset = CheckBoxEqAutoReset->isChecked();
+    CheckBoxEqKillAutoReset->setEnabled(!eqReset);
+    CheckBoxEqKillAutoReset->setChecked(eqReset || m_eqKillAutoReset);
 }
 
 void DlgPrefMixer::slotGainAutoResetToggled(bool checked) {

--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -38,6 +38,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     void slotEqOnlyToggled(bool checked);
     void slotSingleEqToggled(bool checked);
     void slotEqAutoResetToggled(bool checked);
+    void slotEqKillAutoResetToggled(bool checked);
     void slotGainAutoResetToggled(bool checked);
 #ifdef __STEM__
     void slotStemAutoResetToggled(bool checked);
@@ -86,6 +87,12 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     void setUpMainEQ();
     void updateMainEQ();
 
+    // Keeps the "Reset EQ kill switches" checkbox in sync with the "Reset
+    // equalizers" checkbox: resetting the equalizers always resets the kill
+    // switches too, so the kill option is forced on and disabled while
+    // equalizer reset is enabled.
+    void updateEqKillAutoResetState();
+
     typedef bool (*EffectManifestFilterFnc)(EffectManifest* pManifest);
     const QList<EffectManifestPointer> getDeckEqManifests() const;
     const QList<EffectManifestPointer> getMainEqManifests() const;
@@ -127,6 +134,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     bool m_singleEq;
     bool m_eqEffectsOnly;
     bool m_eqAutoReset;
+    bool m_eqKillAutoReset;
     bool m_gainAutoReset;
 #ifdef __STEM__
     bool m_stemAutoReset;

--- a/src/preferences/dialog/dlgprefmixerdlg.ui
+++ b/src/preferences/dialog/dlgprefmixerdlg.ui
@@ -195,7 +195,7 @@
      <property name="title">
       <string>Deck Equalizers</string>
      </property>
-     <layout class="QVBoxLayout" name="DeckEqualizerCheckboxes" stretch="0,0,0,0,0,0,0">
+     <layout class="QVBoxLayout" name="DeckEqualizerCheckboxes" stretch="0,0,0,0,0,0,0,0">
       <item>
        <widget class="QCheckBox" name="CheckBoxEqOnly">
         <property name="toolTip">
@@ -651,6 +651,7 @@
   <tabstop>CheckBoxSingleEqEffect</tabstop>
   <tabstop>CheckBoxBypass</tabstop>
   <tabstop>CheckBoxEqAutoReset</tabstop>
+  <tabstop>CheckBoxEqKillAutoReset</tabstop>
   <tabstop>CheckBoxGainAutoReset</tabstop>
   <tabstop>SliderHiEQ</tabstop>
   <tabstop>SliderLoEQ</tabstop>

--- a/src/preferences/dialog/dlgprefmixerdlg.ui
+++ b/src/preferences/dialog/dlgprefmixerdlg.ui
@@ -300,6 +300,17 @@
       </item>
 
       <item>
+       <widget class="QCheckBox" name="CheckBoxEqKillAutoReset">
+        <property name="toolTip">
+         <string>Resets the EQ kill switches when loading a track. This is always enabled while &quot;Reset equalizers on track load&quot; is active, because resetting the equalizers also resets the kill switches.</string>
+        </property>
+        <property name="text">
+         <string>Reset EQ kill switches on track load</string>
+        </property>
+       </widget>
+      </item>
+
+      <item>
        <widget class="QCheckBox" name="CheckBoxGainAutoReset">
         <property name="toolTip">
          <string>Resets the deck gain to unity when loading a track.</string>

--- a/src/preferences/dialog/dlgprefmixerdlg.ui
+++ b/src/preferences/dialog/dlgprefmixerdlg.ui
@@ -302,10 +302,10 @@
       <item>
        <widget class="QCheckBox" name="CheckBoxEqKillAutoReset">
         <property name="toolTip">
-         <string>Resets the EQ kill switches when loading a track. This is always enabled while &quot;Reset equalizers on track load&quot; is active, because resetting the equalizers also resets the kill switches.</string>
+         <string>Resets the equalizer kill switches when loading a track. This is always enabled while &quot;Reset equalizers on track load&quot; is active, because resetting the equalizers also resets the kill switches.</string>
         </property>
         <property name="text">
-         <string>Reset EQ kill switches on track load</string>
+         <string>Reset equalizer kill switches on track load</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## Summary

Resolves mixxxdj/mixxx#10684.

Previously **"Reset equalizers on track load"** also reset the EQ kill switches, so there was no way to reset the kill switches independently of the EQ knobs — the request in this issue.

## Approach

Add a separate **"Reset EQ kill switches on track load"** option (`[Mixer Profile]/EqKillAutoReset`) and decouple the reset logic in `BaseTrackPlayerImpl::slotLoadTrack()`:

- `EqAutoReset` → resets the EQ knobs
- `EqAutoReset` **or** `EqKillAutoReset` → resets the kill switches

**Backward compatible:** users who had `EqAutoReset` enabled still get their kill switches reset (via the `||`), and the new key defaults off, so nothing changes until it is enabled.

### UI coupling

Following @JosepMaJAZ's proposal in the thread (which @ronso0 endorsed), the kill-switch checkbox is forced on and disabled while "Reset equalizers on track load" is active, because resetting the equalizers inherently resets the kill switches. The user's own kill-switch setting is preserved and restored when equalizer reset is turned off again.

I chose the coupled variant over three fully independent checkboxes because it is backward compatible — a fully independent design would silently stop resetting kill switches for existing `EqAutoReset` users unless their config were migrated. Happy to adjust if maintainers prefer otherwise.

## Changes

- `src/mixer/basetrackplayer.cpp` — decouple knob vs kill-switch reset; read the new config key.
- `src/preferences/dialog/dlgprefmixer.{cpp,h}` — new checkbox load/save/default wiring + coupling logic.
- `src/preferences/dialog/dlgprefmixerdlg.ui` — new checkbox.

## Screenshots

**Before** — EQ / gain / stem reset options:

![before](https://raw.githubusercontent.com/gary-gdbsystems/mixxx/pr-screenshots/10684-before.png)

**After (default)** — new independent "Reset EQ kill switches on track load":

![after default](https://raw.githubusercontent.com/gary-gdbsystems/mixxx/pr-screenshots/10684-after-default.png)

**After (coupled)** — with "Reset equalizers" enabled, the kill option is forced on and locked:

![after coupled](https://raw.githubusercontent.com/gary-gdbsystems/mixxx/pr-screenshots/10684-after-coupled.png)

## Testing

- Builds cleanly (incl. `uic` regeneration of the dialog).
- clang-format, clang-tidy, and the other pre-commit hooks pass.
- Verified the checkbox wiring, coupling behavior, and reset decoupling by code inspection; the existing reset-on-load behavior has no unit-test harness.
