### PR TITLE
FwdSqlQuery: Add `FwdSqlQuery::bindValue(const QString&, int|uint|...)` overload to resolve conflicts

### DIFF
--- a/src/util/db/fwdsqlquery.h
+++ b/src/util/db/fwdsqlquery.h
@@ -72,6 +72,31 @@ class FwdSqlQuery final : protected QSqlQuery {
         bindValue(placeholder, value.toVariant());
     }
 
+    // Overloaded functions for all QVariant types to resolve overload conflicts
+    void bindValue(const QString& placeholder, const int value) {
+        bindValue(placeholder, QVariant(value));
+    }
+
+    void bindValue(const QString& placeholder, const unsigned int value) {
+        bindValue(placeholder, QVariant(value));
+    }
+
+    void bindValue(const QString& placeholder, const long long int value) {
+        bindValue(placeholder, QVariant(value));
+    }
+
+    void bindValue(const QString& placeholder, const unsigned long long int value) {
+        bindValue(placeholder, QVariant(value));
+    }
+
+    void bindValue(const QString& placeholder, const float value) {
+        bindValue(placeholder, QVariant(value));
+    }
+
+    void bindValue(const QString& placeholder, const double value) {
+        bindValue(placeholder, QVariant(value));
+    }
+
     QString executedQuery() const {
         return QSqlQuery::executedQuery();
     }


### PR DESCRIPTION
This prevents e.g. `pQuery->bindValue(":position", 1)` from causing a compile-time error, as the compiler cannot decide between `QVariant(int)` and `DbId(int)` (even though the latter is deleted).

I discovered this while trying to change some uses of `QSqlQuery` to `FwdSqlQuery`.