### PR TITLE
common-controller-scripts: add script.getPlaypositionSamples

### DIFF
--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -222,6 +222,14 @@ script.deckFromGroup = function(group) {
     return parseInt(deck);
 };
 
+// Returns the current play position of the given group as an absolute engine
+// sample position (the same unit as "loop_end_position" and other absolute
+// position controls), computed from the relative "playposition" control and
+// "track_samples". Returns 0 if no track is loaded.
+script.getPlaypositionSamples = function(group) {
+    return engine.getValue(group, "playposition") * engine.getValue(group, "track_samples");
+};
+
 /* -------- ------------------------------------------------------
      script.bindConnections
    Purpose: Binds multiple controls at once. See an example in Pioneer-DDJ-SB-scripts.js


### PR DESCRIPTION
## Summary

Resolves mixxxdj/mixxx#12950.

Adds a mapping script helper `script.getPlaypositionSamples(group)` that returns the current play position of a group as an **absolute engine sample position** — the same unit as `loop_end_position` and other absolute position controls — computed from the relative `playposition` control and `track_samples`:

```javascript
script.getPlaypositionSamples = function(group) {
    return engine.getValue(group, "playposition") * engine.getValue(group, "track_samples");
};
```

## Why a script helper (not a ControlObject or C++ API)

In the issue thread, @Holzhaus and @ronso0 explicitly chose a **JavaScript helper** over adding a new sample-based ControlObject:

> @Holzhaus: "I'd rather not add more sample-based COs when we plan to switch to frame-based COs... If this is just about scripts, we could also add a JS helper method instead."
> @ronso0: "Agreed, let's go with the script helper."

This PR implements exactly that, and **supersedes the closed #16786**, which added a C++ `engine.getPlaypositionSamples()` method instead of the requested script helper.

## Changes

- `res/controllers/common-controller-scripts.js` — one helper function (+8 lines).

## Testing

- `ControllerScriptEngineLegacyTest` passes (41/41), including `commonScriptHasNoErrors`, which evaluates the full `common-controller-scripts.js` in the JS engine.
- eslint and the other applicable pre-commit hooks pass.
