### PR TITLE
chore(Flatpak): disable commit checks when pulling the existing repo

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -134,7 +134,7 @@ jobs:
           ostree --repo=repo init --mode=archive-z2
 
           # Hook publish repo to the remote
-          ostree --repo=repo remote add upstream https://downloads.mixxx.org/flatpak/
+          ostree --repo=repo remote --set=gpg-verify=false add upstream https://downloads.mixxx.org/flatpak/
           ostree --repo=repo pull --depth=-1 --mirror "upstream"
 
           for arch in "x86_64" "aarch64"; do


### PR DESCRIPTION
Fixing [issues](https://github.com/mixxxdj/mixxx/actions/runs/30617865247/job/91252276379) which occurs when pulling all existing commits on the repo. There is no need to verify commits since there is only once producer, so disabling the checks.