### PR TITLE
DbId: Add `DbId::toVariantOrNull()` method for working with nullable database IDs

### DIFF
--- a/src/test/dbidtest.cpp
+++ b/src/test/dbidtest.cpp
@@ -10,15 +10,39 @@ class DbIdTest : public testing::Test {
   protected:
     static DbId fromValidVariant(const QVariant& variant) {
         DbId actual(variant);
+        return fromValid(actual);
+    }
+
+    static DbId fromValid(const DbId& actual) {
         EXPECT_TRUE(actual.isValid());
         EXPECT_NE(DbId(), actual);
+
+        EXPECT_EQ(actual.toVariant().typeId(), QMetaType::Int);
+        EXPECT_NE(actual.toVariant().toInt(), -1);
+        EXPECT_FALSE(actual.toVariant().isNull());
+
+        EXPECT_EQ(actual.toVariantOrNull().typeId(), QMetaType::Int);
+        EXPECT_NE(actual.toVariantOrNull().toInt(), -1);
+        EXPECT_FALSE(actual.toVariantOrNull().isNull());
         return actual;
     }
 
     static DbId fromInvalidVariant(const QVariant& variant) {
         DbId actual(variant);
+        return fromInvalid(actual);
+    }
+
+    static DbId fromInvalid(const DbId& actual) {
         EXPECT_FALSE(actual.isValid());
         EXPECT_EQ(DbId(), actual);
+
+        EXPECT_EQ(actual.toVariant().typeId(), QMetaType::Int);
+        EXPECT_EQ(actual.toVariant().toInt(), -1);
+        EXPECT_FALSE(actual.toVariant().isNull());
+
+        EXPECT_EQ(actual.toVariantOrNull().typeId(), QMetaType::Int);
+        EXPECT_NE(actual.toVariantOrNull().toInt(), -1);
+        EXPECT_TRUE(actual.toVariantOrNull().isNull());
         return actual;
     }
 };
@@ -30,6 +54,7 @@ TEST_F(DbIdTest, DefaultConstructor) {
 }
 
 TEST_F(DbIdTest, Invalid) {
+    fromInvalid(DbId());
     fromInvalidVariant(-1);
     fromInvalidVariant(-12);
     fromInvalidVariant(-123);

--- a/src/util/db/dbid.h
+++ b/src/util/db/dbid.h
@@ -46,20 +46,19 @@ class DbId {
         return dbid.hash();
     }
 
-    // This function should be used for value binding in DB queries
-    // with bindValue().
+    /// This function should be used for value binding in DB queries
+    /// with bindValue().
     QVariant toVariant() const {
         // TODO: Check with DEBUG_ASSERT(isValid())?
         return QVariant(m_value);
     }
 
-    // This function should be used for value binding in DB queries
-    // with bindValue() when invalid DbId values should be passed as NULL.
-    //
-    // Special handling is needed to make sure comparisons against NULL work as
-    // expected. Instead of "SELECT ... WHERE myfield=:parameter", one has to do
-    // something like "SELECT ... WHERE CASE WHEN :parameter IS NULL THEN
-    // myfield IS NULL ELSE myfield=:parameter END".
+    /// This function should be used for value binding in DB queries
+    /// with bindValue() when invalid DbId values should be passed as NULL.
+    ///
+    /// Special care is needed to make sure comparisons against NULL work as
+    /// expected. Instead of "SELECT ... WHERE myfield=:parameter", one has to do
+    /// "SELECT ... WHERE myfield IS :parameter".
     QVariant toVariantOrNull() const {
         if (isValid()) {
             return QVariant(m_value);

--- a/src/util/db/dbid.h
+++ b/src/util/db/dbid.h
@@ -49,7 +49,26 @@ class DbId {
     // This function should be used for value binding in DB queries
     // with bindValue().
     QVariant toVariant() const {
+        // TODO: Check with DEBUG_ASSERT(isValid())?
         return QVariant(m_value);
+    }
+
+    // This function should be used for value binding in DB queries
+    // with bindValue() when invalid DbId values should be passed as NULL.
+    //
+    // Special handling is needed to make sure comparisons against NULL work as
+    // expected. Instead of "SELECT ... WHERE myfield=:parameter", one has to do
+    // something like "SELECT ... WHERE CASE WHEN :parameter IS NULL THEN
+    // myfield IS NULL ELSE myfield=:parameter END".
+    QVariant toVariantOrNull() const {
+        if (isValid()) {
+            return QVariant(m_value);
+        }
+
+        // https://doc.qt.io/qt-6/qsqlquery.html#bindValue:
+        // "To bind a NULL value, use a null QVariant; for example,
+        //  use QVariant(QMetaType::fromType<QString>()) if you are binding a string."
+        return QVariant(QMetaType::fromType<int>());
     }
 
     QString toString() const {
@@ -124,6 +143,9 @@ private:
         int value = variant.toInt(&ok);
         if (ok && isValidValue(value)) {
             return value;
+        }
+        if (variant.isNull()) {
+            return kInvalidValue;
         }
         qCritical() << "Invalid database identifier value:"
                     << variant;


### PR DESCRIPTION
This is required for an upcoming PR for subcrates, because those may or may not have a parent crate (represented as a `parent_id`).

Because SQLite requires some special handling for comparing against a potentially nullable `:parameter` (namely `SELECT ... WHERE CASE WHEN :parameter IS NULL THEN myfield IS NULL ELSE myfield=:parameter END` instead of `SELECT ... WHERE myfield=:parameter`), it is likely a better choice to make the potential of nullable values explicit.