### PR TITLE
Fix #16848 slip mode rendering in split stem view

### DIFF
--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -2,6 +2,7 @@
 
 #include <QDomNode>
 
+#include "engine/engine.h"
 #include "moc_waveformrenderbeat.cpp"
 #include "rendergraph/geometry.h"
 #include "rendergraph/material/unicolormaterial.h"
@@ -9,6 +10,8 @@
 #include "skin/legacy/skincontext.h"
 #include "track/track.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/waveform.h"
+#include "waveform/waveformwidgetfactory.h"
 #include "widget/wskincolor.h"
 
 using namespace rendergraph;
@@ -47,6 +50,11 @@ bool WaveformRenderBeat::preprocessInner() {
     if (!trackInfo || (m_isSlipRenderer && !m_waveformRenderer->isSlipActive())) {
         return false;
     }
+
+    const bool isStemTrack = trackInfo && trackInfo->hasStem() &&
+            trackInfo->getWaveform() && trackInfo->getWaveform()->hasStem();
+    const bool splitStemTracks = isStemTrack &&
+            WaveformWidgetFactory::instance()->isStemSplitTracks();
 
     auto positionType = m_isSlipRenderer ? ::WaveformRendererAbstract::Slip
                                          : ::WaveformRendererAbstract::Play;
@@ -105,10 +113,17 @@ bool WaveformRenderBeat::preprocessInner() {
         numBeatsInRange++;
     }
 
-    const int reserved = numBeatsInRange * numVerticesPerLine;
+    const int numBoxesPerBeat = (m_isSlipRenderer && splitStemTracks)
+            ? mixxx::kMaxSupportedStems
+            : 1;
+    const int reserved = numBeatsInRange * numVerticesPerLine * numBoxesPerBeat;
     geometry().allocate(reserved);
 
     VertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::Point2D>()};
+
+    const float boxBreadth = splitStemTracks
+            ? rendererBreadth / static_cast<float>(mixxx::kMaxSupportedStems)
+            : rendererBreadth;
 
     for (auto it = trackBeats->iteratorFrom(startPosition);
             it != trackBeats->cend() && *it <= endPosition;
@@ -123,8 +138,16 @@ bool WaveformRenderBeat::preprocessInner() {
         const float x1 = static_cast<float>(xBeatPoint);
         const float x2 = x1 + 1.f;
 
-        vertexUpdater.addRectangle({x1, 0.f},
-                {x2, m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth});
+        if (m_isSlipRenderer && splitStemTracks) {
+            for (int stemIdx = 0; stemIdx < mixxx::kMaxSupportedStems; ++stemIdx) {
+                const float posy1 = stemIdx * boxBreadth;
+                const float posy2 = posy1 + boxBreadth / 2.f;
+                vertexUpdater.addRectangle({x1, posy1}, {x2, posy2});
+            }
+        } else {
+            vertexUpdater.addRectangle({x1, 0.f},
+                    {x2, m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth});
+        }
     }
     markDirtyGeometry();
 

--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -2,6 +2,7 @@
 
 #include <QDomNode>
 
+#include "engine/engine.h"
 #include "moc_waveformrenderbeat.cpp"
 #include "rendergraph/geometry.h"
 #include "rendergraph/material/unicolormaterial.h"
@@ -9,6 +10,8 @@
 #include "skin/legacy/skincontext.h"
 #include "track/track.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/waveform.h"
+#include "waveform/waveformwidgetfactory.h"
 #include "widget/wskincolor.h"
 
 using namespace rendergraph;
@@ -47,6 +50,11 @@ bool WaveformRenderBeat::preprocessInner() {
     if (!trackInfo || (m_isSlipRenderer && !m_waveformRenderer->isSlipActive())) {
         return false;
     }
+
+    const bool isStemTrack = trackInfo && trackInfo->hasStem() &&
+            trackInfo->getWaveform() && trackInfo->getWaveform()->hasStem();
+    const bool splitStemTracks = isStemTrack &&
+            WaveformWidgetFactory::instance()->isStemSplitTracks();
 
     auto positionType = m_isSlipRenderer ? ::WaveformRendererAbstract::Slip
                                          : ::WaveformRendererAbstract::Play;
@@ -99,10 +107,17 @@ bool WaveformRenderBeat::preprocessInner() {
         numBeatsInRange++;
     }
 
-    const int reserved = numBeatsInRange * numVerticesPerLine;
+    const int numBoxesPerBeat = (m_isSlipRenderer && splitStemTracks)
+            ? mixxx::kMaxSupportedStems
+            : 1;
+    const int reserved = numBeatsInRange * numVerticesPerLine * numBoxesPerBeat;
     geometry().allocate(reserved);
 
     VertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::Point2D>()};
+
+    const float boxBreadth = splitStemTracks
+            ? rendererBreadth / static_cast<float>(mixxx::kMaxSupportedStems)
+            : rendererBreadth;
 
     for (auto it = trackBeats->iteratorFrom(startPosition);
             it != trackBeats->cend() && *it <= endPosition;
@@ -117,8 +132,16 @@ bool WaveformRenderBeat::preprocessInner() {
         const float x1 = static_cast<float>(xBeatPoint);
         const float x2 = x1 + 1.f;
 
-        vertexUpdater.addRectangle({x1, 0.f},
-                {x2, m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth});
+        if (m_isSlipRenderer && splitStemTracks) {
+            for (int stemIdx = 0; stemIdx < mixxx::kMaxSupportedStems; ++stemIdx) {
+                const float posy1 = stemIdx * boxBreadth;
+                const float posy2 = posy1 + boxBreadth / 2.f;
+                vertexUpdater.addRectangle({x1, posy1}, {x2, posy2});
+            }
+        } else {
+            vertexUpdater.addRectangle({x1, 0.f},
+                    {x2, m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth});
+        }
     }
     markDirtyGeometry();
 

--- a/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
@@ -5,11 +5,14 @@
 #include <memory>
 
 #include "control/controlproxy.h"
+#include "engine/engine.h"
 #include "rendergraph/geometry.h"
 #include "rendergraph/material/rgbamaterial.h"
 #include "rendergraph/vertexupdaters/rgbavertexupdater.h"
+#include "track/track.h"
 #include "util/colorcomponents.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/wskincolor.h"
 
@@ -88,6 +91,12 @@ bool WaveformRendererSlipMode::preprocessInner() {
         return false;
     }
 
+    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+    const bool isStemTrack = pTrack && pTrack->hasStem() &&
+            pTrack->getWaveform() && pTrack->getWaveform()->hasStem();
+    const bool splitStemTracks = isStemTrack &&
+            WaveformWidgetFactory::instance()->isStemSplitTracks();
+
     const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
 
     const float blinkIntensity =
@@ -99,38 +108,55 @@ bool WaveformRendererSlipMode::preprocessInner() {
 
     const float posx1 = 0.f;
     const float posx2 = m_waveformRenderer->getLength();
-    const float posy1 = 0.f;
-    const float posy2 = m_waveformRenderer->getBreadth() / 2.f;
+    const float breadth = m_waveformRenderer->getBreadth();
 
-    const float sideBorderOutlineSide = m_slipBorderTopOutlineSize;
+    const int numBoxes = splitStemTracks ? mixxx::kMaxSupportedStems : 1;
+    const float boxBreadth = splitStemTracks
+            ? breadth / static_cast<float>(mixxx::kMaxSupportedStems)
+            : breadth;
+
+    const float topOutlineSize = splitStemTracks
+            ? m_slipBorderTopOutlineSize / static_cast<float>(mixxx::kMaxSupportedStems)
+            : m_slipBorderTopOutlineSize;
+    const float bottomOutlineSize = splitStemTracks
+            ? m_slipBorderBottomOutlineSize / static_cast<float>(mixxx::kMaxSupportedStems)
+            : m_slipBorderBottomOutlineSize;
+    const float sideBorderOutlineSide = topOutlineSize;
 
     const QVector4D bgColor{0.f, 0.f, 0.f, 1.f};
     const QVector4D borderColor{m_color.redF(), m_color.greenF(), m_color.blueF(), alpha};
     const QVector4D borderColor0{m_color.redF(), m_color.greenF(), m_color.blueF(), 0.f};
 
-    const int numVerticesPerLine = 6;            // 2 triangles
-    geometry().allocate(numVerticesPerLine * 5); // border on 4 sides + bgColor filler in center
+    const int numVerticesPerLine = 6; // 2 triangles
+    geometry().allocate(numVerticesPerLine * 5 *
+            numBoxes); // border on 4 sides + bgColor filler in center
 
     RGBAVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::RGBAColoredPoint2D>()};
 
-    vertexUpdater.addRectangle(
-            {posx1, posy1},
-            {posx2, posy2},
-            bgColor);
+    for (int boxIdx = 0; boxIdx < numBoxes; ++boxIdx) {
+        const float posy1 = boxIdx * boxBreadth;
+        const float posy2 = posy1 + boxBreadth / 2.f;
 
-    vertexUpdater.addRectangle(
-            {posx1, posy1}, {posx2, posy1 + m_slipBorderTopOutlineSize}, borderColor);
-    vertexUpdater.addRectangle({posx1, posy1 + m_slipBorderTopOutlineSize},
-            {posx1 + sideBorderOutlineSide,
-                    posy2},
-            borderColor);
-    vertexUpdater.addRectangle({posx2 - sideBorderOutlineSide, posy1 + m_slipBorderTopOutlineSize},
-            {posx2, posy2},
-            borderColor);
-    vertexUpdater.addRectangleVGradient({posx1, posy2},
-            {posx2, posy2 + m_slipBorderBottomOutlineSize},
-            borderColor,
-            borderColor0);
+        vertexUpdater.addRectangle(
+                {posx1, posy1},
+                {posx2, posy2},
+                bgColor);
+
+        vertexUpdater.addRectangle(
+                {posx1, posy1}, {posx2, posy1 + topOutlineSize}, borderColor);
+        vertexUpdater.addRectangle({posx1, posy1 + topOutlineSize},
+                {posx1 + sideBorderOutlineSide,
+                        posy2},
+                borderColor);
+        vertexUpdater.addRectangle({posx2 - sideBorderOutlineSide, posy1 + topOutlineSize},
+                {posx2, posy2},
+                borderColor);
+        vertexUpdater.addRectangleVGradient({posx1, posy2},
+                {posx2, posy2 + bottomOutlineSize},
+                borderColor,
+                borderColor0);
+    }
+
     markDirtyGeometry();
     markDirtyMaterial();
 

--- a/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
@@ -5,11 +5,14 @@
 #include <memory>
 
 #include "control/controlproxy.h"
+#include "engine/engine.h"
 #include "rendergraph/geometry.h"
 #include "rendergraph/material/rgbamaterial.h"
 #include "rendergraph/vertexupdaters/rgbavertexupdater.h"
+#include "track/track.h"
 #include "util/colorcomponents.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/wskincolor.h"
 
@@ -83,6 +86,12 @@ bool WaveformRendererSlipMode::preprocessInner() {
         return false;
     }
 
+    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+    const bool isStemTrack = pTrack && pTrack->hasStem() &&
+            pTrack->getWaveform() && pTrack->getWaveform()->hasStem();
+    const bool splitStemTracks = isStemTrack &&
+            WaveformWidgetFactory::instance()->isStemSplitTracks();
+
     const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
 
     const float blinkIntensity =
@@ -94,38 +103,55 @@ bool WaveformRendererSlipMode::preprocessInner() {
 
     const float posx1 = 0.f;
     const float posx2 = m_waveformRenderer->getLength();
-    const float posy1 = 0.f;
-    const float posy2 = m_waveformRenderer->getBreadth() / 2.f;
+    const float breadth = m_waveformRenderer->getBreadth();
 
-    const float sideBorderOutlineSide = m_slipBorderTopOutlineSize;
+    const int numBoxes = splitStemTracks ? mixxx::kMaxSupportedStems : 1;
+    const float boxBreadth = splitStemTracks
+            ? breadth / static_cast<float>(mixxx::kMaxSupportedStems)
+            : breadth;
+
+    const float topOutlineSize = splitStemTracks
+            ? m_slipBorderTopOutlineSize / static_cast<float>(mixxx::kMaxSupportedStems)
+            : m_slipBorderTopOutlineSize;
+    const float bottomOutlineSize = splitStemTracks
+            ? m_slipBorderBottomOutlineSize / static_cast<float>(mixxx::kMaxSupportedStems)
+            : m_slipBorderBottomOutlineSize;
+    const float sideBorderOutlineSide = topOutlineSize;
 
     const QVector4D bgColor{0.f, 0.f, 0.f, 1.f};
     const QVector4D borderColor{m_color.redF(), m_color.greenF(), m_color.blueF(), alpha};
     const QVector4D borderColor0{m_color.redF(), m_color.greenF(), m_color.blueF(), 0.f};
 
-    const int numVerticesPerLine = 6;            // 2 triangles
-    geometry().allocate(numVerticesPerLine * 5); // border on 4 sides + bgColor filler in center
+    const int numVerticesPerLine = 6; // 2 triangles
+    geometry().allocate(numVerticesPerLine * 5 *
+            numBoxes); // border on 4 sides + bgColor filler in center
 
     RGBAVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::RGBAColoredPoint2D>()};
 
-    vertexUpdater.addRectangle(
-            {posx1, posy1},
-            {posx2, posy2},
-            bgColor);
+    for (int boxIdx = 0; boxIdx < numBoxes; ++boxIdx) {
+        const float posy1 = boxIdx * boxBreadth;
+        const float posy2 = posy1 + boxBreadth / 2.f;
 
-    vertexUpdater.addRectangle(
-            {posx1, posy1}, {posx2, posy1 + m_slipBorderTopOutlineSize}, borderColor);
-    vertexUpdater.addRectangle({posx1, posy1 + m_slipBorderTopOutlineSize},
-            {posx1 + sideBorderOutlineSide,
-                    posy2},
-            borderColor);
-    vertexUpdater.addRectangle({posx2 - sideBorderOutlineSide, posy1 + m_slipBorderTopOutlineSize},
-            {posx2, posy2},
-            borderColor);
-    vertexUpdater.addRectangleVGradient({posx1, posy2},
-            {posx2, posy2 + m_slipBorderBottomOutlineSize},
-            borderColor,
-            borderColor0);
+        vertexUpdater.addRectangle(
+                {posx1, posy1},
+                {posx2, posy2},
+                bgColor);
+
+        vertexUpdater.addRectangle(
+                {posx1, posy1}, {posx2, posy1 + topOutlineSize}, borderColor);
+        vertexUpdater.addRectangle({posx1, posy1 + topOutlineSize},
+                {posx1 + sideBorderOutlineSide,
+                        posy2},
+                borderColor);
+        vertexUpdater.addRectangle({posx2 - sideBorderOutlineSide, posy1 + topOutlineSize},
+                {posx2, posy2},
+                borderColor);
+        vertexUpdater.addRectangleVGradient({posx1, posy2},
+                {posx2, posy2 + bottomOutlineSize},
+                borderColor,
+                borderColor0);
+    }
+
     markDirtyGeometry();
     markDirtyMaterial();
 


### PR DESCRIPTION
Fixes slip mode for stacked stem visualization: each stem waveform is split in two parts.

<img width="1789" height="385" alt="image" src="https://github.com/user-attachments/assets/88ce5293-23a1-41fb-8267-0ce47d0431c4" />
