### PR TITLE
Rekordbox: detect databases in hidden .PIONEER directory

### DIFF
--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -4,10 +4,12 @@
 #include <rekordbox_anlz.h>
 #include <rekordbox_pdb.h>
 
+#include <QDir>
 #include <QMap>
 #include <QMessageBox>
 #include <QSettings>
 #include <QString>
+#include <QStringList>
 #include <QTextCodec>
 #include <QtDebug>
 
@@ -41,8 +43,22 @@ const QString kRekordboxLibraryTable = QStringLiteral("rekordbox_library");
 const QString kRekordboxPlaylistsTable = QStringLiteral("rekordbox_playlists");
 const QString kRekordboxPlaylistTracksTable = QStringLiteral("rekordbox_playlist_tracks");
 
-const QString kPdbPath = QStringLiteral("PIONEER/rekordbox/export.pdb");
+const QStringList kPdbPaths = {
+        QStringLiteral("PIONEER/rekordbox/export.pdb"),
+        QStringLiteral(".PIONEER/rekordbox/export.pdb"),
+};
 const QString kPLaylistPathDelimiter = QStringLiteral("-->");
+
+QString findRekordboxPdbPath(const QString& devicePath) {
+    const QDir deviceDir(devicePath);
+    for (const auto& pdbPath : kPdbPaths) {
+        const QFileInfo pdbFileInfo(deviceDir.filePath(pdbPath));
+        if (pdbFileInfo.exists() && pdbFileInfo.isFile()) {
+            return pdbFileInfo.filePath();
+        }
+    }
+    return {};
+}
 
 enum class IDForColor : uint8_t {
     Pink = 1,
@@ -185,9 +201,7 @@ QList<TreeItem*> findRekordboxDevices() {
         // drive.filePath() doesn't make any access to the filesystem and consequently
         // shorten the delay
 
-        QFileInfo rbDBFileInfo(drive.filePath() + kPdbPath);
-
-        if (rbDBFileInfo.exists() && rbDBFileInfo.isFile()) {
+        if (!findRekordboxPdbPath(drive.filePath()).isEmpty()) {
             QString displayPath = drive.filePath();
             if (displayPath.endsWith("/")) {
                 displayPath.chop(1);
@@ -220,9 +234,7 @@ QList<TreeItem*> findRekordboxDevices() {
             QDir::AllDirs | QDir::NoDotAndDotDot);
 
     foreach (QFileInfo device, devices) {
-        QFileInfo rbDBFileInfo(device.filePath() + QStringLiteral("/") + kPdbPath);
-
-        if (rbDBFileInfo.exists() && rbDBFileInfo.isFile()) {
+        if (!findRekordboxPdbPath(device.filePath()).isEmpty()) {
             auto* pFoundDevice = new TreeItem(
                     device.fileName(),
                     QVariant(QList<QString>{device.filePath(), IS_RECORDBOX_DEVICE}));
@@ -233,9 +245,7 @@ QList<TreeItem*> findRekordboxDevices() {
     QFileInfoList devices = QDir(QStringLiteral("/Volumes")).entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot);
 
     foreach (QFileInfo device, devices) {
-        QFileInfo rbDBFileInfo(device.filePath() + QStringLiteral("/") + kPdbPath);
-
-        if (rbDBFileInfo.exists() && rbDBFileInfo.isFile()) {
+        if (!findRekordboxPdbPath(device.filePath()).isEmpty()) {
             QList<QString> data;
             data << device.filePath();
             data << IS_RECORDBOX_DEVICE;
@@ -445,9 +455,9 @@ QString parseDeviceDB(mixxx::DbConnectionPoolPtr dbConnectionPool, TreeItem* dev
 
     qDebug() << "parseDeviceDB device: " << device << " devicePath: " << devicePath;
 
-    QString dbPath = devicePath + QStringLiteral("/") + kPdbPath;
+    const QString dbPath = findRekordboxPdbPath(devicePath);
 
-    if (!QFile(dbPath).exists()) {
+    if (dbPath.isEmpty()) {
         return devicePath;
     }
 

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -43,9 +43,11 @@ const QString kRekordboxLibraryTable = QStringLiteral("rekordbox_library");
 const QString kRekordboxPlaylistsTable = QStringLiteral("rekordbox_playlists");
 const QString kRekordboxPlaylistTracksTable = QStringLiteral("rekordbox_playlist_tracks");
 
+// depending on the filesystem of the external media, rekordbox seems
+// to store its metadata in different paths:
 const QStringList kPdbPaths = {
-        QStringLiteral("PIONEER/rekordbox/export.pdb"),
-        QStringLiteral(".PIONEER/rekordbox/export.pdb"),
+        QStringLiteral("PIONEER/rekordbox/export.pdb"), // FAT32/exFat
+        QStringLiteral(".PIONEER/rekordbox/export.pdb"), // HFS+ media
 };
 const QString kPLaylistPathDelimiter = QStringLiteral("-->");
 

--- a/src/library/rekordbox/rekordboxfeature.cpp
+++ b/src/library/rekordbox/rekordboxfeature.cpp
@@ -46,7 +46,7 @@ const QString kRekordboxPlaylistTracksTable = QStringLiteral("rekordbox_playlist
 // depending on the filesystem of the external media, rekordbox seems
 // to store its metadata in different paths:
 const QStringList kPdbPaths = {
-        QStringLiteral("PIONEER/rekordbox/export.pdb"), // FAT32/exFat
+        QStringLiteral("PIONEER/rekordbox/export.pdb"),  // FAT32/exFat
         QStringLiteral(".PIONEER/rekordbox/export.pdb"), // HFS+ media
 };
 const QString kPLaylistPathDelimiter = QStringLiteral("-->");


### PR DESCRIPTION
Fixes #16894

## Summary

Rekordbox uses different export directory names depending on the filesystem:

- FAT32 and exFAT: `PIONEER/rekordbox/export.pdb`
- HFS+: `.PIONEER/rekordbox/export.pdb`

Mixxx currently checks only the non-hidden `PIONEER` path. This change probes both paths while preserving the existing path as the first choice.

The resolved path is used for both device detection and database parsing.

## Testing

- Verified the export directory layouts on physical FAT32 and HFS+ USB drives.
- Built and installed the equivalent change on a Raspberry Pi OS-based DJ system.
- Confirmed that the Rekordbox library on the HFS+ USB drive is detected and loaded.
