### PR TITLE
PlaylistFeature: Fix: Replace hardcoded "PlaylistCountsDurations" with `m_countsDurationTableName`

### DIFF
--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -199,7 +199,7 @@ QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
 
     // Setup the sidebar playlist model
     QSqlTableModel playlistTableModel(this, database);
-    playlistTableModel.setTable("PlaylistsCountsDurations");
+    playlistTableModel.setTable(m_countsDurationTableName);
     playlistTableModel.select();
     while (playlistTableModel.canFetchMore()) {
         playlistTableModel.fetchMore();


### PR DESCRIPTION
Just a small cleanup fix.

The method already uses `m_countsDurationTableName` above, so it should also be used here.