### PR TITLE
HID: serialise hid_open* calls in background report descriptor fetch

### DIFF
--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -19,6 +19,17 @@ class LegacyControllerMapping;
 #ifndef __ANDROID__
 namespace {
 constexpr size_t kMaxHidErrorMessageSize = 512;
+
+// The hidraw backend of hidapi is not thread-safe: hid_open_path() and
+// hid_open() both internally call hid_enumerate(), which calls
+// udev_enumerate_scan_devices(). When multiple HidController objects are
+// constructed at startup each spawns a background fetch thread via
+// fetchReportDescriptorInBackground(), and those threads race inside
+// udev, corrupting the heap (manifesting as "free(): chunks in smallbin
+// corrupted" from an unrelated free() later on). This mutex serialises
+// the hid_open* calls made by the background fetch threads so only one
+// thread touches udev at a time.
+std::mutex s_hidOpenMutex;
 } // namespace
 #endif
 
@@ -406,16 +417,22 @@ void HidController::fetchReportDescriptorInBackground() {
             return;
         }
 
-        hid_device* pHidDevice = hid_open_path(this->m_deviceInfo.pathRaw());
-        if (!pHidDevice) {
-            pHidDevice = hid_open(this->m_deviceInfo.getVendorId(),
-                    this->m_deviceInfo.getProductId(),
-                    this->m_deviceInfo.serialNumberRaw());
-        }
-        if (!pHidDevice) {
-            pHidDevice = hid_open(this->m_deviceInfo.getVendorId(),
-                    this->m_deviceInfo.getProductId(),
-                    nullptr);
+        // Serialise hid_open* calls across all background fetch threads to
+        // avoid concurrent udev access (see s_hidOpenMutex comment above).
+        hid_device* pHidDevice;
+        {
+            std::lock_guard<std::mutex> openLock(s_hidOpenMutex);
+            pHidDevice = hid_open_path(this->m_deviceInfo.pathRaw());
+            if (!pHidDevice) {
+                pHidDevice = hid_open(this->m_deviceInfo.getVendorId(),
+                        this->m_deviceInfo.getProductId(),
+                        this->m_deviceInfo.serialNumberRaw());
+            }
+            if (!pHidDevice) {
+                pHidDevice = hid_open(this->m_deviceInfo.getVendorId(),
+                        this->m_deviceInfo.getProductId(),
+                        nullptr);
+            }
         }
         if (!pHidDevice) {
             return;

--- a/src/controllers/hid/hidenumerator.cpp
+++ b/src/controllers/hid/hidenumerator.cpp
@@ -183,6 +183,15 @@ QList<Controller*> HidEnumerator::queryDevices() {
     }
 #else
 
+    // Explicitly initialise hidapi before hid_enumerate so the hidraw backend
+    // is fully set up on the main thread. The background fetch threads spawned
+    // by HidController::fetchReportDescriptorInBackground() also call hid_open*
+    // (which internally calls hid_enumerate); those calls are serialised by
+    // s_hidOpenMutex in hidcontroller.cpp to avoid concurrent udev access.
+    if (hid_init() != 0) {
+        qWarning() << "Failed to initialise hidapi";
+    }
+
     QStringList enumeratedDevices;
     hid_device_info* p_device_info_list = hid_enumerate(0x0, 0x0);
     for (const auto* p_device_info = p_device_info_list;


### PR DESCRIPTION
## Summary

- Serialises the `hid_open*` calls made by the background report-descriptor fetch threads in `HidController::fetchReportDescriptorInBackground()` with a file-local `std::mutex`, so only one thread touches udev at a time.
- Calls `hid_init()` explicitly on the main thread in `HidEnumerator::queryDevices()` before `hid_enumerate()` and before any `HidController` objects are constructed, so the hidraw backend context is fully set up once up front.

## Problem

The hidraw backend of hidapi is not thread-safe. `hid_open_path()` and `hid_open()` both internally call `hid_enumerate()`, which calls `udev_enumerate_scan_devices()`. Since #15692, each `HidController` constructor spawns a `QtConcurrent::run` background thread that calls `hid_open*` to fetch the report descriptor. With multiple HID devices present at startup, those background threads race inside udev, corrupting the heap.

This surfaces as:
- A double-free in `hid_init` reported by AddressSanitizer (#15980).
- `free(): chunks in smallbin corrupted` aborting from an unrelated `free()` later in the run (e.g. the library scanner `RecursiveScanDirectoryTask` destructor).

`hid_init()` alone is insufficient: it ensures the backend context exists, but the concurrent `hid_open*` calls still race inside `hid_enumerate`/udev.

## Fix

- `HidEnumerator::queryDevices()`: call `hid_init()` on the main thread before enumeration and before constructing any `HidController`.
- `HidController::fetchReportDescriptorInBackground()`: guard the `hid_open_path`/`hid_open` fallback chain with a file-local `std::mutex s_hidOpenMutex` so the background fetch threads serialise their udev access.

Fixes #15980.

#### Test plan

- [x] Builds without errors
- [x] 1219 unit tests pass (pre-push hook)
- [x] Startup with 3+ HID devices no longer aborts with `free(): chunks in smallbin corrupted`; library scan completes cleanly
- [ ] Tested with real DJ hardware by human reviewer

---

This PR description was autonomously generated by the AI Agent.