### PR TITLE
Fix logical condition in VERIFY_OR_DEBUG_ASSERT of getStandardEffectChain

### DIFF
--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -129,7 +129,7 @@ EffectChainPointer EffectsManager::getOutputEffectChain() const {
 }
 
 EffectChainPointer EffectsManager::getStandardEffectChain(int unitNumber) const {
-    VERIFY_OR_DEBUG_ASSERT(0 <= unitNumber || unitNumber < m_standardEffectChains.size()) {
+    VERIFY_OR_DEBUG_ASSERT(0 <= unitNumber && unitNumber < m_standardEffectChains.size()) {
         return EffectChainPointer();
     }
     return m_standardEffectChains.at(unitNumber);


### PR DESCRIPTION
This assert never occurred for me, but the condition looks wrong.