### PR TITLE
Track Info Dialog: Allow buttons to be smaller than their labels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1752,6 +1752,7 @@ add_library(
   src/widget/paintable.cpp
   src/widget/wanalysislibrarytableview.cpp
   src/widget/wbasewidget.cpp
+  src/widget/wbasicpushbutton.cpp
   src/widget/wbattery.cpp
   src/widget/wbeatspinbox.cpp
   src/widget/wbpmeditor.cpp

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -530,16 +530,34 @@
           <item row="11" column="0" colspan="4">
            <layout class="QHBoxLayout" name="meatdata_buttons_layout">
             <item>
-             <widget class="QPushButton" name="btnImportMetadataFromMusicBrainz">
+             <widget class="WBasicPushButton" name="btnImportMetadataFromMusicBrainz">
               <property name="text">
                <string>Import Metadata from MusicBrainz</string>
+              </property>
+              <property name="elideMode">
+                <enum>Qt::ElideLeft</enum>
+               </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="btnImportMetadataFromFile">
+             <widget class="WBasicPushButton" name="btnImportMetadataFromFile">
               <property name="text">
                <string>Re-Import Metadata from file</string>
+              </property>
+              <property name="elideMode">
+               <enum>Qt::ElideLeft</enum>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
              </widget>
             </item>
@@ -973,7 +991,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="bpmClear">
+        <widget class="WBasicPushButton" name="bpmClear">
          <property name="text">
           <string>Clear BPM and Beatgrid</string>
          </property>
@@ -1118,6 +1136,13 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>WBasicPushButton</class>
+   <extends>QPushButton</extends>
+   <header>widget/wbasicpushbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>txtTitle</tabstop>

--- a/src/library/dlgtrackinfomulti.ui
+++ b/src/library/dlgtrackinfomulti.ui
@@ -444,7 +444,7 @@
       </item>
 
       <item row="11" column="0" colspan="4">
-       <widget class="QPushButton" name="btnImportMetadataFromFile">
+       <widget class="WBasicPushButton" name="btnImportMetadataFromFile">
         <property name="text">
          <string>Re-Import Metadata from files</string>
         </property>
@@ -721,6 +721,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>WBasicPushButton</class>
+   <extends>QPushButton</extends>
+   <header>widget/wbasicpushbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>txtTitle</tabstop>
   <tabstop>txtArtist</tabstop>

--- a/src/widget/wbasicpushbutton.cpp
+++ b/src/widget/wbasicpushbutton.cpp
@@ -1,0 +1,68 @@
+#include "widget/wbasicpushbutton.h"
+
+#include <QPaintEvent>
+#include <QStyleOption>
+#include <QStylePainter>
+
+#include "moc_wbasicpushbutton.cpp"
+
+namespace {
+void elideButtonLabelIfNeeded(QStyleOptionButton& option,
+        QStyle* style,
+        QWidget* widget,
+        Qt::TextElideMode elideMode) {
+    if (elideMode == Qt::ElideNone) {
+        return;
+    }
+
+    // Calculate how much space we have left for the text
+    QSize textSize = style->subElementRect(QStyle::SE_PushButtonContents, &option, widget).size();
+
+    if (option.features & QStyleOptionButton::HasMenu) {
+        int indicatorSize = style->pixelMetric(QStyle::PM_MenuButtonIndicator, &option, widget);
+        textSize.setWidth(textSize.width() - indicatorSize);
+    }
+
+    if (!option.icon.isNull()) {
+        int iconSpacing = 4; // ### 4 is currently hardcoded in QPushButton::sizeHint()
+        textSize.setWidth(textSize.width() - option.iconSize.width() - iconSpacing);
+    }
+
+    // Replace overflowing text with ellipsis ("...")
+    option.text = option.fontMetrics.elidedText(option.text, elideMode, textSize.width());
+}
+} // namespace
+
+WBasicPushButton::WBasicPushButton(QWidget* pParent)
+        : QPushButton(pParent),
+          m_elideMode(Qt::ElideNone) {
+}
+
+void WBasicPushButton::setElideMode(Qt::TextElideMode elideMode) {
+    if (elideMode != m_elideMode) {
+        m_elideMode = elideMode;
+        updateGeometry();
+    }
+}
+
+QSize WBasicPushButton::minimumSizeHint() const {
+    QSize fullSize = sizeHint();
+
+    if (m_elideMode == Qt::ElideNone) {
+        // Elision of overflowing text is disabled,
+        // so this button cannot be collapsed beyond
+        // its default size.
+        return fullSize;
+    } else {
+        // Elision of overflowing text is enabled.
+        return QSize(0, fullSize.height());
+    }
+}
+
+void WBasicPushButton::paintEvent(QPaintEvent* /*unused*/) {
+    QStylePainter p(this);
+    QStyleOptionButton option;
+    initStyleOption(&option);
+    elideButtonLabelIfNeeded(option, p.style(), this, m_elideMode);
+    p.drawControl(QStyle::CE_PushButton, option);
+}

--- a/src/widget/wbasicpushbutton.cpp
+++ b/src/widget/wbasicpushbutton.cpp
@@ -3,6 +3,7 @@
 #include <QPaintEvent>
 #include <QStyleOption>
 #include <QStylePainter>
+#include <QToolTip>
 
 #include "moc_wbasicpushbutton.cpp"
 
@@ -65,4 +66,48 @@ void WBasicPushButton::paintEvent(QPaintEvent* /*unused*/) {
     initStyleOption(&option);
     elideButtonLabelIfNeeded(option, p.style(), this, m_elideMode);
     p.drawControl(QStyle::CE_PushButton, option);
+}
+
+QString WBasicPushButton::buildToolTip() const {
+    // Show the button label as a tooltip when the label text
+    // is partially hidden due to the button's size
+    const QString txtToolTip = toolTip();
+    if (!txtToolTip.isEmpty()) {
+        return txtToolTip;
+    }
+
+    const QString txtLabel = text();
+    const QSize currentSize = size();
+    const QSize fullSize = sizeHint();
+
+    if ((currentSize.height() < fullSize.height() ||
+                currentSize.width() < fullSize.width()) &&
+            !txtLabel.isEmpty()) {
+        // The label text is not fully visible,
+        // so show it as a tooltip
+        return txtLabel;
+    }
+
+    return QString();
+}
+
+bool WBasicPushButton::event(QEvent* e) {
+    switch (e->type()) {
+    case QEvent::ToolTip: {
+        const QString toolTipToShow = buildToolTip();
+        if (!toolTipToShow.isEmpty()) {
+            QToolTip::showText(static_cast<QHelpEvent*>(e)->globalPos(),
+                    toolTipToShow,
+                    this,
+                    QRect(),
+                    toolTipDuration());
+        } else {
+            e->ignore();
+        }
+        return true;
+    }
+    default: {
+        return QPushButton::event(e);
+    }
+    }
 }

--- a/src/widget/wbasicpushbutton.h
+++ b/src/widget/wbasicpushbutton.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QPushButton>
+
+/// Subclass of QPushButton that replaces a portion of the button label
+/// with an ellipsis (according to Qt::TextElideMode) when the text would
+/// otherwise overflow the available space.
+///
+/// See WPushButton when you need to connect to a ControlObject.
+class WBasicPushButton : public QPushButton {
+    Q_OBJECT
+    Q_PROPERTY(Qt::TextElideMode elideMode READ elideMode WRITE setElideMode);
+
+  public:
+    explicit WBasicPushButton(QWidget* pParent = nullptr);
+
+    void setElideMode(Qt::TextElideMode elideMode);
+    Qt::TextElideMode elideMode() const {
+        return m_elideMode;
+    };
+
+    QSize minimumSizeHint() const override;
+
+  protected:
+    void paintEvent(QPaintEvent* e) override;
+
+    Qt::TextElideMode m_elideMode;
+};

--- a/src/widget/wbasicpushbutton.h
+++ b/src/widget/wbasicpushbutton.h
@@ -22,6 +22,8 @@ class WBasicPushButton : public QPushButton {
     QSize minimumSizeHint() const override;
 
   protected:
+    QString buildToolTip() const;
+    bool event(QEvent* e) override;
     void paintEvent(QPaintEvent* e) override;
 
     Qt::TextElideMode m_elideMode;


### PR DESCRIPTION
Allow the buttons in the track info dialog to become smaller than their label text. This is relevant for small laptop screens.

If the button is too small for the label text, an ellipse `...` is prepended to the start of the button label, and the full button label is shown as a tooltip when hovering over the button:

<img width="461" height="108" alt="image" src="https://github.com/user-attachments/assets/5c55a21d-1aa1-4e6d-934e-0669f4c92dba" />

This PR is part of an effort to improve the usability & resize behavior of the track info dialog, and was split off from:

- #13818

As a sidenote, when needing to create subclasses for Qt controls for use in dialogs and other UI elements, I've opted to use `WBasic*` as the prefix to distinguish it from the skin controls, which do not have any prefix. I'm not attached to that name, but as this was originally part of a PR that is now open for over 2 years... please just let us focus on just getting this merged, and defer any renaming until after that :upside_down_face: 