### PR TITLE
Search: allow [num]+/- as shortcut for <=/>= eg. `rating:3+`

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -332,6 +332,12 @@ void NumericFilterNode::init(QString argument) {
     if (match.hasMatch()) {
         m_operator = match.captured(1);
         argument = match.captured(2);
+    } else if (argument.endsWith('+')) {
+        m_operator = QStringLiteral(">=");
+        argument.chop(1);
+    } else if (argument.endsWith('-')) {
+        m_operator = QStringLiteral("<=");
+        argument.chop(1);
     }
 
     bool parsed = false;
@@ -575,7 +581,8 @@ BpmFilterNode::BpmFilterNode(
     }
 
     QRegularExpressionMatch opMatch = kNumericOperatorRegex.match(argument);
-    if (opMatch.hasMatch()) {
+    bool operatorMatch = opMatch.hasMatch();
+    if (operatorMatch) {
         if (fuzzy) {
             // fuzzy can't be combined with operators
             // m_matchMode is already Invalid.
@@ -583,6 +590,14 @@ BpmFilterNode::BpmFilterNode(
         }
         m_operator = opMatch.captured(1);
         argument = opMatch.captured(2);
+    } else if (argument.endsWith('+')) {
+        m_operator = QStringLiteral(">=");
+        argument.chop(1);
+        operatorMatch = true;
+    } else if (argument.endsWith('-')) {
+        m_operator = QStringLiteral("<=");
+        argument.chop(1);
+        operatorMatch = true;
     }
 
     // Replace the locale's decimal separator with .
@@ -600,7 +615,7 @@ BpmFilterNode::BpmFilterNode(
         if (fuzzy) {
             // fuzzy search +- n%
             m_matchMode = MatchMode::Fuzzy;
-        } else if (!opMatch.hasMatch() && !negate) {
+        } else if (!operatorMatch && !negate) {
             // Simple 'bpm:NNN' search.
             // Also searches for half/double matches (rounded up/down)
             // Center value is turned into range in order to ...
@@ -864,10 +879,17 @@ QString YearFilterNode::toSql() const {
 }
 
 // TODO Convert to DateFilterNode and allow searching for "last_played"
-DateAddedFilterNode::DateAddedFilterNode(const QString& argument)
+DateAddedFilterNode::DateAddedFilterNode(QString& argument)
         : m_operatorQuery(false),
           m_equalsQuery(false),
           m_operator("=") {
+    if (argument.endsWith('+')) {
+        argument.chop(1);
+        argument.prepend(QStringLiteral(">="));
+    } else if (argument.endsWith('-')) {
+        argument.chop(1);
+        argument.prepend(QStringLiteral("<="));
+    }
     QDateTime date;
     QRegularExpressionMatch opMatch = kNumericOperatorRegex.match(argument);
     if (opMatch.hasMatch()) {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -284,7 +284,7 @@ class YearFilterNode : public NumericFilterNode {
 
 class DateAddedFilterNode : public QueryNode {
   public:
-    DateAddedFilterNode(const QString& argument);
+    DateAddedFilterNode(QString& argument);
     bool match(const TrackPointer& pTrack) const override;
     QString toSql() const override;
 

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -621,6 +621,46 @@ TEST_F(SearchQueryParserTest, BpmFilter) {
             qPrintable(pQuery->toSql()));
 }
 
+TEST_F(SearchQueryParserTest, NumPlusMinusOperator) {
+    m_parser.setSearchColumns({"artist", "album"});
+
+    // Test the +/- suffix for numerical queries
+    // + means >=
+    // - means <=
+
+    // BPM
+    TrackPointer pTrack = newTestTrack();
+    pTrack->trySetBpm(124);
+    auto pQuery = m_parser.parseQuery("bpm:123+", QString());
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+            qPrintable(QString("bpm >= 123")),
+            qPrintable(pQuery->toSql()));
+
+    pQuery = m_parser.parseQuery("bpm:125+", QString());
+    EXPECT_FALSE(pQuery->match(pTrack));
+
+    pQuery = m_parser.parseQuery("bpm:124-", QString());
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    // Duration
+    pTrack->setDuration(91);
+    pQuery = m_parser.parseQuery("duration:1:30+", QString());
+
+    EXPECT_STREQ(
+            qPrintable(QString("duration >= 90")),
+            qPrintable(pQuery->toSql()));
+
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    pQuery = m_parser.parseQuery("duration:1:25-", QString());
+    EXPECT_FALSE(pQuery->match(pTrack));
+
+    pQuery = m_parser.parseQuery("duration:1:31-", QString());
+    EXPECT_TRUE(pQuery->match(pTrack));
+}
+
 TEST_F(SearchQueryParserTest, MultipleFilters) {
     m_parser.setSearchColumns({"artist", "title"});
     auto pQuery(


### PR DESCRIPTION
Backport of a small search tweak I've been using for some time now.
works for BPM, NumericFilterNode incl. Duration

`r:3+` -> 3 or more stars
`bpm:122+` -> 122 BPM or faster
`du:5:30-` -> 5:30 min long or shorter
`y:2002+` -> year 2002 or later

Note: shortcuts will work once 2.6 has been merged to main (fixed in #16315 )