### PR TITLE
set play to 0 on track unload only if it is 1

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -448,7 +448,9 @@ TrackPointer BaseTrackPlayerImpl::unloadTrack() {
     // Do not reset m_pReplayGain here, because the track might be still
     // playing and the last buffer will be processed.
 
-    m_pPlay->set(0.0);
+    if (m_pPlay->toBool()) {
+        m_pPlay->set(0.0);
+    }
 
     TrackPointer pUnloadedTrack(std::move(m_pLoadedTrack));
     DEBUG_ASSERT(!m_pLoadedTrack);


### PR DESCRIPTION
Fixes #16910, avoids issues with unexpected triggers of `engine.makeConnection(someplayer, "play", ...` on track load or eject

(btw strange that a no-op triggers the connection in the first place)