### PR TITLE
Fix use after free issue in EngineBuffer.

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -308,10 +308,10 @@ EngineBuffer::~EngineBuffer() {
     df.close();
 #endif
 
-    qDeleteAll(m_engineControls.rbegin(), m_engineControls.rend());
-
     delete m_pReadAheadManager;
     delete m_pReader;
+
+    qDeleteAll(m_engineControls.rbegin(), m_engineControls.rend());
 
     delete m_playButton;
     delete m_playStartButton;


### PR DESCRIPTION
This issue happens in the 2.6 branch because of two concurrent PRs in 2.5 (#16693) and 2.6. (#14922)

The issue is tracked in #10516