### PR TITLE
Add option to force requested quantum and samplerate

### DIFF
--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -245,6 +245,29 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                                "API selection to take effect."));
                 });
 
+        auto pipewireGroupBox = make_parented<QGroupBox>("PipeWire Settings", this);
+        auto pipewireSettings = make_parented<QVBoxLayout>(pipewireGroupBox);
+        verticalLayout_2->insertWidget(2, pipewireGroupBox.get());
+
+        m_pipewirePatchbayCheckBox = make_parented<QCheckBox>(this);
+        m_pipewirePatchbayCheckBox->setText(tr("Sync with external patchbay"));
+        m_pPipewirePatchbay = make_parented<ControlProxy>(
+                kPipeWirePatchbay.group, kPipeWirePatchbay.item, this);
+        connect(m_pipewirePatchbayCheckBox,
+                &QCheckBox::toggled,
+                this,
+                [this](bool checked) {
+                    m_pSettings->setValue(kPipeWirePatchbay, checked);
+                    m_pPipewirePatchbay->set(checked);
+                    ioTabs->setDisabled(checked);
+                    m_settingsModified = true;
+                });
+
+        bool checked = m_pSettings->getValue(kPipeWirePatchbay, false);
+        m_pipewirePatchbayCheckBox->setChecked(checked);
+        pipewireSettings->addWidget(m_pipewirePatchbayCheckBox.get());
+        pipewireGroupBox->setVisible(pipewireSelected);
+
         if (pipewireSelected) {
             m_forceBufferSize = make_parented<QCheckBox>(this);
             m_forceSamplerate = make_parented<QCheckBox>(this);
@@ -295,6 +318,26 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             m_cpSamplerate = make_parented<ControlProxy>(
                     kAppGroup, QStringLiteral("samplerate"), this);
 
+            if (m_forceSamplerate->isChecked()) {
+                auto samplerates = m_pSoundManager->getSampleRates();
+                updateSampleRates(samplerates);
+            } else {
+                sampleRateComboBox->clear();
+                unsigned int samplerate = static_cast<unsigned int>(m_cpSamplerate->get());
+                sampleRateComboBox->addItem(tr("%1 Hz").arg(samplerate),
+                        QVariant::fromValue(samplerate));
+            }
+
+            if (m_forceBufferSize->isChecked()) {
+                updateAudioBufferSizes(0);
+            } else {
+                audioBufferComboBox->clear();
+                unsigned int bufferSize = static_cast<unsigned int>(m_cpBufferSize->get());
+                audioBufferComboBox->addItem(
+                        tr("%1 frames/period").arg(bufferSize),
+                        QVariant::fromValue(bufferSize));
+            }
+
             m_cpBufferSize->connectValueChanged(this, [this](double value) {
                 qDebug() << "m_cpBufferSize->connectValueChanged" << value;
                 if (!audioBufferComboBox->isEnabled()) {
@@ -313,28 +356,28 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                             QVariant::fromValue(samplerate));
                 }
             });
+
+            m_latencyParamsMismatchText = new QLabel();
+            pipewireSettings->addWidget(m_latencyParamsMismatchText);
+
+            m_cpLatencyParamsMismatch = make_parented<ControlProxy>(
+                    kAppGroup, QStringLiteral("latency_params_mismatch"), this);
+            m_latencyParamsMismatchText->setVisible(
+                    static_cast<bool>(m_cpLatencyParamsMismatch->get()));
+            m_cpLatencyParamsMismatch->connectValueChanged(
+                    this, [this](double mismatch) {
+                        qDebug() << "m_cpLatencyParamsMismatch->"
+                                    "connectValueChanged"
+                                 << static_cast<bool>(mismatch);
+                        m_latencyParamsMismatchText->setText(
+                                tr("Server is providing different buffer size "
+                                   "(%1) or samplerate (%2) than forced.")
+                                        .arg(m_cpBufferSize->get())
+                                        .arg(m_cpSamplerate->get()));
+                        m_latencyParamsMismatchText->setVisible(
+                                static_cast<bool>(mismatch));
+                    });
         }
-        m_pipewirePatchbayCheckBox = make_parented<QCheckBox>(this);
-        m_pipewirePatchbayCheckBox->setText(tr("Sync with external patchbay"));
-        m_pPipewirePatchbay = make_parented<ControlProxy>(
-                kPipeWirePatchbay.group, kPipeWirePatchbay.item, this);
-        connect(m_pipewirePatchbayCheckBox,
-                &QCheckBox::toggled,
-                this,
-                [this](bool checked) {
-                    m_pSettings->setValue(kPipeWirePatchbay, checked);
-                    m_pPipewirePatchbay->set(checked);
-                    ioTabs->setDisabled(checked);
-                    m_settingsModified = true;
-                });
-
-        auto pipewireGroupBox = make_parented<QGroupBox>("PipeWire Settings", this);
-        auto pipewireSettings = make_parented<QVBoxLayout>(pipewireGroupBox);
-        verticalLayout_2->insertWidget(2, pipewireGroupBox.get());
-
-        bool checked = m_pSettings->getValue(kPipeWirePatchbay, false);
-        m_pipewirePatchbayCheckBox->setChecked(checked);
-        pipewireSettings->addWidget(m_pipewirePatchbayCheckBox.get());
     }
 #endif
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -41,6 +41,8 @@ const ConfigKey kPipeWire =
         ConfigKey(kAppGroup, QStringLiteral("pipewire"));
 const ConfigKey kPipeWirePatchbay =
         ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"));
+const ConfigKey kForceBufferSize = ConfigKey(kAppGroup, QStringLiteral("force_buffer_size"));
+const ConfigKey kForceSamplerate = ConfigKey(kAppGroup, QStringLiteral("force_samplerate"));
 
 bool soundItemAlreadyExists(const AudioPath& output, const QWidget& widget) {
     for (const QObject* pObj : widget.children()) {
@@ -226,11 +228,10 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
         m_pipewireCheckBox = make_parented<QCheckBox>(this);
         m_pipewireCheckBox->setText(tr("Use PipeWire API"));
 
-        bool checked = m_pSoundManager->isPipewireSelected();
-        m_pipewireCheckBox->setChecked(checked);
-        apiComboBox->setDisabled(checked);
-
+        bool pipewireSelected = m_pSoundManager->isPipewireSelected();
+        m_pipewireCheckBox->setChecked(pipewireSelected);
         m_pipewireCheckBox->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
+        apiComboBox->setDisabled(pipewireSelected);
         apiHBox->addWidget(m_pipewireCheckBox.get());
 
         connect(m_pipewireCheckBox,
@@ -243,9 +244,76 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                             tr("Mixxx must be restarted for the PipeWire "
                                "API selection to take effect."));
                 });
-    }
 
-    if (m_pSoundManager->isPipewireSelected()) {
+        if (pipewireSelected) {
+            m_forceBufferSize = make_parented<QCheckBox>(this);
+            m_forceSamplerate = make_parented<QCheckBox>(this);
+            m_forceBufferSize->setText(tr("Force PipeWire Buffer Size"));
+            m_forceSamplerate->setText(tr("Force PipeWire Samplerate"));
+            m_forceBufferSize->setChecked(m_pSettings->getValue(kForceBufferSize, false));
+            m_forceSamplerate->setChecked(m_pSettings->getValue(kForceSamplerate, false));
+            audioBufferComboBox->setEnabled(m_forceBufferSize->isChecked());
+            sampleRateComboBox->setEnabled(m_forceSamplerate->isChecked());
+
+            m_forceBufferSize->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
+            m_forceSamplerate->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
+            sampleRateHBox->addWidget(m_forceSamplerate.get());
+            audioBufferHBox->addWidget(m_forceBufferSize.get());
+
+            connect(m_forceSamplerate, &QCheckBox::toggled, this, [this](bool checked) {
+                m_settingsModified = true;
+                sampleRateComboBox->setEnabled(checked);
+
+                if (checked) {
+                    auto samplerates = m_pSoundManager->getSampleRates();
+                    updateSampleRates(samplerates);
+                } else {
+                    sampleRateComboBox->clear();
+                    unsigned int samplerate = static_cast<unsigned int>(m_cpSamplerate->get());
+                    sampleRateComboBox->addItem(tr("%1 Hz").arg(samplerate),
+                            QVariant::fromValue(samplerate));
+                }
+            });
+
+            connect(m_forceBufferSize, &QCheckBox::toggled, this, [this](bool checked) {
+                m_settingsModified = true;
+                audioBufferComboBox->setEnabled(checked);
+
+                if (checked) {
+                    updateAudioBufferSizes(0);
+                } else {
+                    audioBufferComboBox->clear();
+                    unsigned int bufferSize = static_cast<unsigned int>(m_cpBufferSize->get());
+                    audioBufferComboBox->addItem(
+                            tr("%1 frames/period").arg(bufferSize),
+                            QVariant::fromValue(bufferSize));
+                }
+            });
+
+            m_cpBufferSize = make_parented<ControlProxy>(
+                    kAppGroup, QStringLiteral("buffer_size"), this);
+            m_cpSamplerate = make_parented<ControlProxy>(
+                    kAppGroup, QStringLiteral("samplerate"), this);
+
+            m_cpBufferSize->connectValueChanged(this, [this](double value) {
+                qDebug() << "m_cpBufferSize->connectValueChanged" << value;
+                if (!audioBufferComboBox->isEnabled()) {
+                    unsigned int bufferSize = static_cast<unsigned int>(value);
+                    audioBufferComboBox->clear();
+                    audioBufferComboBox->addItem(tr("%1 frames/period").arg(bufferSize),
+                            QVariant::fromValue(bufferSize));
+                }
+            });
+            m_cpSamplerate->connectValueChanged(this, [this](double value) {
+                qDebug() << "m_cpSamplerate->connectValueChanged" << value;
+                if (!sampleRateComboBox->isEnabled()) {
+                    unsigned int samplerate = static_cast<unsigned int>(value);
+                    sampleRateComboBox->clear();
+                    sampleRateComboBox->addItem(tr("%1 Hz").arg(samplerate),
+                            QVariant::fromValue(samplerate));
+                }
+            });
+        }
         m_pipewirePatchbayCheckBox = make_parented<QCheckBox>(this);
         m_pipewirePatchbayCheckBox->setText(tr("Sync with external patchbay"));
         m_pPipewirePatchbay = make_parented<ControlProxy>(
@@ -471,6 +539,17 @@ void DlgPrefSound::slotApply() {
                        "RubberBand setting change will take effect."));
         }
 #endif
+
+#ifdef __PIPEWIRE__
+        if (CmdlineArgs::Instance().getDeveloper()) {
+            m_pSettings->set(kPipeWire, ConfigValue(m_pipewireCheckBox->isChecked()));
+            if (m_pSettings->getValue(kPipeWire, false)) {
+                m_pSettings->setValue(kForceBufferSize, m_forceBufferSize->isChecked());
+                m_pSettings->setValue(kForceSamplerate, m_forceSamplerate->isChecked());
+            }
+        }
+#endif
+
         status = m_pSoundManager->setConfig(m_config);
         m_configValid = (status == SoundDeviceStatus::Ok);
     }
@@ -481,12 +560,6 @@ void DlgPrefSound::slotApply() {
         m_settingsModified = false;
         m_bLatencyChanged = false;
     }
-
-#ifdef __PIPEWIRE__
-    if (CmdlineArgs::Instance().getDeveloper()) {
-        m_pSettings->set(kPipeWire, ConfigValue(m_pipewireCheckBox->isChecked()));
-    }
-#endif
 
     m_bSkipConfigClear = true;
     loadSettings(); // in case SM decided to change anything it didn't like
@@ -729,6 +802,17 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig& config) {
         }
     }
 
+#ifdef __PIPEWIRE__
+    if (CmdlineArgs::Instance().getDeveloper()) {
+        const bool pipewireSelected = m_pSoundManager->isPipewireSelected();
+        m_pipewireCheckBox->setChecked(pipewireSelected);
+        if (pipewireSelected) {
+            m_forceBufferSize->setChecked(m_pSettings->getValue(kForceBufferSize, false));
+            m_forceSamplerate->setChecked(m_pSettings->getValue(kForceSamplerate, false));
+        }
+    }
+#endif
+
     m_loading = false;
     // DlgPrefSoundItem has it's own inhibit flag
     emit loadPaths(m_config);
@@ -750,7 +834,11 @@ void DlgPrefSound::apiChanged(int index) {
     // TODO(Be): Get the buffer size from JACK and update audioBufferComboBox.
     // PortAudio as off v19.7.0 does not have a way to get the buffer size from JACK.
     bool enable = m_config.getAPI() == SoundManagerConfig::kAPIJack ? false : true;
-    sampleRateComboBox->setEnabled(enable);
+
+    if (!m_pSoundManager->isPipewireSelected()) {
+        // With PipeWire it depends if samplerate is forced or not
+        sampleRateComboBox->setEnabled(enable);
+    }
     deviceSyncComboBox->setEnabled(enable);
     engineClockComboBox->setEnabled(enable);
     updateAudioBufferSizes(sampleRateComboBox->currentIndex());
@@ -822,6 +910,19 @@ void DlgPrefSound::engineClockChanged(int index) {
 // but they'll be close).
 void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
     QVariant oldSizeIndex = audioBufferComboBox->currentData();
+#ifdef __PIPEWIRE__
+    if (m_config.getAPI() == SoundManagerConfig::kAPIPipewire) {
+        if (audioBufferComboBox->isEnabled()) {
+            audioBufferComboBox->clear();
+            for (int i = 1; i < 8; i++) {
+                audioBufferComboBox->addItem(tr("%1 frames/period").arg(2 << (i + 4)),
+                        QVariant::fromValue(i));
+            }
+        }
+        return;
+    }
+#endif
+
     audioBufferComboBox->clear();
     if (m_config.getAPI() == SoundManagerConfig::kAPIJack) {
         // in case of jack we configure the frames/period
@@ -839,7 +940,7 @@ void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
                                 JackAudioBufferSizeIndex::Size4096fpp));
     } else {
         DEBUG_ASSERT(sampleRateComboBox->itemData(sampleRateIndex)
-                             .canConvert<mixxx::audio::SampleRate>());
+                        .canConvert<mixxx::audio::SampleRate>());
         double sampleRate = sampleRateComboBox->itemData(sampleRateIndex)
                                     .value<mixxx::audio::SampleRate>()
                                     .toDouble();
@@ -1248,6 +1349,10 @@ bool DlgPrefSound::okayToClose() const {
 }
 
 void DlgPrefSound::updateSampleRates(const QList<mixxx::audio::SampleRate>& sampleRates) {
+    int currentIndex = sampleRateComboBox->currentIndex();
+    mixxx::audio::SampleRate selectedRate =
+            sampleRateComboBox->itemData(currentIndex)
+                    .value<mixxx::audio::SampleRate>();
     sampleRateComboBox->clear();
     for (const auto& sampleRate : sampleRates) {
         if (sampleRate.isValid()) {
@@ -1256,6 +1361,10 @@ void DlgPrefSound::updateSampleRates(const QList<mixxx::audio::SampleRate>& samp
             sampleRateComboBox->addItem(tr("%1 Hz").arg(sampleRate.value()),
                     QVariant::fromValue(sampleRate));
         }
+    }
+    auto newIndex = sampleRateComboBox->findData(QVariant::fromValue(selectedRate));
+    if (newIndex >= 0) {
+        sampleRateComboBox->setCurrentIndex(newIndex);
     }
 }
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -364,6 +364,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                     kAppGroup, QStringLiteral("latency_params_mismatch"), this);
             m_latencyParamsMismatchText->setVisible(
                     static_cast<bool>(m_cpLatencyParamsMismatch->get()));
+            m_latencyParamsMismatchText->setText(
+                    tr("Server is providing different buffer size "
+                       "(%1) or samplerate (%2) than forced.")
+                            .arg(QString::number(m_cpBufferSize->get()),
+                                    QString::number(m_cpSamplerate->get())));
+
             m_cpLatencyParamsMismatch->connectValueChanged(
                     this, [this](double mismatch) {
                         qDebug() << "m_cpLatencyParamsMismatch->"
@@ -372,8 +378,10 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                         m_latencyParamsMismatchText->setText(
                                 tr("Server is providing different buffer size "
                                    "(%1) or samplerate (%2) than forced.")
-                                        .arg(m_cpBufferSize->get())
-                                        .arg(m_cpSamplerate->get()));
+                                        .arg(QString::number(
+                                                     m_cpBufferSize->get()),
+                                                QString::number(m_cpSamplerate
+                                                                ->get())));
                         m_latencyParamsMismatchText->setVisible(
                                 static_cast<bool>(mismatch));
                     });
@@ -586,7 +594,7 @@ void DlgPrefSound::slotApply() {
 #ifdef __PIPEWIRE__
         if (CmdlineArgs::Instance().getDeveloper()) {
             m_pSettings->set(kPipeWire, ConfigValue(m_pipewireCheckBox->isChecked()));
-            if (m_pSettings->getValue(kPipeWire, false)) {
+            if (m_pSoundManager->isPipewireSelected()) {
                 m_pSettings->setValue(kForceBufferSize, m_forceBufferSize->isChecked());
                 m_pSettings->setValue(kForceSamplerate, m_forceSamplerate->isChecked());
             }
@@ -910,15 +918,23 @@ void DlgPrefSound::updateAPIs() {
 void DlgPrefSound::sampleRateChanged(int index) {
     m_config.setSampleRate(sampleRateComboBox->itemData(index).value<mixxx::audio::SampleRate>());
     m_bLatencyChanged = true;
-    updateAudioBufferSizes(index);
+
+    if (!m_pSoundManager->isPipewireSelected()) {
+        updateAudioBufferSizes(index);
+    }
     checkLatencyCompensation();
 }
 
 /// Slot called when the latency combo box is changed to update the
 /// latency in the config.
 void DlgPrefSound::audioBufferChanged(int index) {
-    m_config.setAudioBufferSizeIndex(
-            audioBufferComboBox->itemData(index).toUInt());
+    if (!m_pSoundManager->isPipewireSelected() || audioBufferComboBox->isEnabled()) {
+        // don't update config when working with PipeWire server assigned
+        // buffer size, which can or cannot be power of 2, so keep last forced buffer size
+
+        m_config.setAudioBufferSizeIndex(
+                audioBufferComboBox->itemData(index).toUInt());
+    }
     m_bLatencyChanged = true;
     checkLatencyCompensation();
 }
@@ -953,18 +969,16 @@ void DlgPrefSound::engineClockChanged(int index) {
 // but they'll be close).
 void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
     QVariant oldSizeIndex = audioBufferComboBox->currentData();
-#ifdef __PIPEWIRE__
     if (m_config.getAPI() == SoundManagerConfig::kAPIPipewire) {
         if (audioBufferComboBox->isEnabled()) {
             audioBufferComboBox->clear();
             for (int i = 1; i < 8; i++) {
-                audioBufferComboBox->addItem(tr("%1 frames/period").arg(2 << (i + 4)),
+                audioBufferComboBox->addItem(tr("%1 frames/period").arg(1 << (i + 5)),
                         QVariant::fromValue(i));
             }
         }
         return;
     }
-#endif
 
     audioBufferComboBox->clear();
     if (m_config.getAPI() == SoundManagerConfig::kAPIJack) {

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -37,6 +37,8 @@ const ConfigKey kKeylockMultiThreadingCfgkey =
         ConfigKey(kAppGroup, QStringLiteral("keylock_multithreading"));
 const ConfigKey kPipeWire =
         ConfigKey(kAppGroup, QStringLiteral("pipewire"));
+const ConfigKey kPipeWireForceQuantumRate =
+        ConfigKey(kAppGroup, QStringLiteral("pipewire_force_quantum_rate"));
 
 bool soundItemAlreadyExists(const AudioPath& output, const QWidget& widget) {
     for (const QObject* pObj : widget.children()) {
@@ -216,13 +218,21 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
     if (CmdlineArgs::Instance().getDeveloper()) {
         m_pipewireCheckBox = make_parented<QCheckBox>(this);
         m_pipewireCheckBox->setText(tr("Use PipeWire API"));
+        m_pipewireForceQuantumRate = make_parented<QCheckBox>(this);
+        m_pipewireForceQuantumRate->setText(tr("Force PipeWire Quantum/Rate"));
+        m_pipewireForceQuantumRate->setChecked(
+                m_pSettings->getValue(kPipeWireForceQuantumRate, false));
 
         bool checked = m_pSoundManager->isPipewireSelected();
         m_pipewireCheckBox->setChecked(checked);
         apiComboBox->setDisabled(checked);
+        m_pipewireForceQuantumRate->setDisabled(!checked);
 
         m_pipewireCheckBox->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
+        m_pipewireForceQuantumRate->setSizePolicy(
+                QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
         apiHBox->addWidget(m_pipewireCheckBox.get());
+        apiHBox->addWidget(m_pipewireForceQuantumRate.get());
 
         connect(m_pipewireCheckBox,
                 &QCheckBox::toggled,
@@ -236,6 +246,17 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                                    "API selection to take effect."));
                     }
                 });
+        connect(m_pipewireForceQuantumRate, &QCheckBox::toggled, this, [this](bool checked) {
+            m_settingsModified = true;
+            // this makes the checkBox state persist even if preference page is cancelled
+            // but this is required as this key is queried within single preference page session
+            m_pSettings->set(kPipeWireForceQuantumRate,
+                    ConfigValue(m_pipewireForceQuantumRate->isChecked()));
+            auto samplerates = checked
+                    ? m_pSoundManager->getDefaultSampleRates()
+                    : m_pSoundManager->getSampleRates();
+            updateSampleRates(samplerates);
+        });
     }
 #endif
 
@@ -702,6 +723,8 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig& config) {
 #ifdef __PIPEWIRE__
     if (CmdlineArgs::Instance().getDeveloper()) {
         m_pipewireCheckBox->setChecked(m_pSoundManager->isPipewireSelected());
+        m_pipewireForceQuantumRate->setChecked(
+                m_pSettings->getValue(kPipeWireForceQuantumRate, false));
     }
 #endif
 
@@ -1224,6 +1247,10 @@ bool DlgPrefSound::okayToClose() const {
 }
 
 void DlgPrefSound::updateSampleRates(const QList<mixxx::audio::SampleRate>& sampleRates) {
+    int currentIndex = sampleRateComboBox->currentIndex();
+    mixxx::audio::SampleRate selectedRate =
+            sampleRateComboBox->itemData(currentIndex)
+                    .value<mixxx::audio::SampleRate>();
     sampleRateComboBox->clear();
     for (const auto& sampleRate : sampleRates) {
         if (sampleRate.isValid()) {
@@ -1232,5 +1259,9 @@ void DlgPrefSound::updateSampleRates(const QList<mixxx::audio::SampleRate>& samp
             sampleRateComboBox->addItem(tr("%1 Hz").arg(sampleRate.value()),
                     QVariant::fromValue(sampleRate));
         }
+    }
+    auto newIndex = sampleRateComboBox->findData(QVariant::fromValue(selectedRate));
+    if (newIndex >= 0) {
+        sampleRateComboBox->setCurrentIndex(newIndex);
     }
 }

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -135,5 +135,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     parented_ptr<QCheckBox> m_forceSamplerate;
     parented_ptr<ControlProxy> m_cpSamplerate;
     parented_ptr<ControlProxy> m_cpBufferSize;
+    parented_ptr<ControlProxy> m_cpLatencyParamsMismatch;
+    QLabel* m_latencyParamsMismatchText;
 #endif
 };

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -35,6 +35,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     QUrl helpUrl() const override;
     bool okayToClose() const override;
 
+    inline static const ConfigKey kPipeWireForceQuantumRate =
+            ConfigKey("[App]", QStringLiteral("pipewire_force_quantum_rate"));
   signals:
     void loadPaths(const SoundManagerConfig &config);
     void writePaths(SoundManagerConfig *config);
@@ -127,5 +129,6 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
 
 #ifdef __PIPEWIRE__
     parented_ptr<QCheckBox> m_pipewireCheckBox;
+    parented_ptr<QCheckBox> m_pipewireForceQuantumRate;
 #endif
 };

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -131,5 +131,9 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     parented_ptr<QCheckBox> m_pipewireCheckBox;
     parented_ptr<QCheckBox> m_pipewirePatchbayCheckBox;
     parented_ptr<ControlProxy> m_pPipewirePatchbay;
+    parented_ptr<QCheckBox> m_forceBufferSize;
+    parented_ptr<QCheckBox> m_forceSamplerate;
+    parented_ptr<ControlProxy> m_cpSamplerate;
+    parented_ptr<ControlProxy> m_cpBufferSize;
 #endif
 };

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -47,7 +47,11 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QComboBox" name="sampleRateComboBox"/>
+      <layout class="QHBoxLayout" name="sampleRateHBox">
+        <item>
+          <widget class="QComboBox" name="sampleRateComboBox"/>
+        </item>
+      </layout>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="audioBufferLabel">
@@ -60,7 +64,11 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QComboBox" name="audioBufferComboBox"/>
+      <layout class="QHBoxLayout" name="audioBufferHBox">
+        <item>
+          <widget class="QComboBox" name="audioBufferComboBox"/>
+        </item>
+      </layout>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="deviceSyncLabel">

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -19,6 +19,7 @@
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
 #include "util/assert.h"
+#include "util/defs.h"
 #include "util/sample.h"
 #include "util/trace.h"
 #include "util/types.h"
@@ -424,7 +425,7 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
     }
 
     if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        setLatency(sampleRate, framesPerBuffer);
+        updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
     int deviceId = device.getDeviceId().deviceIndex;
@@ -795,10 +796,13 @@ std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createOutputPorts(const Audi
     return createPorts(outputName, SPA_DIRECTION_OUTPUT);
 }
 
-void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qWarning() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
-    std::string rateStr = "1/" + std::to_string(sampleRate);
-    std::string latencyStr = std::to_string(framesPerBuffer) + "/" + std::to_string(sampleRate);
+void PipewireEnumerator::updateFilterLatency(
+        unsigned int sampleRate, unsigned int framesPerBuffer) {
+    qWarning() << "PipewireEnumerator::updateFilterLatency" << sampleRate << framesPerBuffer;
+    std::string rate = std::to_string(sampleRate);
+    std::string rateStr = "1/" + rate;
+    std::string quantumStr = std::to_string(framesPerBuffer);
+    std::string latencyStr = quantumStr + "/" + std::to_string(sampleRate);
 
     spa_dict_item items[] = {
             SPA_DICT_ITEM_INIT(PW_KEY_NODE_RATE, rateStr.c_str()),
@@ -814,21 +818,24 @@ void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int frames
     int res = pw_filter_update_properties(m_pPwFilter, nullptr, &properties);
 
     pw_thread_loop_unlock(m_pPwThreadLoop);
-
     if (res >= 0) {
-        m_sampleRate = sampleRate;
-        m_framesPerBuffer = framesPerBuffer;
-        ControlObject::set(
-                ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
-                m_framesPerBuffer * 1000 / m_sampleRate);
-        ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
-
+        setLatency(sampleRate, framesPerBuffer);
     } else {
         qWarning() << "PipewireEnumerator::setLatency "
                       "pw_filter_update_properties failed:"
                    << spa_strerror(res);
         qWarning() << "Unable to set requested samplerate";
     }
+}
+
+void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
+    qWarning() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
+    m_sampleRate = sampleRate;
+    m_framesPerBuffer = framesPerBuffer;
+    ControlObject::set(
+            ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
+            m_framesPerBuffer * 1000 / m_sampleRate);
+    ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
 }
 
 void PipewireEnumerator::coreEventError(uint32_t id, int seq, int res, const char* message) {

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -1,7 +1,9 @@
 #include "soundio/pipewireenumerator.h"
 
 #include <pipewire/pipewire.h>
-#include <qobjectdefs.h>
+#include <qendian.h>
+#include <qlogging.h>
+#include <qobject.h>
 #include <spa/utils/defs.h>
 #include <spa/utils/dict.h>
 #include <spa/utils/result.h>
@@ -17,6 +19,8 @@
 #include "audio/types.h"
 #include "control/controlobject.h"
 #include "moc_pipewireenumerator.cpp"
+#include "preferences/configobject.h"
+#include "preferences/dialog/dlgprefsound.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddevicepipewire.h"
 #include "soundio/soundmanager.h"
@@ -76,8 +80,9 @@ static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
 }
 } // namespace
 
-PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManager)
+PipewireEnumerator::PipewireEnumerator(UserSettingsPointer pConfig, SoundManager* pManager)
         : m_pSoundManager(pManager),
+          m_pConfig(pConfig),
           m_pPwThreadLoop(nullptr),
           m_pPwContext(nullptr),
           m_pPwCore(nullptr),
@@ -87,8 +92,11 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
           m_sampleRate(48000),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
           m_coPipewirePatchbaySync(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
+          m_coBufferSize(ConfigKey(kAppGroup, QStringLiteral("buffer_size"))),
           m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
-          m_framesPerBuffer(0) {
+          m_framesPerBuffer(1024),
+          m_forceSamplerate(false),
+          m_forceQuantum(false) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -97,6 +105,11 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
             &SoundManager::outputRegistered,
             this,
             &PipewireEnumerator::registerOutput);
+
+    connect(m_pSoundManager,
+            &SoundManager::devicesSetup,
+            this,
+            &PipewireEnumerator::devicesSetup);
 
     connect(this, &PipewireEnumerator::deviceAdded, m_pSoundManager, &SoundManager::addDevice);
     connect(this, &PipewireEnumerator::deviceRemoved, m_pSoundManager, &SoundManager::removeDevice);
@@ -528,19 +541,8 @@ int PipewireEnumerator::metadataProperty(
 
     if (strcmp(key, "clock.rate") == 0) {
         pEnumerator->m_defaultSampleRate = mixxx::audio::SampleRate(std::atoi(value));
-    } else if (strcmp(key, "clock.allowed-rates") == 0) {
-        qDebug() << "PipewireEnumerator::metadataProperty clock.allowed-rates" << value;
-        // parse json arrays like [ 44100, 48000, 96000 ]
-        QString s = value;
-        s.remove('[');
-        s.remove(']');
-
-        const QStringList parts = s.split(',', Qt::SkipEmptyParts);
-
-        for (const QString& part : parts) {
-            pEnumerator->m_samplerates.push_back(mixxx::audio::SampleRate(part.trimmed().toInt()));
-        }
     }
+
     return 0;
 }
 
@@ -705,7 +707,6 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
         setLatency(sampleRate, framesPerBuffer);
     }
 
-    // qDebug() << "PipewireEnumerator::callback" << sampleRate << framesPerBuffer;
     m_pSoundManager->processUnderflowHappened(framesPerBuffer);
 
     for (const auto& [input, ports] : m_inputs) {
@@ -917,31 +918,27 @@ void PipewireEnumerator::createOutputPorts(const AudioOutput& output, PortPair& 
     createPorts(ports, outputName, SPA_DIRECTION_OUTPUT);
 }
 
-void PipewireEnumerator::updateFilterLatency(
-        unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qDebug() << "PipewireEnumerator::updateFilterLatency" << sampleRate << framesPerBuffer;
-    std::string rate = std::to_string(sampleRate);
-    std::string rateStr = "1/" + rate;
-    std::string quantumStr = std::to_string(framesPerBuffer);
-    std::string latencyStr = quantumStr + "/" + std::to_string(sampleRate);
+void PipewireEnumerator::updateFilterLatency() {
+    qDebug() << "PipewireEnumerator::updateFilterLatency" << m_forceQuantum
+             << m_framesPerBuffer << m_forceSamplerate << m_sampleRate;
 
-    spa_dict_item items[] = {
-            SPA_DICT_ITEM_INIT(PW_KEY_NODE_RATE, rateStr.c_str()),
-            SPA_DICT_ITEM_INIT(PW_KEY_NODE_LATENCY, latencyStr.c_str()),
+    std::string rate = m_forceSamplerate ? std::to_string(m_sampleRate) : "";
+    std::string rateFraction = m_forceSamplerate ? "1/" + std::to_string(m_sampleRate) : "";
+    std::string quantum = m_forceQuantum ? std::to_string(m_framesPerBuffer) : "";
+    std::string latency = m_forceQuantum ? rate + "/" + std::to_string(m_framesPerBuffer) : "";
+
+    const spa_dict_item propItems[] = {
+            SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_RATE, rate.c_str()),
+            SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_QUANTUM, quantum.c_str()),
     };
 
-    // don't set PW_KEY_NODE_LATENCY if framesPerBuffer is 0 (uninitialized)
-    uint32_t numProps = framesPerBuffer == 0 ? 1 : 2;
-    spa_dict properties = SPA_DICT_INIT(items, numProps);
+    spa_dict properties = SPA_DICT_INIT(propItems, std::size(propItems));
 
     pw_thread_loop_lock(m_pPwThreadLoop);
-
     int res = pw_filter_update_properties(m_pPwFilter, nullptr, &properties);
-
     pw_thread_loop_unlock(m_pPwThreadLoop);
-    if (res >= 0) {
-        setLatency(sampleRate, framesPerBuffer);
-    } else {
+
+    if (res < 0) {
         qDebug() << "PipewireEnumerator::setLatency "
                     "pw_filter_update_properties failed:"
                  << spa_strerror(res);
@@ -950,13 +947,16 @@ void PipewireEnumerator::updateFilterLatency(
 }
 
 void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qDebug() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
+    qDebug() << "PipewireEnumerator::setLatency" << m_sampleRate << sampleRate
+             << m_framesPerBuffer << framesPerBuffer;
+
     m_sampleRate = sampleRate;
     m_framesPerBuffer = framesPerBuffer;
     ControlObject::set(
             ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
             m_framesPerBuffer * 1000 / m_sampleRate);
     ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
+    m_coBufferSize.set(m_framesPerBuffer);
 }
 
 void PipewireEnumerator::coreEventDone(uint32_t id, int seq) {
@@ -1022,10 +1022,31 @@ bool PipewireEnumerator::nodeHasPorts(const Node& node) {
     return false;
 }
 
-void PipewireEnumerator::setLatencyParams(
-        mixxx::audio::SampleRate sampleRate, SINT framesPerBuffer) {
-    qDebug() << "PipewireEnumerator::setLatencyParams" << sampleRate << framesPerBuffer;
-    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        updateFilterLatency(sampleRate, framesPerBuffer);
+void PipewireEnumerator::devicesSetup() {
+    const mixxx::audio::SampleRate samplerate = m_pSoundManager->getConfig().getSampleRate();
+    const unsigned int framesPerBuffer = m_pSoundManager->getConfig().getFramesPerBuffer();
+    const bool samplerateChanged = samplerate != m_sampleRate;
+    const bool framesPerBufferChanged = framesPerBuffer != m_framesPerBuffer;
+
+    const bool configForceQuantum = m_pConfig->getValue(
+            ConfigKey(kAppGroup, QStringLiteral("force_buffer_size")), false);
+    const bool configForceSamplerate = m_pConfig->getValue(
+            ConfigKey(kAppGroup, QStringLiteral("force_samplerate")), false);
+    const bool forceQuantumChanged = m_forceQuantum != configForceQuantum;
+    const bool forceSamplerateChanged = m_forceSamplerate != configForceSamplerate;
+    qDebug() << "PipewireEnumerator::devicesSetup" << configForceQuantum
+             << m_forceQuantum << configForceSamplerate << m_forceSamplerate
+             << samplerate << m_sampleRate << framesPerBuffer
+             << m_framesPerBuffer;
+
+    m_sampleRate = samplerate;
+    m_framesPerBuffer = framesPerBuffer;
+
+    if ((forceQuantumChanged || forceSamplerateChanged) ||
+            ((samplerateChanged || framesPerBufferChanged) &&
+                    (configForceQuantum || configForceSamplerate))) {
+        m_forceQuantum = configForceQuantum;
+        m_forceSamplerate = configForceSamplerate;
+        updateFilterLatency();
     }
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -33,6 +33,7 @@
 namespace {
 
 constexpr int kCpuUsageUpdateRate = 30; // in 1/s, fits to display frame rate
+constexpr int kDefaultBufferSize = 1024;
 const QString kAppGroup = QStringLiteral("[App]");
 
 static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
@@ -90,8 +91,6 @@ PipewireEnumerator::PipewireEnumerator(
           m_pPwRegistry(nullptr),
           m_pPwMetadata(nullptr),
           m_pPwFilter(nullptr),
-          m_sampleRate(48000),
-          m_framesPerBuffer(1024),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
           m_coPipewirePatchbaySync(ConfigKey(
                   kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
@@ -99,12 +98,15 @@ PipewireEnumerator::PipewireEnumerator(
                   true,
                   false,
                   false,
-                  m_framesPerBuffer),
+                  kDefaultBufferSize),
           m_coLatencyParamsMismatch(ConfigKey(
                   kAppGroup, QStringLiteral("latency_params_mismatch"))),
           m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
+          m_coSamplerate(kAppGroup, QStringLiteral("samplerate")),
+          m_forceQuantum(false),
           m_forceSamplerate(false),
-          m_forceQuantum(false) {
+          m_samplerate(48000),
+          m_bufferSize(kDefaultBufferSize) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -113,11 +115,6 @@ PipewireEnumerator::PipewireEnumerator(
             &SoundManager::outputRegistered,
             this,
             &PipewireEnumerator::registerOutput);
-
-    connect(m_pSoundManager,
-            &SoundManager::devicesSetup,
-            this,
-            &PipewireEnumerator::devicesSetup);
 
     connect(this, &PipewireEnumerator::deviceAdded, m_pSoundManager, &SoundManager::addDevice);
     connect(this, &PipewireEnumerator::deviceRemoved, m_pSoundManager, &SoundManager::removeDevice);
@@ -706,15 +703,6 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
     const uint32_t sampleRate = pos->clock.rate.denom;
     const uint64_t framesPerBuffer = pos->clock.duration;
 
-    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        qDebug() << "PipewireEnumerator::callback"
-                    "requested"
-                 << m_framesPerBuffer << "samples at" << m_sampleRate << "hz,"
-                                                                         "provided"
-                 << framesPerBuffer << "samples at" << sampleRate << "hz";
-        setLatency(sampleRate, framesPerBuffer);
-    }
-
     m_pSoundManager->processUnderflowHappened(framesPerBuffer);
 
     for (const auto& [input, ports] : m_inputs) {
@@ -783,15 +771,81 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
         }
     }
 
-    updateAudioLatencyUsage(framesPerBuffer);
+    const bool configForceQuantum = m_pConfig->getValue(
+            ConfigKey(kAppGroup, QStringLiteral("force_buffer_size")), false);
+    const bool configForceSamplerate = m_pConfig->getValue(
+            ConfigKey(kAppGroup, QStringLiteral("force_samplerate")), false);
+    const unsigned int engineSamplerate = static_cast<unsigned int>(m_coSamplerate.get());
+    const unsigned int engineBufferSize = static_cast<unsigned int>(m_coBufferSize.get());
+
+    const mixxx::audio::SampleRate configSamplerate = m_pSoundManager->getConfig().getSampleRate();
+    const unsigned int configBufferSize = configForceQuantum
+            ? m_pSoundManager->getConfig().getFramesPerBuffer()
+            // server set buffer size can be arbitrary (non power of 2)
+            // here we don't store it in SoundManagerConfig, and instead use ControlObject
+            : engineBufferSize;
+
+    const bool forceChanged = configForceQuantum != m_forceQuantum ||
+            configForceSamplerate != m_forceSamplerate;
+    const bool latencyParamsChanged = configSamplerate != m_samplerate ||
+            configBufferSize != m_bufferSize;
+
+    if (forceChanged) {
+        m_forceQuantum = configForceQuantum;
+        m_forceSamplerate = configForceSamplerate;
+    }
+
+    if (latencyParamsChanged) {
+        m_samplerate = configSamplerate;
+        m_bufferSize = configBufferSize;
+    }
+
+    if (forceChanged || latencyParamsChanged) {
+        std::string rate = m_forceSamplerate ? std::to_string(m_samplerate) : "";
+        std::string quantum = m_forceQuantum ? std::to_string(m_bufferSize) : "";
+
+        const spa_dict_item propItems[] = {
+                SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_RATE, rate.c_str()),
+                SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_QUANTUM, quantum.c_str()),
+        };
+
+        spa_dict properties = SPA_DICT_INIT(propItems, std::size(propItems));
+
+        pw_thread_loop_lock(m_pPwThreadLoop);
+        int res = pw_filter_update_properties(m_pPwFilter, nullptr, &properties);
+        pw_thread_loop_unlock(m_pPwThreadLoop);
+
+        if (res < 0) {
+            qDebug() << "PipewireEnumerator::setLatency "
+                        "pw_filter_update_properties failed:"
+                     << spa_strerror(res);
+            qDebug() << "Unable to set requested samplerate";
+        }
+
+        const bool bufferSizeMismatch = m_forceQuantum && (framesPerBuffer != m_bufferSize);
+        const bool samplerateMismatch = m_forceSamplerate && (sampleRate != m_samplerate);
+        m_coLatencyParamsMismatch.set(bufferSizeMismatch || samplerateMismatch);
+    }
+
+    if (sampleRate != engineSamplerate || framesPerBuffer != engineBufferSize) {
+        qDebug() << "PipewireEnumerator::callback requested"
+                 << m_samplerate << "samples at" << m_bufferSize << "hz, provided"
+                 << sampleRate << "samples at" << framesPerBuffer << "hz";
+
+        m_coOutputLatencyMs.set(framesPerBuffer * 1000 / sampleRate);
+        m_coSamplerate.set(sampleRate);
+        m_coBufferSize.set(framesPerBuffer);
+    }
+
+    updateAudioLatencyUsage(sampleRate, framesPerBuffer);
 }
 
-void PipewireEnumerator::updateAudioLatencyUsage(const SINT framesPerBuffer) {
+void PipewireEnumerator::updateAudioLatencyUsage(SINT samplerate, SINT framesPerBuffer) {
     m_framesSinceAudioLatencyUsageUpdate += framesPerBuffer;
-    if (m_framesSinceAudioLatencyUsageUpdate > (m_sampleRate.toDouble() / kCpuUsageUpdateRate)) {
+    if (m_framesSinceAudioLatencyUsageUpdate > ((double)samplerate / kCpuUsageUpdateRate)) {
         double secInAudioCb = m_timeInAudioCallback.toDoubleSeconds();
         m_audioLatencyUsage.set(
-                secInAudioCb / (m_framesSinceAudioLatencyUsageUpdate / m_sampleRate.toDouble()));
+                secInAudioCb / (m_framesSinceAudioLatencyUsageUpdate / (double)samplerate));
         m_timeInAudioCallback = mixxx::Duration::fromSeconds(0);
         m_framesSinceAudioLatencyUsageUpdate = 0;
         // qDebug() << m_audioLatencyUsage
@@ -926,14 +980,11 @@ void PipewireEnumerator::createOutputPorts(const AudioOutput& output, PortPair& 
     createPorts(ports, outputName, SPA_DIRECTION_OUTPUT);
 }
 
-void PipewireEnumerator::updateFilterLatency() {
-    qDebug() << "PipewireEnumerator::updateFilterLatency" << m_forceQuantum
-             << m_framesPerBuffer << m_forceSamplerate << m_sampleRate;
+void PipewireEnumerator::updateFilterLatency(const SINT samplerate, const SINT bufferSize) {
+    qDebug() << "PipewireEnumerator::updateFilterLatency" << m_forceQuantum << m_forceSamplerate;
 
-    std::string rate = m_forceSamplerate ? std::to_string(m_sampleRate) : "";
-    std::string rateFraction = m_forceSamplerate ? "1/" + std::to_string(m_sampleRate) : "";
-    std::string quantum = m_forceQuantum ? std::to_string(m_framesPerBuffer) : "";
-    std::string latency = m_forceQuantum ? rate + "/" + std::to_string(m_framesPerBuffer) : "";
+    std::string rate = m_forceSamplerate ? std::to_string(samplerate) : "";
+    std::string quantum = m_forceQuantum ? std::to_string(bufferSize) : "";
 
     const spa_dict_item propItems[] = {
             SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_RATE, rate.c_str()),
@@ -952,25 +1003,6 @@ void PipewireEnumerator::updateFilterLatency() {
                  << spa_strerror(res);
         qDebug() << "Unable to set requested samplerate";
     }
-}
-
-void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
-    const bool samplerateMismatch = m_forceSamplerate && m_sampleRate != sampleRate;
-    const bool quantumMismatch = m_forceQuantum && m_framesPerBuffer != framesPerBuffer;
-
-    qDebug() << "PipewireEnumerator::setLatency" << m_sampleRate << sampleRate
-             << m_framesPerBuffer << framesPerBuffer << m_forceSamplerate << m_forceQuantum;
-
-    m_coLatencyParamsMismatch.set(samplerateMismatch || quantumMismatch);
-    qDebug() << "m_coLatencyParamsMismatch" << m_coLatencyParamsMismatch.get();
-
-    m_sampleRate = sampleRate;
-    m_framesPerBuffer = framesPerBuffer;
-    ControlObject::set(
-            ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
-            m_framesPerBuffer * 1000 / m_sampleRate);
-    ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
-    m_coBufferSize.set(m_framesPerBuffer);
 }
 
 void PipewireEnumerator::coreEventDone(uint32_t id, int seq) {
@@ -1034,33 +1066,4 @@ bool PipewireEnumerator::nodeHasPorts(const Node& node) {
     }
 
     return false;
-}
-
-void PipewireEnumerator::devicesSetup() {
-    const mixxx::audio::SampleRate samplerate = m_pSoundManager->getConfig().getSampleRate();
-    const unsigned int framesPerBuffer = m_pSoundManager->getConfig().getFramesPerBuffer();
-    const bool samplerateChanged = samplerate != m_sampleRate;
-    const bool framesPerBufferChanged = framesPerBuffer != m_framesPerBuffer;
-
-    const bool configForceQuantum = m_pConfig->getValue(
-            ConfigKey(kAppGroup, QStringLiteral("force_buffer_size")), false);
-    const bool configForceSamplerate = m_pConfig->getValue(
-            ConfigKey(kAppGroup, QStringLiteral("force_samplerate")), false);
-    const bool forceQuantumChanged = m_forceQuantum != configForceQuantum;
-    const bool forceSamplerateChanged = m_forceSamplerate != configForceSamplerate;
-    qDebug() << "PipewireEnumerator::devicesSetup" << configForceQuantum
-             << m_forceQuantum << configForceSamplerate << m_forceSamplerate
-             << samplerate << m_sampleRate << framesPerBuffer
-             << m_framesPerBuffer;
-
-    m_sampleRate = samplerate;
-    m_framesPerBuffer = framesPerBuffer;
-
-    if ((forceQuantumChanged || forceSamplerateChanged) ||
-            ((samplerateChanged || framesPerBufferChanged) &&
-                    (configForceQuantum || configForceSamplerate))) {
-        m_forceQuantum = configForceQuantum;
-        m_forceSamplerate = configForceSamplerate;
-        updateFilterLatency();
-    }
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -1,5 +1,6 @@
 #include "soundio/pipewireenumerator.h"
 
+#include <pipewire/keys.h>
 #include <pipewire/pipewire.h>
 #include <spa/utils/defs.h>
 #include <spa/utils/dict.h>
@@ -14,6 +15,7 @@
 #include "audio/types.h"
 #include "control/controlobject.h"
 #include "moc_pipewireenumerator.cpp"
+#include "preferences/dialog/dlgprefsound.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddevicepipewire.h"
 #include "soundio/soundmanager.h"
@@ -75,8 +77,9 @@ static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
 }
 } // namespace
 
-PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManager)
+PipewireEnumerator::PipewireEnumerator(UserSettingsPointer pConfig, SoundManager* pManager)
         : m_pSoundManager(pManager),
+          m_pConfig(pConfig),
           m_pPwThreadLoop(nullptr),
           m_pPwContext(nullptr),
           m_pPwCore(nullptr),
@@ -85,7 +88,8 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
           m_pPwFilter(nullptr),
           m_sampleRate(48000),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
-          m_framesPerBuffer(0) {
+          m_framesPerBuffer(0),
+          m_forceQuantumRate(false) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -424,7 +428,11 @@ std::string PipewireEnumerator::openDevice(const SoundDevicePipewire& device,
         return "PipewireEnumerator uninitialized";
     }
 
-    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
+    bool forceQuantumRate = m_pConfig->getValue(DlgPrefSound::kPipeWireForceQuantumRate, false);
+
+    if (sampleRate != m_sampleRate or framesPerBuffer != m_framesPerBuffer or
+            forceQuantumRate != m_forceQuantumRate) {
+        m_forceQuantumRate = forceQuantumRate;
         updateFilterLatency(sampleRate, framesPerBuffer);
     }
 
@@ -798,26 +806,31 @@ std::pair<uint32_t*, uint32_t*> PipewireEnumerator::createOutputPorts(const Audi
 
 void PipewireEnumerator::updateFilterLatency(
         unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qWarning() << "PipewireEnumerator::updateFilterLatency" << sampleRate << framesPerBuffer;
-    std::string rate = std::to_string(sampleRate);
-    std::string rateStr = "1/" + rate;
-    std::string quantumStr = std::to_string(framesPerBuffer);
-    std::string latencyStr = quantumStr + "/" + std::to_string(sampleRate);
+    qDebug() << "PipewireEnumerator::updateFilterLatency" << sampleRate
+             << framesPerBuffer << m_forceQuantumRate;
 
-    spa_dict_item items[] = {
-            SPA_DICT_ITEM_INIT(PW_KEY_NODE_RATE, rateStr.c_str()),
-            SPA_DICT_ITEM_INIT(PW_KEY_NODE_LATENCY, latencyStr.c_str()),
+    std::string rate = std::to_string(sampleRate);
+    std::string rateFraction = "1/" + rate;
+    std::string quantum = std::to_string(framesPerBuffer);
+    std::string latency = quantum + "/" + rate;
+
+    const spa_dict_item propItems[] = {
+            SPA_DICT_ITEM_INIT(PW_KEY_NODE_RATE, rateFraction.c_str()),
+            SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_RATE,
+                    m_forceQuantumRate ? rate.c_str() : ""),
+            SPA_DICT_ITEM_INIT(PW_KEY_NODE_LATENCY, latency.c_str()),
+            SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_QUANTUM,
+                    m_forceQuantumRate ? quantum.c_str() : ""),
     };
 
     // don't set PW_KEY_NODE_LATENCY if framesPerBuffer is 0 (uninitialized)
-    uint32_t numProps = framesPerBuffer == 0 ? 1 : 2;
-    spa_dict properties = SPA_DICT_INIT(items, numProps);
+    uint32_t numProps = framesPerBuffer == 0 ? 2 : 4;
+    spa_dict properties = SPA_DICT_INIT(propItems, numProps);
 
     pw_thread_loop_lock(m_pPwThreadLoop);
-
     int res = pw_filter_update_properties(m_pPwFilter, nullptr, &properties);
-
     pw_thread_loop_unlock(m_pPwThreadLoop);
+
     if (res >= 0) {
         setLatency(sampleRate, framesPerBuffer);
     } else {
@@ -829,7 +842,7 @@ void PipewireEnumerator::updateFilterLatency(
 }
 
 void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qWarning() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
+    qDebug() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
     m_sampleRate = sampleRate;
     m_framesPerBuffer = framesPerBuffer;
     ControlObject::set(

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -80,7 +80,8 @@ static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
 }
 } // namespace
 
-PipewireEnumerator::PipewireEnumerator(UserSettingsPointer pConfig, SoundManager* pManager)
+PipewireEnumerator::PipewireEnumerator(
+        UserSettingsPointer pConfig, SoundManager* pManager)
         : m_pSoundManager(pManager),
           m_pConfig(pConfig),
           m_pPwThreadLoop(nullptr),
@@ -90,11 +91,18 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer pConfig, SoundManager
           m_pPwMetadata(nullptr),
           m_pPwFilter(nullptr),
           m_sampleRate(48000),
-          m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
-          m_coPipewirePatchbaySync(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
-          m_coBufferSize(ConfigKey(kAppGroup, QStringLiteral("buffer_size"))),
-          m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
           m_framesPerBuffer(1024),
+          m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
+          m_coPipewirePatchbaySync(ConfigKey(
+                  kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
+          m_coBufferSize(ConfigKey(kAppGroup, QStringLiteral("buffer_size")),
+                  true,
+                  false,
+                  false,
+                  m_framesPerBuffer),
+          m_coLatencyParamsMismatch(ConfigKey(
+                  kAppGroup, QStringLiteral("latency_params_mismatch"))),
+          m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
           m_forceSamplerate(false),
           m_forceQuantum(false) {
     connect(m_pSoundManager,
@@ -947,8 +955,14 @@ void PipewireEnumerator::updateFilterLatency() {
 }
 
 void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
+    const bool samplerateMismatch = m_forceSamplerate && m_sampleRate != sampleRate;
+    const bool quantumMismatch = m_forceQuantum && m_framesPerBuffer != framesPerBuffer;
+
     qDebug() << "PipewireEnumerator::setLatency" << m_sampleRate << sampleRate
-             << m_framesPerBuffer << framesPerBuffer;
+             << m_framesPerBuffer << framesPerBuffer << m_forceSamplerate << m_forceQuantum;
+
+    m_coLatencyParamsMismatch.set(samplerateMismatch || quantumMismatch);
+    qDebug() << "m_coLatencyParamsMismatch" << m_coLatencyParamsMismatch.get();
 
     m_sampleRate = sampleRate;
     m_framesPerBuffer = framesPerBuffer;

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -7,6 +7,7 @@
 #include <QObject>
 
 #include "audio/types.h"
+#include "preferences/dialog/dlgprefsound.h"
 #include "preferences/usersettings.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddeviceenumerator.h"
@@ -23,6 +24,12 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     QList<mixxx::audio::SampleRate> getSampleRates(
             [[maybe_unused]] bool jackSampleRates) const override {
+        if (m_pConfig->getValue(DlgPrefSound::kPipeWireForceQuantumRate, false)) {
+            // this is required even though DlgPrefSound updates samplerates to default
+            // in case of forcing quantum/rate because SoundManager::checkConfig matches
+            // the requested rate with what this function returns
+            return {};
+        }
         return m_samplerates;
     }
 
@@ -197,4 +204,5 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     int m_framesSinceAudioLatencyUsageUpdate;
     uint32_t m_filterId;
     uint32_t m_framesPerBuffer;
+    bool m_forceQuantumRate;
 };

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -235,14 +235,16 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     std::unordered_map<AudioInput, PortPair> m_inputs;
     std::unordered_map<AudioOutput, PortPair> m_outputs;
 
+    uint32_t m_framesPerBuffer;
+
     PollingControlProxy m_audioLatencyUsage;
     ControlObject m_coPipewirePatchbaySync;
     ControlObject m_coBufferSize;
+    ControlObject m_coLatencyParamsMismatch;
     ControlProxy m_coOutputLatencyMs;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     uint32_t m_filterId;
-    uint32_t m_framesPerBuffer;
     // Handle all connections made to/from Mixxx node
     // If we do not, then we only track connections made in the
     // preference page, and leave the external patchbay connections

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -58,7 +58,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
   private slots:
     void registerInput(const AudioInput& input, AudioDestination* dest);
     void registerOutput(const AudioOutput& output, AudioSource* src);
-    void devicesSetup();
 
   private:
     struct Link {
@@ -193,7 +192,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
             uint32_t inPortId);
     void destroyLink(uint32_t id);
 
-    void updateAudioLatencyUsage(const SINT framesPerBuffer);
+    void updateAudioLatencyUsage(SINT samplerate, SINT framesPerBuffer);
     void setLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
 
     void createInputPorts(const AudioInput& path, PortPair& ports);
@@ -201,7 +200,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void createPorts(PortPair& ports, std::string_view name, spa_direction direction);
     void closePorts(PortPair& ports);
 
-    void updateFilterLatency();
+    void updateFilterLatency(const SINT samplerate, const SINT bufferSize);
     bool nodeHasPorts(const Node& node);
 
     std::unordered_map<uint32_t, Node> m_nodes;
@@ -229,19 +228,17 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     int m_invalidTimeInfoCount;
     double m_lastCallbackEntrytoDacSecs;
     PerformanceTimer m_clkRefTimer;
-    mixxx::audio::SampleRate m_sampleRate;
     mixxx::audio::SampleRate m_defaultSampleRate;
 
     std::unordered_map<AudioInput, PortPair> m_inputs;
     std::unordered_map<AudioOutput, PortPair> m_outputs;
-
-    uint32_t m_framesPerBuffer;
 
     PollingControlProxy m_audioLatencyUsage;
     ControlObject m_coPipewirePatchbaySync;
     ControlObject m_coBufferSize;
     ControlObject m_coLatencyParamsMismatch;
     ControlProxy m_coOutputLatencyMs;
+    ControlProxy m_coSamplerate;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     uint32_t m_filterId;
@@ -251,6 +248,8 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     // If we do, then all connections to Mixxx will be affected, even
     // the ones made with external patchbay
     int m_coreSyncSeq;
-    bool m_forceSamplerate;
     bool m_forceQuantum;
+    bool m_forceSamplerate;
+    uint32_t m_samplerate;
+    uint32_t m_bufferSize;
 };

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -148,6 +148,8 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     std::pair<uint32_t*, uint32_t*> createOutputPorts(const AudioOutput& path);
     std::pair<uint32_t*, uint32_t*> createPorts(std::string_view name, spa_direction direction);
 
+    void updateFilterLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
+
     struct Link {
         uint32_t input;
         uint32_t output;

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -10,6 +10,7 @@
 #include "audio/types.h"
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
+#include "preferences/dialog/dlgprefsound.h"
 #include "preferences/usersettings.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddeviceenumerator.h"
@@ -27,7 +28,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     QList<mixxx::audio::SampleRate> getSampleRates(
             [[maybe_unused]] bool jackSampleRates) const override {
-        return m_samplerates;
+        return {};
     }
 
     std::vector<SoundDevicePointer> queryDevices() const override;
@@ -39,8 +40,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     std::string openDeviceInput(uint32_t id, const AudioInput& input);
     std::string openDeviceOutput(uint32_t id, const AudioOutput& output);
     void closeDevices();
-
-    void setLatencyParams(mixxx::audio::SampleRate sampleRate, SINT framesPerBuffer) override;
 
     mixxx::audio::SampleRate getDefaultSampleRate() const {
         return m_defaultSampleRate;
@@ -59,6 +58,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
   private slots:
     void registerInput(const AudioInput& input, AudioDestination* dest);
     void registerOutput(const AudioOutput& output, AudioSource* src);
+    void devicesSetup();
 
   private:
     struct Link {
@@ -201,7 +201,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void createPorts(PortPair& ports, std::string_view name, spa_direction direction);
     void closePorts(PortPair& ports);
 
-    void updateFilterLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
+    void updateFilterLatency();
     bool nodeHasPorts(const Node& node);
 
     std::unordered_map<uint32_t, Node> m_nodes;
@@ -237,6 +237,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     PollingControlProxy m_audioLatencyUsage;
     ControlObject m_coPipewirePatchbaySync;
+    ControlObject m_coBufferSize;
     ControlProxy m_coOutputLatencyMs;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
@@ -248,4 +249,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     // If we do, then all connections to Mixxx will be affected, even
     // the ones made with external patchbay
     int m_coreSyncSeq;
+    bool m_forceSamplerate;
+    bool m_forceQuantum;
 };

--- a/src/soundio/sounddeviceenumerator.h
+++ b/src/soundio/sounddeviceenumerator.h
@@ -15,9 +15,6 @@ class SoundDeviceEnumerator : public QObject {
     virtual QList<QString> getAPIs() const = 0;
     virtual void initialize() = 0;
     virtual void deinitialize() = 0;
-    virtual void setLatencyParams(
-            [[maybe_unused]] mixxx::audio::SampleRate sampleRate,
-            [[maybe_unused]] SINT framesPerBuffer) {};
 
     bool initialized() const {
         return m_initialized;

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -248,6 +248,14 @@ void SoundManager::clearDeviceList(bool sleepAfterClosing) {
     }
 }
 
+QList<mixxx::audio::SampleRate> SoundManager::getDefaultSampleRates() const {
+    return {
+            mixxx::audio::SampleRate(44100),
+            mixxx::audio::SampleRate(48000),
+            mixxx::audio::SampleRate(96000),
+    };
+}
+
 QList<mixxx::audio::SampleRate> SoundManager::getSampleRates(const QString& api) const {
     QList<mixxx::audio::SampleRate> samplerates =
             m_pEnumerator->getSampleRates(api == SoundManagerConfig::kAPIJack);
@@ -255,11 +263,7 @@ QList<mixxx::audio::SampleRate> SoundManager::getSampleRates(const QString& api)
         return samplerates;
     }
 
-    return QList<mixxx::audio::SampleRate>{
-            mixxx::audio::SampleRate(44100),
-            mixxx::audio::SampleRate(48000),
-            mixxx::audio::SampleRate(96000),
-    };
+    return getDefaultSampleRates();
 }
 
 QList<mixxx::audio::SampleRate> SoundManager::getSampleRates() const {

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -263,7 +263,7 @@ QList<mixxx::audio::SampleRate> SoundManager::getSampleRates(const QString& api)
         return samplerates;
     }
 
-    return QList<mixxx::audio::SampleRate>{
+    return {
             mixxx::audio::SampleRate(44100),
             mixxx::audio::SampleRate(48000),
             mixxx::audio::SampleRate(96000),
@@ -335,8 +335,6 @@ SoundDeviceStatus SoundManager::setupDevices() {
     // loop over all available devices
 
     std::vector<SoundDevicePointer> devices = m_pEnumerator->queryDevices();
-
-    m_pEnumerator->setLatencyParams(m_config.getSampleRate(), m_config.getFramesPerBuffer());
 
     // here some network device conditions can be separated, currently simply
     // add it to the list of other devices

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -248,10 +248,7 @@ void SoundManager::clearDeviceList(bool sleepAfterClosing) {
     m_pErrorDevice.clear();
 
     // deinitialize in case of PortAudio so the devices are updated
-#ifdef __PIPEWIRE__
-    if (m_config.getAPI() != SoundManagerConfig::kAPIPipewire)
-#endif
-    {
+    if (isPipewireSelected()) {
         m_pEnumerator->deinitialize();
     }
 }

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -58,6 +58,7 @@ class SoundManager : public QObject {
     QString getLastErrorMessage(SoundDeviceStatus status) const;
 
     // Returns a list of samplerates we will attempt to support for a given API.
+    QList<mixxx::audio::SampleRate> getDefaultSampleRates() const;
     QList<mixxx::audio::SampleRate> getSampleRates(const QString& api) const;
 
     // Convenience overload for SoundManager::getSampleRates(QString)

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -21,9 +21,7 @@ const QString SoundManagerConfig::kAPIDirectSound = QStringLiteral("Windows Dire
 // (https://github.com/PortAudio/portaudio/pull/881), we may have to update this
 const QString SoundManagerConfig::kAPIIosAudio = QStringLiteral("iOS Audio");
 const QString SoundManagerConfig::kAPICoreAudio = QStringLiteral("Core Audio");
-#ifdef __PIPEWIRE__
 const QString SoundManagerConfig::kAPIPipewire = QStringLiteral("PipeWire");
-#endif
 
 const QString SoundManagerConfig::kEmptyComboBox = QStringLiteral("---");
 const unsigned int SoundManagerConfig::kDefaultDeckCount = 2;
@@ -418,7 +416,16 @@ unsigned int SoundManagerConfig::getAudioBufferSizeIndex() const {
 // This reflects the configured value only. In case of JACK the
 // setting of the JACK server is used.
 unsigned int SoundManagerConfig::getFramesPerBuffer() const {
-    if (m_api == SoundManagerConfig::kAPIJack) {
+    if (m_api == SoundManagerConfig::kAPIPipewire) {
+        unsigned int audioBufferSizeIndex = m_audioBufferSizeIndex;
+        VERIFY_OR_DEBUG_ASSERT(audioBufferSizeIndex > 0) {
+            const int index1024frames = 5;
+            audioBufferSizeIndex = index1024frames;
+        }
+
+        // audioBufferSize combobox contains from 64 to 4096 frames
+        return 1 << (audioBufferSizeIndex + 5);
+    } else if (m_api == SoundManagerConfig::kAPIJack) {
         // in case of jack we configure the frames/period
         if (m_audioBufferSizeIndex ==
                 static_cast<unsigned int>(


### PR DESCRIPTION
It's upto the PipeWire server to settle on a single quantum/samplerate from all requested quantum/samplerate from all active PipeWire clients. Depending on Mixxx's and other programs' requested quantum/rate, and config defined set of allowed quantum/samplerates,  we may or may not get what we requested. When we force request quantum/samplerate, PipeWire server configures to last force requested quantum/samplerate.