### PR TITLE
Add uniform time base option for library overview waveforms

### DIFF
--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -20,12 +20,18 @@ namespace {
 
 mixxx::Logger kLogger("OverviewCache");
 
-QString pixmapCacheKey(TrackId trackId, QSize size, mixxx::OverviewType type) {
-    return QString("Overview_%1_%2_%3_%4")
+// The cache key includes the uniform time base mode flag so that toggling
+// the preference invalidates stale pixmaps.
+QString pixmapCacheKey(TrackId trackId,
+        QSize size,
+        mixxx::OverviewType type,
+        bool uniformTimeBase) {
+    return QString("Overview_%1_%2_%3_%4_%5")
             .arg(QString::number(static_cast<int>(type)),
                     trackId.toString(),
                     QString::number(size.width()),
-                    QString::number(size.height()));
+                    QString::number(size.height()),
+                    uniformTimeBase ? QLatin1String("u") : QLatin1String("s"));
 }
 
 // The transformation mode when scaling images
@@ -67,6 +73,8 @@ void OverviewCache::onTrackSummaryChanged(TrackId trackId) {
 }
 
 void OverviewCache::invalidateAll() {
+    // Clear all cached overview pixmaps so they are re-rendered with the
+    // current settings.
     QSet<TrackId> affectedIds;
     for (auto it = m_cacheKeysByTrackId.constBegin();
             it != m_cacheKeysByTrackId.constEnd();
@@ -76,6 +84,7 @@ void OverviewCache::invalidateAll() {
     }
     m_cacheKeysByTrackId.clear();
     m_tracksWithoutOverview.clear();
+    // Notify delegates for each affected track
     for (const TrackId& trackId : std::as_const(affectedIds)) {
         emit overviewChanged(trackId);
     }
@@ -101,7 +110,9 @@ QPixmap OverviewCache::requestCachedOverview(
 
     // kLogger.info() << "requestCachedOverview()" << trackId << pRequester << desiredSize;
 
-    const QString cacheKey = pixmapCacheKey(trackId, desiredSize, type);
+    const bool uniform = m_pConfig->getValue(
+            ConfigKey("[Waveform]", QStringLiteral("overview_uniform_time_base")), false);
+    const QString cacheKey = pixmapCacheKey(trackId, desiredSize, type, uniform);
     QPixmap pixmap;
     QPixmapCache::find(cacheKey, &pixmap);
     return pixmap;
@@ -127,7 +138,9 @@ QPixmap OverviewCache::requestUncachedOverview(
         return QPixmap();
     }
 
-    const QString cacheKey = pixmapCacheKey(trackId, desiredSize, type);
+    const bool uniform = m_pConfig->getValue(
+            ConfigKey("[Waveform]", QStringLiteral("overview_uniform_time_base")), false);
+    const QString cacheKey = pixmapCacheKey(trackId, desiredSize, type, uniform);
     QPixmap pixmap;
     // Maybe it has been cached since the request for cached image?
     if (QPixmapCache::find(cacheKey, &pixmap)) {
@@ -174,11 +187,15 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
     result.type = type;
     result.requester = pRequester;
     result.image = QImage();
-    result.resizedToSize = desiredSize;
+    result.requestedSize = desiredSize;
 
     if (!trackId.isValid() || desiredSize.isEmpty()) {
         return result;
     }
+
+    const bool uniformTimeBase = pConfig->getValue(
+            ConfigKey("[Waveform]", QStringLiteral("overview_uniform_time_base")), false);
+    result.uniformTimeBase = uniformTimeBase;
 
     const bool bDrawMinuteMarkers = pConfig->getValue(
             ConfigKey("[Waveform]", QStringLiteral("draw_library_overview_minute_markers")), true);
@@ -205,23 +222,54 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
                     true /* mono, bottom-aligned */);
 
             if (!image.isNull()) {
-                image = resizeImageSize(image, desiredSize);
-                // draw markers on the resized image for crisp lines
-                // at the final display resolution
-                if (trackDurationMillis > 0) {
+                if (uniformTimeBase && trackDurationMillis > 0) {
+                    // scale to a fixed pixels-per-second ratio so the
+                    // waveform uses a consistent time scale across tracks.
+                    // short tracks occupy less than the full column width;
+                    // long tracks are clipped.
+                    const double timeBaseMinutes = pConfig->getValue(
+                            ConfigKey("[Waveform]",
+                                    QStringLiteral("overview_time_base_minutes")),
+                            6.0);
+                    const double pixelsPerSecond =
+                            desiredSize.width() / (timeBaseMinutes * 60.0);
+                    const double trackDurationSeconds = trackDurationMillis / 1000.0;
+                    const int uniformWidth = static_cast<int>(
+                            trackDurationSeconds * pixelsPerSecond);
+                    QSize uniformSize(uniformWidth, desiredSize.height());
+                    image = resizeImageSize(image, uniformSize);
                     if (bDrawMinuteMarkers) {
                         QList<int> markerXPositions;
-                        for (double currentMarkerMillis = 60000;
-                                currentMarkerMillis < trackDurationMillis;
-                                currentMarkerMillis += 60000) {
+                        for (double markerSeconds = 60.0;
+                                markerSeconds < trackDurationSeconds;
+                                markerSeconds += 60.0) {
                             markerXPositions.append(static_cast<int>(
-                                    (currentMarkerMillis / trackDurationMillis) *
-                                    image.width()));
+                                    markerSeconds * pixelsPerSecond));
                         }
                         drawMinuteMarkers(&image, markerXPositions);
                     }
                     if (!cueInfos.isEmpty()) {
                         drawHotcueMarkers(&image, cueInfos, trackDurationMillis);
+                    }
+                } else {
+                    image = resizeImageSize(image, desiredSize);
+                    // draw markers on the resized image for crisp lines
+                    // at the final display resolution
+                    if (trackDurationMillis > 0) {
+                        if (bDrawMinuteMarkers) {
+                            QList<int> markerXPositions;
+                            for (double currentMarkerMillis = 60000;
+                                    currentMarkerMillis < trackDurationMillis;
+                                    currentMarkerMillis += 60000) {
+                                markerXPositions.append(static_cast<int>(
+                                        (currentMarkerMillis / trackDurationMillis) *
+                                        image.width()));
+                            }
+                            drawMinuteMarkers(&image, markerXPositions);
+                        }
+                        if (!cueInfos.isEmpty()) {
+                            drawHotcueMarkers(&image, cueInfos, trackDurationMillis);
+                        }
                     }
                 }
             }
@@ -323,11 +371,14 @@ void OverviewCache::overviewPrepared() {
 
     // Create pixmap, GUI thread only
     QPixmap pixmap = QPixmap::fromImage(res.image);
-    if (!pixmap.isNull() && !res.resizedToSize.isEmpty()) {
+    if (!pixmap.isNull() && !res.requestedSize.isEmpty()) {
         // we have to be sure that cacheKey is unique
         // because insert replaces the images with the same key
+        // Use requestedSize (the cell size) so the key matches the lookup
+        // in requestCachedOverview/requestUncachedOverview. The actual image
+        // may be narrower in uniform mode, but the delegate handles that.
         const QString cacheKey = pixmapCacheKey(
-                res.trackId, res.resizedToSize, res.type);
+                res.trackId, res.requestedSize, res.type, res.uniformTimeBase);
         QPixmapCache::insert(cacheKey, pixmap);
         // Store the cached track id so we can clear ALL pixmaps of a track
         // in case the waveform has been cleared/updated.

--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -66,6 +66,21 @@ void OverviewCache::onTrackSummaryChanged(TrackId trackId) {
     emit overviewChanged(trackId);
 }
 
+void OverviewCache::invalidateAll() {
+    QSet<TrackId> affectedIds;
+    for (auto it = m_cacheKeysByTrackId.constBegin();
+            it != m_cacheKeysByTrackId.constEnd();
+            ++it) {
+        QPixmapCache::remove(it.value());
+        affectedIds.insert(it.key());
+    }
+    m_cacheKeysByTrackId.clear();
+    m_tracksWithoutOverview.clear();
+    for (const TrackId& trackId : std::as_const(affectedIds)) {
+        emit overviewChanged(trackId);
+    }
+}
+
 QPixmap OverviewCache::requestCachedOverview(
         mixxx::OverviewType type,
         TrackId trackId,
@@ -165,6 +180,9 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
         return result;
     }
 
+    const bool bDrawMinuteMarkers = pConfig->getValue(
+            ConfigKey("[Waveform]", QStringLiteral("draw_library_overview_minute_markers")), true);
+
     mixxx::DbConnectionPooler dbConnectionPooler(pDbConnectionPool);
     QSqlDatabase database = mixxx::DbConnectionPooled(pDbConnectionPool);
 
@@ -188,10 +206,23 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
 
             if (!image.isNull()) {
                 image = resizeImageSize(image, desiredSize);
-                // draw hotcue markers on the resized image for crisp 1px lines
-                // at the final display resolution, matching the deck overview style
-                if (trackDurationMillis > 0 && !cueInfos.isEmpty()) {
-                    drawHotcueMarkers(&image, cueInfos, trackDurationMillis);
+                // draw markers on the resized image for crisp lines
+                // at the final display resolution
+                if (trackDurationMillis > 0) {
+                    if (bDrawMinuteMarkers) {
+                        QList<int> markerXPositions;
+                        for (double currentMarkerMillis = 60000;
+                                currentMarkerMillis < trackDurationMillis;
+                                currentMarkerMillis += 60000) {
+                            markerXPositions.append(static_cast<int>(
+                                    (currentMarkerMillis / trackDurationMillis) *
+                                    image.width()));
+                        }
+                        drawMinuteMarkers(&image, markerXPositions);
+                    }
+                    if (!cueInfos.isEmpty()) {
+                        drawHotcueMarkers(&image, cueInfos, trackDurationMillis);
+                    }
                 }
             }
             result.image = image;
@@ -255,6 +286,31 @@ void OverviewCache::drawHotcueMarkers(
         // draw main bright marker line (1px wide)
         markerPainter.setPen(fillColor);
         markerPainter.drawLine(x, 0, x, imageHeight);
+    }
+}
+
+// static
+void OverviewCache::drawMinuteMarkers(
+        QImage* pImage,
+        const QList<int>& markerXPositions) {
+    if (pImage->format() != QImage::Format_ARGB32_Premultiplied) {
+        *pImage = pImage->convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    }
+
+    QPainter markerPainter(pImage);
+    markerPainter.setRenderHint(QPainter::Antialiasing, false);
+    const int imageWidth = pImage->width();
+    const int imageHeight = pImage->height();
+    const int markerHeight = static_cast<int>(imageHeight * 0.2);
+    const int lowerMarkerYPos = static_cast<int>(imageHeight * 0.8);
+    const int inset = 1;
+    const QColor minuteColor(255, 255, 255, 204); // 80% opacity
+
+    for (int x : markerXPositions) {
+        if (x >= 0 && x < imageWidth) {
+            markerPainter.fillRect(x, inset, 1, markerHeight - inset, minuteColor);
+            markerPainter.fillRect(x, lowerMarkerYPos, 1, imageHeight - lowerMarkerYPos - inset, minuteColor);
+        }
     }
 }
 

--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -7,9 +7,11 @@
 
 #include "library/dao/analysisdao.h"
 #include "moc_overviewcache.cpp"
+#include "util/color/color.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/db/dbconnectionpooler.h"
 #include "util/logger.h"
+#include "util/painterscope.h"
 #include "waveform/renderers/waveformoverviewrenderer.h"
 #include "waveform/renderers/waveformsignalcolors.h"
 #include "waveform/waveformfactory.h"
@@ -94,6 +96,8 @@ QPixmap OverviewCache::requestUncachedOverview(
         mixxx::OverviewType type,
         const WaveformSignalColors& signalColors,
         TrackId trackId,
+        const QList<mixxx::CueInfo>& cueInfos,
+        double trackDurationMillis,
         const QObject* pRequester,
         QSize desiredSize) {
     if (!trackId.isValid()) {
@@ -107,8 +111,6 @@ QPixmap OverviewCache::requestUncachedOverview(
     if (m_tracksWithoutOverview.contains(trackId)) {
         return QPixmap();
     }
-
-    // kLogger.info() << "requestUncachedOverview()" << trackId << pRequester << desiredSize;
 
     const QString cacheKey = pixmapCacheKey(trackId, desiredSize, type);
     QPixmap pixmap;
@@ -128,6 +130,8 @@ QPixmap OverviewCache::requestUncachedOverview(
             type,
             signalColors,
             trackId,
+            cueInfos,
+            trackDurationMillis,
             pRequester,
             desiredSize);
     connect(watcher,
@@ -146,9 +150,10 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
         mixxx::OverviewType type,
         const WaveformSignalColors& signalColors,
         TrackId trackId,
+        const QList<mixxx::CueInfo>& cueInfos,
+        double trackDurationMillis,
         const QObject* pRequester,
         QSize desiredSize) {
-    // kLogger.warning() << "prepareOverview" << trackId;
     FutureResult result;
     result.trackId = trackId;
     result.type = type;
@@ -161,9 +166,10 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
     }
 
     mixxx::DbConnectionPooler dbConnectionPooler(pDbConnectionPool);
+    QSqlDatabase database = mixxx::DbConnectionPooled(pDbConnectionPool);
 
     AnalysisDao analysisDao(pConfig);
-    analysisDao.initialize(mixxx::DbConnectionPooled(pDbConnectionPool));
+    analysisDao.initialize(database);
 
     QList<AnalysisDao::AnalysisInfo> analyses =
             analysisDao.getAnalysesForTrackByType(
@@ -182,12 +188,74 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
 
             if (!image.isNull()) {
                 image = resizeImageSize(image, desiredSize);
+                // draw hotcue markers on the resized image for crisp 1px lines
+                // at the final display resolution, matching the deck overview style
+                if (trackDurationMillis > 0 && !cueInfos.isEmpty()) {
+                    drawHotcueMarkers(&image, cueInfos, trackDurationMillis);
+                }
             }
             result.image = image;
         }
     }
 
     return result;
+}
+
+// static
+void OverviewCache::drawHotcueMarkers(
+        QImage* pImage,
+        const QList<mixxx::CueInfo>& cueInfos,
+        double trackDurationMillis) {
+    if (pImage->format() != QImage::Format_ARGB32_Premultiplied) {
+        *pImage = pImage->convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    }
+
+    QPainter markerPainter(pImage);
+    markerPainter.setRenderHint(QPainter::Antialiasing, false);
+    const int imageWidth = pImage->width();
+    const int imageHeight = pImage->height();
+    PainterScope painterScope(&markerPainter);
+    for (const auto& cueInfo : cueInfos) {
+        if (cueInfo.getType() != mixxx::CueType::HotCue) {
+            continue;
+        }
+
+        auto positionMillis = cueInfo.getStartPositionMillis();
+        if (!positionMillis.has_value()) {
+            continue;
+        }
+
+        // allow negative positions (preroll)
+        if (*positionMillis > trackDurationMillis) {
+            continue;
+        }
+
+        const int x = static_cast<int>(
+                (*positionMillis / trackDurationMillis) * imageWidth);
+
+        if (x < 0 || x >= imageWidth) {
+            continue;
+        }
+
+        // use same rendering style as deck overview:
+        // contrasting border line + bright fill line
+        auto color = cueInfo.getColor();
+        if (!color.has_value()) {
+            continue;
+        }
+
+        QColor fillColor = QColor::fromRgb(*color).lighter(110);
+        QColor borderColor = Color::chooseContrastColor(
+                QColor::fromRgb(*color), 120);
+
+        // draw border/shadow line (1px wide, offset by -1)
+        markerPainter.setPen(borderColor);
+        markerPainter.drawLine(x - 1, 0, x - 1, imageHeight);
+
+        // draw main bright marker line (1px wide)
+        markerPainter.setPen(fillColor);
+        markerPainter.drawLine(x, 0, x, imageHeight);
+    }
 }
 
 // watcher

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -16,6 +16,7 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
     Q_OBJECT
   public:
     void onTrackSummaryChanged(TrackId);
+    void invalidateAll();
 
     QPixmap requestCachedOverview(
             mixxx::OverviewType type,
@@ -76,6 +77,10 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
             QImage* pImage,
             const QList<mixxx::CueInfo>& cueInfos,
             double trackDurationMillis);
+
+    static void drawMinuteMarkers(
+            QImage* pImage,
+            const QList<int>& markerXPositions);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -34,14 +34,16 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
 
     struct FutureResult {
         FutureResult()
-                : requester(nullptr) {
+                : requester(nullptr),
+                  uniformTimeBase(false) {
         }
 
         TrackId trackId;
         mixxx::OverviewType type;
         QImage image;
-        QSize resizedToSize;
+        QSize requestedSize;
         const QObject* requester;
+        bool uniformTimeBase;
     };
 
   public slots:

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -4,6 +4,7 @@
 
 #include "analyzer/analyzerprogress.h"
 #include "preferences/usersettings.h"
+#include "track/cueinfo.h"
 #include "track/trackid.h"
 #include "util/db/dbconnectionpool.h"
 #include "util/singleton.h"
@@ -25,6 +26,8 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
             mixxx::OverviewType type,
             const WaveformSignalColors& signalColors,
             TrackId trackId,
+            const QList<mixxx::CueInfo>& cueInfos,
+            double trackDurationMillis,
             const QObject* pRequester,
             QSize desiredSize);
 
@@ -64,8 +67,15 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
             mixxx::OverviewType type,
             const WaveformSignalColors& signalColors,
             TrackId trackId,
+            const QList<mixxx::CueInfo>& cueInfos,
+            double trackDurationMillis,
             const QObject* pRequester,
             QSize desiredSize);
+
+    static void drawHotcueMarkers(
+            QImage* pImage,
+            const QList<mixxx::CueInfo>& cueInfos,
+            double trackDurationMillis);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/library/tabledelegates/overviewdelegate.cpp
+++ b/src/library/tabledelegates/overviewdelegate.cpp
@@ -182,9 +182,15 @@ void OverviewDelegate::paintItem(QPainter* painter,
         }
         paintItemBackground(painter, option, index);
     } else {
-        // We have a cached pixmap, paint it
+        // We have a cached pixmap, paint it.
+        // Draw at natural logical size from the cell's top-left, clipped to
+        // the cell rect. No scaling, so markers stay at 1:1. Short uniform
+        // tracks leave empty space on the right; long tracks clip overflow.
         pixmap.setDevicePixelRatio(scaleFactor);
-        painter->drawPixmap(option.rect, pixmap);
+        painter->save();
+        painter->setClipRect(option.rect);
+        painter->drawPixmap(option.rect.topLeft(), pixmap);
+        painter->restore();
     }
 
     // Draw a border if the cover art cell has focus

--- a/src/library/tabledelegates/overviewdelegate.cpp
+++ b/src/library/tabledelegates/overviewdelegate.cpp
@@ -7,6 +7,7 @@
 #include "library/overviewcache.h"
 #include "library/trackmodel.h"
 #include "moc_overviewdelegate.cpp"
+#include "track/track.h"
 #include "util/logger.h"
 #include "util/make_const_iterator.h"
 #include "widget/wlibrary.h"
@@ -157,11 +158,27 @@ void OverviewDelegate::paintItem(QPainter* painter,
             // non-cache we can request an update.
             m_cacheMissIds.insert(trackId);
         } else {
-            pixmap = m_pCache->requestUncachedOverview(m_type,
-                    m_signalColors,
-                    trackId,
-                    this,
-                    option.rect.size() * scaleFactor);
+            // extract cue data from the Track in the GUI thread so the
+            // async render job only needs plain values, not a TrackPointer
+            TrackPointer pTrack = m_pTrackModel->getTrack(index);
+            if (pTrack) {
+                const double trackDurationMillis = pTrack->getDuration() * 1000.0;
+                const mixxx::audio::SampleRate sampleRate = pTrack->getSampleRate();
+                QList<mixxx::CueInfo> cueInfos;
+                const QList<CuePointer> cuePoints = pTrack->getCuePoints();
+                for (const auto& pCue : cuePoints) {
+                    if (pCue) {
+                        cueInfos.append(pCue->getCueInfo(sampleRate));
+                    }
+                }
+                pixmap = m_pCache->requestUncachedOverview(m_type,
+                        m_signalColors,
+                        trackId,
+                        cueInfos,
+                        trackDurationMillis,
+                        this,
+                        option.rect.size() * scaleFactor);
+            }
         }
         paintItemBackground(painter, option, index);
     } else {

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -6,6 +6,7 @@
 #include "control/controlpushbutton.h"
 #include "library/dao/analysisdao.h"
 #include "library/library.h"
+#include "library/overviewcache.h"
 #include "moc_dlgprefwaveform.cpp"
 #include "preferences/waveformsettings.h"
 #include "util/db/dbconnectionpooled.h"
@@ -89,6 +90,10 @@ DlgPrefWaveform::DlgPrefWaveform(
     m_pOverviewMinuteMarkersControl = std::make_unique<ControlObject>(
             ConfigKey(kWaveformGroup, QStringLiteral("draw_overview_minute_markers")));
     m_pOverviewMinuteMarkersControl->setReadOnly();
+
+    m_pOverviewLibraryMinuteMarkersControl = std::make_unique<ControlObject>(
+            ConfigKey(kWaveformGroup, QStringLiteral("draw_library_overview_minute_markers")));
+    m_pOverviewLibraryMinuteMarkersControl->setReadOnly();
 
     // Populate untilMark options
     untilMarkAlignComboBox->addItem(tr("Top"));
@@ -202,6 +207,10 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QCheckBox::toggled,
             this,
             &DlgPrefWaveform::slotSetOverviewMinuteMarkers);
+    connect(overviewLibraryMinuteMarkersCheckBox,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefWaveform::slotSetOverviewLibraryMinuteMarkers);
     connect(overviewStereoCheckBox,
             &QCheckBox::toggled,
             this,
@@ -389,6 +398,11 @@ void DlgPrefWaveform::slotUpdate() {
     overviewMinuteMarkersCheckBox->setChecked(drawOverviewMinuteMarkers);
     m_pOverviewMinuteMarkersControl->forceSet(drawOverviewMinuteMarkers);
 
+    bool drawLibraryOverviewMinuteMarkers = m_pConfig->getValue(
+            ConfigKey(kWaveformGroup, QStringLiteral("draw_library_overview_minute_markers")), true);
+    overviewLibraryMinuteMarkersCheckBox->setChecked(drawLibraryOverviewMinuteMarkers);
+    m_pOverviewLibraryMinuteMarkersControl->forceSet(drawLibraryOverviewMinuteMarkers);
+
     WaveformSettings waveformSettings(m_pConfig);
     enableWaveformCaching->setChecked(waveformSettings.waveformCachingEnabled());
     enableWaveformGenerationWithAnalysis->setChecked(
@@ -448,6 +462,7 @@ void DlgPrefWaveform::slotResetToDefaults() {
 
     // Show minute markers.
     overviewMinuteMarkersCheckBox->setChecked(true);
+    overviewLibraryMinuteMarkersCheckBox->setChecked(true);
 
     // Use "Global" waveform gain + ReplayGain if enabled
     overview_scale_allReplayGain->setChecked(!WaveformWidgetFactory::isOverviewNormalizedDefault());
@@ -734,6 +749,14 @@ void DlgPrefWaveform::slotSetOverviewMinuteMarkers(bool draw) {
                                 QStringLiteral("draw_overview_minute_markers")),
             draw);
     m_pOverviewMinuteMarkersControl->forceSet(draw);
+}
+
+void DlgPrefWaveform::slotSetOverviewLibraryMinuteMarkers(bool draw) {
+    m_pConfig->setValue(ConfigKey(kWaveformGroup,
+                                QStringLiteral("draw_library_overview_minute_markers")),
+            draw);
+    m_pOverviewLibraryMinuteMarkersControl->forceSet(draw);
+    OverviewCache::instance()->invalidateAll();
 }
 
 void DlgPrefWaveform::slotSetOverviewStereoMode(bool stereo) {

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -95,6 +95,14 @@ DlgPrefWaveform::DlgPrefWaveform(
             ConfigKey(kWaveformGroup, QStringLiteral("draw_library_overview_minute_markers")));
     m_pOverviewLibraryMinuteMarkersControl->setReadOnly();
 
+    m_pOverviewUniformTimeBaseControl = std::make_unique<ControlObject>(
+            ConfigKey(kWaveformGroup, QStringLiteral("overview_uniform_time_base")));
+    m_pOverviewUniformTimeBaseControl->setReadOnly();
+
+    m_pOverviewTimeBaseMinutesControl = std::make_unique<ControlObject>(
+            ConfigKey(kWaveformGroup, QStringLiteral("overview_time_base_minutes")));
+    m_pOverviewTimeBaseMinutesControl->setReadOnly();
+
     // Populate untilMark options
     untilMarkAlignComboBox->addItem(tr("Top"));
     untilMarkAlignComboBox->addItem(tr("Center"));
@@ -215,6 +223,14 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QCheckBox::toggled,
             this,
             &DlgPrefWaveform::slotSetOverviewStereoMode);
+    connect(overviewUniformTimeBaseCheckBox,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefWaveform::slotSetOverviewUniformTimeBase);
+    connect(overviewTimeBaseMinutesSpinBox,
+            QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgPrefWaveform::slotSetOverviewTimeBaseMinutes);
 
     connect(factory,
             &WaveformWidgetFactory::waveformMeasured,
@@ -403,6 +419,16 @@ void DlgPrefWaveform::slotUpdate() {
     overviewLibraryMinuteMarkersCheckBox->setChecked(drawLibraryOverviewMinuteMarkers);
     m_pOverviewLibraryMinuteMarkersControl->forceSet(drawLibraryOverviewMinuteMarkers);
 
+    bool uniformTimeBase = m_pConfig->getValue(
+            ConfigKey(kWaveformGroup, QStringLiteral("overview_uniform_time_base")), false);
+    overviewUniformTimeBaseCheckBox->setChecked(uniformTimeBase);
+    m_pOverviewUniformTimeBaseControl->forceSet(uniformTimeBase);
+
+    double timeBaseMinutes = m_pConfig->getValue(
+            ConfigKey(kWaveformGroup, QStringLiteral("overview_time_base_minutes")), 6.0);
+    overviewTimeBaseMinutesSpinBox->setValue(timeBaseMinutes);
+    m_pOverviewTimeBaseMinutesControl->forceSet(timeBaseMinutes);
+
     WaveformSettings waveformSettings(m_pConfig);
     enableWaveformCaching->setChecked(waveformSettings.waveformCachingEnabled());
     enableWaveformGenerationWithAnalysis->setChecked(
@@ -463,6 +489,10 @@ void DlgPrefWaveform::slotResetToDefaults() {
     // Show minute markers.
     overviewMinuteMarkersCheckBox->setChecked(true);
     overviewLibraryMinuteMarkersCheckBox->setChecked(true);
+
+    // Uniform time base off by default.
+    overviewUniformTimeBaseCheckBox->setChecked(false);
+    overviewTimeBaseMinutesSpinBox->setValue(6.0);
 
     // Use "Global" waveform gain + ReplayGain if enabled
     overview_scale_allReplayGain->setChecked(!WaveformWidgetFactory::isOverviewNormalizedDefault());
@@ -762,6 +792,23 @@ void DlgPrefWaveform::slotSetOverviewLibraryMinuteMarkers(bool draw) {
 void DlgPrefWaveform::slotSetOverviewStereoMode(bool stereo) {
     m_pConfig->setValue(ConfigKey(kWaveformGroup, QStringLiteral("overview_stereo_mode")), stereo);
     m_pOverviewStereoControl->forceSet(stereo);
+}
+
+void DlgPrefWaveform::slotSetOverviewUniformTimeBase(bool uniform) {
+    m_pConfig->setValue(ConfigKey(kWaveformGroup,
+                                QStringLiteral("overview_uniform_time_base")),
+            uniform);
+    m_pOverviewUniformTimeBaseControl->forceSet(uniform);
+    // Invalidate cached overviews so they are re-rendered with the new mode
+    OverviewCache::instance()->invalidateAll();
+}
+
+void DlgPrefWaveform::slotSetOverviewTimeBaseMinutes(double minutes) {
+    m_pConfig->setValue(ConfigKey(kWaveformGroup,
+                                QStringLiteral("overview_time_base_minutes")),
+            minutes);
+    m_pOverviewTimeBaseMinutesControl->forceSet(minutes);
+    OverviewCache::instance()->invalidateAll();
 }
 
 void DlgPrefWaveform::slotWaveformMeasured(float frameRate, int droppedFrames) {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -70,6 +70,8 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetOverviewMinuteMarkers(bool minuteMarkers);
     void slotSetOverviewLibraryMinuteMarkers(bool minuteMarkers);
     void slotSetOverviewScaling();
+    void slotSetOverviewUniformTimeBase(bool uniform);
+    void slotSetOverviewTimeBaseMinutes(double minutes);
 
   private:
     void initWaveformControl();
@@ -89,6 +91,8 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     std::unique_ptr<ControlObject> m_pOverviewMinuteMarkersControl;
     std::unique_ptr<ControlObject> m_pOverviewLibraryMinuteMarkersControl;
     std::unique_ptr<ControlObject> m_pOverviewStereoControl;
+    std::unique_ptr<ControlObject> m_pOverviewUniformTimeBaseControl;
+    std::unique_ptr<ControlObject> m_pOverviewTimeBaseMinutesControl;
 
     UserSettingsPointer m_pConfig;
     std::shared_ptr<Library> m_pLibrary;

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -68,6 +68,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetWaveformOverviewType();
     void slotSetOverviewStereoMode(bool mono);
     void slotSetOverviewMinuteMarkers(bool minuteMarkers);
+    void slotSetOverviewLibraryMinuteMarkers(bool minuteMarkers);
     void slotSetOverviewScaling();
 
   private:
@@ -86,6 +87,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
 
     std::unique_ptr<ControlPushButton> m_pTypeControl;
     std::unique_ptr<ControlObject> m_pOverviewMinuteMarkersControl;
+    std::unique_ptr<ControlObject> m_pOverviewLibraryMinuteMarkersControl;
     std::unique_ptr<ControlObject> m_pOverviewStereoControl;
 
     UserSettingsPointer m_pConfig;

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -761,7 +761,51 @@ Select from different types of displays for the waveform overview, which differ 
       </widget>
      </item>
 
-     <item row="4" column="0">
+     <item row="4" column="1" colspan="4">
+      <widget class="QCheckBox" name="overviewUniformTimeBaseCheckBox">
+       <property name="toolTip">
+        <string>Scale all library overview waveforms to the same pixels-per-second ratio, so minute markers align across tracks regardless of duration. Shorter tracks occupy less than the full column width; longer tracks are clipped.</string>
+       </property>
+       <property name="text">
+        <string>Uniform time base for library overviews</string>
+       </property>
+      </widget>
+     </item>
+
+     <item row="5" column="1">
+      <widget class="QLabel" name="overviewTimeBaseMinutesLabel">
+       <property name="text">
+        <string>Minutes per column width</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QDoubleSpinBox" name="overviewTimeBaseMinutesSpinBox">
+       <property name="toolTip">
+        <string>How many minutes of audio fit across the full overview column width when uniform time base is enabled.</string>
+       </property>
+       <property name="suffix">
+        <string> min</string>
+       </property>
+       <property name="decimals">
+        <number>1</number>
+       </property>
+       <property name="minimum">
+        <double>0.500000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>60.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.500000000000000</double>
+       </property>
+       <property name="value">
+        <double>6.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+
+     <item row="6" column="0">
       <widget class="QLabel" name="overview_gain_label">
        <property name="toolTip">
         <string extracomment="Select a gain mode for the waveform overview."/>
@@ -771,7 +815,7 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="4" column="1" colspan="4">
+     <item row="6" column="1" colspan="4">
       <widget class="QRadioButton" name="overview_scale_normalize">
        <property name="text">
         <string>Normalize to peak</string>
@@ -781,7 +825,7 @@ Select from different types of displays for the waveform overview, which differ 
        </attribute>
       </widget>
      </item>
-     <item row="5" column="1" colspan="4">
+     <item row="7" column="1" colspan="4">
       <widget class="QRadioButton" name="overview_scale_allReplayGain">
        <property name="text">
         <string extracomment="'Global' refers to the 'Global' visual gain in the scrolling waveform settings">Use Waveform "Global" gain and ReplayGain (if enabled)</string>
@@ -938,6 +982,8 @@ Select from different types of displays for the waveform overview, which differ 
   <tabstop>overviewStereoCheckBox</tabstop>
   <tabstop>overviewMinuteMarkersCheckBox</tabstop>
   <tabstop>overviewLibraryMinuteMarkersCheckBox</tabstop>
+  <tabstop>overviewUniformTimeBaseCheckBox</tabstop>
+  <tabstop>overviewTimeBaseMinutesSpinBox</tabstop>
   <tabstop>overview_scale_normalize</tabstop>
   <tabstop>overview_scale_allReplayGain</tabstop>
   <tabstop>enableWaveformCaching</tabstop>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -740,7 +740,7 @@ Select from different types of displays for the waveform overview, which differ 
      <item row="1" column="1" colspan="4">
       <widget class="QCheckBox" name="overviewStereoCheckBox">
        <property name="text">
-        <string>Stereo mode</string>
+        <string>Stereo deck overviews</string>
        </property>
       </widget>
      </item>
@@ -748,12 +748,20 @@ Select from different types of displays for the waveform overview, which differ 
      <item row="2" column="1" colspan="4">
       <widget class="QCheckBox" name="overviewMinuteMarkersCheckBox">
        <property name="text">
-        <string>Show minute markers on waveform overview</string>
+        <string>Show minute markers on deck overviews</string>
        </property>
       </widget>
      </item>
 
-     <item row="3" column="0">
+     <item row="3" column="1" colspan="4">
+      <widget class="QCheckBox" name="overviewLibraryMinuteMarkersCheckBox">
+       <property name="text">
+        <string>Show minute markers on library overviews</string>
+       </property>
+      </widget>
+     </item>
+
+     <item row="4" column="0">
       <widget class="QLabel" name="overview_gain_label">
        <property name="toolTip">
         <string extracomment="Select a gain mode for the waveform overview."/>
@@ -763,7 +771,7 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="3" column="1" colspan="4">
+     <item row="4" column="1" colspan="4">
       <widget class="QRadioButton" name="overview_scale_normalize">
        <property name="text">
         <string>Normalize to peak</string>
@@ -773,7 +781,7 @@ Select from different types of displays for the waveform overview, which differ 
        </attribute>
       </widget>
      </item>
-     <item row="4" column="1" colspan="4">
+     <item row="5" column="1" colspan="4">
       <widget class="QRadioButton" name="overview_scale_allReplayGain">
        <property name="text">
         <string extracomment="'Global' refers to the 'Global' visual gain in the scrolling waveform settings">Use Waveform "Global" gain and ReplayGain (if enabled)</string>
@@ -929,6 +937,7 @@ Select from different types of displays for the waveform overview, which differ 
   <tabstop>waveformOverviewComboBox</tabstop>
   <tabstop>overviewStereoCheckBox</tabstop>
   <tabstop>overviewMinuteMarkersCheckBox</tabstop>
+  <tabstop>overviewLibraryMinuteMarkersCheckBox</tabstop>
   <tabstop>overview_scale_normalize</tabstop>
   <tabstop>overview_scale_allReplayGain</tabstop>
   <tabstop>enableWaveformCaching</tabstop>


### PR DESCRIPTION
> Disclaimer: the code and PR message were written by GLM-5.2 through Devin.

adds a Preferences option to render library overview waveforms using a uniform
pixels-per-second ratio, so that waveform width reflects track duration, rather
than stretching every waveform to the full column width.

- `overview_uniform_time_base`: when enabled, short tracks render narrower than
  the column and long tracks clip at the column edge
- `overview_time_base_minutes`: configurable reference duration (0.5–60 min,
  default 6.0) that maps to the full column width
- minute markers are redrawn at exact pixel positions after the uniform resize
  so they align across tracks regardless of duration
- cache key uses the requested cell size (not the uniform image size) so pixmaps
  are found on lookup; the uniform flag participates in the key to invalidate
  on toggle
- `OverviewCache::invalidateAll()` clears all cached pixmaps and notifies
  delegates when either preference changes
- delegate draws narrow pixmaps left-aligned and clipped rather than stretching
  to fill the cell

default behaviour is unchanged when the option is disabled.

<sub>Disclaimer: the code and PR message were written by GLM-5.2 using Devin.</sub>