### PR TITLE
Revert runner ubuntu-slim to ubuntu-latest for pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   pre-commit:
     name: Detecting code style issues
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v7


### PR DESCRIPTION
As we have many canceled pre-commit runs due to timeouts and ubuntu-slim has lower timeouts than ubuntu-latest.