### PR TITLE
AutoDJProcessor: Add calculateTransitionImpl and make it free from side-effects

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -14,6 +14,7 @@ const char* kTransitionPreferenceName = "Transition";
 const char* kTransitionModePreferenceName = "TransitionMode";
 constexpr double kTransitionPreferenceDefault = 10.0;
 constexpr double kKeepPosition = -1.0;
+constexpr double kSkipToNextTrack = -2.0;
 
 // A track needs to be longer than two callbacks to not stop AutoDJ
 constexpr double kMinimumTrackDurationSec = 0.2;
@@ -1289,6 +1290,15 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
                  << pFromDeck->fadeBeginPos << pFromDeck->fadeEndPos
                  << pToDeck->startPos;
     }
+
+    if (pToDeck->startPos == kSkipToNextTrack) {
+        // This is a safety measure to handle tracks that are too short.
+        // Immediately skip to the next track instead. Note that this
+        // will trigger the playerTrackLoaded slot, which will call
+        // calculateTransition() again.
+        loadNextTrackFromQueue(*pToDeck, false);
+        return;
+    }
 }
 
 void AutoDJProcessor::calculateTransitionImpl(
@@ -1319,10 +1329,11 @@ void AutoDJProcessor::calculateTransitionImpl(
         // This signal is received before the track pointer becomes null.
         return;
     }
+
     VERIFY_OR_DEBUG_ASSERT(toDeckDuration >= kMinimumTrackDurationSec) {
         // Track has no duration or is too short. This should not happen, because short
         // tracks are skipped after load. Immediately pick next track from queue.
-        loadNextTrackFromQueue(*pToDeck, false);
+        pToDeck->startPos = kSkipToNextTrack;
         return;
     }
 

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1295,6 +1295,10 @@ void AutoDJProcessor::calculateTransitionImpl(
         DeckAttributes* pFromDeck,
         DeckAttributes* pToDeck,
         bool seekToStartPoint) {
+    // ===================================
+    // Check for tracks that are too short
+    // ===================================
+
     const double fromDeckEndPosition = getEndSecond(pFromDeck);
     const double toDeckEndPosition = getEndSecond(pToDeck);
     // Since the end position is measured in seconds from 0:00 it is also
@@ -1303,24 +1307,28 @@ void AutoDJProcessor::calculateTransitionImpl(
     const double toDeckDuration = toDeckEndPosition;
 
     VERIFY_OR_DEBUG_ASSERT(fromDeckDuration >= kMinimumTrackDurationSec) {
-        // Track has no duration or too short. This should not happen, because short
-        // tracks are skipped after load. Play ToDeck immediately.
+        // Track has no duration or is too short. This should not happen,
+        // because short tracks are skipped after load. Play ToDeck immediately.
         pFromDeck->fadeBeginPos = 0;
         pFromDeck->fadeEndPos = 0;
         pToDeck->startPos = kKeepPosition;
         return;
     }
     if (toDeckDuration == 0) {
-        // This is a seek call to zero after ejecting the track
-        // this signal is received before the track pointer becomes null
+        // This is a seek call to zero after ejecting the track.
+        // This signal is received before the track pointer becomes null.
         return;
     }
     VERIFY_OR_DEBUG_ASSERT(toDeckDuration >= kMinimumTrackDurationSec) {
-        // Track has no duration or too short. This should not happen, because short
-        // tracks are skipped after load.
+        // Track has no duration or is too short. This should not happen, because short
+        // tracks are skipped after load. Immediately pick next track from queue.
         loadNextTrackFromQueue(*pToDeck, false);
         return;
     }
+
+    // ========================
+    // Handle intros and outros
+    // ========================
 
     // Within this function, the outro refers to the outro of the currently
     // playing track and the intro refers to the intro of the next track.
@@ -1527,7 +1535,7 @@ void AutoDJProcessor::calculateTransitionImpl(
         }
     }
 
-    // These are expected to be a fraction of the track length.
+    // The positions are expected to be a fraction of the track length.
     pFromDeck->fadeBeginPos /= fromDeckDuration;
     pFromDeck->fadeEndPos /= fromDeckDuration;
     pToDeck->startPos /= toDeckDuration;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1282,6 +1282,19 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         return;
     }
 
+    calculateTransitionImpl(pFromDeck, pToDeck, seekToStartPoint);
+
+    if constexpr (sDebug) {
+        qDebug() << this << "calculateTransition" << pFromDeck->group
+                 << pFromDeck->fadeBeginPos << pFromDeck->fadeEndPos
+                 << pToDeck->startPos;
+    }
+}
+
+void AutoDJProcessor::calculateTransitionImpl(
+        DeckAttributes* pFromDeck,
+        DeckAttributes* pToDeck,
+        bool seekToStartPoint) {
     const double fromDeckEndPosition = getEndSecond(pFromDeck);
     const double toDeckEndPosition = getEndSecond(pToDeck);
     // Since the end position is measured in seconds from 0:00 it is also
@@ -1526,12 +1539,6 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
 
     VERIFY_OR_DEBUG_ASSERT(pFromDeck->fadeBeginPos <= 1) {
         pFromDeck->fadeBeginPos = 1;
-    }
-
-    if constexpr (sDebug) {
-        qDebug() << this << "calculateTransition" << pFromDeck->group
-                 << pFromDeck->fadeBeginPos << pFromDeck->fadeEndPos
-                 << pToDeck->startPos;
     }
 }
 

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1054,11 +1054,6 @@ void AutoDJProcessor::playerPlayChanged(DeckAttributes* thisDeck, bool playing) 
             // This forces the other deck to be the fromDeck.
             thisDeck->startPos = kKeepPosition;
             calculateTransition(otherDeck, thisDeck, true);
-            if (thisDeck->startPos != kKeepPosition) {
-                // Note: this seek will trigger the playerPositionChanged slot
-                // which may calls the calculateTransition() again without seek = true;
-                thisDeck->setPlayPosition(thisDeck->startPos);
-            }
         }
     }
 }
@@ -1298,6 +1293,12 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         // calculateTransition() again.
         loadNextTrackFromQueue(*pToDeck, false);
         return;
+    }
+
+    if (seekToStartPoint && pToDeck->startPos != kKeepPosition) {
+        // Note: This seek will trigger the playerPositionChanged slot
+        // which may call calculateTransition() again, but without seekToPosition = true.
+        pToDeck->setPlayPosition(pToDeck->startPos);
     }
 }
 
@@ -1644,11 +1645,6 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
         }
         pDeck->startPos = kKeepPosition;
         calculateTransition(fromDeck, pDeck, true);
-        if (pDeck->startPos != kKeepPosition) {
-            // Note: this seek will trigger the playerPositionChanged slot
-            // which may call the calculateTransition() again without seek = true;
-            pDeck->setPlayPosition(pDeck->startPos);
-        }
         // we are here in the relative domain 0..1
         if (!fromDeck->isPlaying() && fromDeck->playPosition() >= 1.0) {
             // repeat a probably missed update
@@ -1811,11 +1807,6 @@ void AutoDJProcessor::setTransitionMode(TransitionMode newMode) {
 
     if (pLeftDeck->isPlaying() && !pRightDeck->isPlaying()) {
         calculateTransition(pLeftDeck, pRightDeck, true);
-        if (pRightDeck->startPos != kKeepPosition) {
-            // Note: this seek will trigger the playerPositionChanged slot
-            // which may calls the calculateTransition() again without seek = true;
-            pRightDeck->setPlayPosition(pRightDeck->startPos);
-        }
     } else if (pRightDeck->isPlaying() && pLeftDeck->isPlaying()) {
         calculateTransition(pRightDeck, pLeftDeck, true);
         if (pLeftDeck->startPos != kKeepPosition) {

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -280,6 +280,10 @@ class AutoDJProcessor : public QObject {
     void calculateTransition(DeckAttributes* pFromDeck,
             DeckAttributes* pToDeck,
             bool seekToStartPoint);
+    void calculateTransitionImpl(
+            DeckAttributes* pFromDeck,
+            DeckAttributes* pToDeck,
+            bool seekToStartPoint);
     void useFixedFadeTime(
             DeckAttributes* pFromDeck,
             DeckAttributes* pToDeck,


### PR DESCRIPTION
This is necessary so we can use `calculateTransitionImpl` to calculate the transitions between all the tracks in the Auto DJ queue without messing up the currently playing decks.

Please review the four individual commits if you think this PR is too large to review as a whole. Splitting this PR further did not make sense because the commits build upon each other.

Split off on @daschuer's request from: #13183 (which has now been superseded by #16865).

---

This PR is the fourth in a five-part series that culminates in #16865 to display the accurate remaining play time of the Auto DJ queue in the UI.

1. #16861
2. #16862 
3. #16863 
4. #16864
5. #16865