### PR TITLE
add invert zoom direction preference for waveform mouse wheel

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -21,6 +21,8 @@ const ConfigKey kWaveformOptionsKey(kWaveformGroup,
         QStringLiteral("waveform_options"));
 const ConfigKey kHardwareAccelerationKey(kWaveformGroup,
         QStringLiteral("use_hardware_acceleration"));
+const ConfigKey kInvertZoomDirectionKey(kWaveformGroup,
+        QStringLiteral("invert_zoom_direction"));
 } // namespace
 
 // for OverviewType
@@ -177,6 +179,10 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QCheckBox::clicked,
             this,
             &DlgPrefWaveform::slotSetZoomSynchronization);
+    connect(invertZoomDirectionCheckBox,
+            &QCheckBox::clicked,
+            this,
+            &DlgPrefWaveform::slotSetInvertZoomDirection);
     connect(allVisualGain,
             QOverload<double>::of(&QDoubleSpinBox::valueChanged),
             this,
@@ -339,6 +345,8 @@ void DlgPrefWaveform::slotUpdate() {
     endOfTrackWarningTimeSpinBox->setValue(factory->getEndOfTrackWarningTime());
     endOfTrackWarningTimeSlider->setValue(factory->getEndOfTrackWarningTime());
     synchronizeZoomCheckBox->setChecked(factory->isZoomSync());
+    invertZoomDirectionCheckBox->setChecked(
+            m_pConfig->getValue(kInvertZoomDirectionKey, false));
     allVisualGain->setValue(factory->getVisualGain(BandIndex::AllBand));
     lowVisualGain->setValue(factory->getVisualGain(BandIndex::Low));
     midVisualGain->setValue(factory->getVisualGain(BandIndex::Mid));
@@ -392,7 +400,7 @@ void DlgPrefWaveform::slotUpdate() {
     WaveformSettings waveformSettings(m_pConfig);
     enableWaveformCaching->setChecked(waveformSettings.waveformCachingEnabled());
     enableWaveformGenerationWithAnalysis->setChecked(
-        waveformSettings.waveformGenerationWithAnalysisEnabled());
+            waveformSettings.waveformGenerationWithAnalysisEnabled());
     calculateCachedWaveformDiskUsage();
 }
 
@@ -401,7 +409,7 @@ void DlgPrefWaveform::slotApply() {
     WaveformSettings waveformSettings(m_pConfig);
     waveformSettings.setWaveformCachingEnabled(enableWaveformCaching->isChecked());
     waveformSettings.setWaveformGenerationWithAnalysisEnabled(
-        enableWaveformGenerationWithAnalysis->isChecked());
+            enableWaveformGenerationWithAnalysis->isChecked());
 }
 
 void DlgPrefWaveform::slotResetToDefaults() {
@@ -438,6 +446,8 @@ void DlgPrefWaveform::slotResetToDefaults() {
     defaultZoomComboBox->setCurrentIndex(3 + 1);
 
     synchronizeZoomCheckBox->setChecked(true);
+
+    invertZoomDirectionCheckBox->setChecked(false);
 
     // RGB overview.
     waveformOverviewComboBox->setCurrentIndex(
@@ -705,6 +715,10 @@ void DlgPrefWaveform::slotSetDefaultZoom(int index) {
 
 void DlgPrefWaveform::slotSetZoomSynchronization(bool checked) {
     WaveformWidgetFactory::instance()->setZoomSync(checked);
+}
+
+void DlgPrefWaveform::slotSetInvertZoomDirection(bool checked) {
+    m_pConfig->setValue(kInvertZoomDirectionKey, checked);
 }
 
 void DlgPrefWaveform::slotSetVisualGainAll(double gain) {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -47,6 +47,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
 #endif
     void slotSetDefaultZoom(int index);
     void slotSetZoomSynchronization(bool checked);
+    void slotSetInvertZoomDirection(bool checked);
     void slotSetVisualGainAll(double gain);
     void slotSetVisualGainLow(double gain);
     void slotSetVisualGainMid(double gain);

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -322,7 +322,18 @@ Select from different types of displays for the waveform, which differ primarily
       </widget>
      </item>
 
-     <item row="10" column="0">
+     <item row="10" column="1" colspan="4">
+      <widget class="QCheckBox" name="invertZoomDirectionCheckBox">
+       <property name="toolTip">
+        <string>Invert the zoom direction when scrolling with the mouse wheel over the waveform.</string>
+       </property>
+       <property name="text">
+        <string>Invert mouse wheel zoom direction</string>
+       </property>
+      </widget>
+     </item>
+
+     <item row="11" column="0">
       <widget class="QLabel" name="visualGainLabel">
        <property name="text">
         <string>Visual gain</string>
@@ -335,7 +346,7 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="10" column="1" colspan="4">
+     <item row="11" column="1" colspan="4">
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="0" column="0">
         <widget class="QLabel" name="visualGainLabel_global">
@@ -469,7 +480,7 @@ Select from different types of displays for the waveform, which differ primarily
       </layout>
      </item>
 
-     <item row="11" column="0">
+     <item row="12" column="0">
       <widget class="QLabel" name="marker_hints_label">
        <property name="text">
         <string>Play marker hints</string>
@@ -479,14 +490,14 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="11" column="1" colspan="2">
+     <item row="12" column="1" colspan="2">
       <widget class="QCheckBox" name="untilMarkShowBeatsCheckBox">
        <property name="text">
         <string>Beats until next marker</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="3" colspan="2">
+     <item row="12" column="3" colspan="2">
       <widget class="QCheckBox" name="untilMarkShowTimeCheckBox">
        <property name="text">
         <string>Time until next marker</string>
@@ -494,7 +505,7 @@ Select from different types of displays for the waveform, which differ primarily
       </widget>
      </item>
 
-     <item row="12" column="1" colspan="4">
+     <item row="13" column="1" colspan="4">
       <layout class="QHBoxLayout" name="marker_option_layout">
        <item>
         <layout class="QVBoxLayout" name="marker_options_placement_layout">
@@ -578,7 +589,7 @@ Select from different types of displays for the waveform, which differ primarily
       </layout><!-- marker_option_layout -->
      </item>
 
-     <item row="13" column="1" colspan="4">
+     <item row="14" column="1" colspan="4">
       <widget class="QLabel" name="requiresGLSLLabel">
        <property name="text">
         <string>This functionality requires waveform acceleration.</string>
@@ -589,7 +600,7 @@ Select from different types of displays for the waveform, which differ primarily
       </widget>
      </item>
 
-     <item row="14" column="0">
+     <item row="15" column="0">
       <widget class="QLabel" name="stemOpacityLabel">
        <property name="text">
         <string>Stem</string>
@@ -602,7 +613,7 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="14" column="1" colspan="4">
+     <item row="15" column="1" colspan="4">
       <layout class="QGridLayout" name="stemOpacityGridLayout">
        <item row="0" column="0">
         <widget class="QLabel" name="stemOpacityMainLabel">
@@ -699,7 +710,7 @@ Select from different types of displays for the waveform, which differ primarily
       </layout>
      </item>
 
-     <item row="15" column="1" colspan="4">
+     <item row="16" column="1" colspan="4">
       <widget class="QLabel" name="requiresGLSLLabel2">
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -917,6 +928,7 @@ Select from different types of displays for the waveform overview, which differ 
   <tabstop>playMarkerPositionSlider</tabstop>
   <tabstop>defaultZoomComboBox</tabstop>
   <tabstop>synchronizeZoomCheckBox</tabstop>
+  <tabstop>invertZoomDirectionCheckBox</tabstop>
   <tabstop>allVisualGain</tabstop>
   <tabstop>lowVisualGain</tabstop>
   <tabstop>midVisualGain</tabstop>

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -44,7 +44,7 @@ WWaveformViewer::WWaveformViewer(
 }
 
 WWaveformViewer::~WWaveformViewer() {
-    //qDebug() << "~WWaveformViewer";
+    // qDebug() << "~WWaveformViewer";
 }
 
 void WWaveformViewer::setup(const QDomNode& node, const SkinContext& context) {
@@ -91,8 +91,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
             m_bBending = false;
         }
         m_bScratching = true;
-        int eventPosValue = m_waveformWidget->getOrientation() == Qt::Horizontal ?
-                    event->pos().x() : event->pos().y();
+        int eventPosValue = m_waveformWidget->getOrientation() == Qt::Horizontal ? event->pos().x() : event->pos().y();
         double audioSamplePerPixel = m_waveformWidget->getAudioSamplePerPixel();
         double targetPosition = -1.0 * eventPosValue * audioSamplePerPixel * 2;
         m_pScratchPosition->set(targetPosition);
@@ -134,17 +133,15 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
 
     // Only send signals for mouse moving if the left button is pressed
     if (m_bScratching) {
-        int eventPosValue = m_waveformWidget->getOrientation() == Qt::Horizontal ?
-                    event->pos().x() : event->pos().y();
+        int eventPosValue = m_waveformWidget->getOrientation() == Qt::Horizontal ? event->pos().x() : event->pos().y();
         // Adjusts for one-to-one movement.
         double audioSamplePerPixel = m_waveformWidget->getAudioSamplePerPixel();
         double targetPosition = -1.0 * eventPosValue * audioSamplePerPixel * 2;
-        //qDebug() << "Target:" << targetPosition;
+        // qDebug() << "Target:" << targetPosition;
         m_pScratchPosition->set(targetPosition);
     } else if (m_bBending) {
         QPoint diff = event->pos() - m_mouseAnchor;
-        int diffValue = m_waveformWidget->getOrientation() == Qt::Horizontal ?
-                    diff.x() : diff.y();
+        int diffValue = m_waveformWidget->getOrientation() == Qt::Horizontal ? diff.x() : diff.y();
         // Start at the middle of [0.0, 1.0], and emit values based on how far
         // the mouse has traveled horizontally. Note, for legacy (MIDI) reasons,
         // this is tuned to 127.
@@ -194,9 +191,14 @@ void WWaveformViewer::mouseReleaseEvent(QMouseEvent* /*event*/) {
 
 void WWaveformViewer::wheelEvent(QWheelEvent* event) {
     if (m_waveformWidget) {
-        if (event->angleDelta().y() > 0) {
+        const bool invert = m_pConfig->getValue(
+                ConfigKey(QStringLiteral("[Waveform]"),
+                        QStringLiteral("invert_zoom_direction")),
+                false);
+        const int delta = invert ? -event->angleDelta().y() : event->angleDelta().y();
+        if (delta > 0) {
             onZoomChange(m_waveformWidget->getZoom() / 1.05);
-        } else if (event->angleDelta().y() < 0) {
+        } else if (delta < 0) {
             onZoomChange(m_waveformWidget->getZoom() * 1.05);
         }
     }
@@ -249,14 +251,14 @@ void WWaveformViewer::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOld
 }
 
 void WWaveformViewer::onZoomChange(double zoom) {
-    //qDebug() << "WaveformWidgetRenderer::onZoomChange" << this << zoom;
+    // qDebug() << "WaveformWidgetRenderer::onZoomChange" << this << zoom;
     setZoom(zoom);
     // notify back the factory to sync zoom if needed
     WaveformWidgetFactory::instance()->notifyZoomChange(this);
 }
 
 void WWaveformViewer::setZoom(double zoom) {
-    //qDebug() << "WaveformWidgetRenderer::setZoom" << zoom;
+    // qDebug() << "WaveformWidgetRenderer::setZoom" << zoom;
     if (m_waveformWidget) {
         m_waveformWidget->setZoom(zoom);
     }


### PR DESCRIPTION
> Disclaimer: the code and PR message were written by GLM-5.2 using Devin.

adds a Preferences checkbox to invert the mouse wheel zoom direction on
waveforms. some DJs prefer scrolling up to zoom in rather than zoom out,
matching the behaviour of audio editors like Audacity.

- `invert_zoom_direction`: when enabled, scrolling up zooms in and scrolling
  down zooms out; disabled by default
- the preference is read from config at wheel event time, so toggling it
  takes effect immediately without restarting

<sub>Disclaimer: the code and PR message were written by GLM-5.2 using Devin.</sub>