### PR TITLE
Track Info Dialog: Allow keyboard navigation in the color picker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1758,6 +1758,7 @@ add_library(
   src/widget/wcollapsiblegroupbox.cpp
   src/widget/wcolorpicker.cpp
   src/widget/wcolorpickeraction.cpp
+  src/widget/wcolorpickeractionmenu.cpp
   src/widget/wcombobox.cpp
   src/widget/wcoverart.cpp
   src/widget/wcoverartlabel.cpp

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -21,6 +21,7 @@
 #include "util/datetime.h"
 #include "util/desktophelper.h"
 #include "util/duration.h"
+#include "widget/wcolorpickeractionmenu.h"
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
 #include "widget/wstarrating.h"
@@ -52,7 +53,7 @@ DlgTrackInfo::DlgTrackInfo(
           m_pWCoverArtMenu(make_parented<WCoverArtMenu>(this)),
           m_pWCoverArtLabel(make_parented<WCoverArtLabel>(this, m_pWCoverArtMenu)),
           m_pWStarRating(make_parented<WStarRating>(this)),
-          m_pColorPicker(make_parented<WColorPickerAction>(
+          m_pColorPicker(make_parented<WColorPickerActionMenu>(
                   WColorPicker::Option::AllowNoColor |
                           // TODO(xxx) remove this once the preferences are themed via QSS
                           WColorPicker::Option::NoExtStyleSheet,
@@ -60,6 +61,13 @@ DlgTrackInfo::DlgTrackInfo(
                   this)),
           m_widgetSizesFixed(false) {
     init();
+}
+
+DlgTrackInfo::~DlgTrackInfo() {
+    // ~parented_ptr() needs the definition of the wrapped type
+    // upon deletion! Otherwise the behavior is undefined.
+    // The wrapped types of some parented_ptr members are only
+    // forward declared in the header file.
 }
 
 void DlgTrackInfo::init() {
@@ -308,12 +316,10 @@ void DlgTrackInfo::init() {
             &DlgTrackInfo::slotRatingChanged);
 
     btnColorPicker->setStyle(QStyleFactory::create(QStringLiteral("fusion")));
-    QMenu* pColorPickerMenu = new QMenu(this);
-    pColorPickerMenu->addAction(m_pColorPicker);
-    btnColorPicker->setMenu(pColorPickerMenu);
+    btnColorPicker->setMenu(m_pColorPicker.get());
 
     connect(m_pColorPicker.get(),
-            &WColorPickerAction::colorPicked,
+            &WColorPickerActionMenu::colorPicked,
             this,
             [this](const mixxx::RgbColor::optional_t& newColor) {
                 trackColorDialogSetColor(newColor);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -312,10 +312,6 @@ void DlgTrackInfo::init() {
     pColorPickerMenu->addAction(m_pColorPicker);
     btnColorPicker->setMenu(pColorPickerMenu);
 
-    connect(btnColorPicker,
-            &QPushButton::clicked,
-            this,
-            &DlgTrackInfo::slotColorButtonClicked);
     connect(m_pColorPicker.get(),
             &WColorPickerAction::colorPicked,
             this,
@@ -612,13 +608,6 @@ void DlgTrackInfo::slotOpenInFileBrowser() {
         return;
     }
     mixxx::DesktopHelper::openInFileBrowser(QStringList(m_pLoadedTrack->getLocation()));
-}
-
-void DlgTrackInfo::slotColorButtonClicked() {
-    if (!m_pLoadedTrack) {
-        return;
-    }
-    btnColorPicker->showMenu();
 }
 
 void DlgTrackInfo::trackColorDialogSetColor(const mixxx::RgbColor::optional_t& newColor) {

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -79,7 +79,6 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     void slotTrackChanged(TrackId trackId);
     void slotOpenInFileBrowser();
-    void slotColorButtonClicked();
 
     void slotCoverFound(
             const QObject* pRequester,

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -12,10 +12,9 @@
 #include "track/trackrecord.h"
 #include "util/parented_ptr.h"
 #include "util/tapfilter.h"
-#include "widget/wcolorpickeraction.h"
 
 class TrackModel;
-class WColorPickerAction;
+class WColorPickerActionMenu;
 class WStarRating;
 class WCoverArtMenu;
 class WCoverArtLabel;
@@ -32,7 +31,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     explicit DlgTrackInfo(
             UserSettingsPointer pUserSettings,
             const TrackModel* trackModel = nullptr);
-    ~DlgTrackInfo() override = default;
+    ~DlgTrackInfo() override;
 
   public slots:
     // Not thread safe. Only invoke via AutoConnection or QueuedConnection, not
@@ -140,7 +139,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
     parented_ptr<WStarRating> m_pWStarRating;
-    parented_ptr<WColorPickerAction> m_pColorPicker;
+    parented_ptr<WColorPickerActionMenu> m_pColorPicker;
 
     std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
 

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -1132,9 +1132,9 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>txtKey</tabstop>
   <tabstop>spinTuning</tabstop>
   <tabstop>txtComment</tabstop>
-  <tabstop>btnColorPicker</tabstop>
   <tabstop>btnImportMetadataFromMusicBrainz</tabstop>
   <tabstop>btnImportMetadataFromFile</tabstop>
+  <tabstop>btnColorPicker</tabstop>
   <tabstop>btnOpenFileBrowser</tabstop>
   <tabstop>spinBpm</tabstop>
   <tabstop>bpmConst</tabstop>

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -29,7 +29,7 @@ inline int idealColumnCount(int numItems) {
             break;
         }
         if (remainder > numColumnsRemainder) {
-            numColumnsRemainder = numColumnsCandidate;
+            numColumnsRemainder = remainder;
             numColumns = numColumnsCandidate;
         }
     }

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -2,11 +2,13 @@
 
 #include <QColorDialog>
 #include <QGridLayout>
+#include <QKeyEvent>
 #include <QPushButton>
 #include <QStyle>
 #include <QStyleFactory>
 
 #include "moc_wcolorpicker.cpp"
+#include "util/optional.h"
 #include "util/parented_ptr.h"
 
 namespace {
@@ -35,6 +37,109 @@ inline int idealColumnCount(int numItems) {
     }
 
     return numColumns;
+}
+
+WColorGridButton::WColorGridButton(const mixxx::RgbColor::optional_t& color,
+        int row,
+        int column,
+        QWidget* parent)
+        : QPushButton(parent),
+          m_color(color),
+          m_row(row),
+          m_column(column) {
+    if (color) {
+        // Set the background color of the button.
+        // This can't be overridden in skin stylesheets.
+        setStyleSheet(
+                QStringLiteral("QPushButton { background-color: %1; }")
+                        .arg(mixxx::RgbColor::toQString(color.value())));
+        setToolTip(mixxx::RgbColor::toQString(color.value()));
+    } else {
+        setProperty("noColor", true);
+        setToolTip(tr("No color"));
+    }
+
+    setCheckable(true);
+
+    // Without this the button might shrink when setting the checkmark icon,
+    // both here or via external stylesheets.
+    setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
+}
+
+void WColorGridButton::keyPressEvent(QKeyEvent* event) {
+    if (handleNavigation(event)) {
+        // Already handled completely
+    } else if (event->key() == Qt::Key_Return) {
+        // Key_Return should act the same as Key_Space
+        setDown(true);
+    } else {
+        QPushButton::keyPressEvent(event);
+    }
+}
+
+void WColorGridButton::keyReleaseEvent(QKeyEvent* event) {
+    if (event->key() == Qt::Key_Return && !event->isAutoRepeat() && isDown()) {
+        click();
+    } else {
+        QPushButton::keyReleaseEvent(event);
+    }
+}
+
+bool WColorGridButton::handleNavigation(QKeyEvent* event) {
+    QWidget* pParent = qobject_cast<QWidget*>(parent());
+    if (!pParent) {
+        return false;
+    }
+
+    QGridLayout* pGridLayout = qobject_cast<QGridLayout*>(pParent->layout());
+    if (!pGridLayout) {
+        return false;
+    }
+
+    const int maxRow = pGridLayout->rowCount() - 1;
+    const int maxColumn = pGridLayout->columnCount() - 1;
+    int newRow = m_row;
+    int newColumn = m_column;
+
+    switch (event->key()) {
+    case Qt::Key_Up: {
+        newRow = qBound(0, newRow - 1, maxRow);
+        break;
+    }
+    case Qt::Key_Down: {
+        newRow = qBound(0, newRow + 1, maxRow);
+        break;
+    }
+    case Qt::Key_Left: {
+        newColumn = qBound(0, newColumn - 1, maxColumn);
+        break;
+    }
+    case Qt::Key_Right: {
+        newColumn = qBound(0, newColumn + 1, maxColumn);
+        break;
+    }
+    default: {
+        return false;
+    }
+    }
+
+    // Show the keyboard focus frame (if not yet visible)
+    window()->setAttribute(Qt::WA_KeyboardFocusChange);
+
+    QLayoutItem* pNewItem = pGridLayout->itemAtPosition(newRow, newColumn);
+    if (!pNewItem) {
+        // May happen when itemCount < (rowCount * columnCount),
+        // i.e. when some cells in the grid are empty.
+        return false;
+    }
+
+    QWidget* pNewFocus = pNewItem->widget();
+    if (!pNewFocus) {
+        return false;
+    }
+
+    pNewFocus->setFocus();
+    return true;
 }
 
 WColorPicker::WColorPicker(Options options, const ColorPalette& palette, QWidget* parent)
@@ -138,21 +243,11 @@ void WColorPicker::addColorButtons() {
 }
 
 void WColorPicker::addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, int row, int column) {
-    parented_ptr<QPushButton> pButton = make_parented<QPushButton>("", this);
+    auto pButton = make_parented<WColorGridButton>(color, row, column, this);
     if (m_pStyle) {
         pButton->setStyle(m_pStyle);
     }
-
-    // Set the background color of the button. This can't be overridden in skin stylesheets.
-    pButton->setStyleSheet(
-            QString("QPushButton { background-color: %1; }").arg(mixxx::RgbColor::toQString(color)));
-    pButton->setToolTip(mixxx::RgbColor::toQString(color));
-    pButton->setCheckable(true);
-    // Without this the button might shrink when setting the checkmark icon,
-    // both here or via external stylesheets.
-    pButton->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     m_colorButtons.append(pButton);
-
     connect(pButton,
             &QPushButton::clicked,
             this,
@@ -163,25 +258,21 @@ void WColorPicker::addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, i
 }
 
 void WColorPicker::addNoColorButton(QGridLayout* pLayout, int row, int column) {
-    QPushButton* pButton = m_pNoColorButton;
-    if (!pButton) {
-        pButton = make_parented<QPushButton>("", this);
-        if (m_pStyle) {
-            pButton->setStyle(m_pStyle);
-        }
-
-        pButton->setProperty("noColor", true);
-        pButton->setToolTip(tr("No color"));
-        pButton->setCheckable(true);
-        pButton->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
-        connect(pButton,
-                &QPushButton::clicked,
-                this,
-                [this]() {
-                    emit colorPicked(std::nullopt);
-                });
-        m_pNoColorButton = pButton;
+    VERIFY_OR_DEBUG_ASSERT(!m_pNoColorButton) {
+        return;
     }
+
+    auto pButton = make_parented<WColorGridButton>(std::nullopt, row, column, this);
+    if (m_pStyle) {
+        pButton->setStyle(m_pStyle);
+    }
+    connect(pButton,
+            &QPushButton::clicked,
+            this,
+            [this]() {
+                emit colorPicked(std::nullopt);
+            });
+    m_pNoColorButton = pButton;
     pLayout->addWidget(pButton, row, column);
 }
 

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -350,3 +350,22 @@ void WColorPicker::setColorPalette(const ColorPalette& palette) {
 void WColorPicker::slotColorPicked(const mixxx::RgbColor::optional_t& color) {
     setSelectedColor(color);
 }
+
+void WColorPicker::setInitialFocus() {
+    QGridLayout* pLayout = qobject_cast<QGridLayout*>(layout());
+    VERIFY_OR_DEBUG_ASSERT(pLayout) {
+        qWarning() << "Color Picker has no layout!";
+        return;
+    }
+
+    // Focus the top left button when the color picker
+    // popup is opened, so that keyboard navigation
+    // can be used.
+    auto* topLeftItem = pLayout->itemAtPosition(0, 0);
+    if (topLeftItem) {
+        auto* topLeftWidget = topLeftItem->widget();
+        if (topLeftWidget) {
+            topLeftWidget->setFocus();
+        }
+    }
+}

--- a/src/widget/wcolorpicker.h
+++ b/src/widget/wcolorpicker.h
@@ -53,6 +53,7 @@ class WColorPicker : public QWidget {
     void resetSelectedColor();
     void setSelectedColor(const mixxx::RgbColor::optional_t& color);
     void setColorPalette(const ColorPalette& palette);
+    void setInitialFocus();
 
   signals:
     void colorPicked(const mixxx::RgbColor::optional_t& color);

--- a/src/widget/wcolorpicker.h
+++ b/src/widget/wcolorpicker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QMenu>
+#include <QPushButton>
 #include <QStyle>
 #include <QWidget>
 
@@ -7,7 +9,28 @@
 #include "util/parented_ptr.h"
 
 class QGridLayout;
-class QPushButton;
+class WColorPicker;
+
+/// Customized button used internally by WColorPicker
+class WColorGridButton : public QPushButton {
+    Q_OBJECT
+  public:
+    WColorGridButton(const mixxx::RgbColor::optional_t& color,
+            int row,
+            int column,
+            QWidget* parent = nullptr);
+
+  protected:
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
+
+  private:
+    bool handleNavigation(QKeyEvent* event);
+
+    mixxx::RgbColor::optional_t m_color;
+    int m_row;
+    int m_column;
+};
 
 class WColorPicker : public QWidget {
     Q_OBJECT

--- a/src/widget/wcolorpickeraction.cpp
+++ b/src/widget/wcolorpickeraction.cpp
@@ -37,3 +37,7 @@ void WColorPickerAction::setColorPalette(const ColorPalette& palette) {
     }
     pWidget->adjustSize();
 }
+
+void WColorPickerAction::setInitialFocus() {
+    m_pColorPicker->setInitialFocus();
+}

--- a/src/widget/wcolorpickeraction.h
+++ b/src/widget/wcolorpickeraction.h
@@ -15,6 +15,7 @@ class WColorPickerAction : public QWidgetAction {
 
     void resetSelectedColor();
     void setSelectedColor(const mixxx::RgbColor::optional_t& color);
+    void setInitialFocus();
 
     /// Set a new color palette for the underlying color picker.
     ///

--- a/src/widget/wcolorpickeractionmenu.cpp
+++ b/src/widget/wcolorpickeractionmenu.cpp
@@ -18,6 +18,7 @@ WColorPickerActionMenu::WColorPickerActionMenu(
             &WColorPickerActionMenu::colorPicked);
 
     addAction(m_pColorPickerAction.get());
+    m_pColorPickerAction->setInitialFocus();
 }
 
 void WColorPickerActionMenu::setColorPalette(const ColorPalette& palette) {

--- a/src/widget/wcolorpickeractionmenu.cpp
+++ b/src/widget/wcolorpickeractionmenu.cpp
@@ -1,0 +1,40 @@
+#include "widget/wcolorpickeractionmenu.h"
+
+#include <QKeyEvent>
+
+#include "moc_wcolorpickeractionmenu.cpp"
+#include "widget/wcolorpickeraction.h"
+
+WColorPickerActionMenu::WColorPickerActionMenu(
+        WColorPicker::Options options,
+        const ColorPalette& palette,
+        QWidget* parent)
+        : QMenu(parent),
+          m_pColorPickerAction(
+                  make_parented<WColorPickerAction>(options, palette, this)) {
+    connect(m_pColorPickerAction.get(),
+            &WColorPickerAction::colorPicked,
+            this,
+            &WColorPickerActionMenu::colorPicked);
+
+    addAction(m_pColorPickerAction.get());
+}
+
+void WColorPickerActionMenu::setColorPalette(const ColorPalette& palette) {
+    m_pColorPickerAction->setColorPalette(palette);
+    updateGeometry();
+}
+
+void WColorPickerActionMenu::setSelectedColor(const mixxx::RgbColor::optional_t& color) {
+    m_pColorPickerAction->setSelectedColor(color);
+}
+
+void WColorPickerActionMenu::resetSelectedColor() {
+    m_pColorPickerAction->resetSelectedColor();
+}
+
+bool WColorPickerActionMenu::focusNextPrevChild(bool next) {
+    // Override the behavior of QMenu::focusNextPrevChild
+    // which would convert this into a keyPressEvent()
+    return QWidget::focusNextPrevChild(next);
+}

--- a/src/widget/wcolorpickeractionmenu.h
+++ b/src/widget/wcolorpickeractionmenu.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QMenu>
+
+#include "util/color/colorpalette.h"
+#include "util/color/rgbcolor.h"
+#include "widget/wcolorpicker.h"
+
+class WColorPickerAction;
+
+class WColorPickerActionMenu : public QMenu {
+    Q_OBJECT
+  public:
+    explicit WColorPickerActionMenu(
+            WColorPicker::Options options,
+            const ColorPalette& palette,
+            QWidget* parent = nullptr);
+
+    /// Set a new color palette for the underlying color picker.
+    void setColorPalette(const ColorPalette& palette);
+    void setSelectedColor(const mixxx::RgbColor::optional_t& color);
+    void resetSelectedColor();
+
+  signals:
+    void colorPicked(const mixxx::RgbColor::optional_t& color);
+
+  protected:
+    bool focusNextPrevChild(bool next) override;
+
+  private:
+    parented_ptr<WColorPickerAction> m_pColorPickerAction;
+};


### PR DESCRIPTION
Allow the use of the Up/Down/Left/Right arrow keys as well as Tab/Shift-Tab and Space/Enter to interact with the color picker popup.

<img width="456" height="223" alt="image" src="https://github.com/user-attachments/assets/068a89e8-843d-4026-a690-e09e3a26380a" />

This PR is part of an effort to improve the usability & resize behavior of the track info dialog, and was split off from:

- #13818
