### PR TITLE
Update CHANGELOG for 2.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   [#16507](https://github.com/mixxxdj/mixxx/pull/16507)
   [#16619](https://github.com/mixxxdj/mixxx/pull/16619)
   [#16614](https://github.com/mixxxdj/mixxx/issues/16614)
+* Retire Ubuntu Questing 25.10 [#16780](https://github.com/mixxxdj/mixxx/pull/16780)
 * Support Windows 11 25H2
   [#16401](https://github.com/mixxxdj/mixxx/pull/16401)
 * Add Arch Linux build environment script [#16594](https://github.com/mixxxdj/mixxx/pull/16594)
@@ -41,6 +42,9 @@
   [#16368](https://github.com/mixxxdj/mixxx/pull/16368)
 * Flatpak: fix building with Soundtouch, update to 2.4.1
   [#16720](https://github.com/mixxxdj/mixxx/pull/16720)
+* Flatpack: prevent branches to delete each other
+  [#16779](https://github.com/mixxxdj/mixxx/pull/16779)
+  [#16810](https://github.com/mixxxdj/mixxx/pull/16810)
 
 ### Miscellaneous
 
@@ -59,14 +63,28 @@
 * FFmpeg: fix of gap bug fix
   [#16439](https://github.com/mixxxdj/mixxx/pull/16439)
   [#10464](https://github.com/mixxxdj/mixxx/issues/10464)
-* Fix flaky test, due to not waiting for a fully loaded EngineBufferE2ETest
+* Fix flaky unittests test
   [#16275](https://github.com/mixxxdj/mixxx/pull/16275)
   [#12554](https://github.com/mixxxdj/mixxx/issues/12554)
-* Fix flaky test ControllerScriptEngineLegacyTimerTest.beginTimer_repeatedTimer [#16332](https://github.com/mixxxdj/mixxx/pull/16332)
-* Fix flaky test for org.mixxx.Mixxx.metainfo.xml
+  [#16332](https://github.com/mixxxdj/mixxx/pull/16332)
   [#16290](https://github.com/mixxxdj/mixxx/pull/16290)
   [#16162](https://github.com/mixxxdj/mixxx/issues/16162)
+  [#16693](https://github.com/mixxxdj/mixxx/pull/16693)
 * Fix warning/violated debug assertion when opening Preferences (backport [#16257](https://github.com/mixxxdj/mixxx/pull/16257)) [#16274](https://github.com/mixxxdj/mixxx/pull/16274)
+* Don't reset `beatloop_size` to 1/32 when loop doesn't match any of the pre-defined sizes
+  [#16881](https://github.com/mixxxdj/mixxx/pull/16881)
+  [#16880](https://github.com/mixxxdj/mixxx/issues/16880)
+* Fix last played time being wiped on history deletion
+  [#16178](https://github.com/mixxxdj/mixxx/pull/16178)
+  [#14427](https://github.com/mixxxdj/mixxx/issues/14427)
+* Fix Hotcue 350 hours before song start, caused by a race condition with quantize control
+  [#16743](https://github.com/mixxxdj/mixxx/pull/16743)
+  [#16320](https://github.com/mixxxdj/mixxx/issues/16320)
+* Skins: Fix tiny battery icons [#16801](https://github.com/mixxxdj/mixxx/pull/16801)
+* Fix broadcasting using libshout-idjc >= 2.4.6, by using the correct usage flag
+  [#16816](https://github.com/mixxxdj/mixxx/pull/16816)
+  [#16783](https://github.com/mixxxdj/mixxx/issues/16783)
+  [#16592](https://github.com/mixxxdj/mixxx/pull/16592)
 
 ## [2.5.6](https://github.com/mixxxdj/mixxx/milestone/53) (2026-03-25)
 

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -303,7 +303,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.5.5" type="development" date="2026-07-12" timestamp="1783865117">
+    <release version="2.5.5" type="development" date="2026-08-18" timestamp="1787048362">
       <description>
  <p>
   Note: Version 2.5.5 has been skipped following an issue in the release workflow.


### PR DESCRIPTION
Again up to date. 
We slowly approaching the 2.5.7 + 2.6.0 release. 

Open PRs (11) are here waiting for review and testing : 
https://github.com/mixxxdj/mixxx/pulls?q=is%3Aopen+is%3Apr+milestone%3A2.6.0

Please help!