### PR TITLE
TreeItemModel: Add `TreeItemModel::index(TreeItem*)` method overload

### DIFF
--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -102,6 +102,20 @@ QVariant TreeItemModel::headerData(int section, Qt::Orientation orientation, int
     return QVariant();
 }
 
+QModelIndex TreeItemModel::index(TreeItem* pTreeItem) const {
+    VERIFY_OR_DEBUG_ASSERT(pTreeItem) {
+        return QModelIndex();
+    }
+    if (pTreeItem == m_pRootItem.get()) {
+        return QModelIndex();
+    }
+    int row = pTreeItem->parentRow();
+    VERIFY_OR_DEBUG_ASSERT(row != TreeItem::kInvalidRow) {
+        return QModelIndex();
+    }
+    return createIndex(row, 0, pTreeItem);
+}
+
 QModelIndex TreeItemModel::index(int row, int column, const QModelIndex &parent) const {
     if (!hasIndex(row, column, parent)) {
         return QModelIndex();

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -19,6 +19,7 @@ class TreeItemModel : public QAbstractItemModel {
     QVariant data(const QModelIndex &index, int role) const override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QModelIndex index(TreeItem* pTreeItem) const;
     QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
     QModelIndex parent(const QModelIndex &index) const override;
     // Tell the compiler we don't mean to shadow insertRows.


### PR DESCRIPTION
Add a new utility method to `TreeItemModel`.

- `TreeItemModel::getItem` already provides an avenue for `QModelIndex -> TreeItem` conversion.
- The new method `TreeItemModel::index` provides the reverse, i.e. `TreeItem -> QModelIndex` conversion.

This was split off from an upcoming PR for subcrates, and is required by that PR.