### PR TITLE
TreeItemModel: Add `TreeItem::isForceExpandable()` property

### DIFF
--- a/src/library/treeitem.cpp
+++ b/src/library/treeitem.cpp
@@ -31,11 +31,12 @@ TreeItem::TreeItem(
         LibraryFeature* pFeature,
         QString label,
         QVariant data)
-    : m_pFeature(pFeature),
-      m_pParent(nullptr),
-      m_label(std::move(label)),
-      m_data(std::move(data)),
-      m_bold(false) {
+        : m_pFeature(pFeature),
+          m_pParent(nullptr),
+          m_label(std::move(label)),
+          m_data(std::move(data)),
+          m_bold(false),
+          m_forceExpandable(false) {
 }
 
 TreeItem::~TreeItem() {

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -126,6 +126,15 @@ class TreeItem final {
         return m_bold;
     }
 
+    // Gets or sets whether to display the expander triangle next
+    // to this tree item even when it has no children.
+    void setForceExpandable(bool forceExpandable) {
+        m_forceExpandable = forceExpandable;
+    }
+    bool isForceExpandable() const {
+        return m_forceExpandable;
+    }
+
   private:
     explicit TreeItem(
             LibraryFeature* pFeature,
@@ -147,4 +156,5 @@ class TreeItem final {
     QVariant m_data;
     QIcon m_icon;
     bool m_bold;
+    bool m_forceExpandable;
 };

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -126,6 +126,18 @@ class TreeItem final {
         return m_bold;
     }
 
+    /// Sets whether to display the expander triangle next
+    /// to this tree item even when it has no children.
+    void setForceExpandable(bool forceExpandable) {
+        m_forceExpandable = forceExpandable;
+    }
+
+    /// Gets whether to display the expander triangle next
+    /// to this tree item even when it has no children.
+    bool isForceExpandable() const {
+        return m_forceExpandable;
+    }
+
   private:
     explicit TreeItem(
             LibraryFeature* pFeature,
@@ -147,4 +159,5 @@ class TreeItem final {
     QVariant m_data;
     QIcon m_icon;
     bool m_bold;
+    bool m_forceExpandable;
 };

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -152,6 +152,16 @@ int TreeItemModel::rowCount(const QModelIndex& parent) const {
     return pParentItem->childRows();
 }
 
+bool TreeItemModel::hasChildren(const QModelIndex& parent) const {
+    TreeItem* parentItem;
+    if (parent.isValid()) {
+        parentItem = static_cast<TreeItem*>(parent.internalPointer());
+    } else {
+        parentItem = getRootItem();
+    }
+    return parentItem->isForceExpandable() || QAbstractItemModel::hasChildren(parent);
+}
+
 // Populates the model and notifies the view.
 // Call this method first, before you do call any other methods.
 TreeItem* TreeItemModel::setRootItem(std::unique_ptr<TreeItem> pRootItem) {

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -27,6 +27,7 @@ class TreeItemModel : public QAbstractItemModel {
                          int a_iRole = Qt::EditRole) override;
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    bool hasChildren(const QModelIndex& parent = QModelIndex()) const override;
 
     void insertTreeItemRows(
             std::vector<std::unique_ptr<TreeItem>>&&,


### PR DESCRIPTION
This allows e.g. folders for playlists to be displayed as an expandable node in the sidebar tree view, even when it has no children. This is useful if a certain `LibraryFeature` can contain two different types of nodes - "folders" and "leaf nodes" - and one needs a visual differentiation between the two.

This was developed while working on playlist & crate folders/subcrates, but is currently not actively used. Feel free to ignore if you deem this to not be relevant right now. Currently marked as "Draft" for that reason, though the code itself is ready to merge. 