### PR TITLE
CrateFeature: Remove outdated refactoring TODO comment that has already been implemented

### DIFF
--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -678,8 +678,6 @@ void CrateFeature::slotImportPlaylistFile(const QString& playlistFile, CrateId c
     // system sandboxer (if we are sandboxed) has granted us permission to this
     // folder. We don't need access to this file on a regular basis so we do not
     // register a security bookmark.
-    // TODO(XXX): Parsing a list of track locations from a playlist file
-    // is a general task and should be implemented separately.
     QList<QString> locations = Parser().parse(playlistFile);
     if (locations.empty()) {
         return;


### PR DESCRIPTION
...which is apparent because it's directly over the `Parser().parse(...)` invocation.