### PR TITLE
Guard legacy script callbacks against reentrant triggers

### DIFF
--- a/src/controllers/scripting/legacy/scriptconnection.cpp
+++ b/src/controllers/scripting/legacy/scriptconnection.cpp
@@ -1,9 +1,16 @@
 #include "controllers/scripting/legacy/scriptconnection.h"
 
+#include <QScopedValueRollback>
+
 #include "controllers/scripting/legacy/controllerscriptenginelegacy.h"
 #include "util/trace.h"
 
 void ScriptConnection::executeCallback(double value) const {
+    if (m_pCallbackState->isExecuting) {
+        return;
+    }
+    QScopedValueRollback<bool> callbackExecuting(m_pCallbackState->isExecuting, true);
+
     Trace executeCallbackTrace("JS %1 callback", key.item);
     const auto args = QJSValueList{
             value,

--- a/src/controllers/scripting/legacy/scriptconnection.h
+++ b/src/controllers/scripting/legacy/scriptconnection.h
@@ -2,6 +2,7 @@
 
 #include <QJSValue>
 #include <QUuid>
+#include <memory>
 
 #include "preferences/configobject.h"
 
@@ -29,4 +30,10 @@ class ScriptConnection {
     inline bool operator!=(const ScriptConnection& other) const {
         return !(*this == other);
     }
+
+  private:
+    struct CallbackState {
+        bool isExecuting = false;
+    };
+    std::shared_ptr<CallbackState> m_pCallbackState = std::make_shared<CallbackState>();
 };

--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -759,6 +759,23 @@ TEST_F(ControllerScriptEngineLegacyTest, connectionObject_trigger) {
     EXPECT_DOUBLE_EQ(1.0, counter->get());
 }
 
+TEST_F(ControllerScriptEngineLegacyTest, connectionObject_ignoreReentrantTrigger) {
+    auto co = std::make_unique<ControlObject>(ConfigKey("[Test]", "co"));
+    auto counter = std::make_unique<ControlObject>(ConfigKey("[Test]", "counter"));
+
+    EXPECT_TRUE(evaluateAndAssert(
+            "var callback = function () {"
+            "  let counter = engine.getValue('[Test]', 'counter');"
+            "  engine.setValue('[Test]', 'counter', counter + 1);"
+            "  connection.trigger();"
+            "};"
+            "var connection = engine.makeConnection('[Test]', 'co', callback);"
+            "connection.trigger();"
+            "connection.trigger();"));
+
+    EXPECT_DOUBLE_EQ(2.0, counter->get());
+}
+
 TEST_F(ControllerScriptEngineLegacyTest, connectionExecutesWithCorrectThisObject) {
     // Test that callback functions are executed with JavaScript's
     // 'this' keyword referring to the object in which the connection


### PR DESCRIPTION
## Summary

- Ignore a legacy ScriptConnection trigger call while that connection callback is already running.
- Share callback execution state across ScriptConnection copies used by control-object dispatch.
- Add a regression test proving a nested trigger is ignored while a later independent trigger still runs.

## Root cause

Legacy callbacks were invoked without a reentrancy guard. A callback that triggered its own connection recursively re-entered the same callback until the process exhausted the stack.

The guard uses QScopedValueRollback, so execution state is restored when the callback returns, including when JavaScript reports an exception.

## Validation

- CMake build of the mixxx-test target passed in the local Windows developer environment.
- The focused test was started with the Qt offscreen platform, but this local headless Mixxx fixture did not complete before the process had to be stopped. The default Debug runner also breaks on an existing setup assertion before producing a GoogleTest result. No focused runtime pass is claimed here.

Fixes #16899
Related to #11525