### PR TITLE
Track Info Dialog: Allow navigation between tracks

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -356,9 +356,14 @@ void DlgTrackInfo::slotPrevDlgTagFetcher() {
     loadPrevTrack();
 }
 
+QModelIndex DlgTrackInfo::getPrevNextTrack(bool next) {
+    return m_currentTrackIndex.sibling(
+            m_currentTrackIndex.row() + (next ? 1 : -1),
+            m_currentTrackIndex.column());
+}
+
 void DlgTrackInfo::loadNextTrack() {
-    auto nextRow = m_currentTrackIndex.sibling(
-            m_currentTrackIndex.row() + 1, m_currentTrackIndex.column());
+    auto nextRow = getPrevNextTrack(true);
     if (nextRow.isValid()) {
         loadTrack(nextRow);
         emit next();
@@ -366,8 +371,7 @@ void DlgTrackInfo::loadNextTrack() {
 }
 
 void DlgTrackInfo::loadPrevTrack() {
-    QModelIndex prevRow = m_currentTrackIndex.sibling(
-            m_currentTrackIndex.row() - 1, m_currentTrackIndex.column());
+    auto prevRow = getPrevNextTrack(false);
     if (prevRow.isValid()) {
         loadTrack(prevRow);
         emit previous();
@@ -557,6 +561,9 @@ void DlgTrackInfo::loadTrack(const QModelIndex& index) {
         return;
     }
     m_currentTrackIndex = index;
+    btnPrev->setEnabled(getPrevNextTrack(false).isValid());
+    btnNext->setEnabled(getPrevNextTrack(true).isValid());
+
     loadTrackInternal(pTrack);
     if (m_pDlgTagFetcher && m_pDlgTagFetcher->isVisible()) {
         m_pDlgTagFetcher->loadTrack(m_currentTrackIndex);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -1,5 +1,6 @@
 #include "library/dlgtrackinfo.h"
 
+#include <QShortcut>
 #include <QSignalBlocker>
 #include <QStyleFactory>
 #include <QtDebug>
@@ -104,6 +105,18 @@ void DlgTrackInfo::init() {
                 &QPushButton::clicked,
                 this,
                 &DlgTrackInfo::slotPrevButton);
+
+        QShortcut* nextShortcut = new QShortcut(QKeySequence("Alt+Right"), this);
+        QShortcut* prevShortcut = new QShortcut(QKeySequence("Alt+Left"), this);
+
+        connect(nextShortcut,
+                &QShortcut::activated,
+                btnNext,
+                [this] { btnNext->animateClick(); });
+        connect(prevShortcut,
+                &QShortcut::activated,
+                btnPrev,
+                [this] { btnPrev->animateClick(); });
     } else {
         btnNext->hide();
         btnPrev->hide();

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -379,6 +379,7 @@ void DlgTrackInfo::loadNextTrack() {
     auto nextRow = getPrevNextTrack(true);
     if (nextRow.isValid()) {
         loadTrack(nextRow);
+        refocusCurrentWidget();
         emit next();
     }
 }
@@ -387,7 +388,23 @@ void DlgTrackInfo::loadPrevTrack() {
     auto prevRow = getPrevNextTrack(false);
     if (prevRow.isValid()) {
         loadTrack(prevRow);
+        refocusCurrentWidget();
         emit previous();
+    }
+}
+
+/// Simulate moving the focus out of and then back into the currently
+/// focused widget to trigger behaviors like the "Select all on focus"
+/// for QLineEdit.
+///
+/// This is done when moving to the previous/next track, because,
+/// logically, the user has moved to a new dialog, even though we
+/// reuse the current dialog instance internally.
+void DlgTrackInfo::refocusCurrentWidget() {
+    QWidget* focusedWidget = QApplication::focusWidget();
+    if (focusedWidget && isAncestorOf(focusedWidget)) {
+        focusedWidget->clearFocus();
+        focusedWidget->setFocus(Qt::ShortcutFocusReason);
     }
 }
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -497,7 +497,6 @@ void DlgTrackInfo::updateTrackMetadataFields() {
     txtGrouping->setCursorPosition(0);
     txtYear->setCursorPosition(0);
     txtTrackNumber->setCursorPosition(0);
-    txtBpm->setCursorPosition(0);
 
     // Non-editable fields
     txtDuration->setText(

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -486,6 +486,19 @@ void DlgTrackInfo::updateTrackMetadataFields() {
     displayKeyText();
     displayTuningFields();
 
+    // Set cursor / scroll position of editable fields (only relevant
+    // when the content's width is larger than the width of the QLineEdit)
+    txtTitle->setCursorPosition(0);
+    txtArtist->setCursorPosition(0);
+    txtAlbum->setCursorPosition(0);
+    txtAlbumArtist->setCursorPosition(0);
+    txtGenre->setCursorPosition(0);
+    txtComposer->setCursorPosition(0);
+    txtGrouping->setCursorPosition(0);
+    txtYear->setCursorPosition(0);
+    txtTrackNumber->setCursorPosition(0);
+    txtBpm->setCursorPosition(0);
+
     // Non-editable fields
     txtDuration->setText(
             m_trackRecord.getMetadata().getDurationText(mixxx::Duration::Precision::SECONDS));

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -89,6 +89,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotReloadCoverArt();
 
   private:
+    QModelIndex getPrevNextTrack(bool next);
     void loadNextTrack();
     void loadPrevTrack();
     void loadTrackInternal(const TrackPointer& pTrack);

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -92,6 +92,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     QModelIndex getPrevNextTrack(bool next);
     void loadNextTrack();
     void loadPrevTrack();
+    void refocusCurrentWidget();
     void loadTrackInternal(const TrackPointer& pTrack);
     void reloadTrackBeats(const Track& track);
     void trackColorDialogSetColor(const mixxx::RgbColor::optional_t& color);


### PR DESCRIPTION
Allow using Alt+Left/Alt+Right in the track info dialog to skip to the previous/next track in the list. Conditionally enable/disable the Prev/Next buttons in the dialog depending on whether there is a previous/next track. Automatically select the text in the current textbox after switching tracks to allow for easy bulk edit.

<img width="600" height="66" alt="image" src="https://github.com/user-attachments/assets/bd982c32-9b8e-4705-a187-3d559146f793" />

This PR is part of an effort to improve the usability & resize behavior of the track info dialog, and was split off from:

- #13818