### PR TITLE
feat: add Matroska/WebM (mkv/webm) file support with library duration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1630,6 +1630,7 @@ add_library(
   src/track/taglib/trackmetadata_common.cpp
   src/track/taglib/trackmetadata_file.cpp
   src/track/taglib/trackmetadata_id3v2.cpp
+  src/track/taglib/trackmetadata_matroska.cpp
   src/track/taglib/trackmetadata_mp4.cpp
   src/track/taglib/trackmetadata_riff.cpp
   src/track/taglib/trackmetadata_xiph.cpp

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -13,6 +13,7 @@
 #if (TAGLIB_MAJOR_VERSION > 2) || \
         ((TAGLIB_MAJOR_VERSION == 2) && (TAGLIB_MINOR_VERSION >= 2))
 #include <matroskafile.h>
+#include "track/taglib/trackmetadata_matroska.h"
 #endif
 #include "track/taglib/trackmetadata_common.h"
 #include "util/logger.h"
@@ -302,6 +303,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         }
         if (file.tag() && !file.tag()->isEmpty()) {
             taglib::importTrackMetadataFromTag(pTrackMetadata, *file.tag());
+            taglib::matroska::importCoverImageFromTag(pCoverImage, file);
             return afterImport(ImportResult::Succeeded);
         }
         break;

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -4,6 +4,7 @@
 #include <vorbisfile.h>
 
 #include <QFile>
+#include <QFileInfo>
 #include <memory>
 
 #include "track/taglib/trackmetadata.h"

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -108,11 +108,27 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
                         << "of type" << fileTypeToString(m_fileType);
     }
 
-    // Rationale: If a file contains different types of tags only
-    // a single type of tag will be read. Tag types are read in a
-    // fixed order. Both track metadata and cover art will be read
-    // from the same tag types. Only the first available tag type
-    // is read and data in subsequent tags is ignored.
+// Rationale: If a file contains different types of tags only
+// a single type of tag will be read. Tag types are read in a
+// fixed order. Both track metadata and cover art will be read
+// from the same tag types. Only the first available tag type
+// is read and data in subsequent tags is ignored.
+
+    // Bypass TagLib for Matroska/WebM files — TagLib does not support
+    // these container formats (returns FileType::Unknown). Duration and
+    // metadata are read from the FFmpeg-based sound source instead
+    // (see soundsource.cpp for the mime-type bypass).
+    if (m_fileType == taglib::FileType::Unknown) {
+        QString fileSuffix = QFileInfo(m_fileName).suffix().toLower();
+        if (fileSuffix == QLatin1String("mkv") || fileSuffix == QLatin1String("webm")) {
+            kLogger.debug()
+                    << "TagLib does not support" << m_fileName
+                    << "— using FFmpeg-based duration/metadata instead";
+            // Return empty metadata; duration will be read from the
+            // sound source's FFmpeg stream info.
+            return afterImport(ImportResult::Unavailable);
+        }
+    }
 
     switch (m_fileType) {
     case taglib::FileType::MPEG: {

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -13,6 +13,7 @@
 #if (TAGLIB_MAJOR_VERSION > 2) || \
         ((TAGLIB_MAJOR_VERSION == 2) && (TAGLIB_MINOR_VERSION >= 2))
 #include <matroskafile.h>
+
 #include "track/taglib/trackmetadata_matroska.h"
 #endif
 #include "track/taglib/trackmetadata_common.h"

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -115,11 +115,11 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
                         << "of type" << fileTypeToString(m_fileType);
     }
 
-// Rationale: If a file contains different types of tags only
-// a single type of tag will be read. Tag types are read in a
-// fixed order. Both track metadata and cover art will be read
-// from the same tag types. Only the first available tag type
-// is read and data in subsequent tags is ignored.
+    // Rationale: If a file contains different types of tags only
+    // a single type of tag will be read. Tag types are read in a
+    // fixed order. Both track metadata and cover art will be read
+    // from the same tag types. Only the first available tag type
+    // is read and data in subsequent tags is ignored.
 
     switch (m_fileType) {
     case taglib::FileType::MPEG: {

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -4,10 +4,16 @@
 #include <vorbisfile.h>
 
 #include <QFile>
-#include <QFileInfo>
 #include <memory>
 
 #include "track/taglib/trackmetadata.h"
+// TagLib < 2.2 has no Matroska module; the header only exists from 2.2 on.
+// The TAGLIB_* macros are defined by taglib_config.h, pulled in via the
+// taglib headers included through trackmetadata.h above.
+#if (TAGLIB_MAJOR_VERSION > 2) || \
+        ((TAGLIB_MAJOR_VERSION == 2) && (TAGLIB_MINOR_VERSION >= 2))
+#include <matroskafile.h>
+#endif
 #include "track/taglib/trackmetadata_common.h"
 #include "util/logger.h"
 #include "util/safelywritablefile.h"
@@ -114,22 +120,6 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
 // fixed order. Both track metadata and cover art will be read
 // from the same tag types. Only the first available tag type
 // is read and data in subsequent tags is ignored.
-
-    // Bypass TagLib for Matroska/WebM files — TagLib does not support
-    // these container formats (returns FileType::Unknown). Duration and
-    // metadata are read from the FFmpeg-based sound source instead
-    // (see soundsource.cpp for the mime-type bypass).
-    if (m_fileType == taglib::FileType::Unknown) {
-        QString fileSuffix = QFileInfo(m_fileName).suffix().toLower();
-        if (fileSuffix == QLatin1String("mkv") || fileSuffix == QLatin1String("webm")) {
-            kLogger.debug()
-                    << "TagLib does not support" << m_fileName
-                    << "— using FFmpeg-based duration/metadata instead";
-            // Return empty metadata; duration will be read from the
-            // sound source's FFmpeg stream info.
-            return afterImport(ImportResult::Unavailable);
-        }
-    }
 
     switch (m_fileType) {
     case taglib::FileType::MPEG: {
@@ -301,6 +291,28 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
             return afterImport(ImportResult::Succeeded);
         }
         break;
+    }
+    case taglib::FileType::Matroska: {
+#if (TAGLIB_MAJOR_VERSION > 2) || \
+        ((TAGLIB_MAJOR_VERSION == 2) && (TAGLIB_MINOR_VERSION >= 2))
+        // TagLib >= 2.2 natively supports Matroska (MKA, MKV) and WebM.
+        TagLib::Matroska::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
+        if (!taglib::readAudioPropertiesFromFile(pTrackMetadata, file)) {
+            break;
+        }
+        if (file.tag() && !file.tag()->isEmpty()) {
+            taglib::importTrackMetadataFromTag(pTrackMetadata, *file.tag());
+            return afterImport(ImportResult::Succeeded);
+        }
+        break;
+#else
+        // TagLib < 2.2 has no Matroska support; duration and metadata
+        // are read from the FFmpeg-based sound source instead.
+        kLogger.debug()
+                << "TagLib does not support" << m_fileName
+                << "— using FFmpeg-based duration/metadata instead";
+        return afterImport(ImportResult::Unavailable);
+#endif
     }
     default:
         kLogger.warning()

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -301,9 +301,19 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         if (!taglib::readAudioPropertiesFromFile(pTrackMetadata, file)) {
             break;
         }
+        // @anchor: matroska:import-metadata-cover
+        bool importSucceeded = false;
         if (file.tag() && !file.tag()->isEmpty()) {
             taglib::importTrackMetadataFromTag(pTrackMetadata, *file.tag());
-            taglib::matroska::importCoverImageFromTag(pCoverImage, file);
+            importSucceeded = true;
+        }
+        // Cover art is stored in file-level attachments and may be present
+        // even when the standard tags are empty.
+        if (pCoverImage &&
+                taglib::matroska::importCoverImageFromTag(pCoverImage, file)) {
+            importSucceeded = true;
+        }
+        if (importSucceeded) {
             return afterImport(ImportResult::Succeeded);
         }
         break;

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -53,6 +53,14 @@ QString SoundSource::getTypeFromFile(const QFileInfo& fileInfo) {
         // https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/mimetype.20sometimes.20wrong
         return fileSuffix;
     }
+    if (fileSuffix == QLatin1String("mkv") || fileSuffix == QLatin1String("webm")) {
+        // Bypass the insufficient mime type lookup from content for Matroska/WebM files.
+        // Qt's QMimeDatabase may not properly recognize these container formats,
+        // causing "no mime type registered" errors. The file suffix is used instead
+        // to determine the appropriate SoundSource provider.
+        return fileSuffix;
+    }
+
     QMimeType mimeType = QMimeDatabase().mimeTypeForFile(
             fileInfo, QMimeDatabase::MatchContent);
 #ifdef __STEM__

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -53,8 +53,8 @@ QString SoundSource::getTypeFromFile(const QFileInfo& fileInfo) {
         // https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/mimetype.20sometimes.20wrong
         return fileSuffix;
     }
-    if (fileSuffix == QLatin1String("mkv") || fileSuffix == QLatin1String("webm")) {
-        // Bypass the insufficient mime type lookup from content for Matroska/WebM files.
+    if (fileSuffix == QLatin1String("mkv") || fileSuffix == QLatin1String("mka") || fileSuffix == QLatin1String("webm")) {
+        // Bypass the insufficient mime type lookup from content for Matroska/MKA/WebM files.
         // Qt's QMimeDatabase may not properly recognize these container formats,
         // causing "no mime type registered" errors. The file suffix is used instead
         // to determine the appropriate SoundSource provider.

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -53,7 +53,9 @@ QString SoundSource::getTypeFromFile(const QFileInfo& fileInfo) {
         // https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/mimetype.20sometimes.20wrong
         return fileSuffix;
     }
-    if (fileSuffix == QLatin1String("mkv") || fileSuffix == QLatin1String("mka") || fileSuffix == QLatin1String("webm")) {
+    if (fileSuffix == QLatin1String("mkv") ||
+            fileSuffix == QLatin1String("mka") ||
+            fileSuffix == QLatin1String("webm")) {
         // Bypass the insufficient mime type lookup from content for Matroska/MKA/WebM files.
         // Qt's QMimeDatabase may not properly recognize these container formats,
         // causing "no mime type registered" errors. The file suffix is used instead

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -411,6 +411,7 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileTypes() const {
                 continue;
             } else if (!strcmp(pavInputFormat->name, "matroska,webm")) {
                 list.append("mkv");
+                list.append("mka");
                 list.append("webm");
                 continue;
 
@@ -855,6 +856,7 @@ SoundSourceFFmpeg::importTrackMetadataAndCoverImage(
     const QString fileSuffix =
             QFileInfo(getLocalFileName()).suffix().toLower();
     if (fileSuffix != QLatin1String("mkv") &&
+            fileSuffix != QLatin1String("mka") &&
             fileSuffix != QLatin1String("webm")) {
         return MetadataSourceTagLib::importTrackMetadataAndCoverImage(
                 pTrackMetadata,

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -411,7 +411,6 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileTypes() const {
                 list.append("mkv");
                 list.append("webm");
                 continue;
-            }
 
                 ///////////////////////////////////////////////////////////
                 // Codecs with failing tests

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1,5 +1,7 @@
 #include "sources/soundsourceffmpeg.h"
 
+#include <QFileInfo>
+
 extern "C" {
 
 #include <libavutil/avutil.h>
@@ -812,6 +814,126 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
 #endif
 
     return OpenResult::Succeeded;
+}
+
+// @anchor: ffmpeg:import-metadata-override
+// TagLib does not support Matroska/WebM containers and its default
+// implementation in MetadataSourceTagLib returns Unavailable for these
+// file types. This override provides the stream info (especially the
+// duration) from the FFmpeg container, so the Mixxx library does not
+// show an empty duration column for such files.
+std::pair<MetadataSource::ImportResult, QDateTime>
+SoundSourceFFmpeg::importTrackMetadataAndCoverImage(
+        TrackMetadata* pTrackMetadata,
+        QImage* pCoverArt,
+        bool resetMissingTagMetadata) const {
+    // Delegate all file types supported by TagLib to the default
+    // implementation, which also imports tags like title and artist.
+    const QString fileSuffix =
+            QFileInfo(getLocalFileName()).suffix().toLower();
+    if (fileSuffix != QLatin1String("mkv") &&
+            fileSuffix != QLatin1String("webm")) {
+        return MetadataSourceTagLib::importTrackMetadataAndCoverImage(
+                pTrackMetadata,
+                pCoverArt,
+                resetMissingTagMetadata);
+    }
+
+    const auto sourceSynchronizedAt = getFileSynchronizedAt(
+            QFile(getLocalFileName()));
+    if (pTrackMetadata == nullptr) {
+        // Cover art cannot be imported from Matroska/WebM files.
+        return std::make_pair(ImportResult::Unavailable, sourceSynchronizedAt);
+    }
+
+    // Open the container for metadata inspection. No decoder is required.
+    AVFormatContext* pavInputFormatContext =
+            openInputFile(getLocalFileName());
+    if (pavInputFormatContext == nullptr) {
+        return std::make_pair(ImportResult::Failed, sourceSynchronizedAt);
+    }
+    const int findStreamInfoResult =
+            avformat_find_stream_info(pavInputFormatContext, nullptr);
+    if (findStreamInfoResult != 0) {
+        kLogger.warning()
+                << "Failed to read stream info for metadata import"
+                << getLocalFileName();
+        avformat_close_input(&pavInputFormatContext);
+        return std::make_pair(ImportResult::Failed, sourceSynchronizedAt);
+    }
+
+    // Select the same audio stream as tryOpen() without opening a decoder.
+    const int streamIndex = av_find_best_stream(
+            pavInputFormatContext,
+            AVMEDIA_TYPE_AUDIO,
+            m_wantedStreamIndex,
+            /*related_stream=*/ -1,
+            /*decoder_ret=*/ nullptr,
+            /*flags=*/ 0);
+    if (streamIndex < 0) {
+        kLogger.warning()
+                << "Failed to find audio stream for metadata import"
+                << getLocalFileName();
+        avformat_close_input(&pavInputFormatContext);
+        return std::make_pair(ImportResult::Failed, sourceSynchronizedAt);
+    }
+    AVStream* pavStream = pavInputFormatContext->streams[streamIndex];
+    VERIFY_OR_DEBUG_ASSERT(pavStream != nullptr) {
+        avformat_close_input(&pavInputFormatContext);
+        return std::make_pair(ImportResult::Failed, sourceSynchronizedAt);
+    }
+
+    // Mirror the duration fallback of tryOpen(): the stream duration of
+    // Matroska/WebM files is often unknown, in which case the format
+    // context duration is rescaled from AV_TIME_BASE to the stream time base.
+    if (pavStream->duration == AV_NOPTS_VALUE) {
+        if (pavInputFormatContext->duration == AV_NOPTS_VALUE) {
+            kLogger.warning()
+                    << "Unknown or unlimited stream duration"
+                    << getLocalFileName();
+            avformat_close_input(&pavInputFormatContext);
+            return std::make_pair(ImportResult::Failed, sourceSynchronizedAt);
+        }
+        pavStream->duration = av_rescale_q(
+                pavInputFormatContext->duration,
+                AV_TIME_BASE_Q,
+                pavStream->time_base);
+    }
+
+    const auto streamFrameIndexRange =
+            getStreamFrameIndexRange(*pavStream);
+    VERIFY_OR_DEBUG_ASSERT(
+            streamFrameIndexRange.start() <= streamFrameIndexRange.end()) {
+        kLogger.warning()
+                << "Stream with unsupported or invalid frame index range"
+                << streamFrameIndexRange;
+        avformat_close_input(&pavInputFormatContext);
+        return std::make_pair(ImportResult::Failed, sourceSynchronizedAt);
+    }
+
+    // Report the same stream properties as initResampling() to avoid a
+    // mismatch between the imported and the decoded stream info.
+    const auto channelCount = audio::ChannelCount(
+#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100) // FFmpeg 5.1
+            pavStream->codecpar->ch_layout.nb_channels
+#else
+            pavStream->codecpar->channels
+#endif
+    );
+    const auto sampleRate =
+            audio::SampleRate(pavStream->codecpar->sample_rate);
+    if (channelCount.isValid() && sampleRate.isValid()) {
+        pTrackMetadata->setStreamInfo(audio::StreamInfo{
+                audio::SignalInfo{channelCount, sampleRate},
+                audio::Bitrate(pavStream->codecpar->bit_rate / 1000), // kbit/s
+                Duration::fromSeconds(
+                        static_cast<double>(streamFrameIndexRange.length()) /
+                        sampleRate),
+        });
+    }
+
+    avformat_close_input(&pavInputFormatContext);
+    return std::make_pair(ImportResult::Succeeded, sourceSynchronizedAt);
 }
 
 bool SoundSourceFFmpeg::initResampling(

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -517,6 +517,22 @@ SoundSourceFFmpeg::~SoundSourceFFmpeg() {
 #endif
 }
 
+// Returns true if the audio codec is covered by patents that have not
+// expired yet. Mixxx intentionally refuses to decode such codecs, which
+// mainly occur in MKV files.
+bool isPatentEncumberedAudioCodec(enum AVCodecID codec_id) {
+    switch (codec_id) {
+    case AV_CODEC_ID_AC3:
+    case AV_CODEC_ID_EAC3:
+    case AV_CODEC_ID_TRUEHD:
+    case AV_CODEC_ID_MLP:
+    case AV_CODEC_ID_DTS:
+        return true;
+    default:
+        return false;
+    }
+}
+
 SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
         OpenMode /*mode*/,
         const OpenParams& params) {
@@ -607,6 +623,13 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
         return SoundSource::OpenResult::Aborted;
     }
     DEBUG_ASSERT(pDecoder);
+
+    if (isPatentEncumberedAudioCodec(pDecoder->id)) {
+        kLogger.warning().noquote()
+                << "Refusing to decode patent-encumbered audio codec:"
+                << pDecoder->long_name << pDecoder->name;
+        return SoundSource::OpenResult::Aborted;
+    }
 
     if (pDecoder->id == AV_CODEC_ID_AAC ||
             pDecoder->id == AV_CODEC_ID_AAC_LATM) {

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -518,22 +518,6 @@ SoundSourceFFmpeg::~SoundSourceFFmpeg() {
 #endif
 }
 
-// Returns true if the audio codec is covered by patents that have not
-// expired yet. Mixxx intentionally refuses to decode such codecs, which
-// mainly occur in MKV files.
-bool isPatentEncumberedAudioCodec(enum AVCodecID codec_id) {
-    switch (codec_id) {
-    case AV_CODEC_ID_AC3:
-    case AV_CODEC_ID_EAC3:
-    case AV_CODEC_ID_TRUEHD:
-    case AV_CODEC_ID_MLP:
-    case AV_CODEC_ID_DTS:
-        return true;
-    default:
-        return false;
-    }
-}
-
 SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
         OpenMode /*mode*/,
         const OpenParams& params) {
@@ -624,13 +608,6 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
         return SoundSource::OpenResult::Aborted;
     }
     DEBUG_ASSERT(pDecoder);
-
-    if (isPatentEncumberedAudioCodec(pDecoder->id)) {
-        kLogger.warning().noquote()
-                << "Refusing to decode patent-encumbered audio codec:"
-                << pDecoder->long_name << pDecoder->name;
-        return SoundSource::OpenResult::Aborted;
-    }
 
     if (pDecoder->id == AV_CODEC_ID_AAC ||
             pDecoder->id == AV_CODEC_ID_AAC_LATM) {

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -841,11 +841,12 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
 }
 
 // @anchor: ffmpeg:import-metadata-override
-// TagLib does not support Matroska/WebM containers and its default
+// TagLib < 2.2 does not support Matroska/WebM containers and its default
 // implementation in MetadataSourceTagLib returns Unavailable for these
 // file types. This override provides the stream info (especially the
 // duration) from the FFmpeg container, so the Mixxx library does not
-// show an empty duration column for such files.
+// show an empty duration column for such files. TagLib >= 2.2 supports
+// Matroska/WebM natively, including the duration and the cover art.
 std::pair<MetadataSource::ImportResult, QDateTime>
 SoundSourceFFmpeg::importTrackMetadataAndCoverImage(
         TrackMetadata* pTrackMetadata,
@@ -853,6 +854,16 @@ SoundSourceFFmpeg::importTrackMetadataAndCoverImage(
         bool resetMissingTagMetadata) const {
     // Delegate all file types supported by TagLib to the default
     // implementation, which also imports tags like title and artist.
+    // TagLib >= 2.2 handles Matroska/WebM (duration, cover art) natively.
+#if (TAGLIB_MAJOR_VERSION > 2) || \
+        ((TAGLIB_MAJOR_VERSION == 2) && (TAGLIB_MINOR_VERSION >= 2))
+    return MetadataSourceTagLib::importTrackMetadataAndCoverImage(
+            pTrackMetadata,
+            pCoverArt,
+            resetMissingTagMetadata);
+#else
+    // TagLib < 2.2 fallback: import the stream info for Matroska/WebM
+    // from the FFmpeg container.
     const QString fileSuffix =
             QFileInfo(getLocalFileName()).suffix().toLower();
     if (fileSuffix != QLatin1String("mkv") &&
@@ -959,6 +970,7 @@ SoundSourceFFmpeg::importTrackMetadataAndCoverImage(
 
     avformat_close_input(&pavInputFormatContext);
     return std::make_pair(ImportResult::Succeeded, sourceSynchronizedAt);
+#endif
 }
 
 bool SoundSourceFFmpeg::initResampling(

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -749,7 +749,16 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
 
     if (m_pavStream->duration == AV_NOPTS_VALUE) {
         if (m_pavInputFormatContext->duration != AV_NOPTS_VALUE) {
-            m_pavStream->duration = m_pavInputFormatContext->duration;
+            // AVFormatContext::duration is measured in AV_TIME_BASE units
+            // (1/1e6 s), whereas AVStream::duration is measured in
+            // stream->time_base units. Rescale accordingly, otherwise the
+            // frame index range is inflated (e.g. ~1000x for webm/mkv
+            // streams with a 1/1000 s time base) which breaks seeking and
+            // the waveform/spectrogram.
+            m_pavStream->duration = av_rescale_q(
+                    m_pavInputFormatContext->duration,
+                    AV_TIME_BASE_Q,
+                    m_pavStream->time_base);
             kLogger.debug()
                     << "using format context duration instead of stream duration";
         } else {

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -407,6 +407,12 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileTypes() const {
             } else if (!strcmp(pavInputFormat->name, "wv")) {
                 list.append("wv");
                 continue;
+            } else if (!strcmp(pavInputFormat->name, "matroska,webm")) {
+                list.append("mkv");
+                list.append("webm");
+                continue;
+            }
+
                 ///////////////////////////////////////////////////////////
                 // Codecs with failing tests
                 ///////////////////////////////////////////////////////////

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -867,9 +867,9 @@ SoundSourceFFmpeg::importTrackMetadataAndCoverImage(
             pavInputFormatContext,
             AVMEDIA_TYPE_AUDIO,
             m_wantedStreamIndex,
-            /*related_stream=*/ -1,
-            /*decoder_ret=*/ nullptr,
-            /*flags=*/ 0);
+            /*related_stream=*/-1,
+            /*decoder_ret=*/nullptr,
+            /*flags=*/0);
     if (streamIndex < 0) {
         kLogger.warning()
                 << "Failed to find audio stream for metadata import"

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -748,11 +748,17 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
     }
 
     if (m_pavStream->duration == AV_NOPTS_VALUE) {
-        // Streams with unknown or unlimited duration are
-        // not (yet) supported.
-        kLogger.warning()
-                << "Unknown or unlimited stream duration";
-        return OpenResult::Failed;
+        if (m_pavInputFormatContext->duration != AV_NOPTS_VALUE) {
+            m_pavStream->duration = m_pavInputFormatContext->duration;
+            kLogger.debug()
+                    << "using format context duration instead of stream duration";
+        } else {
+            // Streams with unknown or unlimited duration are
+            // not (yet) supported.
+            kLogger.warning()
+                    << "Unknown or unlimited stream duration";
+            return OpenResult::Failed;
+        }
     }
     const auto streamFrameIndexRange =
             getStreamFrameIndexRange(*m_pavStream);

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -23,9 +23,10 @@ class SoundSourceFFmpeg : public SoundSource {
     ~SoundSourceFFmpeg() override;
 
     // Overrides the TagLib-based default implementation, because TagLib
-    // does not support Matroska/WebM containers. For these file types the
-    // stream info (especially the duration) is imported from the FFmpeg
-    // container, otherwise the library would show an empty duration.
+    // < 2.2 does not support Matroska/WebM containers. For these file
+    // types the stream info (especially the duration) is imported from
+    // the FFmpeg container, otherwise the library would show an empty
+    // duration. TagLib >= 2.2 handles Matroska/WebM natively.
     std::pair<ImportResult, QDateTime> importTrackMetadataAndCoverImage(
             TrackMetadata* pTrackMetadata,
             QImage* pCoverArt,

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -22,6 +22,15 @@ class SoundSourceFFmpeg : public SoundSource {
 
     ~SoundSourceFFmpeg() override;
 
+    // Overrides the TagLib-based default implementation, because TagLib
+    // does not support Matroska/WebM containers. For these file types the
+    // stream info (especially the duration) is imported from the FFmpeg
+    // container, otherwise the library would show an empty duration.
+    std::pair<ImportResult, QDateTime> importTrackMetadataAndCoverImage(
+            TrackMetadata* pTrackMetadata,
+            QImage* pCoverArt,
+            bool resetMissingTagMetadata) const override;
+
     void close() override;
 
     static QString formatErrorString(int errnum);

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -106,7 +106,9 @@ FileType stringToEnumFileType(
             TypePair{"xm"_L1, FileType::XM},
             TypePair{"dsf"_L1, FileType::DSF},
             TypePair{"dff"_L1, FileType::DSDIFF},
-            TypePair{"dsdiff"_L1, FileType::DSDIFF}};
+            TypePair{"dsdiff"_L1, FileType::DSDIFF},
+            TypePair{"mkv"_L1, FileType::Matroska},
+            TypePair{"webm"_L1, FileType::Matroska}};
 
     // NOLINTNEXTLINE(readability-qualified-auto)
     const auto it = std::find_if(

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -108,6 +108,7 @@ FileType stringToEnumFileType(
             TypePair{"dff"_L1, FileType::DSDIFF},
             TypePair{"dsdiff"_L1, FileType::DSDIFF},
             TypePair{"mkv"_L1, FileType::Matroska},
+            TypePair{"mka"_L1, FileType::Matroska},
             TypePair{"webm"_L1, FileType::Matroska}};
 
     // NOLINTNEXTLINE(readability-qualified-auto)

--- a/src/track/taglib/trackmetadata_file.h
+++ b/src/track/taglib/trackmetadata_file.h
@@ -39,7 +39,8 @@ enum class FileType {
     XM,
     Opus,
     DSF,
-    DSDIFF
+    DSDIFF,
+    Matroska
 };
 Q_ENUM_NS(FileType);
 

--- a/src/track/taglib/trackmetadata_matroska.cpp
+++ b/src/track/taglib/trackmetadata_matroska.cpp
@@ -58,7 +58,7 @@ bool importCoverImageFromTag(
         if (image.isNull()) {
             kLogger.warning()
                     << "Failed to load image from Matroska cover art attachment of type"
-                    << mimeType;
+                    << mimeType.toCString();
             continue;
         }
         *pCoverArt = image;

--- a/src/track/taglib/trackmetadata_matroska.cpp
+++ b/src/track/taglib/trackmetadata_matroska.cpp
@@ -1,0 +1,79 @@
+#if defined(_MSC_VER)
+#pragma warning(push)
+// https://github.com/taglib/taglib/issues/1185
+// warning C4251: 'TagLib::FileName::m_wname': class
+// 'std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>'
+// needs to have dll-interface to be used by clients of class 'TagLib::FileName'
+#pragma warning(disable : 4251)
+#endif
+
+#include "track/taglib/trackmetadata_matroska.h"
+
+#if (TAGLIB_MAJOR_VERSION > 2) || \
+        ((TAGLIB_MAJOR_VERSION == 2) && (TAGLIB_MINOR_VERSION >= 2))
+#include "track/taglib/trackmetadata_common.h"
+#include "util/logger.h"
+
+namespace mixxx {
+
+namespace {
+
+Logger kLogger("TagLib");
+
+} // anonymous namespace
+
+namespace taglib {
+
+namespace matroska {
+
+bool importCoverImageFromTag(
+        QImage* pCoverArt,
+        const TagLib::Matroska::File& file) {
+    if (!pCoverArt) {
+        return false; // nothing to do
+    }
+
+    const auto pictures = file.complexProperties("PICTURE");
+    if (pictures.isEmpty()) {
+        if (kLogger.debugEnabled()) {
+            kLogger.debug()
+                    << "No cover art: None or empty list of Matroska attachments";
+        }
+        return false; // abort
+    }
+
+    for (const auto& picture : pictures) {
+        const auto data = picture.value("data").toByteVector();
+        const auto mimeType = picture.value("mimeType").toString();
+        if (data.isEmpty()) {
+            if (kLogger.debugEnabled()) {
+                kLogger.debug()
+                        << "Skipping empty Matroska cover art attachment";
+            }
+            continue;
+        }
+        const QImage image(loadImageFromByteVector(
+                data,
+                mimeType.toCString()));
+        if (image.isNull()) {
+            kLogger.warning()
+                    << "Failed to load image from Matroska cover art attachment of type"
+                    << mimeType;
+            continue;
+        }
+        *pCoverArt = image;
+        return true; // success
+    }
+
+    kLogger.warning()
+            << "Failed to load cover art image from Matroska attachments";
+    return false;
+}
+
+} // namespace matroska
+
+} // namespace taglib
+
+} // namespace mixxx
+
+#endif // TagLib >= 2.2

--- a/src/track/taglib/trackmetadata_matroska.h
+++ b/src/track/taglib/trackmetadata_matroska.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// TagLib < 2.2 has no Matroska module; the header only exists from 2.2 on.
+// The TAGLIB_* macros are defined by taglib_config.h, pulled in via the
+// taglib headers included through trackmetadata.h before this file.
+#if (TAGLIB_MAJOR_VERSION > 2) || \
+        ((TAGLIB_MAJOR_VERSION == 2) && (TAGLIB_MINOR_VERSION >= 2))
+#include <matroskafile.h>
+
+#include "track/taglib/trackmetadata_file.h"
+
+namespace mixxx {
+
+namespace taglib {
+
+namespace matroska {
+
+bool importCoverImageFromTag(
+        QImage* pCoverArt,
+        const TagLib::Matroska::File& file);
+
+} // namespace matroska
+
+} // namespace taglib
+
+} // namespace mixxx
+#endif

--- a/src/track/taglib/trackmetadata_matroska.h
+++ b/src/track/taglib/trackmetadata_matroska.h
@@ -1,8 +1,9 @@
 #pragma once
 
 // TagLib < 2.2 has no Matroska module; the header only exists from 2.2 on.
-// The TAGLIB_* macros are defined by taglib_config.h, pulled in via the
-// taglib headers included through trackmetadata.h before this file.
+// taglib.h defines the TAGLIB_* version macros; include it first so the
+// guard below works even when this header is the first TagLib include.
+#include <taglib.h>
 #if (TAGLIB_MAJOR_VERSION > 2) || \
         ((TAGLIB_MAJOR_VERSION == 2) && (TAGLIB_MINOR_VERSION >= 2))
 #include <matroskafile.h>


### PR DESCRIPTION
## feat: add Matroska/WebM (mkv/webm) file support with library duration

Text is partly AI written as I am no native english language speaker, however manually checked against errors. 
Code patches are checked on a ubuntu 20.04 container, build with CI, then tested on a 20.04 system.
All features tested manually, code reviewed by hand. 

- MKV/WEBM extensions are loaded in the file browser
- playing of those formats works
- no seek errors
- spectroscope waveform buildup works
- seeking in files works
- scratching works.
- duration timing is correct in the file browser

tested with ffmpeg 4.2.7, custom compiled QT6 (so it works on 20.04)

### Motivation

The FFmpeg sound source provider already advertises `.mkv` and `.webm`, and
such files can be opened and played. However, the library showed an **empty
Duration column** for these files.

Root cause:

- `SoundSourceFFmpeg` had no metadata override, so no stream info was imported
  from the container.
- `MetadataSourceTagLib` returned `ImportResult::Unavailable` for mkv/webm
  (TagLib cannot read these containers), which made `updateTrackFromSource()`
  skip the import entirely.

### Changes

1. `feat: advertise MKV/WebM as supported file types` — register the `mkv` /
   `webm` suffixes in `SoundSourceProviderFFmpeg::getSupportedFileTypes()`.
2. `fix: drop stray brace from MKV/WebM file type block` — cleanup of the
   previous commit.
3. `fix: bypass content mime lookup for MKV/WebM` — resolve the sound source
   type by file suffix in `SoundSource::getTypeFromFile()`, because Qt's
   `QMimeDatabase` may not recognize Matroska/WebM from content.
4. `Add mkv/webm bypass in MetadataSourceTagLib` — return
   `ImportResult::Unavailable` for mkv/webm so the FFmpeg path is used,
   avoiding a TagLib "unsupported type" warning.
5. `Add QFileInfo include for TagLib mkv/webm bypass` — needed include for the
   suffix check.
6. `fix: fall back to format context duration for MKV/WebM` — in `tryOpen()`,
   use the format context duration when the stream duration is
   `AV_NOPTS_VALUE` instead of failing to open.
7. `fix: rescale format context duration to stream time base` — rescale the
   container duration to the stream time base before use.
8. `feat: import Matroska/WebM stream info from FFmpeg container` — new
   `importTrackMetadataAndCoverImage()` override in `SoundSourceFFmpeg` that
   opens the container, picks the audio stream with `av_find_best_stream`, and
   imports duration, channels, sample rate and bitrate from `AVCodecParameters`.
   All other file types are delegated to `MetadataSourceTagLib`.

