### PR TITLE
CrateFeature: Move certain less-frequently used context menu actions into a "More" submenu

### DIFF
--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -404,13 +404,25 @@ void CrateFeature::onRightClickChild(
     menu.addSeparator();
     menu.addAction(m_pAutoDjTrackSourceAction.get());
     menu.addSeparator();
-    menu.addAction(m_pAnalyzeCrateAction.get());
-    menu.addSeparator();
-    menu.addAction(m_pImportPlaylistAction.get());
-    menu.addAction(m_pExportPlaylistAction.get());
-    menu.addAction(m_pExportTrackFilesAction.get());
+
+    QMenu* moreMenu;
+    bool showMoreMenu = true;
+    if (showMoreMenu) {
+        moreMenu = new QMenu(&menu);
+        moreMenu->setTitle(tr("More"));
+        moreMenu->setObjectName("MoreMenu");
+        menu.addMenu(moreMenu);
+    } else {
+        moreMenu = &menu;
+    }
+
+    moreMenu->addAction(m_pAnalyzeCrateAction.get());
+    moreMenu->addSeparator();
+    moreMenu->addAction(m_pImportPlaylistAction.get());
+    moreMenu->addAction(m_pExportPlaylistAction.get());
+    moreMenu->addAction(m_pExportTrackFilesAction.get());
 #ifdef __ENGINEPRIME__
-    menu.addAction(m_pExportCrateAction.get());
+    moreMenu->addAction(m_pExportCrateAction.get());
 #endif
     menu.exec(globalPos);
 }


### PR DESCRIPTION
Unclutter the "Crate" context menu by moving all the import/export actions that are not needed as often into a "More" submenu. This way, new users can also easily distinguish the primary actions they can do with crates (Create, Rename, etc.) from the more specialized ones. Also makes the mouse movements a bit more efficient by shrinking the total size of the menu.

<img width="517" height="386" alt="Bildschirmfoto vom 2026-08-08 11-55-06" src="https://github.com/user-attachments/assets/2e9d6f3b-f021-47dc-bf7a-7a05c21d7783" />

We could also expose a settings flag to turn this on or off if some power users require the old layout, but I'm not really sure about that.

See also:

- #16854 