### PR TITLE
PlaylistFeature: Move certain less-frequently used context menu actions into a "More" submenu

### DIFF
--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -98,13 +98,26 @@ void PlaylistFeature::onRightClickChild(
     m_pLockPlaylistAction->setText(locked ? tr("Unlock") : tr("Lock"));
 
     QMenu menu(m_pSidebarWidget);
+
+    QMenu* moreMenu;
+    bool showMoreMenu = true;
+    if (showMoreMenu) {
+        moreMenu = new QMenu(&menu);
+        moreMenu->setTitle(tr("More"));
+        moreMenu->setObjectName("MoreMenu");
+    } else {
+        moreMenu = &menu;
+    }
+
     menu.addAction(m_pCreatePlaylistAction);
     menu.addSeparator();
+
     // TODO If playlist is selected and has more than one track selected
     // show "Shuffle selected tracks", else show "Shuffle playlist"?
-    menu.addAction(m_pShufflePlaylistAction);
-    menu.addAction(m_pOrderByCurrentPosAction);
-    menu.addSeparator();
+    moreMenu->addAction(m_pShufflePlaylistAction);
+    moreMenu->addAction(m_pOrderByCurrentPosAction);
+    moreMenu->addSeparator();
+
     menu.addAction(m_pRenamePlaylistAction);
     menu.addAction(m_pDuplicatePlaylistAction);
     menu.addAction(m_pDeletePlaylistAction);
@@ -115,15 +128,8 @@ void PlaylistFeature::onRightClickChild(
     menu.addAction(m_pAddToAutoDJReplaceAction);
     menu.addSeparator();
 
-    QMenu* moreMenu;
-    bool showMoreMenu = true;
     if (showMoreMenu) {
-        moreMenu = new QMenu(&menu);
-        moreMenu->setTitle(tr("More"));
-        moreMenu->setObjectName("MoreMenu");
         menu.addMenu(moreMenu);
-    } else {
-        moreMenu = &menu;
     }
 
     moreMenu->addAction(m_pAnalyzePlaylistAction);

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -114,13 +114,25 @@ void PlaylistFeature::onRightClickChild(
     menu.addAction(m_pAddToAutoDJTopAction);
     menu.addAction(m_pAddToAutoDJReplaceAction);
     menu.addSeparator();
-    menu.addAction(m_pAnalyzePlaylistAction);
-    menu.addSeparator();
-    menu.addAction(m_pImportPlaylistAction);
-    menu.addAction(m_pExportPlaylistAction);
-    menu.addAction(m_pExportTrackFilesAction);
+
+    QMenu* moreMenu;
+    bool showMoreMenu = true;
+    if (showMoreMenu) {
+        moreMenu = new QMenu(&menu);
+        moreMenu->setTitle(tr("More"));
+        moreMenu->setObjectName("MoreMenu");
+        menu.addMenu(moreMenu);
+    } else {
+        moreMenu = &menu;
+    }
+
+    moreMenu->addAction(m_pAnalyzePlaylistAction);
+    moreMenu->addSeparator();
+    moreMenu->addAction(m_pImportPlaylistAction);
+    moreMenu->addAction(m_pExportPlaylistAction);
+    moreMenu->addAction(m_pExportTrackFilesAction);
 #ifdef __ENGINEPRIME__
-    menu.addAction(m_pExportPlaylistToEngineAction);
+    moreMenu->addAction(m_pExportPlaylistToEngineAction);
 #endif
     menu.exec(globalPos);
 }


### PR DESCRIPTION
Unclutter the "Playlist" context menu by moving all the import/export actions that are not needed as often into a "More" submenu. This way, new users can also easily distinguish the primary actions they can do with playlists (Create, Rename, etc.) from the more specialized ones. Also makes the mouse movements a bit more efficient by shrinking the total size of the menu.

<img width="476" height="428" alt="image" src="https://github.com/user-attachments/assets/58026396-dc6a-4116-b330-2dafb60f14ac" />

We could also expose a settings flag to turn this on or off if some power users require the old layout, but I'm not really sure about that. Please direct discussion related to such a setting to #16853.

See also:

- #16853