### PR TITLE
Numark_DJ2GO2_Touch_scripts.js: Bug Fix

### DIFF
--- a/res/controllers/Numark_DJ2GO2_Touch_scripts.js
+++ b/res/controllers/Numark_DJ2GO2_Touch_scripts.js
@@ -21,11 +21,14 @@ DJ2GO2Touch.browseEncoder = new components.Encoder({
     previewSeekEnabled: false,
     onKnobEvent: function(rotateValue) {
         if (rotateValue !== 0) {
-            if (this.previewSeekEnabled  && engine.getValue("[PreviewDeck1]", "play")) {
+            if (this.previewSeekEnabled) {
                 var oldPos = engine.getValue("[PreviewDeck1]", "playposition");
                 var newPos = Math.max(0, oldPos + (0.05 * rotateValue));
                 engine.setValue("[PreviewDeck1]", "playposition", newPos);
-            } else if (!this.previewSeekEnabled) {
+                if (engine.getValue("[PreviewDeck1]", "play") === 0) {
+                    engine.setValue("[PreviewDeck1]", "play", 1);
+                }
+            } else {
                 engine.setValue("[Playlist]", "SelectTrackKnob", rotateValue);
             }
         }


### PR DESCRIPTION
Fix bug where, when previewing a track, if the trackhead reached the end of the track, the encoder would become irreponsive. There is no logic branch to account for being in the state of strip searching when a track is not playing. Maintaining that logic, now if the track ever stops while the encoder is in strip searching mode, the preview deck is set to play again.