### PR TITLE
KrugerMatz DJ-001: Add controller mapping and scripts

### DIFF
--- a/res/controllers/KrugerMatz-DJ-001-scripts.js
+++ b/res/controllers/KrugerMatz-DJ-001-scripts.js
@@ -53,9 +53,5 @@ KrugerMatzDJ001.wheelTurn = function (channel, control, value, status, group) {
 
 // -- Rotary selector (library navigation) -------------------------------------
 KrugerMatzDJ001.rotarySelector = function (channel, control, value, status, group) {
-    if (value === 0x7F) {
-        engine.setValue("[Library]", "MoveDown", 1);
-    } else {
-        engine.setValue("[Library]", "MoveUp", 1);
-    }
+    engine.setValue("[Library]", "MoveVertical", value === 0x7f ? 1 : -1);
 };

--- a/res/controllers/KrugerMatz-DJ-001-scripts.js
+++ b/res/controllers/KrugerMatz-DJ-001-scripts.js
@@ -1,0 +1,68 @@
+/**
+ * Krüger & Matz DJ-001 Controller Script
+ *
+ * @author Jairo Master Zion
+ */
+
+function KrugerMatzDJ001() {}
+
+// -- Speed multipliers --------------------------------------------------------
+// Tune these values if needed to adjust jog wheel scratch & pitch bend response.
+KrugerMatzDJ001.deck1Forward = 0.33; // Deck 1 -- turning forward
+KrugerMatzDJ001.deck1Backward = 0.33; // Deck 1 -- turning backward
+KrugerMatzDJ001.deck2Forward = 0.33; // Deck 2 -- turning forward
+KrugerMatzDJ001.deck2Backward = 0.33; // Deck 2 -- turning backward
+
+// -- Wheel touch (enables / disables scratch mode) ----------------------------
+KrugerMatzDJ001.wheelTouch = function (channel, control, value, status, group) {
+    var currentDeck = (group === "[Channel2]") ? 2 : 1;
+
+    if ((status & 0xF0) === 0x90) { // Note On = platter touched
+        var alpha = 1.0 / 8;
+        var beta = alpha / 32;
+        engine.scratchEnable(currentDeck, 128, 33 + 1 / 3, alpha, beta);
+    } else { // Note Off = platter released
+        engine.scratchDisable(currentDeck, true); // true = ramp down naturally
+    }
+};
+
+// -- Wheel turn (scratch or pitch bend) ---------------------------------------
+KrugerMatzDJ001.wheelTurn = function (channel, control, value, status, group) {
+    var currentDeck = (group === "[Channel2]") ? 2 : 1;
+
+    // Ignore touch events that leak into wheelTurn (they cause a large position jump)
+    if ((status & 0xF0) === 0x90) {
+        return;
+    }
+
+    // Two's complement decode -- center is 64:
+    //   value  1- 63 -> small positive delta (one direction)
+    //   value 65-127 -> small negative delta (other direction, e.g. 127 = -1)
+    var delta = (value < 64) ? value : (value - 128);
+
+    // Pick the speed multiplier for this deck + direction
+    var scale;
+    if (currentDeck === 1) {
+        scale = (delta > 0) ? KrugerMatzDJ001.deck1Forward : KrugerMatzDJ001.deck1Backward;
+        delta = delta * -1; // invert physical direction for deck 1
+    } else {
+        scale = (delta > 0) ? KrugerMatzDJ001.deck2Forward : KrugerMatzDJ001.deck2Backward;
+    }
+
+    var newValue = delta * scale;
+
+    if (engine.isScratching(currentDeck)) {
+        engine.scratchTick(currentDeck, newValue); // Scratch
+    } else {
+        engine.setValue("[Channel" + currentDeck + "]", "jog", newValue); // Pitch bend
+    }
+};
+
+// -- Rotary selector (library navigation) -------------------------------------
+KrugerMatzDJ001.rotarySelector = function (channel, control, value, status, group) {
+    if (value === 0x7F) {
+        engine.setValue("[Library]", "MoveDown", 1);
+    } else {
+        engine.setValue("[Library]", "MoveUp", 1);
+    }
+};

--- a/res/controllers/KrugerMatz-DJ-001-scripts.js
+++ b/res/controllers/KrugerMatz-DJ-001-scripts.js
@@ -4,14 +4,11 @@
  * @author Jairo Master Zion
  */
 
-function KrugerMatzDJ001() {}
+function KrugerMatzDJ001() { }
 
-// -- Speed multipliers --------------------------------------------------------
-// Tune these values if needed to adjust jog wheel scratch & pitch bend response.
-KrugerMatzDJ001.deck1Forward = 0.33; // Deck 1 -- turning forward
-KrugerMatzDJ001.deck1Backward = 0.33; // Deck 1 -- turning backward
-KrugerMatzDJ001.deck2Forward = 0.33; // Deck 2 -- turning forward
-KrugerMatzDJ001.deck2Backward = 0.33; // Deck 2 -- turning backward
+// -- Jog wheel sensitivity ---------------------------------------------------
+// Tune this value if needed to adjust jog wheel scratch & pitch bend response.
+KrugerMatzDJ001.jogSensitivity = 6;
 
 // -- Wheel touch (enables / disables scratch mode) ----------------------------
 KrugerMatzDJ001.wheelTouch = function (channel, control, value, status, group) {
@@ -40,16 +37,12 @@ KrugerMatzDJ001.wheelTurn = function (channel, control, value, status, group) {
     //   value 65-127 -> small negative delta (other direction, e.g. 127 = -1)
     var delta = (value < 64) ? value : (value - 128);
 
-    // Pick the speed multiplier for this deck + direction
-    var scale;
+    /*
     if (currentDeck === 1) {
-        scale = (delta > 0) ? KrugerMatzDJ001.deck1Forward : KrugerMatzDJ001.deck1Backward;
-        delta = delta * -1; // invert physical direction for deck 1
-    } else {
-        scale = (delta > 0) ? KrugerMatzDJ001.deck2Forward : KrugerMatzDJ001.deck2Backward;
+        delta = -delta; // Invert physical direction for deck 1
     }
-
-    var newValue = delta * scale;
+*/
+    var newValue = delta * KrugerMatzDJ001.jogSensitivity;
 
     if (engine.isScratching(currentDeck)) {
         engine.scratchTick(currentDeck, newValue); // Scratch

--- a/res/controllers/KrugerMatz-DJ-001.midi.xml
+++ b/res/controllers/KrugerMatz-DJ-001.midi.xml
@@ -1,0 +1,441 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MixxxControllerPreset mixxxVersion="2.5+" schemaVersion="1">
+    <info>
+        <name>Krüger &amp; Matz DJ-001</name>
+        <author>Jairo Master Zion</author>
+        <description>Mapping for Krüger &amp; Matz DJ-001 controller</description>
+        <manual>krugermatz_dj001</manual>
+    </info>
+    <controller id="KrugerMatzDJ001">
+        <scriptfiles>
+            <file filename="KrugerMatz-DJ-001-scripts.js" functionprefix="KrugerMatzDJ001"/>
+        </scriptfiles>
+        <controls>
+            <!-- Jog Wheel Touch & Turn -->
+            <control>
+                <group>[Channel1]</group>
+                <key>KrugerMatzDJ001.wheelTouch</key>
+                <status>0x80</status>
+                <midino>0x4D</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>KrugerMatzDJ001.wheelTurn</key>
+                <status>0xB0</status>
+                <midino>0x19</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>KrugerMatzDJ001.wheelTouch</key>
+                <status>0x80</status>
+                <midino>0x4E</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>KrugerMatzDJ001.wheelTurn</key>
+                <status>0xB0</status>
+                <midino>0x18</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+
+            <!-- Library Navigation -->
+            <control>
+                <group>[Library]</group>
+                <key>KrugerMatzDJ001.rotarySelector</key>
+                <description>Rotary knob for library track selection</description>
+                <status>0xB0</status>
+                <midino>0x1A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>MoveFocus</key>
+                <description>Switch focus between tree view and track list</description>
+                <status>0x90</status>
+                <midino>0x0D</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+
+            <!-- Channel 1 Transport & Controls -->
+            <control>
+                <group>[Channel1]</group>
+                <key>play</key>
+                <description>Play / Pause</description>
+                <status>0x90</status>
+                <midino>0x4A</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>cue_gotoandplay</key>
+                <description>CUE</description>
+                <status>0x90</status>
+                <midino>0x3B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>LoadSelectedTrack</key>
+                <description>Load Track Deck 1 (Press)</description>
+                <status>0x90</status>
+                <midino>0x4B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>LoadSelectedTrack</key>
+                <description>Load Track Deck 1 (Release)</description>
+                <status>0x80</status>
+                <midino>0x4B</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>volume</key>
+                <description>Volume Fader Deck 1</description>
+                <status>0xB0</status>
+                <midino>0x08</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>rate_perm_up_small</key>
+                <description>Pitch Up Deck 1</description>
+                <status>0x90</status>
+                <midino>0x44</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>rate_perm_down_small</key>
+                <description>Pitch Down Deck 1</description>
+                <status>0x90</status>
+                <midino>0x43</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>loop_in</key>
+                <description>Loop In Deck 1</description>
+                <status>0x90</status>
+                <midino>0x40</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>loop_out</key>
+                <description>Loop Out Deck 1</description>
+                <status>0x90</status>
+                <midino>0x33</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+
+            <!-- Channel 2 Transport & Controls -->
+            <control>
+                <group>[Channel2]</group>
+                <key>play</key>
+                <description>Play / Pause</description>
+                <status>0x90</status>
+                <midino>0x4C</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>cue_gotoandplay</key>
+                <description>CUE</description>
+                <status>0x90</status>
+                <midino>0x42</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>LoadSelectedTrack</key>
+                <description>Load Track Deck 2 (Press)</description>
+                <status>0x90</status>
+                <midino>0x34</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>LoadSelectedTrack</key>
+                <description>Load Track Deck 2 (Release)</description>
+                <status>0x80</status>
+                <midino>0x34</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>volume</key>
+                <description>Volume Fader Deck 2</description>
+                <status>0xB0</status>
+                <midino>0x09</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>rate_perm_up_small</key>
+                <description>Pitch Up Deck 2</description>
+                <status>0x90</status>
+                <midino>0x46</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>rate_perm_down_small</key>
+                <description>Pitch Down Deck 2</description>
+                <status>0x90</status>
+                <midino>0x45</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>loop_in</key>
+                <description>Loop In Deck 2</description>
+                <status>0x90</status>
+                <midino>0x47</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>loop_out</key>
+                <description>Loop Out Deck 2</description>
+                <status>0x90</status>
+                <midino>0x3C</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+
+            <!-- Equalizer & Effects -->
+            <control>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter1</key>
+                <description>EQ Low Deck 1</description>
+                <status>0xB0</status>
+                <midino>0x14</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>parameter2</key>
+                <description>EQ High Deck 1</description>
+                <status>0xB0</status>
+                <midino>0x10</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter1</key>
+                <description>EQ Low Deck 2</description>
+                <status>0xB0</status>
+                <midino>0x11</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>parameter2</key>
+                <description>EQ High Deck 2</description>
+                <status>0xB0</status>
+                <midino>0x15</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[QuickEffectRack1_[Channel1]]</group>
+                <key>super1_set_default</key>
+                <description>QuickEffect Reset Deck 1</description>
+                <status>0x90</status>
+                <midino>0x4D</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>group_[Channel1]_enable</key>
+                <description>Effect Unit 1 Enable Deck 1 (Press)</description>
+                <status>0x90</status>
+                <midino>0x48</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>group_[Channel1]_enable</key>
+                <description>Effect Unit 1 Enable Deck 1 (Release)</description>
+                <status>0x80</status>
+                <midino>0x48</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EffectRack1_EffectUnit2]</group>
+                <key>group_[Channel2]_enable</key>
+                <description>Effect Unit 2 Enable Deck 2 (Press)</description>
+                <status>0x90</status>
+                <midino>0x35</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[EffectRack1_EffectUnit2]</group>
+                <key>group_[Channel2]_enable</key>
+                <description>Effect Unit 2 Enable Deck 2 (Release)</description>
+                <status>0x80</status>
+                <midino>0x35</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+
+            <!-- Master & Crossfader -->
+            <control>
+                <group>[Master]</group>
+                <key>gain</key>
+                <description>Master Gain</description>
+                <status>0xB0</status>
+                <midino>0x17</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Master]</group>
+                <key>crossfader</key>
+                <description>Crossfader</description>
+                <status>0xB0</status>
+                <midino>0x0A</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+        </controls>
+        <outputs>
+            <!-- LED Indicators -->
+            <output>
+                <group>[Channel1]</group>
+                <key>play_indicator</key>
+                <status>0x90</status>
+                <midino>0x4A</midino>
+                <on>0x01</on>
+                <minimum>0.01</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>cue_indicator</key>
+                <status>0x90</status>
+                <midino>0x3B</midino>
+                <on>0x01</on>
+                <minimum>0.01</minimum>
+            </output>
+            <output>
+                <group>[Channel1]</group>
+                <key>loop_enabled</key>
+                <status>0x90</status>
+                <midino>0x40</midino>
+                <on>0x01</on>
+                <minimum>0.01</minimum>
+            </output>
+            <output>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>group_[Channel1]_enable</key>
+                <status>0x90</status>
+                <midino>0x48</midino>
+                <on>0x01</on>
+                <minimum>0.01</minimum>
+            </output>
+
+            <output>
+                <group>[Channel2]</group>
+                <key>play_indicator</key>
+                <status>0x90</status>
+                <midino>0x4C</midino>
+                <on>0x01</on>
+                <minimum>0.01</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>cue_indicator</key>
+                <status>0x90</status>
+                <midino>0x42</midino>
+                <on>0x01</on>
+                <minimum>0.01</minimum>
+            </output>
+            <output>
+                <group>[Channel2]</group>
+                <key>loop_enabled</key>
+                <status>0x90</status>
+                <midino>0x47</midino>
+                <on>0x01</on>
+                <minimum>0.01</minimum>
+            </output>
+            <output>
+                <group>[EffectRack1_EffectUnit2]</group>
+                <key>group_[Channel2]_enable</key>
+                <status>0x90</status>
+                <midino>0x35</midino>
+                <on>0x01</on>
+                <minimum>0.01</minimum>
+            </output>
+        </outputs>
+    </controller>
+</MixxxControllerPreset>


### PR DESCRIPTION
## Summary
This pull request adds controller mapping and JavaScript scripting for the **Krüger & Matz DJ-001** 2-deck DJ controller.

- **Manufacturer page:** https://www.krugermatz.com/en_US/p/DJ-001-controller/2280
- **Base branch:** `2.5`
- **Manual PR:** *(link your mixxxdj/manual PR here)*

## Hardware Overview
- **Type:** 2-deck MIDI DJ controller with built-in USB audio interface.
- **Audio Routing:** USB Class Compliant 4-channel audio interface (Channels 1-2 for Master, Channels 3-4 for Headphone cueing).
- **Driver requirements:** None (works out of the box on Linux, Windows, and macOS).

## Mapping Details
- [x] **Jog Wheels:** Touch-sensitive scratch mode when touching the top platter; jog pitch bending / nudging when rotated without touching the top.
- [x] **Transport:** PLAY/PAUSE and CUE with hardware LED indicator feedback.
- [x] **Track Loading:** Dedicated LOAD buttons for Deck 1 and Deck 2.
- [x] **Pitch Bend:** PITCH (+) and PITCH (-) buttons.
- [x] **Loops:** LOOP IN and LOOP OUT with loop active LED indicator feedback.
- [x] **Equalizer:** 2-band EQ (LOW and HIGH) per channel.
- [x] **Mixer:** Channel volume faders, Master gain knob, and crossfader.
- [x] **Effects:** FX Unit 1 and FX Unit 2 toggle buttons with LED feedback.
- [x] **Library:** Rotary encoder for library track selection and Focus button to switch between sidebar tree and track table.

## Testing
- [x] Tested with physical hardware.
- [x] Verified jog wheel scratch and pitch bend directions and sensitivity.
- [x] Verified LED feedback for Play, Cue, Loop, and FX buttons.
- [x] Code style checked with pre-commit / ESLint.
