### PR TITLE
CI: Prevent PR builds from trashing our build caches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ on:
       ref:
         type: string
         required: true
+      save_cache:
+        type: boolean
+        default: false
     secrets:
       AZURE_CLIENT_ID:
         required: false
@@ -708,6 +711,7 @@ jobs:
         with:
           manifest-path: packaging/flatpak/org.mixxx.Mixxx.yaml
           arch: ${{ matrix.variant.arch }}
+          save-cache: ${{ inputs.save_cache }}
           build-bundle: false
           upload-artifact: false
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -75,6 +75,7 @@ jobs:
     with:
       branch: ${{ github.head_ref || github.ref_name }}
       ref: ${{ github.ref }}
+      save_cache: false
 
   # This task is used as a probe for auto merge
   # In the future, it could also be used to perform a status update (e.g once the whole CI is passing + is ready for review, add a specific label such as `need review`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       publish: true
       branch: ${{ github.head_ref || github.ref_name }}
       ref: ${{ github.ref }}
+      save_cache: true
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
The pull request builds currently cause the build cache for our default branch (`main`) to be evicted, which effectively means that no caching takes place (due to the rules of which build jobs can see which caches[^1]). This causes specifically the Flatpak build to fail intermittently due to rate limiting of some source code downloads.

Note that this requires flatpak/flatpak-github-actions#260 to be merged first, which introduces the `save-cache` option that we use here.

[^1]: TLDR: The pull requests can see the cache created for the `main` branch, but cannot see caches created by other pull requests, as per the [GitHub docs](https://github.com/flatpak/flatpak-github-actions/pull/260).