### PR TITLE
Database: Make it possible to trigger the "Repair Database" action via CLI option and menu item 

### DIFF
--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -11,6 +11,7 @@
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "util/assert.h"
+#include "util/cmdlineargs.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/logger.h"
 
@@ -43,9 +44,11 @@ TrackCollectionManager::TrackCollectionManager(
       m_pInternalCollection(createInternalTrackCollection(this, pConfig, deleteTrackForTestingFn)) {
     const QSqlDatabase dbConnection = mixxx::DbConnectionPooled(pDbConnectionPool);
 
-    // TODO(XXX): Add a checkbox in the library preferences for checking
-    // and repairing the database on the next restart of the application.
-    if (pConfig->getValue(kRepairDatabaseOnNextRestartConfigKey, false)) {
+    // The database repair can be triggered via "Repair Database"
+    // in the options menu, as well as using the command line option
+    // "--repair-database".
+    if (CmdlineArgs::Instance().getRepairDatabase() ||
+            pConfig->getValue(kRepairDatabaseOnNextRestartConfigKey, false)) {
         m_pInternalCollection->repairDatabase(dbConnection);
         // Reset config value
         pConfig->setValue(kRepairDatabaseOnNextRestartConfigKey, false);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -853,6 +853,11 @@ void MixxxMainWindow::connectMenuBar() {
             &MixxxMainWindow::slotOptionsPreferences,
             Qt::UniqueConnection);
     connect(m_pMenuBar,
+            &WMainMenuBar::repairDatabase,
+            this,
+            &MixxxMainWindow::slotOptionsRepairDatabase,
+            Qt::UniqueConnection);
+    connect(m_pMenuBar,
             &WMainMenuBar::loadTrackToDeck,
             this,
             &MixxxMainWindow::slotFileLoadSongPlayer,
@@ -1132,6 +1137,28 @@ void MixxxMainWindow::slotOptionsPreferences() {
     m_pPrefDlg->show();
     m_pPrefDlg->raise();
     m_pPrefDlg->activateWindow();
+}
+
+void MixxxMainWindow::slotOptionsRepairDatabase() {
+    QMessageBox::StandardButton btn = QMessageBox::warning(
+            this,
+            VersionStore::applicationName(),
+            tr("Repairing the database requires a restart of Mixxx.\n"
+               "Do you want to exit out of Mixxx and run the database repair on the next launch?"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+    if (btn == QMessageBox::Yes) {
+        // TODO(cr7pt0gr4ph7): Implement an external restart handler that
+        // automatically restarts Mixxx here. Basically just a small
+        // cmdline application that, when invoked, forwards everything to the
+        // main Mixxx executable, but also listens for a a special restart flag.
+
+        // Set flag and exit out of Mixxx
+        m_pCoreServices->getSettings()->setValue(
+            mixxx::library::prefs::kRepairDatabaseOnNextRestartConfigKey,
+            true);
+        close();
+    }
 }
 
 void MixxxMainWindow::slotNoVinylControlInputConfigured() {

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1155,8 +1155,8 @@ void MixxxMainWindow::slotOptionsRepairDatabase() {
 
         // Set flag and exit out of Mixxx
         m_pCoreServices->getSettings()->setValue(
-            mixxx::library::prefs::kRepairDatabaseOnNextRestartConfigKey,
-            true);
+                mixxx::library::prefs::kRepairDatabaseOnNextRestartConfigKey,
+                true);
         close();
     }
 }

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -62,6 +62,8 @@ class MixxxMainWindow : public QMainWindow {
     void slotFileLoadSongPlayer(int deck);
     /// show the preferences dialog
     void slotOptionsPreferences();
+    /// set up a database repair for next start
+    void slotOptionsRepairDatabase();
     /// show the about dialog
     void slotHelpAbout();
     /// show popup with library scan results

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -59,6 +59,7 @@ CmdlineArgs::CmdlineArgs()
           m_qml(false),
 #endif
           m_safeMode(false),
+          m_repairDatabase(false),
           m_useLegacyVuMeter(false),
           m_useLegacySpinny(false),
           m_debugAssertBreak(false),
@@ -198,6 +199,12 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                                       "Rescans the library when Mixxx is launched.")
                             : QString());
     parser.addOption(rescanLibrary);
+
+    const QCommandLineOption repairDatabase(QStringLiteral("repair-database"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Run a database cleanup when Mixxx is launched.")
+                            : QString());
+    parser.addOption(repairDatabase);
 
     // An option with a value
     const QCommandLineOption settingsPath(QStringLiteral("settings-path"),
@@ -444,6 +451,10 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
 
     if (parser.isSet(rescanLibrary)) {
         m_rescanLibrary = true;
+    }
+
+    if (parser.isSet(repairDatabase)) {
+        m_repairDatabase = true;
     }
 
     if (parser.isSet(settingsPath)) {

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -55,6 +55,9 @@ class CmdlineArgs final {
     }
 #endif
     bool getSafeMode() const { return m_safeMode; }
+    bool getRepairDatabase() const {
+        return m_repairDatabase;
+    }
     bool useColors() const {
         return m_useColors;
     }
@@ -112,6 +115,7 @@ class CmdlineArgs final {
     bool m_awareOfRisk;
 #endif
     bool m_safeMode;
+    bool m_repairDatabase;
     bool m_useLegacyVuMeter;
     bool m_useLegacySpinny;
     bool m_debugAssertBreak;

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -541,6 +541,14 @@ void WMainMenuBar::initialize() {
 
     pOptionsMenu->addSeparator();
 
+    QString repairDatabaseTitle = tr("Repair Database");
+    QString repairDatabaseText = tr("Restart Mixxx & repair database inconsistencies");
+    auto* pOptionsRepairDatabase = new QAction(repairDatabaseTitle, this);
+    pOptionsRepairDatabase->setStatusTip(repairDatabaseText);
+    pOptionsRepairDatabase->setWhatsThis(buildWhatsThis(repairDatabaseTitle, repairDatabaseText));
+    connect(pOptionsRepairDatabase, &QAction::triggered, this, &WMainMenuBar::repairDatabase);
+    pOptionsMenu->addAction(pOptionsRepairDatabase);
+
     QString preferencesTitle = tr("&Preferences");
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
     auto* pOptionsPreferences = new QAction(preferencesTitle, this);

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -65,6 +65,7 @@ class WMainMenuBar : public QMenuBar {
     void createPlaylist();
     void loadTrackToDeck(int deck);
     void reloadSkin();
+    void repairDatabase();
     void rescanLibrary();
 #ifdef __ENGINEPRIME__
     void exportLibrary();


### PR DESCRIPTION
I can split this into two separate PRs, but have kept is as one PR for now because updating the comment in `trackcollectionmanager` would cause a merge conflict anyway.

<img width="303" height="221" alt="image" src="https://github.com/user-attachments/assets/bf654df0-e435-4732-95d9-ed5f1dbfd4d5" />

<img width="534" height="163" alt="image" src="https://github.com/user-attachments/assets/d362e8ef-cbf6-45f8-9e64-1ae7433b5c93" />

```txt
$ ./mixxx --help

Usage: ./mixxx [options] file
Mixxx is an open source DJ software. For more information, see: https://manual.mixxx.org/2.7/chapters/appendix/commandline_dev_tools.html

Options:
  [...]
  --repair-database                       Run a database cleanup when Mixxx is
                                          launched.
  [...]
```