### PR TITLE
TreeItemModel: Add `TreeItem::getUrl`/`setUrl`, `TreeItemModel::kUrlRole` and `SidebarModel::UrlRole`

### DIFF
--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -314,6 +314,9 @@ QVariant SidebarModel::data(const QModelIndex& index, int role) const {
             return pTreeItem->getData();
         case SidebarModel::IconNameRole:
             // TODO: Add support for icon names in tree items
+            return QVariant();
+        case SidebarModel::UrlRole:
+            return pTreeItem->getUrl();
         default:
             return QVariant();
         }

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -18,6 +18,7 @@ class SidebarModel : public QAbstractItemModel {
     enum Roles {
         IconNameRole = Qt::UserRole + 1,
         DataRole,
+        UrlRole,
     };
     Q_ENUM(Roles);
 

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -3,6 +3,7 @@
 #include <QIcon>
 #include <QList>
 #include <QString>
+#include <QUrl>
 #include <QVariant>
 #include <memory>
 
@@ -112,6 +113,13 @@ class TreeItem final {
         return m_data;
     }
 
+    void setUrl(const QUrl& url) {
+        m_url = url;
+    }
+    const QUrl& getUrl() const {
+        return m_url;
+    }
+
     void setIcon(const QIcon& icon) {
         m_icon = icon;
     }
@@ -145,6 +153,7 @@ class TreeItem final {
 
     QString m_label;
     QVariant m_data;
+    QUrl m_url;
     QIcon m_icon;
     bool m_bold;
 };

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -55,6 +55,8 @@ QVariant TreeItemModel::data(const QModelIndex &index, int role) const {
         return item->getData();
     case kBoldRole:
         return item->isBold();
+    case kUrlRole:
+        return item->getUrl();
     default:
         return QVariant();
     }

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -10,8 +10,9 @@ class TreeItem;
 class TreeItemModel : public QAbstractItemModel {
     Q_OBJECT
   public:
-    static const int kDataRole = Qt::UserRole;
-    static const int kBoldRole = Qt::UserRole + 1;
+    static constexpr int kDataRole = Qt::UserRole;
+    static constexpr int kBoldRole = Qt::UserRole + 1;
+    static constexpr int kUrlRole = Qt::UserRole + 2;
 
     explicit TreeItemModel(QObject* parent = nullptr);
     ~TreeItemModel() override;


### PR DESCRIPTION
The URLs associated with the tree items will be used during Drag & Drop operations to identify those tree items.

This is required for an upcoming PR for subcrates, but is also useful independently.