### PR TITLE
MIDI preferences: add missing HercJogFast option

### DIFF
--- a/src/controllers/delegates/midioptionsdelegate.cpp
+++ b/src/controllers/delegates/midioptionsdelegate.cpp
@@ -28,6 +28,7 @@ const QList<MidiOption> kMidiOptions = {
         MidiOption::Switch,
         MidiOption::Spread64,
         MidiOption::HercJog,
+        MidiOption::HercJogFast,
         MidiOption::SelectKnob,
         MidiOption::SoftTakeover,
         MidiOption::Script,

--- a/src/controllers/delegates/midioptionsdelegate.cpp
+++ b/src/controllers/delegates/midioptionsdelegate.cpp
@@ -19,7 +19,11 @@ const QList<MidiOption> kMidiOptions = {
         // Furthermore, the mapping list is cleaner without it, mappings that
         // have options set are much easier to spot.
         // MidiOption::None,
+        MidiOption::Script,
         MidiOption::Invert,
+        MidiOption::SoftTakeover,
+        MidiOption::FourteenBitMSB,
+        MidiOption::FourteenBitLSB,
         MidiOption::Rot64,
         MidiOption::Rot64Invert,
         MidiOption::Rot64Fast,
@@ -30,10 +34,6 @@ const QList<MidiOption> kMidiOptions = {
         MidiOption::HercJog,
         MidiOption::HercJogFast,
         MidiOption::SelectKnob,
-        MidiOption::SoftTakeover,
-        MidiOption::Script,
-        MidiOption::FourteenBitMSB,
-        MidiOption::FourteenBitLSB,
 };
 
 } // namespace


### PR DESCRIPTION
to MIDI options delegate in controller -> Inouts table
(this slipped through in #12348)

and reorder items so we have "modifiers" Invert and SoftTakeover at the top of the list.