### PR TITLE
Track Info Dialog: Associate read-only fields with track property names

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -68,7 +68,7 @@ void DlgTrackInfo::init() {
 
     // Store tag edit widget pointers to allow focusing a specific widgets when
     // this is opened by double-clicking a WTrackProperty label.
-    // Associate with property strings taken from library/dao/trackdao.h
+    // Associate with property strings taken from library/dao/trackdao.cpp
     m_propertyWidgets.insert("artist", txtArtist);
     m_propertyWidgets.insert("title", txtTitle);
     m_propertyWidgets.insert("titleInfo", txtTitle);
@@ -83,6 +83,15 @@ void DlgTrackInfo::init() {
     m_propertyWidgets.insert("grouping", txtGrouping);
     m_propertyWidgets.insert("comment", txtComment);
     m_propertyWidgets.insert("color", btnColorPicker);
+    m_propertyWidgets.insert("datetime_added", txtDateAdded);
+    m_propertyWidgets.insert("duration", txtDuration);
+    m_propertyWidgets.insert("filetype", txtType);
+    m_propertyWidgets.insert("filesize", txtFileSize);
+    m_propertyWidgets.insert("bitrate", txtBitrate);
+    m_propertyWidgets.insert("samplerate", txtSamplerate);
+    m_propertyWidgets.insert("replaygain", txtReplayGain);
+    m_propertyWidgets.insert("replaygain_peak", txtReplayGain);
+    m_propertyWidgets.insert("track_locations.location", txtLocation);
 
     coverLayout->insertWidget(0, m_pWCoverArtLabel.get());
 


### PR DESCRIPTION
There's no reason why the auto-focus behavior of `WTrackProperty` shouldn't work for read-only track properties, too.