### PR TITLE
Fix broadcasting using libshout-idjc >= 2.4.6, by using the correct usage flag

### DIFF
--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -393,9 +393,16 @@ void ShoutConnection::updateFromPreferences() {
     }
 
 #ifdef MIXXX_USE_SHOUT_API_246
-    if (shout_set_content_format(
-                m_pShout, format, 0 /* SHOUT_USAGE_UNKNOWN */, nullptr) !=
-            SHOUTERR_SUCCESS) {
+    // Note: shout_set_format() in libshout-idjc < 2.4.6 Ogg uses mime type
+    // "application/ogg" Using here usage = SHOUT_USAGE_UNKNOWN keep that
+    // unchanged
+    // TODO: verify if we can us usage = SHOUT_USAGE_AUDIO for all, using for
+    // mime type "audio/ogg" for Ogg.
+    if (shout_set_content_format(m_pShout,
+                format,
+                format == SHOUT_FORMAT_OGG ? SHOUT_USAGE_UNKNOWN
+                                           : SHOUT_USAGE_AUDIO,
+                nullptr) != SHOUTERR_SUCCESS) {
 #else
     if (shout_set_format(m_pShout, format) != SHOUTERR_SUCCESS) {
 #endif


### PR DESCRIPTION
This fixes https://github.com/mixxxdj/mixxx/issues/16783 restoring the < 2.4.6 state 1:1. 
The change of the ogg mime type to "audio/ogg" might be added along with retiring libshout-idjc 2.4.1 