### PR TITLE
Fix Auto DJ sometimes stopping at end of a track

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -5,9 +5,12 @@
 #include "mixer/playermanager.h"
 #include "moc_autodjprocessor.cpp"
 #include "track/track.h"
+#include "util/logger.h"
 #include "util/math.h"
 
 namespace {
+
+const mixxx::Logger kLogger("AutoDJ");
 const QString kPreferenceGroup = QStringLiteral("[Auto DJ]");
 const QString kControlGroup = QStringLiteral("[AutoDJ]");
 const char* kTransitionPreferenceName = "Transition";
@@ -18,7 +21,24 @@ constexpr double kKeepPosition = -1.0;
 // A track needs to be longer than two callbacks to not stop AutoDJ
 constexpr double kMinimumTrackDurationSec = 0.2;
 
-constexpr bool sDebug = false;
+const char* autoDJStateName(AutoDJProcessor::AutoDJState state) {
+    switch (state) {
+    case AutoDJProcessor::ADJ_IDLE:
+        return "IDLE";
+    case AutoDJProcessor::ADJ_LEFT_FADING:
+        return "LEFT_FADING";
+    case AutoDJProcessor::ADJ_RIGHT_FADING:
+        return "RIGHT_FADING";
+    case AutoDJProcessor::ADJ_ENABLE_P1LOADED:
+        return "ENABLE_P1LOADED";
+    case AutoDJProcessor::ADJ_ENABLE_P1PLAYING:
+        return "ENABLE_P1PLAYING";
+    case AutoDJProcessor::ADJ_DISABLED:
+        return "DISABLED";
+    }
+    return "UNKNOWN";
+}
+
 } // anonymous namespace
 
 DeckAttributes::DeckAttributes(int index,
@@ -90,7 +110,7 @@ void DeckAttributes::slotTrackLoaded(TrackPointer pTrack) {
 }
 
 void DeckAttributes::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    //qDebug() << "DeckAttributes::slotLoadingTrack";
+    // kLogger.debug() << "DeckAttributes::slotLoadingTrack";
     emit loadingTrack(this, pNewTrack, pOldTrack);
 }
 
@@ -376,7 +396,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         bool rightDeckPlaying = pRightDeck->isPlaying();
 
         if (leftDeckPlaying && rightDeckPlaying) {
-            qDebug() << "One deck must be stopped before enabling Auto DJ mode";
+            kLogger.debug() << "One deck must be stopped before enabling Auto DJ mode";
             // Keep the current state.
             emitAutoDJStateChanged(m_eState);
             emit autoDJError(ADJ_BOTH_DECKS_PLAYING);
@@ -436,7 +456,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
 
         TrackPointer nextTrack = getNextTrackFromQueue();
         if (!nextTrack) {
-            qDebug() << "Queue is empty now, disable Auto DJ";
+            kLogger.debug() << "Queue is empty now, disable Auto DJ";
             m_enabledAutoDJ.setAndConfirm(0.0);
             emitAutoDJStateChanged(m_eState);
             emit autoDJError(ADJ_QUEUE_EMPTY);
@@ -445,7 +465,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
 
         // Track is available so GO
         m_enabledAutoDJ.setAndConfirm(1.0);
-        qDebug() << "Auto DJ enabled";
+        kLogger.debug() << "Auto DJ enabled";
 
         m_coCrossfader.connectValueChanged(this, &AutoDJProcessor::crossfaderChanged);
 
@@ -588,7 +608,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         emitAutoDJStateChanged(m_eState);
     } else { // Disable Auto DJ
         m_enabledAutoDJ.setAndConfirm(0.0);
-        qDebug() << "Auto DJ disabled";
+        kLogger.debug() << "Auto DJ disabled";
         m_eState = ADJ_DISABLED;
         disconnect(&m_coCrossfader,
                 &ControlProxy::valueChanged,
@@ -680,7 +700,7 @@ void AutoDJProcessor::crossfaderChanged(double value) {
 
 void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                                             double thisPlayPosition) {
-    // qDebug() << "player" << pAttributes->group << "PositionChanged(" << value << ")";
+    // kLogger.debug() << "player" << pAttributes->group << "PositionChanged(" << value << ")";
     if (m_eState == ADJ_DISABLED) {
         // nothing to do
         return;
@@ -746,9 +766,9 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             } else {
                 // At least right deck is playing
                 // Set crossfade thresholds for right deck.
-                if constexpr (sDebug) {
-                    qDebug() << this << "playerPositionChanged"
-                             << "right deck playing";
+                if (kLogger.debugEnabled()) {
+                    kLogger.debug() << "playerPositionChanged"
+                                    << "right deck playing";
                 }
                 calculateTransition(rightDeck, leftDeck, false);
             }
@@ -796,9 +816,9 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             // recalculated here.
             // Don't adjust transition when reaching the end. In this case it is
             // always stopped.
-            if constexpr (sDebug) {
-                qDebug() << this << "playerPositionChanged"
-                         << "cueing seek";
+            if (kLogger.debugEnabled()) {
+                kLogger.debug() << "playerPositionChanged"
+                                << "cueing seek";
             }
             calculateTransition(otherDeck, thisDeck, false);
         } else if (thisDeck->isRepeat()) {
@@ -842,10 +862,10 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                 // Note: This is a DB call and takes long.
                 removeLoadedTrackFromTopOfQueue(*otherDeck);
             } else {
-                if constexpr (sDebug) {
-                    qDebug() << this << "playerPositionChanged()"
-                             << pAttributes->group << thisPlayPosition
-                             << "but not playing";
+                if (kLogger.debugEnabled()) {
+                    kLogger.debug() << "playerPositionChanged()"
+                                    << pAttributes->group << thisPlayPosition
+                                    << "but not playing";
                 }
             }
         }
@@ -1009,14 +1029,14 @@ void AutoDJProcessor::maybeFillRandomTracks() {
 
     int tracksToAdd = minAutoDJCrateTracks - m_pAutoDJTableModel->rowCount();
     if (randomQueueEnabled && (tracksToAdd > 0)) {
-        qDebug() << "Randomly adding tracks";
+        kLogger.debug() << "Randomly adding tracks";
         emit randomTrackRequested(tracksToAdd);
     }
 }
 
 void AutoDJProcessor::playerPlayChanged(DeckAttributes* thisDeck, bool playing) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerPlayChanged" << thisDeck->group << playing;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerPlayChanged" << thisDeck->group << playing;
     }
 
     if (m_eState != ADJ_IDLE) {
@@ -1063,16 +1083,16 @@ void AutoDJProcessor::playerPlayChanged(DeckAttributes* thisDeck, bool playing) 
 }
 
 void AutoDJProcessor::playerIntroStartChanged(DeckAttributes* pAttributes, double position) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerIntroStartChanged" << pAttributes->group << position;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerIntroStartChanged" << pAttributes->group << position;
     }
     // nothing to do, because we want not to re-cue the toDeck and the from
     // Deck has already passed the intro
 }
 
 void AutoDJProcessor::playerIntroEndChanged(DeckAttributes* pAttributes, double position) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerIntroEndChanged" << pAttributes->group << position;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerIntroEndChanged" << pAttributes->group << position;
     }
 
     if (m_eState != ADJ_IDLE) {
@@ -1092,8 +1112,8 @@ void AutoDJProcessor::playerIntroEndChanged(DeckAttributes* pAttributes, double 
 }
 
 void AutoDJProcessor::playerOutroStartChanged(DeckAttributes* pAttributes, double position) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerOutroStartChanged" << pAttributes->group << position;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerOutroStartChanged" << pAttributes->group << position;
     }
 
     if (m_eState != ADJ_IDLE) {
@@ -1109,8 +1129,8 @@ void AutoDJProcessor::playerOutroStartChanged(DeckAttributes* pAttributes, doubl
 }
 
 void AutoDJProcessor::playerOutroEndChanged(DeckAttributes* pAttributes, double position) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerOutroEndChanged" << pAttributes->group << position;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerOutroEndChanged" << pAttributes->group << position;
     }
 
     if (m_eState != ADJ_IDLE) {
@@ -1368,10 +1388,10 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         }
     }
 
-    if constexpr (sDebug) {
-        qDebug() << this << "calculateTransition"
-                 << "introLength" << introLength
-                 << "outroLength" << outroLength;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "calculateTransition"
+                        << "introLength" << introLength
+                        << "outroLength" << outroLength;
     }
 
     m_crossfaderStartCenter = false;
@@ -1528,10 +1548,10 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         pFromDeck->fadeBeginPos = 1;
     }
 
-    if constexpr (sDebug) {
-        qDebug() << this << "calculateTransition" << pFromDeck->group
-                 << pFromDeck->fadeBeginPos << pFromDeck->fadeEndPos
-                 << pToDeck->startPos;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "calculateTransition" << pFromDeck->group
+                        << pFromDeck->fadeBeginPos << pFromDeck->fadeEndPos
+                        << pToDeck->startPos;
     }
 }
 
@@ -1584,9 +1604,9 @@ void AutoDJProcessor::useFixedFadeTime(
 }
 
 void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTrack) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerTrackLoaded" << pDeck->group
-                 << (pTrack ? pTrack->getLocation() : "(null)");
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerTrackLoaded" << pDeck->group
+                        << (pTrack ? pTrack->getLocation() : "(null)");
     }
 
     pDeck->loading = false;
@@ -1608,8 +1628,8 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
         DeckAttributes* fromDeck = getOtherDeck(pDeck);
         // check if this deck has suitable alignment
         if (fromDeck && getOtherDeck(fromDeck) != pDeck) {
-            if constexpr (sDebug) {
-                qDebug() << this << "playerTrackLoaded()" << pDeck->group << "but not a toDeck";
+            if (kLogger.debugEnabled()) {
+                kLogger.debug() << "playerTrackLoaded()" << pDeck->group << "but not a toDeck";
             }
             // User has changed the orientation, disable Auto DJ
             toggleAutoDJ(false);
@@ -1643,10 +1663,10 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
 
 void AutoDJProcessor::playerLoadingTrack(DeckAttributes* pDeck,
         TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerLoadingTrack" << pDeck->group
-                 << "new:" << (pNewTrack ? pNewTrack->getLocation() : "(null)")
-                 << "old:" << (pOldTrack ? pOldTrack->getLocation() : "(null)");
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerLoadingTrack" << pDeck->group
+                        << "new:" << (pNewTrack ? pNewTrack->getLocation() : "(null)")
+                        << "old:" << (pOldTrack ? pOldTrack->getLocation() : "(null)");
     }
 
     pDeck->loading = true;
@@ -1672,8 +1692,8 @@ void AutoDJProcessor::playerLoadingTrack(DeckAttributes* pDeck,
 }
 
 void AutoDJProcessor::playerEmpty(DeckAttributes* pDeck) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerEmpty()" << pDeck->group;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerEmpty()" << pDeck->group;
     }
 
     // The Deck has ejected a track and no new one is loaded.
@@ -1689,8 +1709,8 @@ void AutoDJProcessor::playerEmpty(DeckAttributes* pDeck) {
 }
 
 void AutoDJProcessor::playerRateChanged(DeckAttributes* pAttributes) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerRateChanged" << pAttributes->group;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerRateChanged" << pAttributes->group;
     }
 
     if (m_eState != ADJ_IDLE) {
@@ -1706,8 +1726,8 @@ void AutoDJProcessor::playerRateChanged(DeckAttributes* pAttributes) {
 }
 
 void AutoDJProcessor::playerOrientationChanged(DeckAttributes* pAttributes) {
-    if constexpr (sDebug) {
-        qDebug() << this << "playerOrientationChanged" << pAttributes->group;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playerOrientationChanged" << pAttributes->group;
     }
 
     if (m_eState != ADJ_DISABLED) {
@@ -1718,8 +1738,8 @@ void AutoDJProcessor::playerOrientationChanged(DeckAttributes* pAttributes) {
 }
 
 void AutoDJProcessor::playlistFirstTrackChanged() {
-    if constexpr (sDebug) {
-        qDebug() << this << "playlistFirstTrackChanged";
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "playlistFirstTrackChanged";
     }
     if (m_eState != ADJ_DISABLED) {
         DeckAttributes* pLeftDeck = getLeftDeck();
@@ -1734,8 +1754,8 @@ void AutoDJProcessor::playlistFirstTrackChanged() {
 }
 
 void AutoDJProcessor::setTransitionTime(int time) {
-    if constexpr (sDebug) {
-        qDebug() << this << "setTransitionTime" << time;
+    if (kLogger.debugEnabled()) {
+        kLogger.debug() << "setTransitionTime" << time;
     }
 
     // Update the transition time first.

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -9,7 +9,6 @@
 #include "util/math.h"
 
 namespace {
-
 const mixxx::Logger kLogger("AutoDJ");
 const QString kPreferenceGroup = QStringLiteral("[Auto DJ]");
 const QString kControlGroup = QStringLiteral("[AutoDJ]");
@@ -39,6 +38,19 @@ const char* autoDJStateName(AutoDJProcessor::AutoDJState state) {
     return "UNKNOWN";
 }
 
+// True when the from-deck has reached its fade point, or the engine has
+// stopped it at EOF before playposition caught up to 1.0 / fadeBeginPos.
+bool fromDeckReachedFadeOrEnd(
+        const DeckAttributes* pDeck, double playPosition, double durationSec) {
+    if (!pDeck->isFromDeck) {
+        return false;
+    }
+    if (playPosition >= pDeck->fadeBeginPos || playPosition >= 1.0) {
+        return true;
+    }
+    return durationSec > 0.0 &&
+            (1.0 - playPosition) * durationSec <= kMinimumTrackDurationSec;
+}
 } // anonymous namespace
 
 DeckAttributes::DeckAttributes(int index,
@@ -110,7 +122,7 @@ void DeckAttributes::slotTrackLoaded(TrackPointer pTrack) {
 }
 
 void DeckAttributes::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    // kLogger.debug() << "DeckAttributes::slotLoadingTrack";
+    // qDebug() << "DeckAttributes::slotLoadingTrack";
     emit loadingTrack(this, pNewTrack, pOldTrack);
 }
 
@@ -396,7 +408,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         bool rightDeckPlaying = pRightDeck->isPlaying();
 
         if (leftDeckPlaying && rightDeckPlaying) {
-            kLogger.debug() << "One deck must be stopped before enabling Auto DJ mode";
+            qDebug() << "One deck must be stopped before enabling Auto DJ mode";
             // Keep the current state.
             emitAutoDJStateChanged(m_eState);
             emit autoDJError(ADJ_BOTH_DECKS_PLAYING);
@@ -456,7 +468,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
 
         TrackPointer nextTrack = getNextTrackFromQueue();
         if (!nextTrack) {
-            kLogger.debug() << "Queue is empty now, disable Auto DJ";
+            qDebug() << "Queue is empty now, disable Auto DJ";
             m_enabledAutoDJ.setAndConfirm(0.0);
             emitAutoDJStateChanged(m_eState);
             emit autoDJError(ADJ_QUEUE_EMPTY);
@@ -465,7 +477,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
 
         // Track is available so GO
         m_enabledAutoDJ.setAndConfirm(1.0);
-        kLogger.debug() << "Auto DJ enabled";
+        qDebug() << "Auto DJ enabled";
 
         m_coCrossfader.connectValueChanged(this, &AutoDJProcessor::crossfaderChanged);
 
@@ -608,12 +620,16 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         emitAutoDJStateChanged(m_eState);
     } else { // Disable Auto DJ
         m_enabledAutoDJ.setAndConfirm(0.0);
-        kLogger.debug() << "Auto DJ disabled";
+        qDebug() << "Auto DJ disabled";
         m_eState = ADJ_DISABLED;
         disconnect(&m_coCrossfader,
                 &ControlProxy::valueChanged,
                 this,
                 &AutoDJProcessor::crossfaderChanged);
+        disconnect(m_pAutoDJTableModel,
+                &PlaylistTableModel::firstTrackChanged,
+                this,
+                &AutoDJProcessor::playlistFirstTrackChanged);
         for (const auto& pDeck : m_decks) {
             pDeck->disconnect(this);
         }
@@ -675,6 +691,12 @@ void AutoDJProcessor::crossfaderChanged(double value) {
         double crossfaderPosition = value * (m_coCrossfaderReverse.toBool() ? -1 : 1);
         if ((crossfaderPosition == 1.0 && pFromDeck->isLeft()) ||       // crossfader right
                 (crossfaderPosition == -1.0 && pFromDeck->isRight())) { // crossfader left
+            if (kLogger.debugEnabled()) {
+                kLogger.debug() << "crossfaderChanged force-advance"
+                                << "from" << pFromDeck->group
+                                << "to" << pToDeck->group
+                                << "xfader" << crossfaderPosition;
+            }
             if (!pToDeck->isPlaying()) {
                 if (getEndSecond(pToDeck) >= kMinimumTrackDurationSec) {
                     // Re-cue the track if the user has seeked it to the very end
@@ -700,7 +722,7 @@ void AutoDJProcessor::crossfaderChanged(double value) {
 
 void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                                             double thisPlayPosition) {
-    // kLogger.debug() << "player" << pAttributes->group << "PositionChanged(" << value << ")";
+    // qDebug() << "player" << pAttributes->group << "PositionChanged(" << value << ")";
     if (m_eState == ADJ_DISABLED) {
         // nothing to do
         return;
@@ -791,6 +813,11 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             } else {
                 setCrossfader(1.0);
             }
+            if (kLogger.debugEnabled()) {
+                kLogger.debug() << "playerPositionChanged" << thisDeck->group
+                                << "fade complete" << autoDJStateName(m_eState)
+                                << "-> IDLE";
+            }
             m_eState = ADJ_IDLE;
             // Invalidate threshold calculated for the old otherDeck
             // This avoids starting a fade back before the new track is
@@ -805,6 +832,9 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
         }
     }
 
+    const bool fromDeckAtFadeOrEnd = fromDeckReachedFadeOrEnd(
+            thisDeck, thisPlayPosition, getEndSecond(thisDeck));
+
     if (m_eState == ADJ_IDLE) {
         if (!thisDeckPlaying && thisPlayPosition < 1) {
             // this is a cueing seek, recalculate the transition, from the
@@ -815,12 +845,23 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             // thisDeckPlaying will be false but the transition should not be
             // recalculated here.
             // Don't adjust transition when reaching the end. In this case it is
-            // always stopped.
-            if (kLogger.debugEnabled()) {
-                kLogger.debug() << "playerPositionChanged"
-                                << "cueing seek";
+            // always stopped. The engine may also stop play before playposition
+            // reaches 1.0, so treat a from-deck stopped near EOF as the fade
+            // point rather than a cueing seek (which would swap from/to roles).
+            if (fromDeckAtFadeOrEnd) {
+                if (kLogger.debugEnabled()) {
+                    kLogger.debug() << "playerPositionChanged" << thisDeck->group
+                                    << "from-deck stopped at EOF, start transition"
+                                    << "pos" << thisPlayPosition
+                                    << "fadeBegin" << thisDeck->fadeBeginPos;
+                }
+            } else {
+                if (kLogger.debugEnabled()) {
+                    kLogger.debug() << "playerPositionChanged" << thisDeck->group
+                                    << "cueing seek" << thisPlayPosition;
+                }
+                calculateTransition(otherDeck, thisDeck, false);
             }
-            calculateTransition(otherDeck, thisDeck, false);
         } else if (thisDeck->isRepeat()) {
             // repeat pauses auto DJ
             return;
@@ -831,11 +872,21 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
     // - transition into fading mode, play the other deck and fade to it.
     // - check if fading is done and stop the deck
     // - update the crossfader
-    if (thisPlayPosition >= thisDeck->fadeBeginPos && thisDeck->isFromDeck && !otherDeck->loading) {
+    if (thisDeck->isFromDeck && !otherDeck->loading &&
+            (thisPlayPosition >= thisDeck->fadeBeginPos ||
+                    (!thisDeckPlaying && fromDeckAtFadeOrEnd))) {
         if (m_eState == ADJ_IDLE) {
-            if (thisDeckPlaying || thisPlayPosition >= 1.0) {
+            if (thisDeckPlaying || thisPlayPosition >= 1.0 || fromDeckAtFadeOrEnd) {
                 // Set the state as FADING.
                 m_eState = thisDeck->isLeft() ? ADJ_LEFT_FADING : ADJ_RIGHT_FADING;
+                if (kLogger.debugEnabled()) {
+                    kLogger.debug() << "playerPositionChanged" << thisDeck->group
+                                    << "start fade" << autoDJStateName(m_eState)
+                                    << "pos" << thisPlayPosition
+                                    << "fadeBegin" << thisDeck->fadeBeginPos
+                                    << "fadeEnd" << thisDeck->fadeEndPos
+                                    << "playing" << thisDeckPlaying;
+                }
                 m_transitionProgress = 0.0;
                 emitAutoDJStateChanged(m_eState);
 
@@ -863,7 +914,7 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
                 removeLoadedTrackFromTopOfQueue(*otherDeck);
             } else {
                 if (kLogger.debugEnabled()) {
-                    kLogger.debug() << "playerPositionChanged()"
+                    kLogger.debug() << "playerPositionChanged"
                                     << pAttributes->group << thisPlayPosition
                                     << "but not playing";
                 }
@@ -917,6 +968,15 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
             // if we are at 1.0 here, we need an additional callback until the last
             // step is processed and we can stop the deck.
         }
+    } else if (kLogger.debugEnabled() &&
+            (thisPlayPosition >= thisDeck->fadeBeginPos || fromDeckAtFadeOrEnd)) {
+        kLogger.debug() << "playerPositionChanged skip fade" << thisDeck->group
+                        << "pos" << thisPlayPosition
+                        << "fadeBegin" << thisDeck->fadeBeginPos
+                        << "isFromDeck" << thisDeck->isFromDeck
+                        << "otherLoading" << otherDeck->loading
+                        << "playing" << thisDeckPlaying
+                        << "state" << autoDJStateName(m_eState);
     }
 }
 
@@ -1029,7 +1089,7 @@ void AutoDJProcessor::maybeFillRandomTracks() {
 
     int tracksToAdd = minAutoDJCrateTracks - m_pAutoDJTableModel->rowCount();
     if (randomQueueEnabled && (tracksToAdd > 0)) {
-        kLogger.debug() << "Randomly adding tracks";
+        qDebug() << "Randomly adding tracks";
         emit randomTrackRequested(tracksToAdd);
     }
 }
@@ -1064,6 +1124,21 @@ void AutoDJProcessor::playerPlayChanged(DeckAttributes* thisDeck, bool playing) 
         }
     } else {
         // Deck paused
+        if (fromDeckReachedFadeOrEnd(
+                    thisDeck, thisDeck->playPosition(), getEndSecond(thisDeck))) {
+            // Engine may stop play at EOF before playposition reaches fadeBeginPos
+            // or 1.0. Start the same IDLE->FADING path used when position crosses
+            // the threshold. Pass at least fadeBeginPos so the fade gate matches.
+            if (kLogger.debugEnabled()) {
+                kLogger.debug() << "playerPlayChanged" << thisDeck->group
+                                << "from-deck stopped at fade/EOF, start transition"
+                                << "pos" << thisDeck->playPosition()
+                                << "fadeBegin" << thisDeck->fadeBeginPos;
+            }
+            playerPositionChanged(thisDeck,
+                    math_max(thisDeck->playPosition(), thisDeck->fadeBeginPos));
+            return;
+        }
         // This may happen if the user has previously pressed play on the "to deck"
         // before fading, for example to adjust the intro/outro cues, and lets the
         // deck play until the end, seek back to the start point instead of keeping

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -1896,3 +1896,163 @@ TEST_F(AutoDJProcessorTest, TrackZeroLength) {
     // Signal that the request to load pTrack succeeded.
     deck1.fakeTrackLoadedEvent(pTrack);
 }
+
+TEST_F(AutoDJProcessorTest, FadeToDeck2_ZeroTransition_PlayStopsBeforeEnd) {
+    // Reproduces the engine EOF race: play is cleared before playposition
+    // reaches fadeBeginPos (1.0 for Full Track / 0 s). Auto DJ must start the
+    // next deck instead of treating this as a cueing seek that swaps roles.
+    pProcessor->setTransitionMode(AutoDJProcessor::TransitionMode::FixedFullTrack);
+    pProcessor->setTransitionTime(0);
+
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
+    ASSERT_TRUE(testId.isValid());
+
+    mixer.crossfader.set(-1.0);
+    TrackPointer pTrack = newTestTrack();
+    pTrack->setDuration(120);
+    deck1.slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            true);
+    deck1.fakeTrackLoadedEvent(pTrack);
+
+    PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
+    pAutoDJTableModel->appendTrack(testId);
+
+    EXPECT_CALL(*pProcessor, emitAutoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
+    EXPECT_CALL(*pProcessor, emitLoadTrackToPlayer(_, QString("[Channel2]"), false));
+
+    AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
+    EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
+    EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
+
+    deck2.slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            false);
+    deck2.fakeTrackLoadedEvent(pTrack);
+
+    EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
+    EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
+
+    // Last playposition tick before EOF, still playing. Fade begins at 1.0.
+    deck1.playposition.set(0.999);
+    EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
+    EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
+
+    EXPECT_CALL(*pProcessor, emitAutoDJStateChanged(AutoDJProcessor::ADJ_LEFT_FADING));
+
+    // Engine stops play at EOF before playposition reaches 1.0.
+    deck1.play.set(0.0);
+
+    EXPECT_EQ(AutoDJProcessor::ADJ_LEFT_FADING, pProcessor->getState());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
+    EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
+    EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
+
+    // A delayed playposition callback at 0.999 must not swap from/to roles.
+    deck1.playposition.set(0.999);
+    EXPECT_EQ(AutoDJProcessor::ADJ_LEFT_FADING, pProcessor->getState());
+    EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
+    EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
+}
+
+TEST_F(AutoDJProcessorTest, FadeToDeck2_ZeroTransition_MidTrackPauseDoesNotFade) {
+    pProcessor->setTransitionMode(AutoDJProcessor::TransitionMode::FixedFullTrack);
+    pProcessor->setTransitionTime(0);
+
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
+    ASSERT_TRUE(testId.isValid());
+
+    mixer.crossfader.set(-1.0);
+    TrackPointer pTrack = newTestTrack();
+    pTrack->setDuration(120);
+    deck1.slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            true);
+    deck1.fakeTrackLoadedEvent(pTrack);
+
+    PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
+    pAutoDJTableModel->appendTrack(testId);
+
+    EXPECT_CALL(*pProcessor, emitAutoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
+    EXPECT_CALL(*pProcessor, emitLoadTrackToPlayer(_, QString("[Channel2]"), false));
+
+    AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
+    EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
+    EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
+
+    deck2.slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            false);
+    deck2.fakeTrackLoadedEvent(pTrack);
+
+    deck1.playposition.set(0.5);
+    EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
+
+    // Pausing the from-deck in the middle of the track is not EOF.
+    deck1.play.set(0.0);
+    EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
+    EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
+    EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
+}
+
+TEST_F(AutoDJProcessorTest, FadeToDeck2_ZeroTransition_DelayedPlaypositionAfterStop) {
+    // Engine may emit play=0 first, then a delayed playposition near EOF.
+    // That must start the transition, not a cueing-seek role swap.
+    pProcessor->setTransitionMode(AutoDJProcessor::TransitionMode::FixedFullTrack);
+    pProcessor->setTransitionTime(0);
+
+    TrackId testId = addTrackToCollection(kTrackLocationTest);
+    ASSERT_TRUE(testId.isValid());
+
+    mixer.crossfader.set(-1.0);
+    TrackPointer pTrack = newTestTrack();
+    pTrack->setDuration(120);
+    deck1.slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            true);
+    deck1.fakeTrackLoadedEvent(pTrack);
+
+    PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
+    pAutoDJTableModel->appendTrack(testId);
+
+    EXPECT_CALL(*pProcessor, emitAutoDJStateChanged(AutoDJProcessor::ADJ_IDLE));
+    EXPECT_CALL(*pProcessor, emitLoadTrackToPlayer(_, QString("[Channel2]"), false));
+
+    AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
+    EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
+    EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
+
+    deck2.slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            false);
+    deck2.fakeTrackLoadedEvent(pTrack);
+
+    deck1.playposition.set(0.5);
+    deck1.play.set(0.0);
+    EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
+    EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
+
+    EXPECT_CALL(*pProcessor, emitAutoDJStateChanged(AutoDJProcessor::ADJ_LEFT_FADING));
+
+    deck1.playposition.set(0.999);
+
+    EXPECT_EQ(AutoDJProcessor::ADJ_LEFT_FADING, pProcessor->getState());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
+    EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
+    EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
+}


### PR DESCRIPTION
Fixes #15260

### Root cause

At end of track the engine sets play = 0 immediately, but the playposition control only updates at 15 Hz and can still be slightly below 1.0 (e.g. 0.999). Auto DJ treated that as a cueing seek and called calculateTransition(other, this), which swapped from/to deck roles. The fade then never started, Auto DJ stayed enabled, and both decks sat stopped. This is most likely with Full Track / 0 s transitions, where the fade point is exactly the track end.

That also matches recovering by moving the crossfader: the xfader path starts the “to” deck without those gates. After the role swap, that “to” deck is the track that just ended, so it can repeat until you move the xfader again.

### Solution

If the from-deck stops at or near the fade/end, start the transition instead of treating it as a cueing seek. playerPlayChanged recovers when play drops at EOF even if playposition has not reached 1.0 yet. Mid-track pauses still do not start a fade.