### PR TITLE
CrateFeature: Rename Engine DJ-specific actions in CrateFeature

### DIFF
--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -129,13 +129,13 @@ void CrateFeature::initActions() {
             this,
             &CrateFeature::slotExportTrackFiles);
 #ifdef __ENGINEPRIME__
-    m_pExportAllCratesAction = make_parented<QAction>(tr("Export to Engine DJ"), this);
-    connect(m_pExportAllCratesAction.get(),
+    m_pExportAllCratesToEngineDJAction = make_parented<QAction>(tr("Export to Engine DJ"), this);
+    connect(m_pExportAllCratesToEngineDJAction.get(),
             &QAction::triggered,
             this,
             &CrateFeature::exportAllCrates);
-    m_pExportCrateAction = make_parented<QAction>(tr("Export to Engine DJ"), this);
-    connect(m_pExportCrateAction.get(),
+    m_pExportCrateToEngineDJAction = make_parented<QAction>(tr("Export to Engine DJ"), this);
+    connect(m_pExportCrateToEngineDJAction.get(),
             &QAction::triggered,
             this,
             [this]() {
@@ -367,7 +367,7 @@ void CrateFeature::onRightClick(const QPoint& globalPos) {
     menu.addAction(m_pCreateImportPlaylistAction.get());
 #ifdef __ENGINEPRIME__
     menu.addSeparator();
-    menu.addAction(m_pExportAllCratesAction.get());
+    menu.addAction(m_pExportAllCratesToEngineDJAction.get());
 #endif
     menu.exec(globalPos);
 }
@@ -410,7 +410,7 @@ void CrateFeature::onRightClickChild(
     menu.addAction(m_pExportPlaylistAction.get());
     menu.addAction(m_pExportTrackFilesAction.get());
 #ifdef __ENGINEPRIME__
-    menu.addAction(m_pExportCrateAction.get());
+    menu.addAction(m_pExportCrateToEngineDJAction.get());
 #endif
     menu.exec(globalPos);
 }

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -126,8 +126,8 @@ class CrateFeature : public BaseTrackSetFeature {
     parented_ptr<QAction> m_pExportPlaylistAction;
     parented_ptr<QAction> m_pExportTrackFilesAction;
 #ifdef __ENGINEPRIME__
-    parented_ptr<QAction> m_pExportAllCratesAction;
-    parented_ptr<QAction> m_pExportCrateAction;
+    parented_ptr<QAction> m_pExportAllCratesToEngineDJAction;
+    parented_ptr<QAction> m_pExportCrateToEngineDJAction;
 #endif
     parented_ptr<QAction> m_pAnalyzeCrateAction;
 


### PR DESCRIPTION
...so that the name `m_pExportAllCrates` can be used for exporting all crates to playlists.