### PR TITLE
WLibrarySidebar: Add `setChildIndexExpanded`/`isChildIndexExpanded`

### DIFF
--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -225,6 +225,44 @@ void WLibrarySidebar::toggleSelectedItem() {
     }
 }
 
+void WLibrarySidebar::setChildIndexExpanded(const QModelIndex& index, bool expand) {
+    // qDebug() << "WLibrarySidebar::setChildIndexExpanded" << index << expand;
+    QModelIndex selIndex = selectedIndex();
+    if (!selIndex.isValid()) {
+        return;
+    }
+    SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
+    VERIFY_OR_DEBUG_ASSERT(sidebarModel) {
+        // qDebug() << " >> model() is not SidebarModel";
+        return;
+    }
+    QModelIndex translated = sidebarModel->translateChildIndex(index);
+    if (!translated.isValid()) {
+        // qDebug() << " >> index can't be translated";
+        return;
+    }
+    setExpanded(translated, expand);
+}
+
+bool WLibrarySidebar::isChildIndexExpanded(const QModelIndex& index) {
+    // qDebug() << "WLibrarySidebar::isChildIndexExpanded" << index;
+    QModelIndex selIndex = selectedIndex();
+    if (!selIndex.isValid()) {
+        return false;
+    }
+    SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
+    VERIFY_OR_DEBUG_ASSERT(sidebarModel) {
+        // qDebug() << " >> model() is not SidebarModel";
+        return false;
+    }
+    QModelIndex translated = sidebarModel->translateChildIndex(index);
+    if (!translated.isValid()) {
+        // qDebug() << " >> index can't be translated";
+        return false;
+    }
+    return isExpanded(translated);
+}
+
 bool WLibrarySidebar::isLeafNodeSelected() {
     QModelIndex index = selectedIndex();
     if (index.isValid()) {

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -27,6 +27,8 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void toggleSelectedItem();
     void renameSelectedItem();
     bool isLeafNodeSelected();
+    void setChildIndexExpanded(const QModelIndex& index, bool expand);
+    bool isChildIndexExpanded(const QModelIndex& index);
     bool isChildIndexSelected(const QModelIndex& index);
     bool isFeatureRootIndexSelected(LibraryFeature* pFeature);
 


### PR DESCRIPTION
This allows restoring the expansion state of child nodes for `LibraryFeature`s when they rebuilt the node tree.

This is required for an upcoming PR for subcrates, but is also useful indepedently.