### PR TITLE
Track Info Dialog: Make star rating editable via keyboard controls

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -75,6 +75,7 @@ void DlgTrackInfo::init() {
     m_propertyWidgets.insert("album_artist", txtAlbumArtist);
     m_propertyWidgets.insert("composer", txtComposer);
     m_propertyWidgets.insert("genre", txtGenre);
+    m_propertyWidgets.insert("rating", starRating);
     m_propertyWidgets.insert("year", txtYear);
     m_propertyWidgets.insert(kBpmPropertyName, spinBpm);
     m_propertyWidgets.insert("tracknumber", txtTrackNumber);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -51,7 +51,6 @@ DlgTrackInfo::DlgTrackInfo(
           m_tapFilter(this, kFilterLength, kMaxInterval),
           m_pWCoverArtMenu(make_parented<WCoverArtMenu>(this)),
           m_pWCoverArtLabel(make_parented<WCoverArtLabel>(this, m_pWCoverArtMenu)),
-          m_pWStarRating(make_parented<WStarRating>(this)),
           m_pColorPicker(make_parented<WColorPickerAction>(
                   WColorPicker::Option::AllowNoColor |
                           // TODO(xxx) remove this once the preferences are themed via QSS
@@ -87,13 +86,6 @@ void DlgTrackInfo::init() {
     coverLayout->setSpacing(0);
     coverLayout->setContentsMargins(0, 0, 0, 0);
     coverLayout->insertWidget(0, m_pWCoverArtLabel.get());
-
-    starsLayout->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    starsLayout->setSpacing(0);
-    starsLayout->setContentsMargins(0, 0, 0, 0);
-    starsLayout->insertWidget(0, m_pWStarRating.get());
-    // This is necessary to pass on mouseMove events to WStarRating
-    m_pWStarRating->setMouseTracking(true);
 
     if (m_pTrackModel) {
         connect(btnNext,
@@ -302,7 +294,7 @@ void DlgTrackInfo::init() {
             this,
             &DlgTrackInfo::slotReloadCoverArt);
 
-    connect(m_pWStarRating,
+    connect(starRating,
             &WStarRating::ratingChangeRequest,
             this,
             &DlgTrackInfo::slotRatingChanged);
@@ -391,7 +383,7 @@ void DlgTrackInfo::updateFromTrack(const Track& track) {
 
     reloadTrackBeats(track);
 
-    m_pWStarRating->slotSetRating(m_pLoadedTrack->getRating());
+    starRating->slotSetRating(m_pLoadedTrack->getRating());
 }
 
 void DlgTrackInfo::replaceTrackRecord(
@@ -709,7 +701,7 @@ void DlgTrackInfo::clear() {
 
     txtLocation->setText("");
 
-    m_pWStarRating->slotSetRating(0);
+    starRating->slotSetRating(0);
 }
 
 void DlgTrackInfo::slotBpmScale(mixxx::Beats::BpmScale bpmScale) {
@@ -908,7 +900,7 @@ void DlgTrackInfo::slotRatingChanged(int rating) {
     }
     if (m_trackRecord.isValidRating(rating) &&
             rating != m_trackRecord.getRating()) {
-        m_pWStarRating->slotSetRating(rating);
+        starRating->slotSetRating(rating);
         m_trackRecord.setRating(rating);
     }
 }
@@ -1060,7 +1052,7 @@ void DlgTrackInfo::adjustWidgetSizes() {
 
     // Set fixed height on stars widget so it doesn't make the adjacent
     // txtAlbumArtist expand vertically
-    m_pWStarRating->setFixedHeight(txtAlbumArtist->height());
+    starRating->setFixedHeight(txtAlbumArtist->height());
 
     // Set the minimum height for the Comment editor to at least 3 line. Let's
     // use the triple the height of a QLineEdit because they are sized correctly.

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -140,7 +140,6 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
-    parented_ptr<WStarRating> m_pWStarRating;
     parented_ptr<WColorPickerAction> m_pColorPicker;
 
     std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -209,7 +209,13 @@
           </item>
 
           <item row="3" column="2" colspan="2">
-           <widget class="QWidget" name="verticalWidgetStars" native="true">
+           <widget class="WStarRating" name="starRating">
+            <property name="mouseTracking">
+              <bool>true</bool>
+            </property>
+            <property name="focusPolicy">
+              <enum>Qt::StrongFocus</enum>
+            </property>
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -220,8 +226,14 @@
              <property name="spacing">
               <number>0</number>
              </property>
+             <property name="margin">
+              <number>0</number>
+             </property>
              <property name="sizeConstraint">
               <enum>QLayout::SetDefaultConstraint</enum>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignVCenter</set>
              </property>
             </layout>
            </widget>
@@ -1118,12 +1130,20 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>WStarRating</class>
+   <extends>QWidget</extends>
+   <header>widget/wstarrating.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>txtTitle</tabstop>
   <tabstop>txtArtist</tabstop>
   <tabstop>txtAlbum</tabstop>
   <tabstop>txtAlbumArtist</tabstop>
+  <tabstop>starRating</tabstop>
   <tabstop>txtComposer</tabstop>
   <tabstop>txtYear</tabstop>
   <tabstop>txtGenre</tabstop>

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -107,7 +107,6 @@ DlgTrackInfoMulti::DlgTrackInfoMulti(UserSettingsPointer pUserSettings)
           m_pUserSettings(std::move(pUserSettings)),
           m_pWCoverArtMenu(make_parented<WCoverArtMenu>(this)),
           m_pWCoverArtLabel(make_parented<WCoverArtLabel>(this, m_pWCoverArtMenu)),
-          m_pWStarRating(make_parented<WStarRating>(this)),
           m_starRatingModified(false),
           m_newRating(0),
           m_colorChanged(false),
@@ -257,14 +256,7 @@ void DlgTrackInfoMulti::init() {
             this,
             &DlgTrackInfoMulti::slotColorPicked);
 
-    // Insert the star rating widget
-    starsLayout->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
-    starsLayout->setSpacing(0);
-    starsLayout->setContentsMargins(0, 0, 0, 0);
-    starsLayout->insertWidget(0, m_pWStarRating.get());
-    // This is necessary to pass on mouseMove events to WStarRating
-    m_pWStarRating->setMouseTracking(true);
-    connect(m_pWStarRating,
+    connect(starRating,
             &WStarRating::ratingChangeRequest,
             this,
             &DlgTrackInfoMulti::slotStarRatingChanged);
@@ -350,8 +342,8 @@ void DlgTrackInfoMulti::updateFromTracks() {
     replaceTrackRecords(trackRecords);
 
     // Collect star ratings and track colors
-    // If track value differs from the current value, add it to the list.
-    // If new and current are identical, keep only one.
+    // Check if all tracks have the same value for the rating (resp. color).
+    // If yes, show that value, if no, show a placeholder value instead.
     int commonRating = m_trackRecords.first().getRating();
     for (const auto& rec : std::as_const(m_trackRecords)) {
         if (commonRating != rec.getRating()) {
@@ -360,7 +352,7 @@ void DlgTrackInfoMulti::updateFromTracks() {
         }
     }
     // Update the star widget
-    m_pWStarRating->slotSetRating(commonRating);
+    starRating->slotSetRating(commonRating);
     m_starRatingModified = false;
 
     // Same procedure for the track color
@@ -664,7 +656,7 @@ void DlgTrackInfoMulti::adjustWidgetSizes() {
 
     // Set fixed height on stars widget so it doesn't make the adjacent
     // txtAlbumArtist expand vertically
-    m_pWStarRating->setFixedHeight(txtAlbumArtist->height());
+    starRating->setFixedHeight(txtAlbumArtist->height());
 
     // Set the minimum height for the Comment editor to at least 3 line. Let's
     // use the triple the height of a QLineEdit because they are sized correctly.
@@ -1069,7 +1061,7 @@ void DlgTrackInfoMulti::trackColorDialogSetColorStyleButton(
 void DlgTrackInfoMulti::slotStarRatingChanged(int rating) {
     if (!m_pLoadedTracks.isEmpty() && mixxx::TrackRecord::isValidRating(rating)) {
         m_starRatingModified = true;
-        m_pWStarRating->slotSetRating(rating);
+        starRating->slotSetRating(rating);
         m_newRating = rating;
     }
 }

--- a/src/library/dlgtrackinfomulti.h
+++ b/src/library/dlgtrackinfomulti.h
@@ -114,7 +114,6 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
 
     parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
-    parented_ptr<WStarRating> m_pWStarRating;
     bool m_starRatingModified;
     int m_newRating;
     bool m_colorChanged;

--- a/src/library/dlgtrackinfomulti.ui
+++ b/src/library/dlgtrackinfomulti.ui
@@ -194,21 +194,19 @@
       </item>
 
       <item row="3" column="2" colspan="2">
-       <widget class="QWidget" name="starsWidget" native="true">
+       <widget class="WStarRating" name="starRating">
+        <property name="mouseTracking">
+          <bool>true</bool>
+        </property>
+        <property name="focusPolicy">
+          <enum>Qt::StrongFocus</enum>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <layout class="QHBoxLayout" name="starsLayout">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="sizeConstraint">
-          <enum>QLayout::SetDefaultConstraint</enum>
-         </property>
-        </layout>
        </widget>
       </item>
 
@@ -721,6 +719,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>WStarRating</class>
+   <extends>QWidget</extends>
+   <header>widget/wstarrating.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>txtTitle</tabstop>
   <tabstop>txtArtist</tabstop>
@@ -731,6 +736,7 @@
   <tabstop>txtGrouping</tabstop>
   <tabstop>txtCommentBox</tabstop>
   <tabstop>txtComment</tabstop>
+  <tabstop>starRating</tabstop>
   <tabstop>txtYear</tabstop>
   <tabstop>txtKey</tabstop>
   <tabstop>txtTrackNumber</tabstop>

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -53,11 +53,7 @@ void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
 }
 
 void WStarRating::mouseMoveEvent(QMouseEvent *event) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     const int pos = event->position().toPoint().x();
-#else
-    const int pos = event->x();
-#endif
     int star = m_visualStarRating.starAtPosition(pos, rect());
 
     if (star == StarRating::kInvalidStarCount) {

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -52,6 +52,48 @@ void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
     m_visualStarRating.paint(&painter, m_contentRect);
 }
 
+void WStarRating::keyPressEvent(QKeyEvent* event) {
+    // Change rating when certain keys are pressed
+    QKeyEvent* ke = static_cast<QKeyEvent*>(event);
+    int newRating = m_visualStarRating.starCount();
+    switch (ke->key()) {
+    case Qt::Key_0:
+    case Qt::Key_1:
+    case Qt::Key_2:
+    case Qt::Key_3:
+    case Qt::Key_4:
+    case Qt::Key_5:
+    case Qt::Key_6:
+    case Qt::Key_7:
+    case Qt::Key_8:
+    case Qt::Key_9: {
+        bool ok = false;
+        int keyInt = ke->text().toInt(&ok);
+        if (ok) {
+            newRating = keyInt;
+        }
+        break;
+    }
+    case Qt::Key_Right:
+    case Qt::Key_Plus: {
+        newRating++;
+        break;
+    }
+    case Qt::Key_Left:
+    case Qt::Key_Minus: {
+        newRating--;
+        break;
+    }
+    default: {
+        event->ignore();
+        return;
+    }
+    }
+    newRating = math_clamp(newRating, StarRating::kMinStarCount, m_visualStarRating.maxStarCount());
+    updateVisualRating(newRating);
+    m_starCount = newRating;
+}
+
 void WStarRating::mouseMoveEvent(QMouseEvent *event) {
     const int pos = event->position().toPoint().x();
     int star = m_visualStarRating.starAtPosition(pos, rect());

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -11,8 +11,10 @@ class QWidgets;
 
 WStarRating::WStarRating(QWidget* pParent)
         : WWidget(pParent),
+          m_focusedViaKeyboard(false),
           m_starCount(0),
           m_visualStarRating(m_starCount) {
+    setAttribute(Qt::WA_Hover);
 }
 
 void WStarRating::setup(const QDomNode& node, const SkinContext& context) {
@@ -41,13 +43,45 @@ void WStarRating::slotSetRating(int starCount) {
     updateVisualRating(starCount);
 }
 
+void WStarRating::focusInEvent(QFocusEvent* event) {
+    m_focusedViaKeyboard = event->reason() == Qt::TabFocusReason ||
+            event->reason() == Qt::BacktabFocusReason ||
+            event->reason() == Qt::ShortcutFocusReason;
+    QWidget::focusInEvent(event);
+}
+
+void WStarRating::focusOutEvent(QFocusEvent* event) {
+    auto shouldUpdateVisual = m_focusedViaKeyboard;
+    m_focusedViaKeyboard = false;
+    QWidget::focusInEvent(event);
+    if (shouldUpdateVisual) {
+        update();
+    }
+}
+
 void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
     QStyleOption option;
     option.initFrom(this);
     QStylePainter painter(this);
 
-    painter.setBrush(option.palette.text());
+    // The default value for State_KeyboardFocusChange is never
+    // reset once set to true for a certain window, so we
+    // implement our own custom version of it instead.
+    if (m_focusedViaKeyboard) {
+        option.state |= QStyle::State_KeyboardFocusChange;
+    } else {
+        option.state &= ~QStyle::State_KeyboardFocusChange;
+    }
+
     painter.drawPrimitive(QStyle::PE_Widget, option);
+
+    if (focusPolicy() != Qt::NoFocus &&
+            (option.state & QStyle::State_HasFocus) &&
+            (option.state & QStyle::State_KeyboardFocusChange)) {
+        painter.setBrush(option.palette.highlight().color());
+    } else {
+        painter.setBrush(option.palette.text().color());
+    }
 
     m_visualStarRating.paint(&painter, m_contentRect);
 }
@@ -89,8 +123,10 @@ void WStarRating::keyPressEvent(QKeyEvent* event) {
         return;
     }
     }
+    bool shouldUpdateVisual = !m_focusedViaKeyboard;
+    m_focusedViaKeyboard = true;
     newRating = math_clamp(newRating, StarRating::kMinStarCount, m_visualStarRating.maxStarCount());
-    updateVisualRating(newRating);
+    updateVisualRating(newRating, shouldUpdateVisual);
     m_starCount = newRating;
 }
 
@@ -109,8 +145,11 @@ void WStarRating::leaveEvent(QEvent* /*unused*/) {
     resetVisualRating();
 }
 
-void WStarRating::updateVisualRating(int starCount) {
+void WStarRating::updateVisualRating(int starCount, bool forceRepaint) {
     if (starCount == m_visualStarRating.starCount()) {
+        if (forceRepaint) {
+            update();
+        }
         return;
     }
     m_visualStarRating.setStarCount(starCount);

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -22,6 +22,7 @@ class WStarRating : public WWidget {
 
   protected:
     void paintEvent(QPaintEvent* e) override;
+    void keyPressEvent(QKeyEvent* event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
     void leaveEvent(QEvent * /*unused*/) override;

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -21,6 +21,8 @@ class WStarRating : public WWidget {
     void ratingChangeRequest(int starCount);
 
   protected:
+    void focusInEvent(QFocusEvent* e) override;
+    void focusOutEvent(QFocusEvent* e) override;
     void paintEvent(QPaintEvent* e) override;
     void keyPressEvent(QKeyEvent* event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
@@ -29,12 +31,14 @@ class WStarRating : public WWidget {
     void fillDebugTooltip(QStringList* debug) override;
 
   private:
+    bool m_focusedViaKeyboard;
+
     int m_starCount;
 
     StarRating m_visualStarRating;
     mutable QRect m_contentRect;
 
-    void updateVisualRating(int starCount);
+    void updateVisualRating(int starCount, bool forceRepaint = false);
     void resetVisualRating() {
         updateVisualRating(m_starCount);
     }


### PR DESCRIPTION
Allow the star rating control to be focused via "Tab" / "Shift+Tab", and rating to be edited via Left/Right arrow keys as well as the number keys.

<img width="160" height="131" alt="image" src="https://github.com/user-attachments/assets/2d25bf06-2ec8-4961-9f42-3ee9a15fb504" />

This PR is part of an effort to improve the usability & resize behavior of the track info dialog, and was split off from:

- #13818