### PR TITLE
Track Info Dialog: Add tooltip to cover art image

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -84,9 +84,6 @@ void DlgTrackInfo::init() {
     m_propertyWidgets.insert("comment", txtComment);
     m_propertyWidgets.insert("color", btnColorPicker);
 
-    coverLayout->setAlignment(Qt::AlignRight | Qt::AlignTop);
-    coverLayout->setSpacing(0);
-    coverLayout->setContentsMargins(0, 0, 0, 0);
     coverLayout->insertWidget(0, m_pWCoverArtLabel.get());
 
     starsLayout->setAlignment(Qt::AlignRight | Qt::AlignVCenter);

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -101,8 +101,14 @@
              <property name="spacing">
               <number>0</number>
              </property>
+             <property name="margin">
+              <number>0</number>
+             </property>
              <property name="sizeConstraint">
               <enum>QLayout::SetDefaultConstraint</enum>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignVCenter</set>
              </property>
             </layout>
            </widget>

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -270,9 +270,6 @@ void DlgTrackInfoMulti::init() {
             &DlgTrackInfoMulti::slotStarRatingChanged);
 
     // Insert the cover widget
-    coverLayout->setAlignment(Qt::AlignRight | Qt::AlignTop);
-    coverLayout->setSpacing(0);
-    coverLayout->setContentsMargins(0, 0, 0, 0);
     coverLayout->insertWidget(0, m_pWCoverArtLabel.get());
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {

--- a/src/library/dlgtrackinfomulti.ui
+++ b/src/library/dlgtrackinfomulti.ui
@@ -87,8 +87,14 @@
          <property name="spacing">
           <number>0</number>
          </property>
+         <property name="margin">
+          <number>0</number>
+         </property>
          <property name="sizeConstraint">
           <enum>QLayout::SetDefaultConstraint</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignVCenter</set>
          </property>
         </layout>
        </widget>

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -1004,6 +1004,8 @@ void Tooltips::addStandardTooltips() {
             << tr("Audio Latency Overload Indicator")
             << tr("Indicates that the audio buffer is too small to do all audio processing.");
 
+    // Note: Some of the coverart strings below are reused in src/widget/wcoverartlabel.cpp.
+    // Please sync changes made here to wcoverartlabel.cpp, and vice versa.
     add("coverart")
             << tr("Cover Art")
             << tr("Displays cover artwork of the loaded track.")

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -48,6 +48,20 @@ WCoverArtLabel::WCoverArtLabel(QWidget* pParent, WCoverArtMenu* pCoverMenu)
     setFrameShape(QFrame::Box);
     setAlignment(Qt::AlignCenter);
     setPixmapAndResize(m_defaultCover);
+
+    // Note: We reuse existing translation strings from src/skin/legacy/tooltips.cpp
+    // to avoid having to retranslate basically the same content twice.
+    // Please sync changes made here to tooltips.cpp, and vice versa.
+    QString tooltip = QString("%1: %2").arg(
+            tr("Left-click"),
+            tr("Opens separate artwork viewer."));
+    if (m_pCoverMenu) {
+        tooltip += "\n";
+        tooltip += QString("%1: %2").arg(
+                tr("Right-click"),
+                tr("Displays options for editing cover artwork."));
+    }
+    setToolTip(tooltip);
 }
 
 WCoverArtLabel::~WCoverArtLabel() = default;


### PR DESCRIPTION
Add a tooltip describing the interaction options to the cover art image in the track info dialog.

<img width="340" height="152" alt="image" src="https://github.com/user-attachments/assets/8b777089-1318-4193-8fab-e118d77d1ce2" />

This PR is part of an effort to improve the usability & resize behavior of the track info dialog, and was split off from:

- #13818