### PR TITLE
Implement Pipewire default device

### DIFF
--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -245,6 +245,29 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                                "API selection to take effect."));
                 });
 
+        auto pipewireGroupBox = make_parented<QGroupBox>("PipeWire Settings", this);
+        auto pipewireSettings = make_parented<QVBoxLayout>(pipewireGroupBox);
+        verticalLayout_2->insertWidget(2, pipewireGroupBox.get());
+
+        m_pipewirePatchbayCheckBox = make_parented<QCheckBox>(this);
+        m_pipewirePatchbayCheckBox->setText(tr("Sync with external patchbay"));
+        m_pPipewirePatchbay = make_parented<ControlProxy>(
+                kPipeWirePatchbay.group, kPipeWirePatchbay.item, this);
+        connect(m_pipewirePatchbayCheckBox,
+                &QCheckBox::toggled,
+                this,
+                [this](bool checked) {
+                    m_pSettings->setValue(kPipeWirePatchbay, checked);
+                    m_pPipewirePatchbay->set(checked);
+                    ioTabs->setDisabled(checked);
+                    m_settingsModified = true;
+                });
+
+        bool checked = m_pSettings->getValue(kPipeWirePatchbay, false);
+        m_pipewirePatchbayCheckBox->setChecked(checked);
+        pipewireSettings->addWidget(m_pipewirePatchbayCheckBox.get());
+        pipewireGroupBox->setVisible(pipewireSelected);
+
         if (pipewireSelected) {
             m_forceBufferSize = make_parented<QCheckBox>(this);
             m_forceSamplerate = make_parented<QCheckBox>(this);
@@ -295,6 +318,26 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             m_cpSamplerate = make_parented<ControlProxy>(
                     kAppGroup, QStringLiteral("samplerate"), this);
 
+            if (m_forceSamplerate->isChecked()) {
+                auto samplerates = m_pSoundManager->getSampleRates();
+                updateSampleRates(samplerates);
+            } else {
+                sampleRateComboBox->clear();
+                unsigned int samplerate = static_cast<unsigned int>(m_cpSamplerate->get());
+                sampleRateComboBox->addItem(tr("%1 Hz").arg(samplerate),
+                        QVariant::fromValue(samplerate));
+            }
+
+            if (m_forceBufferSize->isChecked()) {
+                updateAudioBufferSizes(0);
+            } else {
+                audioBufferComboBox->clear();
+                unsigned int bufferSize = static_cast<unsigned int>(m_cpBufferSize->get());
+                audioBufferComboBox->addItem(
+                        tr("%1 frames/period").arg(bufferSize),
+                        QVariant::fromValue(bufferSize));
+            }
+
             m_cpBufferSize->connectValueChanged(this, [this](double value) {
                 qDebug() << "m_cpBufferSize->connectValueChanged" << value;
                 if (!audioBufferComboBox->isEnabled()) {
@@ -313,28 +356,28 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                             QVariant::fromValue(samplerate));
                 }
             });
+
+            m_latencyParamsMismatchText = new QLabel();
+            pipewireSettings->addWidget(m_latencyParamsMismatchText);
+
+            m_cpLatencyParamsMismatch = make_parented<ControlProxy>(
+                    kAppGroup, QStringLiteral("latency_params_mismatch"), this);
+            m_latencyParamsMismatchText->setVisible(
+                    static_cast<bool>(m_cpLatencyParamsMismatch->get()));
+            m_cpLatencyParamsMismatch->connectValueChanged(
+                    this, [this](double mismatch) {
+                        qDebug() << "m_cpLatencyParamsMismatch->"
+                                    "connectValueChanged"
+                                 << static_cast<bool>(mismatch);
+                        m_latencyParamsMismatchText->setText(
+                                tr("Server is providing different buffer size "
+                                   "(%1) or samplerate (%2) than forced.")
+                                        .arg(m_cpBufferSize->get())
+                                        .arg(m_cpSamplerate->get()));
+                        m_latencyParamsMismatchText->setVisible(
+                                static_cast<bool>(mismatch));
+                    });
         }
-        m_pipewirePatchbayCheckBox = make_parented<QCheckBox>(this);
-        m_pipewirePatchbayCheckBox->setText(tr("Sync with external patchbay"));
-        m_pPipewirePatchbay = make_parented<ControlProxy>(
-                kPipeWirePatchbay.group, kPipeWirePatchbay.item, this);
-        connect(m_pipewirePatchbayCheckBox,
-                &QCheckBox::toggled,
-                this,
-                [this](bool checked) {
-                    m_pSettings->setValue(kPipeWirePatchbay, checked);
-                    m_pPipewirePatchbay->set(checked);
-                    ioTabs->setDisabled(checked);
-                    m_settingsModified = true;
-                });
-
-        auto pipewireGroupBox = make_parented<QGroupBox>("PipeWire Settings", this);
-        auto pipewireSettings = make_parented<QVBoxLayout>(pipewireGroupBox);
-        verticalLayout_2->insertWidget(2, pipewireGroupBox.get());
-
-        bool checked = m_pSettings->getValue(kPipeWirePatchbay, false);
-        m_pipewirePatchbayCheckBox->setChecked(checked);
-        pipewireSettings->addWidget(m_pipewirePatchbayCheckBox.get());
     }
 #endif
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -245,6 +245,28 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                                "API selection to take effect."));
                 });
 
+        auto pipewireGroupBox = make_parented<QGroupBox>("PipeWire Settings", this);
+        auto pipewireSettings = make_parented<QVBoxLayout>(pipewireGroupBox);
+        verticalLayout_2->insertWidget(2, pipewireGroupBox.get());
+
+        m_pipewirePatchbayCheckBox = make_parented<QCheckBox>(this);
+        m_pipewirePatchbayCheckBox->setText(tr("Sync with external patchbay"));
+        m_pPipewirePatchbay = make_parented<ControlProxy>(
+                kPipeWirePatchbay.group, kPipeWirePatchbay.item, this);
+        connect(m_pipewirePatchbayCheckBox,
+                &QCheckBox::toggled,
+                this,
+                [this](bool checked) {
+                    m_pSettings->setValue(kPipeWirePatchbay, checked);
+                    m_pPipewirePatchbay->set(checked);
+                    ioTabs->setDisabled(checked);
+                    m_settingsModified = true;
+                });
+
+        bool checked = m_pSettings->getValue(kPipeWirePatchbay, false);
+        m_pipewirePatchbayCheckBox->setChecked(checked);
+        pipewireSettings->addWidget(m_pipewirePatchbayCheckBox.get());
+
         if (pipewireSelected) {
             m_forceBufferSize = make_parented<QCheckBox>(this);
             m_forceSamplerate = make_parented<QCheckBox>(this);
@@ -295,6 +317,26 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             m_cpSamplerate = make_parented<ControlProxy>(
                     kAppGroup, QStringLiteral("samplerate"), this);
 
+            if (m_forceSamplerate->isChecked()) {
+                auto samplerates = m_pSoundManager->getSampleRates();
+                updateSampleRates(samplerates);
+            } else {
+                sampleRateComboBox->clear();
+                unsigned int samplerate = static_cast<unsigned int>(m_cpSamplerate->get());
+                sampleRateComboBox->addItem(tr("%1 Hz").arg(samplerate),
+                        QVariant::fromValue(samplerate));
+            }
+
+            if (m_forceBufferSize->isChecked()) {
+                updateAudioBufferSizes(0);
+            } else {
+                audioBufferComboBox->clear();
+                unsigned int bufferSize = static_cast<unsigned int>(m_cpBufferSize->get());
+                audioBufferComboBox->addItem(
+                        tr("%1 frames/period").arg(bufferSize),
+                        QVariant::fromValue(bufferSize));
+            }
+
             m_cpBufferSize->connectValueChanged(this, [this](double value) {
                 qDebug() << "m_cpBufferSize->connectValueChanged" << value;
                 if (!audioBufferComboBox->isEnabled()) {
@@ -313,28 +355,28 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                             QVariant::fromValue(samplerate));
                 }
             });
+
+            m_latencyParamsMismatchText = new QLabel();
+            pipewireSettings->addWidget(m_latencyParamsMismatchText);
+
+            m_cpLatencyParamsMismatch = make_parented<ControlProxy>(
+                    kAppGroup, QStringLiteral("latency_params_mismatch"), this);
+            m_latencyParamsMismatchText->setVisible(
+                    static_cast<bool>(m_cpLatencyParamsMismatch->get()));
+            m_cpLatencyParamsMismatch->connectValueChanged(
+                    this, [this](double mismatch) {
+                        qDebug() << "m_cpLatencyParamsMismatch->"
+                                    "connectValueChanged"
+                                 << static_cast<bool>(mismatch);
+                        m_latencyParamsMismatchText->setText(
+                                tr("Server is providing different buffer size "
+                                   "(%1) or samplerate (%2) than forced.")
+                                        .arg(m_cpBufferSize->get())
+                                        .arg(m_cpSamplerate->get()));
+                        m_latencyParamsMismatchText->setVisible(
+                                static_cast<bool>(mismatch));
+                    });
         }
-        m_pipewirePatchbayCheckBox = make_parented<QCheckBox>(this);
-        m_pipewirePatchbayCheckBox->setText(tr("Sync with external patchbay"));
-        m_pPipewirePatchbay = make_parented<ControlProxy>(
-                kPipeWirePatchbay.group, kPipeWirePatchbay.item, this);
-        connect(m_pipewirePatchbayCheckBox,
-                &QCheckBox::toggled,
-                this,
-                [this](bool checked) {
-                    m_pSettings->setValue(kPipeWirePatchbay, checked);
-                    m_pPipewirePatchbay->set(checked);
-                    ioTabs->setDisabled(checked);
-                    m_settingsModified = true;
-                });
-
-        auto pipewireGroupBox = make_parented<QGroupBox>("PipeWire Settings", this);
-        auto pipewireSettings = make_parented<QVBoxLayout>(pipewireGroupBox);
-        verticalLayout_2->insertWidget(2, pipewireGroupBox.get());
-
-        bool checked = m_pSettings->getValue(kPipeWirePatchbay, false);
-        m_pipewirePatchbayCheckBox->setChecked(checked);
-        pipewireSettings->addWidget(m_pipewirePatchbayCheckBox.get());
     }
 #endif
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -302,7 +302,13 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                 audioBufferComboBox->setEnabled(checked);
 
                 if (checked) {
-                    updateAudioBufferSizes(0);
+                    if (audioBufferComboBox->isEnabled()) {
+                        audioBufferComboBox->clear();
+                        for (int i = 1; i < 8; i++) {
+                            audioBufferComboBox->addItem(tr("%1 frames/period").arg(2 << (i + 4)),
+                                    QVariant::fromValue(i));
+                        }
+                    }
                 } else {
                     audioBufferComboBox->clear();
                     unsigned int bufferSize = static_cast<unsigned int>(m_cpBufferSize->get());
@@ -363,6 +369,15 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                     kAppGroup, QStringLiteral("latency_params_mismatch"), this);
             m_latencyParamsMismatchText->setVisible(
                     static_cast<bool>(m_cpLatencyParamsMismatch->get()));
+
+            if (m_latencyParamsMismatchText->isVisible()) {
+                m_latencyParamsMismatchText->setText(
+                        tr("Server is providing different buffer size "
+                           "(%1) or samplerate (%2) than forced.")
+                                .arg(m_cpBufferSize->get())
+                                .arg(m_cpSamplerate->get()));
+            }
+
             m_cpLatencyParamsMismatch->connectValueChanged(
                     this, [this](double mismatch) {
                         qDebug() << "m_cpLatencyParamsMismatch->"
@@ -585,7 +600,7 @@ void DlgPrefSound::slotApply() {
 #ifdef __PIPEWIRE__
         if (CmdlineArgs::Instance().getDeveloper()) {
             m_pSettings->set(kPipeWire, ConfigValue(m_pipewireCheckBox->isChecked()));
-            if (m_pSettings->getValue(kPipeWire, false)) {
+            if (m_pSoundManager->isPipewireSelected()) {
                 m_pSettings->setValue(kForceBufferSize, m_forceBufferSize->isChecked());
                 m_pSettings->setValue(kForceSamplerate, m_forceSamplerate->isChecked());
             }
@@ -952,8 +967,12 @@ void DlgPrefSound::engineClockChanged(int index) {
 // but they'll be close).
 void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
     QVariant oldSizeIndex = audioBufferComboBox->currentData();
-#ifdef __PIPEWIRE__
-    if (m_config.getAPI() == SoundManagerConfig::kAPIPipewire) {
+
+    if (!m_pSoundManager->isPipewireSelected()) {
+        audioBufferComboBox->clear();
+    }
+
+    if (m_pSoundManager->isPipewireSelected()) {
         if (audioBufferComboBox->isEnabled()) {
             audioBufferComboBox->clear();
             for (int i = 1; i < 8; i++) {
@@ -961,12 +980,7 @@ void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
                         QVariant::fromValue(i));
             }
         }
-        return;
-    }
-#endif
-
-    audioBufferComboBox->clear();
-    if (m_config.getAPI() == SoundManagerConfig::kAPIJack) {
+    } else if (m_config.getAPI() == SoundManagerConfig::kAPIJack) {
         // in case of jack we configure the frames/period
         // we cannot calc the resulting buffer size in ms because the
         // Sample rate is not known yet. We assume 48000 KHz here

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -41,6 +41,8 @@ const ConfigKey kPipeWire =
         ConfigKey(kAppGroup, QStringLiteral("pipewire"));
 const ConfigKey kPipeWirePatchbay =
         ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"));
+const ConfigKey kForceBufferSize = ConfigKey(kAppGroup, QStringLiteral("force_buffer_size"));
+const ConfigKey kForceSamplerate = ConfigKey(kAppGroup, QStringLiteral("force_samplerate"));
 
 bool soundItemAlreadyExists(const AudioPath& output, const QWidget& widget) {
     for (const QObject* pObj : widget.children()) {
@@ -226,11 +228,10 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
         m_pipewireCheckBox = make_parented<QCheckBox>(this);
         m_pipewireCheckBox->setText(tr("Use PipeWire API"));
 
-        bool checked = m_pSoundManager->isPipewireSelected();
-        m_pipewireCheckBox->setChecked(checked);
-        apiComboBox->setDisabled(checked);
-
+        bool pipewireSelected = m_pSoundManager->isPipewireSelected();
+        m_pipewireCheckBox->setChecked(pipewireSelected);
         m_pipewireCheckBox->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
+        apiComboBox->setDisabled(pipewireSelected);
         apiHBox->addWidget(m_pipewireCheckBox.get());
 
         connect(m_pipewireCheckBox,
@@ -243,9 +244,76 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                             tr("Mixxx must be restarted for the PipeWire "
                                "API selection to take effect."));
                 });
-    }
 
-    if (m_pSoundManager->isPipewireSelected()) {
+        if (pipewireSelected) {
+            m_forceBufferSize = make_parented<QCheckBox>(this);
+            m_forceSamplerate = make_parented<QCheckBox>(this);
+            m_forceBufferSize->setText(tr("Force PipeWire Buffer Size"));
+            m_forceSamplerate->setText(tr("Force PipeWire Samplerate"));
+            m_forceBufferSize->setChecked(m_pSettings->getValue(kForceBufferSize, false));
+            m_forceSamplerate->setChecked(m_pSettings->getValue(kForceSamplerate, false));
+            audioBufferComboBox->setEnabled(m_forceBufferSize->isChecked());
+            sampleRateComboBox->setEnabled(m_forceSamplerate->isChecked());
+
+            m_forceBufferSize->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
+            m_forceSamplerate->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
+            sampleRateHBox->addWidget(m_forceSamplerate.get());
+            audioBufferHBox->addWidget(m_forceBufferSize.get());
+
+            connect(m_forceSamplerate, &QCheckBox::toggled, this, [this](bool checked) {
+                m_settingsModified = true;
+                sampleRateComboBox->setEnabled(checked);
+
+                if (checked) {
+                    auto samplerates = m_pSoundManager->getSampleRates();
+                    updateSampleRates(samplerates);
+                } else {
+                    sampleRateComboBox->clear();
+                    unsigned int samplerate = static_cast<unsigned int>(m_cpSamplerate->get());
+                    sampleRateComboBox->addItem(tr("%1 Hz").arg(samplerate),
+                            QVariant::fromValue(samplerate));
+                }
+            });
+
+            connect(m_forceBufferSize, &QCheckBox::toggled, this, [this](bool checked) {
+                m_settingsModified = true;
+                audioBufferComboBox->setEnabled(checked);
+
+                if (checked) {
+                    updateAudioBufferSizes(0);
+                } else {
+                    audioBufferComboBox->clear();
+                    unsigned int bufferSize = static_cast<unsigned int>(m_cpBufferSize->get());
+                    audioBufferComboBox->addItem(
+                            tr("%1 frames/period").arg(bufferSize),
+                            QVariant::fromValue(bufferSize));
+                }
+            });
+
+            m_cpBufferSize = make_parented<ControlProxy>(
+                    kAppGroup, QStringLiteral("buffer_size"), this);
+            m_cpSamplerate = make_parented<ControlProxy>(
+                    kAppGroup, QStringLiteral("samplerate"), this);
+
+            m_cpBufferSize->connectValueChanged(this, [this](double value) {
+                qDebug() << "m_cpBufferSize->connectValueChanged" << value;
+                if (!audioBufferComboBox->isEnabled()) {
+                    unsigned int bufferSize = static_cast<unsigned int>(value);
+                    audioBufferComboBox->clear();
+                    audioBufferComboBox->addItem(tr("%1 frames/period").arg(bufferSize),
+                            QVariant::fromValue(bufferSize));
+                }
+            });
+            m_cpSamplerate->connectValueChanged(this, [this](double value) {
+                qDebug() << "m_cpSamplerate->connectValueChanged" << value;
+                if (!sampleRateComboBox->isEnabled()) {
+                    unsigned int samplerate = static_cast<unsigned int>(value);
+                    sampleRateComboBox->clear();
+                    sampleRateComboBox->addItem(tr("%1 Hz").arg(samplerate),
+                            QVariant::fromValue(samplerate));
+                }
+            });
+        }
         m_pipewirePatchbayCheckBox = make_parented<QCheckBox>(this);
         m_pipewirePatchbayCheckBox->setText(tr("Sync with external patchbay"));
         m_pPipewirePatchbay = make_parented<ControlProxy>(
@@ -471,6 +539,17 @@ void DlgPrefSound::slotApply() {
                        "RubberBand setting change will take effect."));
         }
 #endif
+
+#ifdef __PIPEWIRE__
+        if (CmdlineArgs::Instance().getDeveloper()) {
+            m_pSettings->set(kPipeWire, ConfigValue(m_pipewireCheckBox->isChecked()));
+            if (m_pSettings->getValue(kPipeWire, false)) {
+                m_pSettings->setValue(kForceBufferSize, m_forceBufferSize->isChecked());
+                m_pSettings->setValue(kForceSamplerate, m_forceSamplerate->isChecked());
+            }
+        }
+#endif
+
         status = m_pSoundManager->setConfig(m_config);
         m_configValid = (status == SoundDeviceStatus::Ok);
     }
@@ -481,12 +560,6 @@ void DlgPrefSound::slotApply() {
         m_settingsModified = false;
         m_bLatencyChanged = false;
     }
-
-#ifdef __PIPEWIRE__
-    if (CmdlineArgs::Instance().getDeveloper()) {
-        m_pSettings->set(kPipeWire, ConfigValue(m_pipewireCheckBox->isChecked()));
-    }
-#endif
 
     m_bSkipConfigClear = true;
     loadSettings(); // in case SM decided to change anything it didn't like
@@ -729,6 +802,17 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig& config) {
         }
     }
 
+#ifdef __PIPEWIRE__
+    if (CmdlineArgs::Instance().getDeveloper()) {
+        const bool pipewireSelected = m_pSoundManager->isPipewireSelected();
+        m_pipewireCheckBox->setChecked(pipewireSelected);
+        if (pipewireSelected) {
+            m_forceBufferSize->setChecked(m_pSettings->getValue(kForceBufferSize, false));
+            m_forceSamplerate->setChecked(m_pSettings->getValue(kForceSamplerate, false));
+        }
+    }
+#endif
+
     m_loading = false;
     // DlgPrefSoundItem has it's own inhibit flag
     emit loadPaths(m_config);
@@ -750,7 +834,11 @@ void DlgPrefSound::apiChanged(int index) {
     // TODO(Be): Get the buffer size from JACK and update audioBufferComboBox.
     // PortAudio as off v19.7.0 does not have a way to get the buffer size from JACK.
     bool enable = m_config.getAPI() == SoundManagerConfig::kAPIJack ? false : true;
-    sampleRateComboBox->setEnabled(enable);
+
+    if (!m_pSoundManager->isPipewireSelected()) {
+        // With PipeWire it depends if samplerate is forced or not
+        sampleRateComboBox->setEnabled(enable);
+    }
     deviceSyncComboBox->setEnabled(enable);
     engineClockComboBox->setEnabled(enable);
     updateAudioBufferSizes(sampleRateComboBox->currentIndex());
@@ -822,6 +910,19 @@ void DlgPrefSound::engineClockChanged(int index) {
 // but they'll be close).
 void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
     QVariant oldSizeIndex = audioBufferComboBox->currentData();
+#ifdef __PIPEWIRE__
+    if (m_config.getAPI() == SoundManagerConfig::kAPIPipewire) {
+        if (audioBufferComboBox->isEnabled()) {
+            audioBufferComboBox->clear();
+            for (int i = 1; i < 8; i++) {
+                audioBufferComboBox->addItem(tr("%1 frames/period").arg(2 << (i + 4)),
+                        QVariant::fromValue(i));
+            }
+        }
+        return;
+    }
+#endif
+
     audioBufferComboBox->clear();
     if (m_config.getAPI() == SoundManagerConfig::kAPIJack) {
         // in case of jack we configure the frames/period
@@ -839,7 +940,7 @@ void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
                                 JackAudioBufferSizeIndex::Size4096fpp));
     } else {
         DEBUG_ASSERT(sampleRateComboBox->itemData(sampleRateIndex)
-                             .canConvert<mixxx::audio::SampleRate>());
+                        .canConvert<mixxx::audio::SampleRate>());
         double sampleRate = sampleRateComboBox->itemData(sampleRateIndex)
                                     .value<mixxx::audio::SampleRate>()
                                     .toDouble();
@@ -1248,6 +1349,10 @@ bool DlgPrefSound::okayToClose() const {
 }
 
 void DlgPrefSound::updateSampleRates(const QList<mixxx::audio::SampleRate>& sampleRates) {
+    int currentIndex = sampleRateComboBox->currentIndex();
+    mixxx::audio::SampleRate selectedRate =
+            sampleRateComboBox->itemData(currentIndex)
+                    .value<mixxx::audio::SampleRate>();
     sampleRateComboBox->clear();
     for (const auto& sampleRate : sampleRates) {
         if (sampleRate.isValid()) {
@@ -1256,6 +1361,10 @@ void DlgPrefSound::updateSampleRates(const QList<mixxx::audio::SampleRate>& samp
             sampleRateComboBox->addItem(tr("%1 Hz").arg(sampleRate.value()),
                     QVariant::fromValue(sampleRate));
         }
+    }
+    auto newIndex = sampleRateComboBox->findData(QVariant::fromValue(selectedRate));
+    if (newIndex >= 0) {
+        sampleRateComboBox->setCurrentIndex(newIndex);
     }
 }
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -364,6 +364,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                     kAppGroup, QStringLiteral("latency_params_mismatch"), this);
             m_latencyParamsMismatchText->setVisible(
                     static_cast<bool>(m_cpLatencyParamsMismatch->get()));
+            m_latencyParamsMismatchText->setText(
+                    tr("Server is providing different buffer size "
+                       "(%1) or samplerate (%2) than forced.")
+                            .arg(QString::number(m_cpBufferSize->get()),
+                                    QString::number(m_cpSamplerate->get())));
+
             m_cpLatencyParamsMismatch->connectValueChanged(
                     this, [this](double mismatch) {
                         qDebug() << "m_cpLatencyParamsMismatch->"
@@ -372,8 +378,10 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                         m_latencyParamsMismatchText->setText(
                                 tr("Server is providing different buffer size "
                                    "(%1) or samplerate (%2) than forced.")
-                                        .arg(m_cpBufferSize->get())
-                                        .arg(m_cpSamplerate->get()));
+                                        .arg(QString::number(
+                                                     m_cpBufferSize->get()),
+                                                QString::number(m_cpSamplerate
+                                                                ->get())));
                         m_latencyParamsMismatchText->setVisible(
                                 static_cast<bool>(mismatch));
                     });
@@ -586,7 +594,7 @@ void DlgPrefSound::slotApply() {
 #ifdef __PIPEWIRE__
         if (CmdlineArgs::Instance().getDeveloper()) {
             m_pSettings->set(kPipeWire, ConfigValue(m_pipewireCheckBox->isChecked()));
-            if (m_pSettings->getValue(kPipeWire, false)) {
+            if (m_pSoundManager->isPipewireSelected()) {
                 m_pSettings->setValue(kForceBufferSize, m_forceBufferSize->isChecked());
                 m_pSettings->setValue(kForceSamplerate, m_forceSamplerate->isChecked());
             }
@@ -910,15 +918,23 @@ void DlgPrefSound::updateAPIs() {
 void DlgPrefSound::sampleRateChanged(int index) {
     m_config.setSampleRate(sampleRateComboBox->itemData(index).value<mixxx::audio::SampleRate>());
     m_bLatencyChanged = true;
-    updateAudioBufferSizes(index);
+
+    if (!m_pSoundManager->isPipewireSelected()) {
+        updateAudioBufferSizes(index);
+    }
     checkLatencyCompensation();
 }
 
 /// Slot called when the latency combo box is changed to update the
 /// latency in the config.
 void DlgPrefSound::audioBufferChanged(int index) {
-    m_config.setAudioBufferSizeIndex(
-            audioBufferComboBox->itemData(index).toUInt());
+    if (!m_pSoundManager->isPipewireSelected() || audioBufferComboBox->isEnabled()) {
+        // don't update config when working with PipeWire server assigned
+        // buffer size, which can or cannot be power of 2, so keep last forced buffer size
+
+        m_config.setAudioBufferSizeIndex(
+                audioBufferComboBox->itemData(index).toUInt());
+    }
     m_bLatencyChanged = true;
     checkLatencyCompensation();
 }
@@ -953,18 +969,16 @@ void DlgPrefSound::engineClockChanged(int index) {
 // but they'll be close).
 void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
     QVariant oldSizeIndex = audioBufferComboBox->currentData();
-#ifdef __PIPEWIRE__
     if (m_config.getAPI() == SoundManagerConfig::kAPIPipewire) {
         if (audioBufferComboBox->isEnabled()) {
             audioBufferComboBox->clear();
             for (int i = 1; i < 8; i++) {
-                audioBufferComboBox->addItem(tr("%1 frames/period").arg(2 << (i + 4)),
+                audioBufferComboBox->addItem(tr("%1 frames/period").arg(1 << (i + 5)),
                         QVariant::fromValue(i));
             }
         }
         return;
     }
-#endif
 
     audioBufferComboBox->clear();
     if (m_config.getAPI() == SoundManagerConfig::kAPIJack) {

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -135,5 +135,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     parented_ptr<QCheckBox> m_forceSamplerate;
     parented_ptr<ControlProxy> m_cpSamplerate;
     parented_ptr<ControlProxy> m_cpBufferSize;
+    parented_ptr<ControlProxy> m_cpLatencyParamsMismatch;
+    QLabel* m_latencyParamsMismatchText;
 #endif
 };

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -131,5 +131,9 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     parented_ptr<QCheckBox> m_pipewireCheckBox;
     parented_ptr<QCheckBox> m_pipewirePatchbayCheckBox;
     parented_ptr<ControlProxy> m_pPipewirePatchbay;
+    parented_ptr<QCheckBox> m_forceBufferSize;
+    parented_ptr<QCheckBox> m_forceSamplerate;
+    parented_ptr<ControlProxy> m_cpSamplerate;
+    parented_ptr<ControlProxy> m_cpBufferSize;
 #endif
 };

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -47,7 +47,11 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QComboBox" name="sampleRateComboBox"/>
+      <layout class="QHBoxLayout" name="sampleRateHBox">
+        <item>
+          <widget class="QComboBox" name="sampleRateComboBox"/>
+        </item>
+      </layout>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="audioBufferLabel">
@@ -60,7 +64,11 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QComboBox" name="audioBufferComboBox"/>
+      <layout class="QHBoxLayout" name="audioBufferHBox">
+        <item>
+          <widget class="QComboBox" name="audioBufferComboBox"/>
+        </item>
+      </layout>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="deviceSyncLabel">

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -4,6 +4,7 @@
 
 #include "audio/types.h"
 #include "moc_dlgprefsounditem.cpp"
+#include "soundio/pipewireenumerator.h"
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
 #include "soundio/soundmanagerutil.h"
@@ -96,16 +97,28 @@ void DlgPrefSoundItem::removeDevice(const SoundDevicePointer pDevice) {
 
 void DlgPrefSoundItem::updateDeviceChannels(SoundDevicePointer pDevice) {
     const auto& id = pDevice->getDeviceId();
-    int index = deviceComboBox->findData(QVariant::fromValue(id));
-    if (index >= 0 && deviceComboBox->currentIndex() == index) {
+    const SoundDeviceId& selectedDevice = deviceComboBox->currentData().value<SoundDeviceId>();
+    // not good, comparing int with uint32_t, but we cannot do much since
+    // SoundDeviceId stored int only
+    const bool defaultDevice =
+            static_cast<uint32_t>(selectedDevice.deviceIndex) ==
+            PipewireEnumerator::kDefaultDeviceId;
+    int index = defaultDevice
+            ? deviceComboBox->currentIndex()
+            : deviceComboBox->findData(QVariant::fromValue(id));
+
+    if (defaultDevice || (index >= 0 && deviceComboBox->currentIndex() == index)) {
         // if changed device is not selected no need to update
         int currentIndex = channelComboBox->currentIndex();
         auto channelData = channelComboBox->itemData(currentIndex).value<QPoint>();
         deviceChanged(index);
-        auto newIndex = channelComboBox->findData(QVariant::fromValue(channelData));
+        int newIndex = channelComboBox->findData(QVariant::fromValue(channelData));
 
         m_emitSettingChanged = false;
-        channelComboBox->setCurrentIndex(newIndex);
+
+        if (!defaultDevice && newIndex >= 0) {
+            channelComboBox->setCurrentIndex(newIndex);
+        }
         m_emitSettingChanged = true;
     }
 }

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -4,9 +4,6 @@
 
 #include "audio/types.h"
 #include "moc_dlgprefsounditem.cpp"
-#ifdef __PIPEWIRE__
-#include "soundio/pipewireenumerator.h"
-#endif
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
 #include "soundio/soundmanagerutil.h"
@@ -102,9 +99,11 @@ void DlgPrefSoundItem::updateDeviceChannels(SoundDevicePointer pDevice) {
     const SoundDeviceId& selectedDevice = deviceComboBox->currentData().value<SoundDeviceId>();
     // not good, comparing int with uint32_t, but we cannot do much since
     // SoundDeviceId stored int only
+    // NOTE(pri-yan-shu) copied PW_ID_ANY verbatim, any more sensible id may be used in future,
+    // with a dedicated identifier
     const bool defaultDevice =
             static_cast<uint32_t>(selectedDevice.deviceIndex) ==
-            PipewireEnumerator::kDefaultDeviceId;
+            (uint32_t)(0xffffffff);
     int index = defaultDevice
             ? deviceComboBox->currentIndex()
             : deviceComboBox->findData(QVariant::fromValue(id));

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -4,7 +4,9 @@
 
 #include "audio/types.h"
 #include "moc_dlgprefsounditem.cpp"
+#ifdef __PIPEWIRE__
 #include "soundio/pipewireenumerator.h"
+#endif
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
 #include "soundio/soundmanagerutil.h"

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -608,7 +608,12 @@ std::vector<SoundDevicePointer> PipewireEnumerator::queryDevices() const {
 int PipewireEnumerator::metadataEventSetting(
         uint32_t, const char* key, const char*, const char* value) {
     if (strcmp(key, "clock.rate") == 0) {
-        m_defaultSampleRate = mixxx::audio::SampleRate(std::atoi(value));
+        int32_t samplerate;
+        if (spa_atoi32(value, &samplerate, 10)) {
+            m_defaultSampleRate = mixxx::audio::SampleRate(samplerate);
+        } else {
+            m_defaultSampleRate = mixxx::audio::SampleRate();
+        }
     }
 
     return 0;

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -680,6 +680,9 @@ int PipewireEnumerator::metadataEventDefault(
             m_pSoundManager->updateDeviceChannels(device);
 
             if (defaultDevice->isOpen()) {
+                qDebug() << "PipewireEnumerator::metadataEventDefault "
+                            "defaultDevice->isOpen()"
+                         << name;
                 // currently SoundDevicePipewire ignores clockReference and syncBuffers
                 // update this when we start respecting
                 defaultDevice->open(false, 0);
@@ -731,6 +734,9 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
     }
 
     uint32_t actualDeviceId = deviceId == kDefaultDeviceId ? m_defaultSourceId : deviceId;
+
+    qDebug() << "PipewireEnumerator::openDeviceInput" << deviceId
+             << actualDeviceId << input.getString();
 
     // before default device changes due to device removal
     // the default device is in invalid state, do nothing
@@ -796,6 +802,9 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId, const AudioO
     }
 
     uint32_t actualDeviceId = deviceId == kDefaultDeviceId ? m_defaultSinkId : deviceId;
+
+    qDebug() << "PipewireEnumerator::openDeviceOutput" << deviceId
+             << actualDeviceId << output.getString();
 
     // before default device changes due to device removal
     // the default device is in invalid state, do nothing

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -524,7 +524,17 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
             return;
         }
 
-        emit deviceRemoved(m_soundDevices.at(id));
+        auto pDevice = m_soundDevices.at(id);
+
+        emit deviceRemoved(pDevice);
+        for (const AudioInputBuffer& input : pDevice->inputs()) {
+            m_inputs.at(input).activeDevice = 0;
+        }
+
+        for (const AudioOutputBuffer& output : pDevice->outputs()) {
+            m_outputs.at(output).activeDevice = 0;
+        }
+
         m_soundDevices.erase(id);
     } else if (m_ports.contains(id)) {
         const Port& port = m_ports.at(id);

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -33,7 +33,6 @@
 namespace {
 
 constexpr int kCpuUsageUpdateRate = 30; // in 1/s, fits to display frame rate
-constexpr uint32_t kDefaultDeviceId = PW_ID_ANY;
 constexpr int kDefaultBufferSize = 1024;
 const QString kAppGroup = QStringLiteral("[App]");
 
@@ -671,6 +670,8 @@ int PipewireEnumerator::metadataEventDefault(
                 m_defaultSinkId = deviceId;
                 m_defaultSinkName = name.toStdString();
             }
+
+            m_pSoundManager->updateDeviceChannels(device);
 
             if (isOpen) {
                 // currently SoundDevicePipewire ignores clockReference and syncBuffers

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -1,7 +1,9 @@
 #include "soundio/pipewireenumerator.h"
 
 #include <pipewire/pipewire.h>
-#include <qobjectdefs.h>
+#include <qendian.h>
+#include <qlogging.h>
+#include <qobject.h>
 #include <spa/utils/defs.h>
 #include <spa/utils/dict.h>
 #include <spa/utils/result.h>
@@ -17,6 +19,8 @@
 #include "audio/types.h"
 #include "control/controlobject.h"
 #include "moc_pipewireenumerator.cpp"
+#include "preferences/configobject.h"
+#include "preferences/dialog/dlgprefsound.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddevicepipewire.h"
 #include "soundio/soundmanager.h"
@@ -76,8 +80,9 @@ static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
 }
 } // namespace
 
-PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManager)
+PipewireEnumerator::PipewireEnumerator(UserSettingsPointer pConfig, SoundManager* pManager)
         : m_pSoundManager(pManager),
+          m_pConfig(pConfig),
           m_pPwThreadLoop(nullptr),
           m_pPwContext(nullptr),
           m_pPwCore(nullptr),
@@ -87,8 +92,11 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
           m_sampleRate(48000),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
           m_coPipewirePatchbaySync(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
+          m_coBufferSize(ConfigKey(kAppGroup, QStringLiteral("buffer_size"))),
           m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
-          m_framesPerBuffer(0) {
+          m_framesPerBuffer(1024),
+          m_forceSamplerate(false),
+          m_forceQuantum(false) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -97,6 +105,11 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer, SoundManager* pManag
             &SoundManager::outputRegistered,
             this,
             &PipewireEnumerator::registerOutput);
+
+    connect(m_pSoundManager,
+            &SoundManager::devicesSetup,
+            this,
+            &PipewireEnumerator::devicesSetup);
 
     connect(this, &PipewireEnumerator::deviceAdded, m_pSoundManager, &SoundManager::addDevice);
     connect(this, &PipewireEnumerator::deviceRemoved, m_pSoundManager, &SoundManager::removeDevice);
@@ -528,19 +541,8 @@ int PipewireEnumerator::metadataProperty(
 
     if (strcmp(key, "clock.rate") == 0) {
         pEnumerator->m_defaultSampleRate = mixxx::audio::SampleRate(std::atoi(value));
-    } else if (strcmp(key, "clock.allowed-rates") == 0) {
-        qDebug() << "PipewireEnumerator::metadataProperty clock.allowed-rates" << value;
-        // parse json arrays like [ 44100, 48000, 96000 ]
-        QString s = value;
-        s.remove('[');
-        s.remove(']');
-
-        const QStringList parts = s.split(',', Qt::SkipEmptyParts);
-
-        for (const QString& part : parts) {
-            pEnumerator->m_samplerates.push_back(mixxx::audio::SampleRate(part.trimmed().toInt()));
-        }
     }
+
     return 0;
 }
 
@@ -705,7 +707,6 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
         setLatency(sampleRate, framesPerBuffer);
     }
 
-    // qDebug() << "PipewireEnumerator::callback" << sampleRate << framesPerBuffer;
     m_pSoundManager->processUnderflowHappened(framesPerBuffer);
 
     for (const auto& [input, ports] : m_inputs) {
@@ -917,31 +918,27 @@ void PipewireEnumerator::createOutputPorts(const AudioOutput& output, PortPair& 
     createPorts(ports, outputName, SPA_DIRECTION_OUTPUT);
 }
 
-void PipewireEnumerator::updateFilterLatency(
-        unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qDebug() << "PipewireEnumerator::updateFilterLatency" << sampleRate << framesPerBuffer;
-    std::string rate = std::to_string(sampleRate);
-    std::string rateStr = "1/" + rate;
-    std::string quantumStr = std::to_string(framesPerBuffer);
-    std::string latencyStr = quantumStr + "/" + std::to_string(sampleRate);
+void PipewireEnumerator::updateFilterLatency() {
+    qDebug() << "PipewireEnumerator::updateFilterLatency" << m_forceQuantum
+             << m_framesPerBuffer << m_forceSamplerate << m_sampleRate;
 
-    spa_dict_item items[] = {
-            SPA_DICT_ITEM_INIT(PW_KEY_NODE_RATE, rateStr.c_str()),
-            SPA_DICT_ITEM_INIT(PW_KEY_NODE_LATENCY, latencyStr.c_str()),
+    std::string rate = m_forceSamplerate ? std::to_string(m_sampleRate) : "";
+    std::string rateFraction = m_forceSamplerate ? "1/" + std::to_string(m_sampleRate) : "";
+    std::string quantum = m_forceQuantum ? std::to_string(m_framesPerBuffer) : "";
+    std::string latency = m_forceQuantum ? rate + "/" + std::to_string(m_framesPerBuffer) : "";
+
+    const spa_dict_item propItems[] = {
+            SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_RATE, rate.c_str()),
+            SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_QUANTUM, quantum.c_str()),
     };
 
-    // don't set PW_KEY_NODE_LATENCY if framesPerBuffer is 0 (uninitialized)
-    uint32_t numProps = framesPerBuffer == 0 ? 1 : 2;
-    spa_dict properties = SPA_DICT_INIT(items, numProps);
+    spa_dict properties = SPA_DICT_INIT(propItems, std::size(propItems));
 
     pw_thread_loop_lock(m_pPwThreadLoop);
-
     int res = pw_filter_update_properties(m_pPwFilter, nullptr, &properties);
-
     pw_thread_loop_unlock(m_pPwThreadLoop);
-    if (res >= 0) {
-        setLatency(sampleRate, framesPerBuffer);
-    } else {
+
+    if (res < 0) {
         qDebug() << "PipewireEnumerator::setLatency "
                     "pw_filter_update_properties failed:"
                  << spa_strerror(res);
@@ -950,13 +947,16 @@ void PipewireEnumerator::updateFilterLatency(
 }
 
 void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
-    qDebug() << "PipewireEnumerator::setLatency" << sampleRate << framesPerBuffer;
+    qDebug() << "PipewireEnumerator::setLatency" << m_sampleRate << sampleRate
+             << m_framesPerBuffer << framesPerBuffer;
+
     m_sampleRate = sampleRate;
     m_framesPerBuffer = framesPerBuffer;
     ControlObject::set(
             ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
             m_framesPerBuffer * 1000 / m_sampleRate);
     ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
+    m_coBufferSize.set(m_framesPerBuffer);
 }
 
 void PipewireEnumerator::coreEventDone(uint32_t id, int seq) {
@@ -1022,10 +1022,31 @@ bool PipewireEnumerator::nodeHasPorts(const Node& node) {
     return false;
 }
 
-void PipewireEnumerator::setLatencyParams(
-        mixxx::audio::SampleRate sampleRate, SINT framesPerBuffer) {
-    qDebug() << "PipewireEnumerator::setLatencyParams" << sampleRate << framesPerBuffer;
-    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        updateFilterLatency(sampleRate, framesPerBuffer);
+void PipewireEnumerator::devicesSetup() {
+    const mixxx::audio::SampleRate samplerate = m_pSoundManager->getConfig().getSampleRate();
+    const unsigned int framesPerBuffer = m_pSoundManager->getConfig().getFramesPerBuffer();
+    const bool samplerateChanged = samplerate != m_sampleRate;
+    const bool framesPerBufferChanged = framesPerBuffer != m_framesPerBuffer;
+
+    const bool configForceQuantum = m_pConfig->getValue(
+            ConfigKey(kAppGroup, QStringLiteral("force_buffer_size")), false);
+    const bool configForceSamplerate = m_pConfig->getValue(
+            ConfigKey(kAppGroup, QStringLiteral("force_samplerate")), false);
+    const bool forceQuantumChanged = m_forceQuantum != configForceQuantum;
+    const bool forceSamplerateChanged = m_forceSamplerate != configForceSamplerate;
+    qDebug() << "PipewireEnumerator::devicesSetup" << configForceQuantum
+             << m_forceQuantum << configForceSamplerate << m_forceSamplerate
+             << samplerate << m_sampleRate << framesPerBuffer
+             << m_framesPerBuffer;
+
+    m_sampleRate = samplerate;
+    m_framesPerBuffer = framesPerBuffer;
+
+    if ((forceQuantumChanged || forceSamplerateChanged) ||
+            ((samplerateChanged || framesPerBufferChanged) &&
+                    (configForceQuantum || configForceSamplerate))) {
+        m_forceQuantum = configForceQuantum;
+        m_forceSamplerate = configForceSamplerate;
+        updateFilterLatency();
     }
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -33,6 +33,7 @@
 namespace {
 
 constexpr int kCpuUsageUpdateRate = 30; // in 1/s, fits to display frame rate
+constexpr int kDefaultBufferSize = 1024;
 const QString kAppGroup = QStringLiteral("[App]");
 
 static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
@@ -90,8 +91,6 @@ PipewireEnumerator::PipewireEnumerator(
           m_pPwRegistry(nullptr),
           m_pPwMetadata(nullptr),
           m_pPwFilter(nullptr),
-          m_sampleRate(48000),
-          m_framesPerBuffer(1024),
           m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
           m_coPipewirePatchbaySync(ConfigKey(
                   kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
@@ -99,12 +98,15 @@ PipewireEnumerator::PipewireEnumerator(
                   true,
                   false,
                   false,
-                  m_framesPerBuffer),
+                  kDefaultBufferSize),
           m_coLatencyParamsMismatch(ConfigKey(
                   kAppGroup, QStringLiteral("latency_params_mismatch"))),
           m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
+          m_coSamplerate(kAppGroup, QStringLiteral("samplerate")),
+          m_forceQuantum(false),
           m_forceSamplerate(false),
-          m_forceQuantum(false) {
+          m_samplerate(48000),
+          m_bufferSize(kDefaultBufferSize) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -113,11 +115,6 @@ PipewireEnumerator::PipewireEnumerator(
             &SoundManager::outputRegistered,
             this,
             &PipewireEnumerator::registerOutput);
-
-    connect(m_pSoundManager,
-            &SoundManager::devicesSetup,
-            this,
-            &PipewireEnumerator::devicesSetup);
 
     connect(this, &PipewireEnumerator::deviceAdded, m_pSoundManager, &SoundManager::addDevice);
     connect(this, &PipewireEnumerator::deviceRemoved, m_pSoundManager, &SoundManager::removeDevice);
@@ -706,15 +703,6 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
     const uint32_t sampleRate = pos->clock.rate.denom;
     const uint64_t framesPerBuffer = pos->clock.duration;
 
-    if (sampleRate != m_sampleRate || framesPerBuffer != m_framesPerBuffer) {
-        qDebug() << "PipewireEnumerator::callback"
-                    "requested"
-                 << m_framesPerBuffer << "samples at" << m_sampleRate << "hz,"
-                                                                         "provided"
-                 << framesPerBuffer << "samples at" << sampleRate << "hz";
-        setLatency(sampleRate, framesPerBuffer);
-    }
-
     m_pSoundManager->processUnderflowHappened(framesPerBuffer);
 
     for (const auto& [input, ports] : m_inputs) {
@@ -783,15 +771,81 @@ void PipewireEnumerator::callback(const spa_io_position* pos) {
         }
     }
 
-    updateAudioLatencyUsage(framesPerBuffer);
+    const bool configForceQuantum = m_pConfig->getValue(
+            ConfigKey(kAppGroup, QStringLiteral("force_buffer_size")), false);
+    const bool configForceSamplerate = m_pConfig->getValue(
+            ConfigKey(kAppGroup, QStringLiteral("force_samplerate")), false);
+    const unsigned int engineSamplerate = static_cast<unsigned int>(m_coSamplerate.get());
+    const unsigned int engineBufferSize = static_cast<unsigned int>(m_coBufferSize.get());
+
+    const mixxx::audio::SampleRate configSamplerate = m_pSoundManager->getConfig().getSampleRate();
+    const unsigned int configBufferSize = configForceQuantum
+            ? m_pSoundManager->getConfig().getFramesPerBuffer()
+            // server set buffer size can be arbitrary (non power of 2)
+            // here we don't store it in SoundManagerConfig, and instead use ControlObject
+            : engineBufferSize;
+
+    const bool forceChanged = configForceQuantum != m_forceQuantum ||
+            configForceSamplerate != m_forceSamplerate;
+    const bool latencyParamsChanged = configSamplerate != m_samplerate ||
+            configBufferSize != m_bufferSize;
+
+    if (forceChanged) {
+        m_forceQuantum = configForceQuantum;
+        m_forceSamplerate = configForceSamplerate;
+    }
+
+    if (latencyParamsChanged) {
+        m_samplerate = configSamplerate;
+        m_bufferSize = configBufferSize;
+    }
+
+    if (forceChanged || latencyParamsChanged) {
+        std::string rate = m_forceSamplerate ? std::to_string(m_samplerate) : "";
+        std::string quantum = m_forceQuantum ? std::to_string(m_bufferSize) : "";
+
+        const spa_dict_item propItems[] = {
+                SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_RATE, rate.c_str()),
+                SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_QUANTUM, quantum.c_str()),
+        };
+
+        spa_dict properties = SPA_DICT_INIT(propItems, std::size(propItems));
+
+        pw_thread_loop_lock(m_pPwThreadLoop);
+        int res = pw_filter_update_properties(m_pPwFilter, nullptr, &properties);
+        pw_thread_loop_unlock(m_pPwThreadLoop);
+
+        if (res < 0) {
+            qDebug() << "PipewireEnumerator::setLatency "
+                        "pw_filter_update_properties failed:"
+                     << spa_strerror(res);
+            qDebug() << "Unable to set requested samplerate";
+        }
+
+        const bool bufferSizeMismatch = m_forceQuantum && (framesPerBuffer != m_bufferSize);
+        const bool samplerateMismatch = m_forceSamplerate && (sampleRate != m_samplerate);
+        m_coLatencyParamsMismatch.set(bufferSizeMismatch || samplerateMismatch);
+    }
+
+    if (sampleRate != engineSamplerate || framesPerBuffer != engineBufferSize) {
+        qDebug() << "PipewireEnumerator::callback requested"
+                 << m_samplerate << "samples at" << m_bufferSize << "hz, provided"
+                 << sampleRate << "samples at" << framesPerBuffer << "hz";
+
+        m_coOutputLatencyMs.set(framesPerBuffer * 1000 / sampleRate);
+        m_coSamplerate.set(sampleRate);
+        m_coBufferSize.set(framesPerBuffer);
+    }
+
+    updateAudioLatencyUsage(sampleRate, framesPerBuffer);
 }
 
-void PipewireEnumerator::updateAudioLatencyUsage(const SINT framesPerBuffer) {
+void PipewireEnumerator::updateAudioLatencyUsage(SINT samplerate, SINT framesPerBuffer) {
     m_framesSinceAudioLatencyUsageUpdate += framesPerBuffer;
-    if (m_framesSinceAudioLatencyUsageUpdate > (m_sampleRate.toDouble() / kCpuUsageUpdateRate)) {
+    if (m_framesSinceAudioLatencyUsageUpdate > ((double)samplerate / kCpuUsageUpdateRate)) {
         double secInAudioCb = m_timeInAudioCallback.toDoubleSeconds();
         m_audioLatencyUsage.set(
-                secInAudioCb / (m_framesSinceAudioLatencyUsageUpdate / m_sampleRate.toDouble()));
+                secInAudioCb / (m_framesSinceAudioLatencyUsageUpdate / (double)samplerate));
         m_timeInAudioCallback = mixxx::Duration::fromSeconds(0);
         m_framesSinceAudioLatencyUsageUpdate = 0;
         // qDebug() << m_audioLatencyUsage
@@ -926,14 +980,11 @@ void PipewireEnumerator::createOutputPorts(const AudioOutput& output, PortPair& 
     createPorts(ports, outputName, SPA_DIRECTION_OUTPUT);
 }
 
-void PipewireEnumerator::updateFilterLatency() {
-    qDebug() << "PipewireEnumerator::updateFilterLatency" << m_forceQuantum
-             << m_framesPerBuffer << m_forceSamplerate << m_sampleRate;
+void PipewireEnumerator::updateFilterLatency(const SINT samplerate, const SINT bufferSize) {
+    qDebug() << "PipewireEnumerator::updateFilterLatency" << m_forceQuantum << m_forceSamplerate;
 
-    std::string rate = m_forceSamplerate ? std::to_string(m_sampleRate) : "";
-    std::string rateFraction = m_forceSamplerate ? "1/" + std::to_string(m_sampleRate) : "";
-    std::string quantum = m_forceQuantum ? std::to_string(m_framesPerBuffer) : "";
-    std::string latency = m_forceQuantum ? rate + "/" + std::to_string(m_framesPerBuffer) : "";
+    std::string rate = m_forceSamplerate ? std::to_string(samplerate) : "";
+    std::string quantum = m_forceQuantum ? std::to_string(bufferSize) : "";
 
     const spa_dict_item propItems[] = {
             SPA_DICT_ITEM_INIT(PW_KEY_NODE_FORCE_RATE, rate.c_str()),
@@ -952,25 +1003,6 @@ void PipewireEnumerator::updateFilterLatency() {
                  << spa_strerror(res);
         qDebug() << "Unable to set requested samplerate";
     }
-}
-
-void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
-    const bool samplerateMismatch = m_forceSamplerate && m_sampleRate != sampleRate;
-    const bool quantumMismatch = m_forceQuantum && m_framesPerBuffer != framesPerBuffer;
-
-    qDebug() << "PipewireEnumerator::setLatency" << m_sampleRate << sampleRate
-             << m_framesPerBuffer << framesPerBuffer << m_forceSamplerate << m_forceQuantum;
-
-    m_coLatencyParamsMismatch.set(samplerateMismatch || quantumMismatch);
-    qDebug() << "m_coLatencyParamsMismatch" << m_coLatencyParamsMismatch.get();
-
-    m_sampleRate = sampleRate;
-    m_framesPerBuffer = framesPerBuffer;
-    ControlObject::set(
-            ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
-            m_framesPerBuffer * 1000 / m_sampleRate);
-    ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_sampleRate);
-    m_coBufferSize.set(m_framesPerBuffer);
 }
 
 void PipewireEnumerator::coreEventDone(uint32_t id, int seq) {
@@ -1034,33 +1066,4 @@ bool PipewireEnumerator::nodeHasPorts(const Node& node) {
     }
 
     return false;
-}
-
-void PipewireEnumerator::devicesSetup() {
-    const mixxx::audio::SampleRate samplerate = m_pSoundManager->getConfig().getSampleRate();
-    const unsigned int framesPerBuffer = m_pSoundManager->getConfig().getFramesPerBuffer();
-    const bool samplerateChanged = samplerate != m_sampleRate;
-    const bool framesPerBufferChanged = framesPerBuffer != m_framesPerBuffer;
-
-    const bool configForceQuantum = m_pConfig->getValue(
-            ConfigKey(kAppGroup, QStringLiteral("force_buffer_size")), false);
-    const bool configForceSamplerate = m_pConfig->getValue(
-            ConfigKey(kAppGroup, QStringLiteral("force_samplerate")), false);
-    const bool forceQuantumChanged = m_forceQuantum != configForceQuantum;
-    const bool forceSamplerateChanged = m_forceSamplerate != configForceSamplerate;
-    qDebug() << "PipewireEnumerator::devicesSetup" << configForceQuantum
-             << m_forceQuantum << configForceSamplerate << m_forceSamplerate
-             << samplerate << m_sampleRate << framesPerBuffer
-             << m_framesPerBuffer;
-
-    m_sampleRate = samplerate;
-    m_framesPerBuffer = framesPerBuffer;
-
-    if ((forceQuantumChanged || forceSamplerateChanged) ||
-            ((samplerateChanged || framesPerBufferChanged) &&
-                    (configForceQuantum || configForceSamplerate))) {
-        m_forceQuantum = configForceQuantum;
-        m_forceSamplerate = configForceSamplerate;
-        updateFilterLatency();
-    }
 }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -1,13 +1,13 @@
 #include "soundio/pipewireenumerator.h"
 
 #include <pipewire/pipewire.h>
-#include <qendian.h>
-#include <qlogging.h>
-#include <qobject.h>
 #include <spa/utils/defs.h>
 #include <spa/utils/dict.h>
 #include <spa/utils/result.h>
 
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
 #include <QList>
 #include <QMessageBox>
 #include <QMetaObject>
@@ -33,6 +33,7 @@
 namespace {
 
 constexpr int kCpuUsageUpdateRate = 30; // in 1/s, fits to display frame rate
+constexpr uint32_t kDefaultDeviceId = PW_ID_ANY;
 const QString kAppGroup = QStringLiteral("[App]");
 
 static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
@@ -88,7 +89,8 @@ PipewireEnumerator::PipewireEnumerator(
           m_pPwContext(nullptr),
           m_pPwCore(nullptr),
           m_pPwRegistry(nullptr),
-          m_pPwMetadata(nullptr),
+          m_pPwMetadataSetting(nullptr),
+          m_pPwMetadataDefault(nullptr),
           m_pPwFilter(nullptr),
           m_sampleRate(48000),
           m_framesPerBuffer(1024),
@@ -104,7 +106,9 @@ PipewireEnumerator::PipewireEnumerator(
                   kAppGroup, QStringLiteral("latency_params_mismatch"))),
           m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
           m_forceSamplerate(false),
-          m_forceQuantum(false) {
+          m_forceQuantum(false),
+          m_defaultSourceId(0),
+          m_defaultSinkId(0) {
     connect(m_pSoundManager,
             &SoundManager::inputRegistered,
             this,
@@ -127,7 +131,8 @@ PipewireEnumerator::PipewireEnumerator(
     m_pPwThreadLoop = pw_thread_loop_new("mixxx_loop", nullptr);
     spa_zero(m_pwCoreListener);
     spa_zero(m_pwRegistryListener);
-    spa_zero(m_pwMetadataListener);
+    spa_zero(m_pwMetadataSettingListener);
+    spa_zero(m_pwMetadataDefaultListener);
     spa_zero(m_pwFilterListener);
 }
 
@@ -143,6 +148,14 @@ void PipewireEnumerator::initialize() {
     if (m_initialized) {
         return;
     }
+
+    m_soundDevices.insert_or_assign(kDefaultDeviceId,
+            QSharedPointer<SoundDevicePipewire>::create(m_pConfig,
+                    m_pSoundManager,
+                    this,
+                    kDefaultDeviceId,
+                    "default",
+                    "default"));
 
     if (!m_pPwContext) {
         m_pPwContext = pw_context_new(pw_thread_loop_get_loop(m_pPwThreadLoop), nullptr, 0);
@@ -233,6 +246,16 @@ void PipewireEnumerator::deinitialize() {
     pw_thread_loop_stop(m_pPwThreadLoop);
 
     // clear everything we get through registry
+    for (auto& ports : std::views::values(m_inputs)) {
+        ports.active.store(false);
+        ports.activeDevice = 0;
+    }
+
+    for (auto& ports : std::views::values(m_outputs)) {
+        ports.active.store(false);
+        ports.activeDevice = 0;
+    }
+
     m_soundDevices.clear();
     m_nodes.clear();
     m_ports.clear();
@@ -247,10 +270,16 @@ void PipewireEnumerator::deinitialize() {
         m_pPwFilter = nullptr;
     }
 
-    if (m_pPwMetadata) {
-        spa_hook_remove(&m_pwMetadataListener);
-        pw_proxy_destroy((struct pw_proxy*)m_pPwMetadata);
-        m_pPwMetadata = nullptr;
+    if (m_pPwMetadataSetting) {
+        spa_hook_remove(&m_pwMetadataSettingListener);
+        pw_proxy_destroy((struct pw_proxy*)m_pPwMetadataSetting);
+        m_pPwMetadataSetting = nullptr;
+    }
+
+    if (m_pPwMetadataDefault) {
+        spa_hook_remove(&m_pwMetadataDefaultListener);
+        pw_proxy_destroy((struct pw_proxy*)m_pPwMetadataDefault);
+        m_pPwMetadataDefault = nullptr;
     }
 
     if (m_pPwRegistry) {
@@ -275,20 +304,34 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         const struct spa_dict* pProps) {
     if (strcmp(pType, PW_TYPE_INTERFACE_Metadata) == 0) {
         const char* name = spa_dict_lookup(pProps, PW_KEY_METADATA_NAME);
-        if (strcmp(name, "settings") != 0) {
-            return;
+        if (strcmp(name, "settings") == 0) {
+            void* data = pw_registry_bind(m_pPwRegistry,
+                    id,
+                    PW_TYPE_INTERFACE_Metadata,
+                    PW_VERSION_METADATA,
+                    0);
+            m_pPwMetadataSetting = static_cast<pw_metadata*>(data);
+            pw_metadata_add_listener(m_pPwMetadataSetting,
+                    &m_pwMetadataSettingListener,
+                    &metadataEventsSetting,
+                    this);
+        } else if (strcmp(name, "default") == 0) {
+            void* data = pw_registry_bind(m_pPwRegistry,
+                    id,
+                    PW_TYPE_INTERFACE_Metadata,
+                    PW_VERSION_METADATA,
+                    0);
+            m_pPwMetadataDefault = static_cast<pw_metadata*>(data);
+            pw_metadata_add_listener(m_pPwMetadataDefault,
+                    &m_pwMetadataDefaultListener,
+                    &metadataEventsDefault,
+                    this);
         }
 
-        void* data = pw_registry_bind(m_pPwRegistry,
-                id,
-                PW_TYPE_INTERFACE_Metadata,
-                PW_VERSION_METADATA,
-                0);
-        m_pPwMetadata = static_cast<pw_metadata*>(data);
-        pw_metadata_add_listener(m_pPwMetadata, &m_pwMetadataListener, &metadataEvents, this);
     } else if (strcmp(pType, PW_TYPE_INTERFACE_Node) == 0) {
         const char* media_class = spa_dict_lookup(pProps, PW_KEY_MEDIA_CLASS);
         const char* media_type = spa_dict_lookup(pProps, PW_KEY_MEDIA_TYPE);
+        const char* nodeName = spa_dict_lookup(pProps, PW_KEY_NODE_NAME);
 
         bool isAudioNode = (media_class && strstr(media_class, "Audio")) ||
                 (media_type && strstr(media_type, "Audio"));
@@ -301,11 +344,21 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
 
         m_nodes.insert_or_assign(id, Node{});
         auto pDevice = QSharedPointer<SoundDevicePipewire>::create(
-                m_pConfig, m_pSoundManager, this, id, name);
+                m_pConfig, m_pSoundManager, this, id, name, nodeName);
         emit deviceAdded(pDevice);
         // pipewire assigns each object with a unique ID
         // any previous element is either invalid or already removed
         m_soundDevices.insert_or_assign(id, std::move(pDevice));
+
+        // not sure if metadata events happen after respective devices
+        // are enumerated, so checking here as well
+        if (m_defaultSinkId == 0 && m_defaultSinkName == nodeName) {
+            m_defaultSinkId = id;
+        }
+
+        if (m_defaultSourceId == 0 && m_defaultSourceName == nodeName) {
+            m_defaultSourceId = id;
+        }
 
         if (name.find("Mixxx") != std::string::npos) {
             uint32_t filterId = pw_filter_get_node_id(m_pPwFilter);
@@ -347,9 +400,18 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         if (isInput) {
             node.inputs.push_back(id);
             pSoundDevice->setNumOutputs(node.inputs.size());
+
+            if (node_id == m_defaultSourceId) {
+                auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
+                defaultDevice->setNumOutputs(node.inputs.size());
+            }
         } else {
             node.outputs.push_back(id);
             pSoundDevice->setNumInputs(node.outputs.size());
+            if (node_id == m_defaultSinkId) {
+                auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
+                defaultDevice->setNumInputs(node.outputs.size());
+            }
         }
 
         m_ports.insert_or_assign(id, std::move(port));
@@ -464,9 +526,17 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
         if (port.isInput) {
             std::erase(node.inputs, id);
             pSoundDevice->setNumOutputs(node.inputs.size());
+            if (port.node == m_defaultSourceId) {
+                auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
+                defaultDevice->setNumOutputs(node.inputs.size());
+            }
         } else {
             std::erase(node.outputs, id);
             pSoundDevice->setNumInputs(node.outputs.size());
+            if (port.node == m_defaultSinkId) {
+                auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
+                defaultDevice->setNumInputs(node.outputs.size());
+            }
         }
 
         m_pSoundManager->updateDeviceChannels(pSoundDevice);
@@ -484,16 +554,12 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
                     Port& rightPort = m_ports.at(ports.right.id);
                     if (outputPort.links.empty() && rightPort.links.empty()) {
                         ports.active.store(false);
-                        // close the device if device is disconnected externally
-                        ports.activeDevice = 0;
                         m_pSoundManager->unconfigureOutput(output);
                     }
                 } else if (ports.right.id == link.output) {
                     Port& leftPort = m_ports.at(ports.left.id);
                     if (outputPort.links.empty() && leftPort.links.empty()) {
                         ports.active.store(false);
-                        // close the device if device is disconnected externally
-                        ports.activeDevice = 0;
                         m_pSoundManager->unconfigureOutput(output);
                     }
                 } else {
@@ -507,16 +573,12 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
                 if (ports.left.id == link.input) {
                     Port& rightPort = m_ports.at(ports.right.id);
                     if (inputPort.links.empty() && rightPort.links.empty()) {
-                        // close the device if device is disconnected externally
-                        ports.activeDevice = 0;
                         ports.active.store(false);
                         m_pSoundManager->unconfigureInput(input);
                     }
                 } else if (ports.right.id == link.input) {
                     Port& leftPort = m_ports.at(ports.left.id);
                     if (inputPort.links.empty() && leftPort.links.empty()) {
-                        // close the device if device is disconnected externally
-                        ports.activeDevice = 0;
                         ports.active.store(false);
                         m_pSoundManager->unconfigureInput(input);
                     }
@@ -543,12 +605,67 @@ std::vector<SoundDevicePointer> PipewireEnumerator::queryDevices() const {
     return devices;
 }
 
-int PipewireEnumerator::metadataProperty(
-        void* data, uint32_t, const char* key, const char*, const char* value) {
-    PipewireEnumerator* pEnumerator = static_cast<PipewireEnumerator*>(data);
-
+int PipewireEnumerator::metadataEventSetting(
+        uint32_t, const char* key, const char*, const char* value) {
     if (strcmp(key, "clock.rate") == 0) {
-        pEnumerator->m_defaultSampleRate = mixxx::audio::SampleRate(std::atoi(value));
+        m_defaultSampleRate = mixxx::audio::SampleRate(std::atoi(value));
+    }
+
+    return 0;
+}
+
+int PipewireEnumerator::metadataEventDefault(
+        uint32_t id, const char* key, const char* type, const char* value) {
+    bool defaultAudioSource = strcmp(key, "default.audio.source") == 0;
+    bool defaultAudioSink = strcmp(key, "default.audio.sink") == 0;
+    if (!defaultAudioSource && !defaultAudioSink) {
+        return 0;
+    }
+
+    qDebug() << "PipewireEnumerator::metadataEventDefault" << id << key << type << value;
+
+    QJsonParseError parseError;
+    QJsonDocument doc = QJsonDocument::fromJson(value, &parseError);
+
+    VERIFY_OR_DEBUG_ASSERT(parseError.error == QJsonParseError::NoError) {
+        qWarning() << "JSON Parse error: " << parseError.errorString();
+    }
+
+    QJsonObject obj = doc.object();
+    QString name = obj["name"].toString();
+
+    if (defaultAudioSource) {
+        m_defaultSourceName = name.toStdString();
+    } else {
+        m_defaultSinkName = name.toStdString();
+    }
+
+    for (const auto& [deviceId, device] : m_soundDevices) {
+        if (device->getDeviceId().alsaHwDevice == name) {
+            auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
+            bool isOpen = defaultDevice->isOpen();
+            if (isOpen) {
+                defaultDevice->close();
+            }
+
+            // these values should only be modified here, when m_defaultDevice
+            // is closed, since device opening/closing depends on these values
+            if (defaultAudioSource) {
+                defaultDevice->setNumInputs(device->getNumInputChannels());
+                m_defaultSourceId = deviceId;
+            } else {
+                defaultDevice->setNumOutputs(device->getNumOutputChannels());
+                m_defaultSinkId = deviceId;
+            }
+
+            if (isOpen) {
+                // currently SoundDevicePipewire ignores clockReference and syncBuffers
+                // update this when we start respecting
+                defaultDevice->open(false, 0);
+            }
+
+            break;
+        }
     }
 
     return 0;
@@ -556,13 +673,13 @@ int PipewireEnumerator::metadataProperty(
 
 bool PipewireEnumerator::isOpen(uint32_t id) {
     for (const auto& ports : std::views::values(m_inputs)) {
-        if (ports.activeDevice == id) {
+        if (ports.activeDevice == id && ports.active.load()) {
             return true;
         }
     }
 
     for (const auto& ports : std::views::values(m_outputs)) {
-        if (ports.activeDevice == id) {
+        if (ports.activeDevice == id && ports.active.load()) {
             return true;
         }
     }
@@ -583,6 +700,8 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
         return {};
     }
 
+    uint32_t actualDeviceId = deviceId == kDefaultDeviceId ? m_defaultSourceId : deviceId;
+
     PortPair& ports = m_inputs.at(input);
     ports.activeDevice = deviceId;
 
@@ -593,16 +712,16 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
     ChannelGroup channelGroup = input.getChannelGroup();
     unsigned char channelBase = channelGroup.getChannelBase();
     unsigned char channelCount = channelGroup.getChannelCount().value();
-    std::span<const uint32_t> portIds = m_nodes.at(deviceId).outputs;
+    std::span<const uint32_t> portIds = m_nodes.at(actualDeviceId).outputs;
 
     pw_thread_loop_lock(m_pPwThreadLoop);
 
     if (channelCount == 1) {
-        result += createLink(deviceId, portIds[channelBase], m_filterId, ports.left.id);
-        result += createLink(deviceId, portIds[channelBase], m_filterId, ports.right.id);
+        result += createLink(actualDeviceId, portIds[channelBase], m_filterId, ports.left.id);
+        result += createLink(actualDeviceId, portIds[channelBase], m_filterId, ports.right.id);
     } else {
-        result += createLink(deviceId, portIds[channelBase], m_filterId, ports.left.id);
-        result += createLink(deviceId,
+        result += createLink(actualDeviceId, portIds[channelBase], m_filterId, ports.left.id);
+        result += createLink(actualDeviceId,
                 portIds[channelBase + 1],
                 m_filterId,
                 ports.right.id);
@@ -624,29 +743,32 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId, const AudioO
         return {};
     }
 
+    uint32_t actualDeviceId = deviceId == kDefaultDeviceId ? m_defaultSinkId : deviceId;
+
     PortPair& ports = m_outputs.at(output);
-    ports.activeDevice = deviceId;
 
     if (ports.active.load()) {
         closePorts(ports);
     }
 
+    ports.activeDevice = deviceId;
+
     ChannelGroup channelGroup = output.getChannelGroup();
     unsigned char channelBase = channelGroup.getChannelBase();
     unsigned char channelCount = channelGroup.getChannelCount().value();
 
-    std::span<const uint32_t> portIds = m_nodes.at(deviceId).inputs;
+    std::span<const uint32_t> portIds = m_nodes.at(actualDeviceId).inputs;
 
     pw_thread_loop_lock(m_pPwThreadLoop);
 
     if (channelCount == 1) {
         uint32_t filterPort = channelBase % 2 ? ports.right.id : ports.left.id;
-        result += createLink(m_filterId, filterPort, deviceId, portIds[channelBase]);
+        result += createLink(m_filterId, filterPort, actualDeviceId, portIds[channelBase]);
     } else {
-        result += createLink(m_filterId, ports.left.id, deviceId, portIds[channelBase]);
+        result += createLink(m_filterId, ports.left.id, actualDeviceId, portIds[channelBase]);
         result += createLink(m_filterId,
                 ports.right.id,
-                deviceId,
+                actualDeviceId,
                 portIds[channelBase + 1]);
     }
 
@@ -998,6 +1120,13 @@ QString PipewireEnumerator::getChannelString(
     unsigned char base = channelGroup.getChannelBase();
     mixxx::audio::ChannelCount count = channelGroup.getChannelCount();
 
+    if (id == kDefaultDeviceId) {
+        id = input ? m_defaultSourceId : m_defaultSinkId;
+        VERIFY_OR_DEBUG_ASSERT(id) {
+            return {};
+        }
+    }
+
     const Node& node = m_nodes.at(id);
 
     std::span<const uint32_t> ports = input ? node.outputs : node.inputs;
@@ -1009,6 +1138,10 @@ QString PipewireEnumerator::getChannelString(
     std::string channelString = firstPort.name + firstPort.channel;
 
     for (uint32_t portId : subspan) {
+        if (!m_ports.contains(portId)) {
+            continue;
+        }
+
         const Port& port = m_ports.at(portId);
         if (!port.name.empty() and port.name == currentCommonSubstr) {
             channelString = channelString + '/' + port.channel;

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -654,10 +654,6 @@ int PipewireEnumerator::metadataEventDefault(
     for (const auto& [deviceId, device] : m_soundDevices) {
         if (device->getDeviceId().alsaHwDevice == name) {
             auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
-            bool isOpen = defaultDevice->isOpen();
-            if (isOpen) {
-                defaultDevice->close();
-            }
 
             // these values should only be modified here, when m_defaultDevice
             // is closed, since device opening/closing depends on these values
@@ -673,7 +669,7 @@ int PipewireEnumerator::metadataEventDefault(
 
             m_pSoundManager->updateDeviceChannels(device);
 
-            if (isOpen) {
+            if (defaultDevice->isOpen()) {
                 // currently SoundDevicePipewire ignores clockReference and syncBuffers
                 // update this when we start respecting
                 defaultDevice->open(false, 0);
@@ -745,6 +741,11 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
     std::span<const uint32_t> portIds = m_nodes.at(actualDeviceId).outputs;
 
     if (deviceId == kDefaultDeviceId) {
+        if (isOpen(m_defaultSourceId)) {
+            // we don't want any popup
+            return {};
+        }
+
         // for default device we only bother to wire up the most basic
         // routing, and ignore the preference page channels
         channelBase = 0;
@@ -806,6 +807,10 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId, const AudioO
     std::span<const uint32_t> portIds = m_nodes.at(actualDeviceId).inputs;
 
     if (deviceId == kDefaultDeviceId) {
+        if (isOpen(m_defaultSinkId)) {
+            // we don't want any popup
+            return {};
+        }
         // for default device we only bother to wire up the most basic
         // routing, and ignore the preference page channels
         channelBase = 0;

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -76,8 +76,12 @@ static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
         }
     }
 
-    // worst case scenario, we still have node ID as name
-    return name + ":" + std::to_string(id);
+    if (name.empty()) {
+        // worst case scenario, we still have node ID as name
+        return std::to_string(id);
+    } else {
+        return name + ":" + std::to_string(id);
+    }
 }
 } // namespace
 
@@ -331,7 +335,7 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
     } else if (strcmp(pType, PW_TYPE_INTERFACE_Node) == 0) {
         const char* media_class = spa_dict_lookup(pProps, PW_KEY_MEDIA_CLASS);
         const char* media_type = spa_dict_lookup(pProps, PW_KEY_MEDIA_TYPE);
-        const char* nodeName = spa_dict_lookup(pProps, PW_KEY_NODE_NAME);
+        const char* pNodeName = spa_dict_lookup(pProps, PW_KEY_NODE_NAME);
 
         bool isAudioNode = (media_class && strstr(media_class, "Audio")) ||
                 (media_type && strstr(media_type, "Audio"));
@@ -341,10 +345,13 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
         }
 
         std::string name = find_node_name(id, pProps);
+        if (!pNodeName) {
+            pNodeName = name.c_str();
+        }
 
         m_nodes.insert_or_assign(id, Node{});
         auto pDevice = QSharedPointer<SoundDevicePipewire>::create(
-                m_pConfig, m_pSoundManager, this, id, name, nodeName);
+                m_pConfig, m_pSoundManager, this, id, name, pNodeName);
         emit deviceAdded(pDevice);
         // pipewire assigns each object with a unique ID
         // any previous element is either invalid or already removed
@@ -352,11 +359,11 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
 
         // not sure if metadata events happen after respective devices
         // are enumerated, so checking here as well
-        if (m_defaultSinkId == 0 && m_defaultSinkName == nodeName) {
+        if (m_defaultSinkId == 0 && m_defaultSinkName == pNodeName) {
             m_defaultSinkId = id;
         }
 
-        if (m_defaultSourceId == 0 && m_defaultSourceName == nodeName) {
+        if (m_defaultSourceId == 0 && m_defaultSourceName == pNodeName) {
             m_defaultSourceId = id;
         }
 
@@ -401,14 +408,14 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
             node.inputs.push_back(id);
             pSoundDevice->setNumOutputs(node.inputs.size());
 
-            if (node_id == m_defaultSourceId) {
+            if (node_id == m_defaultSinkId) {
                 auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
                 defaultDevice->setNumOutputs(node.inputs.size());
             }
         } else {
             node.outputs.push_back(id);
             pSoundDevice->setNumInputs(node.outputs.size());
-            if (node_id == m_defaultSinkId) {
+            if (node_id == m_defaultSourceId) {
                 auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
                 defaultDevice->setNumInputs(node.outputs.size());
             }
@@ -507,6 +514,14 @@ void PipewireEnumerator::registryEventGlobal(uint32_t id,
 
 void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
     if (m_nodes.contains(id)) {
+        if (id == m_defaultSourceId) {
+            m_defaultSourceId = 0;
+        }
+
+        if (id == m_defaultSinkId) {
+            m_defaultSinkId = 0;
+        }
+
         m_nodes.erase(id);
         VERIFY_OR_DEBUG_ASSERT(m_soundDevices.contains(id)) {
             return;
@@ -526,14 +541,14 @@ void PipewireEnumerator::registryEventGlobalRemove(unsigned int id) {
         if (port.isInput) {
             std::erase(node.inputs, id);
             pSoundDevice->setNumOutputs(node.inputs.size());
-            if (port.node == m_defaultSourceId) {
+            if (port.node == m_defaultSinkId) {
                 auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
                 defaultDevice->setNumOutputs(node.inputs.size());
             }
         } else {
             std::erase(node.outputs, id);
             pSoundDevice->setNumInputs(node.outputs.size());
-            if (port.node == m_defaultSinkId) {
+            if (port.node == m_defaultSourceId) {
                 auto defaultDevice = m_soundDevices.at(kDefaultDeviceId);
                 defaultDevice->setNumInputs(node.outputs.size());
             }
@@ -623,11 +638,11 @@ int PipewireEnumerator::metadataEventDefault(
         uint32_t id, const char* key, const char* type, const char* value) {
     bool defaultAudioSource = strcmp(key, "default.audio.source") == 0;
     bool defaultAudioSink = strcmp(key, "default.audio.sink") == 0;
+    qDebug() << "PipewireEnumerator::metadataEventDefault" << id << key << type
+             << value << defaultAudioSource << defaultAudioSink;
     if (!defaultAudioSource && !defaultAudioSink) {
         return 0;
     }
-
-    qDebug() << "PipewireEnumerator::metadataEventDefault" << id << key << type << value;
 
     QJsonParseError parseError;
     QJsonDocument doc = QJsonDocument::fromJson(value, &parseError);
@@ -638,12 +653,6 @@ int PipewireEnumerator::metadataEventDefault(
 
     QJsonObject obj = doc.object();
     QString name = obj["name"].toString();
-
-    if (defaultAudioSource) {
-        m_defaultSourceName = name.toStdString();
-    } else {
-        m_defaultSinkName = name.toStdString();
-    }
 
     for (const auto& [deviceId, device] : m_soundDevices) {
         if (device->getDeviceId().alsaHwDevice == name) {
@@ -658,9 +667,11 @@ int PipewireEnumerator::metadataEventDefault(
             if (defaultAudioSource) {
                 defaultDevice->setNumInputs(device->getNumInputChannels());
                 m_defaultSourceId = deviceId;
+                m_defaultSourceName = name.toStdString();
             } else {
                 defaultDevice->setNumOutputs(device->getNumOutputChannels());
                 m_defaultSinkId = deviceId;
+                m_defaultSinkName = name.toStdString();
             }
 
             if (isOpen) {
@@ -668,9 +679,18 @@ int PipewireEnumerator::metadataEventDefault(
                 // update this when we start respecting
                 defaultDevice->open(false, 0);
             }
-
-            break;
+            return 0;
         }
+    }
+
+    qWarning() << "PipewireEnumerator::metadataEventDefault no default"
+               << (defaultAudioSource ? "source" : "sink") << name;
+    if (defaultAudioSource) {
+        m_defaultSourceId = 0;
+        m_defaultSourceName = {};
+    } else {
+        m_defaultSinkId = 0;
+        m_defaultSinkName = {};
     }
 
     return 0;
@@ -678,13 +698,13 @@ int PipewireEnumerator::metadataEventDefault(
 
 bool PipewireEnumerator::isOpen(uint32_t id) {
     for (const auto& ports : std::views::values(m_inputs)) {
-        if (ports.activeDevice == id && ports.active.load()) {
+        if (ports.activeDevice == id) {
             return true;
         }
     }
 
     for (const auto& ports : std::views::values(m_outputs)) {
-        if (ports.activeDevice == id && ports.active.load()) {
+        if (ports.activeDevice == id) {
             return true;
         }
     }
@@ -707,6 +727,12 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
 
     uint32_t actualDeviceId = deviceId == kDefaultDeviceId ? m_defaultSourceId : deviceId;
 
+    // before default device changes due to device removal
+    // the default device is in invalid state, do nothing
+    if (!actualDeviceId) {
+        return "default device not set";
+    }
+
     PortPair& ports = m_inputs.at(input);
     ports.activeDevice = deviceId;
 
@@ -718,6 +744,17 @@ std::string PipewireEnumerator::openDeviceInput(uint32_t deviceId,
     unsigned char channelBase = channelGroup.getChannelBase();
     unsigned char channelCount = channelGroup.getChannelCount().value();
     std::span<const uint32_t> portIds = m_nodes.at(actualDeviceId).outputs;
+
+    if (deviceId == kDefaultDeviceId) {
+        // for default device we only bother to wire up the most basic
+        // routing, and ignore the preference page channels
+        channelBase = 0;
+        channelCount = std::min<unsigned char>(portIds.size(), 2);
+    }
+
+    VERIFY_OR_DEBUG_ASSERT(channelCount) {
+        return {};
+    }
 
     pw_thread_loop_lock(m_pPwThreadLoop);
 
@@ -750,6 +787,12 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId, const AudioO
 
     uint32_t actualDeviceId = deviceId == kDefaultDeviceId ? m_defaultSinkId : deviceId;
 
+    // before default device changes due to device removal
+    // the default device is in invalid state, do nothing
+    if (!actualDeviceId) {
+        return "default device not set";
+    }
+
     PortPair& ports = m_outputs.at(output);
 
     if (ports.active.load()) {
@@ -761,8 +804,18 @@ std::string PipewireEnumerator::openDeviceOutput(uint32_t deviceId, const AudioO
     ChannelGroup channelGroup = output.getChannelGroup();
     unsigned char channelBase = channelGroup.getChannelBase();
     unsigned char channelCount = channelGroup.getChannelCount().value();
-
     std::span<const uint32_t> portIds = m_nodes.at(actualDeviceId).inputs;
+
+    if (deviceId == kDefaultDeviceId) {
+        // for default device we only bother to wire up the most basic
+        // routing, and ignore the preference page channels
+        channelBase = 0;
+        channelCount = std::min<unsigned char>(portIds.size(), 2);
+    }
+
+    VERIFY_OR_DEBUG_ASSERT(channelCount) {
+        return {};
+    }
 
     pw_thread_loop_lock(m_pPwThreadLoop);
 
@@ -1127,6 +1180,8 @@ QString PipewireEnumerator::getChannelString(
 
     if (id == kDefaultDeviceId) {
         id = input ? m_defaultSourceId : m_defaultSinkId;
+        // before default device changes due to device removal
+        // the default device is in invalid state, do nothing
         VERIFY_OR_DEBUG_ASSERT(id) {
             return {};
         }

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -80,7 +80,8 @@ static std::string find_node_name(uint32_t id, const struct spa_dict* props) {
 }
 } // namespace
 
-PipewireEnumerator::PipewireEnumerator(UserSettingsPointer pConfig, SoundManager* pManager)
+PipewireEnumerator::PipewireEnumerator(
+        UserSettingsPointer pConfig, SoundManager* pManager)
         : m_pSoundManager(pManager),
           m_pConfig(pConfig),
           m_pPwThreadLoop(nullptr),
@@ -90,11 +91,18 @@ PipewireEnumerator::PipewireEnumerator(UserSettingsPointer pConfig, SoundManager
           m_pPwMetadata(nullptr),
           m_pPwFilter(nullptr),
           m_sampleRate(48000),
-          m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
-          m_coPipewirePatchbaySync(ConfigKey(kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
-          m_coBufferSize(ConfigKey(kAppGroup, QStringLiteral("buffer_size"))),
-          m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
           m_framesPerBuffer(1024),
+          m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
+          m_coPipewirePatchbaySync(ConfigKey(
+                  kAppGroup, QStringLiteral("pipewire_patchbay_sync"))),
+          m_coBufferSize(ConfigKey(kAppGroup, QStringLiteral("buffer_size")),
+                  true,
+                  false,
+                  false,
+                  m_framesPerBuffer),
+          m_coLatencyParamsMismatch(ConfigKey(
+                  kAppGroup, QStringLiteral("latency_params_mismatch"))),
+          m_coOutputLatencyMs(kAppGroup, QStringLiteral("output_latency_ms")),
           m_forceSamplerate(false),
           m_forceQuantum(false) {
     connect(m_pSoundManager,
@@ -947,8 +955,14 @@ void PipewireEnumerator::updateFilterLatency() {
 }
 
 void PipewireEnumerator::setLatency(unsigned int sampleRate, unsigned int framesPerBuffer) {
+    const bool samplerateMismatch = m_forceSamplerate && m_sampleRate != sampleRate;
+    const bool quantumMismatch = m_forceQuantum && m_framesPerBuffer != framesPerBuffer;
+
     qDebug() << "PipewireEnumerator::setLatency" << m_sampleRate << sampleRate
-             << m_framesPerBuffer << framesPerBuffer;
+             << m_framesPerBuffer << framesPerBuffer << m_forceSamplerate << m_forceQuantum;
+
+    m_coLatencyParamsMismatch.set(samplerateMismatch || quantumMismatch);
+    qDebug() << "m_coLatencyParamsMismatch" << m_coLatencyParamsMismatch.get();
 
     m_sampleRate = sampleRate;
     m_framesPerBuffer = framesPerBuffer;

--- a/src/soundio/pipewireenumerator.cpp
+++ b/src/soundio/pipewireenumerator.cpp
@@ -643,6 +643,10 @@ int PipewireEnumerator::metadataEventSetting(
 
 int PipewireEnumerator::metadataEventDefault(
         uint32_t id, const char* key, const char* type, const char* value) {
+    if (!key || !type || !value) {
+        return 0;
+    }
+
     bool defaultAudioSource = strcmp(key, "default.audio.source") == 0;
     bool defaultAudioSink = strcmp(key, "default.audio.sink") == 0;
     qDebug() << "PipewireEnumerator::metadataEventDefault" << id << key << type
@@ -656,6 +660,7 @@ int PipewireEnumerator::metadataEventDefault(
 
     VERIFY_OR_DEBUG_ASSERT(parseError.error == QJsonParseError::NoError) {
         qWarning() << "JSON Parse error: " << parseError.errorString();
+        return 0;
     }
 
     QJsonObject obj = doc.object();

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -235,14 +235,16 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     std::unordered_map<AudioInput, PortPair> m_inputs;
     std::unordered_map<AudioOutput, PortPair> m_outputs;
 
+    uint32_t m_framesPerBuffer;
+
     PollingControlProxy m_audioLatencyUsage;
     ControlObject m_coPipewirePatchbaySync;
     ControlObject m_coBufferSize;
+    ControlObject m_coLatencyParamsMismatch;
     ControlProxy m_coOutputLatencyMs;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     uint32_t m_filterId;
-    uint32_t m_framesPerBuffer;
     // Handle all connections made to/from Mixxx node
     // If we do not, then we only track connections made in the
     // preference page, and leave the external patchbay connections

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -51,6 +51,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     QString getChannelString(uint32_t id, ChannelGroup channelGroup, bool input) const;
 
+    static constexpr uint32_t kDefaultDeviceId = PW_ID_ANY;
   signals:
     void deviceAdded(SoundDevicePointer pDevice);
     void deviceRemoved(SoundDevicePointer pDevice);

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -58,7 +58,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
   private slots:
     void registerInput(const AudioInput& input, AudioDestination* dest);
     void registerOutput(const AudioOutput& output, AudioSource* src);
-    void devicesSetup();
 
   private:
     struct Link {
@@ -193,7 +192,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
             uint32_t inPortId);
     void destroyLink(uint32_t id);
 
-    void updateAudioLatencyUsage(const SINT framesPerBuffer);
+    void updateAudioLatencyUsage(SINT samplerate, SINT framesPerBuffer);
     void setLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
 
     void createInputPorts(const AudioInput& path, PortPair& ports);
@@ -201,7 +200,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void createPorts(PortPair& ports, std::string_view name, spa_direction direction);
     void closePorts(PortPair& ports);
 
-    void updateFilterLatency();
+    void updateFilterLatency(const SINT samplerate, const SINT bufferSize);
     bool nodeHasPorts(const Node& node);
 
     std::unordered_map<uint32_t, Node> m_nodes;
@@ -229,19 +228,17 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     int m_invalidTimeInfoCount;
     double m_lastCallbackEntrytoDacSecs;
     PerformanceTimer m_clkRefTimer;
-    mixxx::audio::SampleRate m_sampleRate;
     mixxx::audio::SampleRate m_defaultSampleRate;
 
     std::unordered_map<AudioInput, PortPair> m_inputs;
     std::unordered_map<AudioOutput, PortPair> m_outputs;
-
-    uint32_t m_framesPerBuffer;
 
     PollingControlProxy m_audioLatencyUsage;
     ControlObject m_coPipewirePatchbaySync;
     ControlObject m_coBufferSize;
     ControlObject m_coLatencyParamsMismatch;
     ControlProxy m_coOutputLatencyMs;
+    ControlProxy m_coSamplerate;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     uint32_t m_filterId;
@@ -251,6 +248,8 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     // If we do, then all connections to Mixxx will be affected, even
     // the ones made with external patchbay
     int m_coreSyncSeq;
-    bool m_forceSamplerate;
     bool m_forceQuantum;
+    bool m_forceSamplerate;
+    uint32_t m_samplerate;
+    uint32_t m_bufferSize;
 };

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -10,6 +10,7 @@
 #include "audio/types.h"
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
+#include "preferences/dialog/dlgprefsound.h"
 #include "preferences/usersettings.h"
 #include "soundio/sounddevice.h"
 #include "soundio/sounddeviceenumerator.h"
@@ -27,7 +28,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     QList<mixxx::audio::SampleRate> getSampleRates(
             [[maybe_unused]] bool jackSampleRates) const override {
-        return m_samplerates;
+        return {};
     }
 
     std::vector<SoundDevicePointer> queryDevices() const override;
@@ -39,8 +40,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     std::string openDeviceInput(uint32_t id, const AudioInput& input);
     std::string openDeviceOutput(uint32_t id, const AudioOutput& output);
     void closeDevices();
-
-    void setLatencyParams(mixxx::audio::SampleRate sampleRate, SINT framesPerBuffer) override;
 
     mixxx::audio::SampleRate getDefaultSampleRate() const {
         return m_defaultSampleRate;
@@ -59,6 +58,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
   private slots:
     void registerInput(const AudioInput& input, AudioDestination* dest);
     void registerOutput(const AudioOutput& output, AudioSource* src);
+    void devicesSetup();
 
   private:
     struct Link {
@@ -201,7 +201,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     void createPorts(PortPair& ports, std::string_view name, spa_direction direction);
     void closePorts(PortPair& ports);
 
-    void updateFilterLatency(unsigned int sampleRate, unsigned int framesPerBuffer);
+    void updateFilterLatency();
     bool nodeHasPorts(const Node& node);
 
     std::unordered_map<uint32_t, Node> m_nodes;
@@ -237,6 +237,7 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
 
     PollingControlProxy m_audioLatencyUsage;
     ControlObject m_coPipewirePatchbaySync;
+    ControlObject m_coBufferSize;
     ControlProxy m_coOutputLatencyMs;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
@@ -248,4 +249,6 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     // If we do, then all connections to Mixxx will be affected, even
     // the ones made with external patchbay
     int m_coreSyncSeq;
+    bool m_forceSamplerate;
+    bool m_forceQuantum;
 };

--- a/src/soundio/pipewireenumerator.h
+++ b/src/soundio/pipewireenumerator.h
@@ -145,15 +145,41 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
             .global_remove = registryEventGlobalRemoveOuter,
     };
 
-    static int metadataProperty(void* data,
+    static int metadataEventSetting(void* data,
             uint32_t id,
+            const char* key,
+            const char* type,
+            const char* value) {
+        return static_cast<PipewireEnumerator*>(data)->metadataEventSetting(id, key, type, value);
+    }
+
+    int metadataEventSetting(uint32_t id,
             const char* key,
             const char* type,
             const char* value);
 
-    static constexpr struct pw_metadata_events metadataEvents = {
+    static constexpr struct pw_metadata_events metadataEventsSetting{
             .version = PW_VERSION_METADATA_EVENTS,
-            .property = metadataProperty};
+            .property = metadataEventSetting,
+    };
+
+    static int metadataEventDefault(void* data,
+            uint32_t id,
+            const char* key,
+            const char* type,
+            const char* value) {
+        return static_cast<PipewireEnumerator*>(data)->metadataEventDefault(id, key, type, value);
+    }
+
+    int metadataEventDefault(uint32_t id,
+            const char* key,
+            const char* type,
+            const char* value);
+
+    static constexpr struct pw_metadata_events metadataEventsDefault{
+            .version = PW_VERSION_METADATA_EVENTS,
+            .property = metadataEventDefault,
+    };
 
     static void callback(void* data, spa_io_position* pos) {
         ((PipewireEnumerator*)data)->callback(pos);
@@ -216,12 +242,14 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     pw_context* m_pPwContext;
     pw_core* m_pPwCore;
     pw_registry* m_pPwRegistry;
-    pw_metadata* m_pPwMetadata;
+    pw_metadata* m_pPwMetadataSetting;
+    pw_metadata* m_pPwMetadataDefault;
     pw_filter* m_pPwFilter;
     spa_hook m_pwCoreListener;
     spa_hook m_pwRegistryListener;
     spa_hook m_pwFilterListener;
-    spa_hook m_pwMetadataListener;
+    spa_hook m_pwMetadataSettingListener;
+    spa_hook m_pwMetadataDefaultListener;
 
     std::unordered_map<uint32_t, QSharedPointer<SoundDevicePipewire>> m_soundDevices;
 
@@ -253,4 +281,9 @@ class PipewireEnumerator : public SoundDeviceEnumerator {
     int m_coreSyncSeq;
     bool m_forceSamplerate;
     bool m_forceQuantum;
+
+    uint32_t m_defaultSourceId;
+    uint32_t m_defaultSinkId;
+    std::string m_defaultSourceName;
+    std::string m_defaultSinkName;
 };

--- a/src/soundio/sounddeviceenumerator.h
+++ b/src/soundio/sounddeviceenumerator.h
@@ -15,9 +15,6 @@ class SoundDeviceEnumerator : public QObject {
     virtual QList<QString> getAPIs() const = 0;
     virtual void initialize() = 0;
     virtual void deinitialize() = 0;
-    virtual void setLatencyParams(
-            [[maybe_unused]] mixxx::audio::SampleRate sampleRate,
-            [[maybe_unused]] SINT framesPerBuffer) {};
 
     bool initialized() const {
         return m_initialized;

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -17,13 +17,15 @@ SoundDevicePipewire::SoundDevicePipewire(UserSettingsPointer pConfig,
         SoundManager* pManager,
         PipewireEnumerator* pEnumerator,
         uint32_t id,
-        const std::string_view name)
+        std::string_view displayName,
+        std::string_view name)
         : SoundDevice(pConfig, pManager),
           m_pEnumerator(pEnumerator) {
     m_hostAPI = SoundManagerConfig::kAPIPipewire;
-    m_deviceId.name = name.data();
+    m_deviceId.name = displayName.data();
+    m_deviceId.alsaHwDevice = name.data();
     m_deviceId.deviceIndex = id;
-    m_strDisplayName = QString::fromUtf8(name);
+    m_strDisplayName = QString::fromUtf8(displayName);
     m_numInputChannels = mixxx::audio::ChannelCount(0);
     m_numOutputChannels = mixxx::audio::ChannelCount(0);
     m_sampleRate = getDefaultSampleRate();

--- a/src/soundio/sounddevicepipewire.cpp
+++ b/src/soundio/sounddevicepipewire.cpp
@@ -32,9 +32,6 @@ SoundDevicePipewire::SoundDevicePipewire(UserSettingsPointer pConfig,
 }
 
 SoundDevicePipewire::~SoundDevicePipewire() {
-    if (isOpen()) {
-        close();
-    }
 }
 
 SoundDeviceStatus SoundDevicePipewire::open(bool, int) {

--- a/src/soundio/sounddevicepipewire.h
+++ b/src/soundio/sounddevicepipewire.h
@@ -16,7 +16,8 @@ class SoundDevicePipewire : public SoundDevice {
             SoundManager* pManager,
             PipewireEnumerator* pEnumerator,
             uint32_t id,
-            const std::string_view name);
+            std::string_view displayName,
+            std::string_view name);
     ~SoundDevicePipewire() override;
 
     SoundDeviceStatus open(bool isClkRefDevice, int syncBuffers) override;

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -716,17 +716,13 @@ void SoundManager::unconfigureOutput(const AudioOutput& output) {
 }
 
 void SoundManager::devicesEnumerated() {
-    qDebug() << "SoundManager::devicesEnumerated";
-    for (const auto& device : m_pEnumerator->queryDevices()) {
-        qDebug() << device->getDisplayName();
-    }
-
     // currently PipeWire has no sane default device options, we need to obtain
     // it from metadata, and select it in SoundManagerConfig::loadDefaults
     if (!m_config.validateDevices() && !isPipewireSelected()) {
         qDebug() << "!m_config.validateDevices()";
         m_config.loadDefaults(this, SoundManagerConfig::DEVICES);
     }
+    emit devicesUpdated();
 }
 
 void SoundManager::invalidateConfig() {

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -263,7 +263,7 @@ QList<mixxx::audio::SampleRate> SoundManager::getSampleRates(const QString& api)
         return samplerates;
     }
 
-    return QList<mixxx::audio::SampleRate>{
+    return {
             mixxx::audio::SampleRate(44100),
             mixxx::audio::SampleRate(48000),
             mixxx::audio::SampleRate(96000),
@@ -335,8 +335,6 @@ SoundDeviceStatus SoundManager::setupDevices() {
     // loop over all available devices
 
     std::vector<SoundDevicePointer> devices = m_pEnumerator->queryDevices();
-
-    m_pEnumerator->setLatencyParams(m_config.getSampleRate(), m_config.getFramesPerBuffer());
 
     // here some network device conditions can be separated, currently simply
     // add it to the list of other devices

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -248,10 +248,7 @@ void SoundManager::clearDeviceList(bool sleepAfterClosing) {
     m_pErrorDevice.clear();
 
     // deinitialize in case of PortAudio so the devices are updated
-#ifdef __PIPEWIRE__
-    if (m_config.getAPI() != SoundManagerConfig::kAPIPipewire)
-#endif
-    {
+    if (isPipewireSelected()) {
         m_pEnumerator->deinitialize();
     }
 }

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -21,9 +21,7 @@ const QString SoundManagerConfig::kAPIDirectSound = QStringLiteral("Windows Dire
 // (https://github.com/PortAudio/portaudio/pull/881), we may have to update this
 const QString SoundManagerConfig::kAPIIosAudio = QStringLiteral("iOS Audio");
 const QString SoundManagerConfig::kAPICoreAudio = QStringLiteral("Core Audio");
-#ifdef __PIPEWIRE__
 const QString SoundManagerConfig::kAPIPipewire = QStringLiteral("PipeWire");
-#endif
 
 const QString SoundManagerConfig::kEmptyComboBox = QStringLiteral("---");
 const unsigned int SoundManagerConfig::kDefaultDeckCount = 2;
@@ -418,7 +416,16 @@ unsigned int SoundManagerConfig::getAudioBufferSizeIndex() const {
 // This reflects the configured value only. In case of JACK the
 // setting of the JACK server is used.
 unsigned int SoundManagerConfig::getFramesPerBuffer() const {
-    if (m_api == SoundManagerConfig::kAPIJack) {
+    if (m_api == SoundManagerConfig::kAPIPipewire) {
+        unsigned int audioBufferSizeIndex = m_audioBufferSizeIndex;
+        VERIFY_OR_DEBUG_ASSERT(audioBufferSizeIndex > 0) {
+            const int index1024frames = 5;
+            audioBufferSizeIndex = index1024frames;
+        }
+
+        // audioBufferSize combobox contains from 64 to 4096 frames
+        return 1 << (audioBufferSizeIndex + 5);
+    } else if (m_api == SoundManagerConfig::kAPIJack) {
         // in case of jack we configure the frames/period
         if (m_audioBufferSizeIndex ==
                 static_cast<unsigned int>(


### PR DESCRIPTION
Listen to PipeWire metadata events to get default source/sink. Automatically update connections when default source/sink changes, for instance manually by `wpctl set-default ID`, or by connecting/disconnecting a soundcard or bluetooth device.