### PR TITLE
Add reusable QML sampler and Mic/Aux components

### DIFF
--- a/res/qml/AuxiliaryUnit.qml
+++ b/res/qml/AuxiliaryUnit.qml
@@ -1,110 +1,152 @@
+pragma ComponentBehavior: Bound
+
 import "." as Skin
+import Mixxx 1.0 as Mixxx
 import QtQuick 2.12
+import QtQuick.Layouts 1.12
 import "Theme"
 
 Row {
     id: root
 
     required property int unitNumber
+    property int fxUnitCount: 4
     property string group: "[Auxiliary" + unitNumber + "]"
+    readonly property bool inputConfigured: inputConfiguredControl.value > 0
+
+    signal fxAssignmentChanged(int unitNumber, bool enabled)
 
     spacing: 5
 
-    Skin.VuMeter {
-        id: vuMeter
+    Loader {
+        sourceComponent: root.inputConfigured ? configuredComponent : unconfiguredComponent
+    }
+    Mixxx.ControlProxy {
+        id: inputConfiguredControl
 
         group: root.group
-        key: "vu_meter"
-        width: 4
-        height: parent.height
+        key: "input_configured"
     }
+    Component {
+        id: configuredComponent
 
-    Rectangle {
-        id: gainKnobFrame
+        Row {
+            layoutDirection: root.layoutDirection
+            spacing: root.spacing
 
-        width: 52
-        height: width
-        color: Theme.knobBackgroundColor
-        radius: 5
+            Skin.VuMeter {
+                group: root.group
+                height: parent.height
+                key: "vu_meter"
+                width: 4
+            }
+            Rectangle {
+                color: Theme.knobBackgroundColor
+                height: 52
+                radius: 5
+                width: 52
 
-        Skin.ControlKnob {
-            id: gainKnob
+                Skin.ControlKnob {
+                    anchors.centerIn: parent
+                    arcStart: Knob.ArcStart.Minimum
+                    color: Theme.gainKnobColor
+                    group: root.group
+                    height: 48
+                    key: "pregain"
+                    width: 48
+                }
+            }
+            Column {
+                Skin.SectionText {
+                    height: 26
+                    text: "AUX " + root.unitNumber
+                    width: 52
+                }
+                Skin.ControlButton {
+                    activeColor: Theme.pflActiveButtonColor
+                    group: root.group
+                    key: "pfl"
+                    text: "PFL"
+                    toggleable: true
+                }
+            }
+            Skin.EmbeddedBackground {
+                height: parent.height
+                width: Math.max(56, fxAssignments.implicitWidth)
 
-            anchors.centerIn: parent
-            width: 48
-            height: width
-            arcStart: Knob.ArcStart.Minimum
-            group: root.group
-            key: "pregain"
-            color: Theme.gainKnobColor
-        }
-    }
+                ColumnLayout {
+                    anchors.fill: parent
+                    spacing: 0
 
-    Column {
-        Skin.SectionText {
-            width: parent.width
-            height: root.height / 2
-            text: "AUX " + root.unitNumber
-        }
+                    RowLayout {
+                        Layout.fillHeight: true
+                        Layout.fillWidth: true
+                        spacing: 0
 
-        Skin.ControlButton {
-            id: pflButton
+                        Skin.OrientationToggleButton {
+                            Layout.fillHeight: true
+                            Layout.fillWidth: true
+                            color: Theme.crossfaderOrientationColor
+                            group: root.group
+                            key: "orientation"
+                        }
+                        Skin.ControlButton {
+                            Layout.fillHeight: true
+                            Layout.fillWidth: true
+                            activeColor: Theme.deckActiveColor
+                            group: root.group
+                            key: "main_mix"
+                            text: "Main"
+                            toggleable: true
+                        }
+                    }
+                    RowLayout {
+                        id: fxAssignments
 
-            group: root.group
-            key: "pfl"
-            text: "PFL"
-            activeColor: Theme.pflActiveButtonColor
-            toggleable: true
-        }
-    }
+                        Layout.fillHeight: true
+                        Layout.fillWidth: true
+                        spacing: 0
 
-    Skin.EmbeddedBackground {
-        id: embedded
+                        Repeater {
+                            model: Math.max(0, root.fxUnitCount)
 
-        height: parent.height
-        width: 56
+                            Skin.ControlButton {
+                                required property int index
 
-        Skin.OrientationToggleButton {
-            id: orientationButton
+                                Layout.fillHeight: true
+                                Layout.fillWidth: true
+                                activeColor: Theme.effectUnitColor
+                                group: "[EffectRack1_EffectUnit" + (index + 1) + "]"
+                                implicitWidth: 28
+                                key: "group_" + root.group + "_enable"
+                                text: "FX" + (index + 1)
+                                toggleable: true
 
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.bottom: parent.verticalCenter
-            group: root.group
-            key: "orientation"
-            color: Theme.crossfaderOrientationColor
-        }
-
-        Skin.InfoBarButton {
-            id: fx1Button
-
-            anchors.left: parent.left
-            anchors.right: parent.horizontalCenter
-            anchors.top: parent.verticalCenter
-            anchors.bottom: parent.bottom
-            group: "[EffectRack1_EffectUnit1]"
-            key: "group_" + root.group + "_enable"
-            activeColor: Theme.deckActiveColor
-
-            foreground: Skin.EmbeddedText {
-                anchors.centerIn: parent
-                text: "FX1"
+                                onHighlightChanged: root.fxAssignmentChanged(index + 1, highlight)
+                            }
+                        }
+                    }
+                }
             }
         }
+    }
+    Component {
+        id: unconfiguredComponent
 
-        Skin.InfoBarButton {
-            group: "[EffectRack1_EffectUnit2]"
-            anchors.left: parent.horizontalCenter
-            anchors.right: parent.right
-            anchors.top: parent.verticalCenter
-            anchors.bottom: parent.bottom
-            key: "group_" + root.group + "_enable"
-            activeColor: Theme.deckActiveColor
+        Column {
+            spacing: 2
 
-            foreground: Skin.EmbeddedText {
-                anchors.centerIn: parent
-                text: "FX2"
+            Skin.SectionText {
+                color: Theme.darkGray3
+                height: 21
+                text: "Aux " + root.unitNumber
+                width: 80
+            }
+            Skin.ControlButton {
+                group: root.group
+                key: "main_mix"
+                text: "Configure"
+                width: 80
             }
         }
     }

--- a/res/qml/Fader.qml
+++ b/res/qml/Fader.qml
@@ -6,10 +6,12 @@ import "Theme"
 MixxxControls.Fader {
     id: root
 
+    property real backgroundMargin: bar.margin
     property alias bg: backgroundImage.source
     property alias fg: handleImage.source
     property alias handleImage: handleImage
     property bool showDefaultHandle: true
+    property bool showHandleShadow: true
 
     bar.enabled: true
     bar.margin: 10
@@ -20,7 +22,7 @@ MixxxControls.Fader {
         id: backgroundImage
 
         anchors.fill: parent
-        anchors.margins: root.bar.margin
+        anchors.margins: root.backgroundMargin
     }
     handle: Item {
         id: handleItem
@@ -31,12 +33,19 @@ MixxxControls.Fader {
         x: root.horizontal ? (root.visualPosition * (root.width - width)) : ((root.width - width) / 2)
         y: root.vertical ? (root.visualPosition * (root.height - height)) : ((root.height - height) / 2)
 
+        Image {
+            anchors.fill: parent
+            fillMode: Image.PreserveAspectFit
+            source: handleImage.source
+            visible: !root.showHandleShadow
+        }
         DropShadow {
             color: "#80000000"
             height: parent.height + 5
             radius: 5
             source: handleImage
             verticalOffset: 5
+            visible: root.showHandleShadow
             width: parent.width + 5
         }
     }

--- a/res/qml/MicrophoneDuckingPanel.qml
+++ b/res/qml/MicrophoneDuckingPanel.qml
@@ -4,6 +4,8 @@ import QtQuick 2.12
 import "Theme"
 
 Column {
+    id: root
+
     enum DuckingMode {
         Off,
         Auto,
@@ -11,49 +13,49 @@ Column {
         NumModes // This always needs to be the last value
     }
 
-    Skin.ControlFader {
-        bar.color: Theme.crossfaderBarColor
-        bar.start: 1
-        bg: Theme.imgMicDuckingSlider
-        fg: Theme.imgMicDuckingSliderHandle
-        group: "[Master]"
-        height: 26
-        key: "duckStrength"
-        orientation: Qt.Horizontal
-        width: 50
-    }
-    Skin.Button {
-        id: pflButton
+    property string duckingModeKey: "talkoverDucking"
+    property string duckingStrengthKey: "duckStrength"
+    property string group: "[Master]"
 
+    spacing: 2
+
+    Skin.Button {
         activeColor: Theme.pflActiveButtonColor
         highlight: duckingControl.duckingEnabled
         text: duckingControl.duckingModeName
+        width: 50
 
         onClicked: duckingControl.nextMode()
+    }
+    Skin.ControlKnob {
+        anchors.horizontalCenter: parent.horizontalCenter
+        arcStart: Knob.ArcStart.Maximum
+        color: Theme.effectUnitColor
+        group: root.group
+        height: 35
+        key: root.duckingStrengthKey
+        width: 35
+    }
+    Mixxx.ControlProxy {
+        id: duckingControl
 
-        Mixxx.ControlProxy {
-            id: duckingControl
-
-            property bool duckingEnabled: {
-                return (this.value == MicrophoneDuckingPanel.DuckingMode.Auto || this.value == MicrophoneDuckingPanel.DuckingMode.Manual);
+        readonly property bool duckingEnabled: value === MicrophoneDuckingPanel.DuckingMode.Auto || value === MicrophoneDuckingPanel.DuckingMode.Manual
+        readonly property string duckingModeName: {
+            switch (value) {
+            case MicrophoneDuckingPanel.DuckingMode.Auto:
+                return "Auto";
+            case MicrophoneDuckingPanel.DuckingMode.Manual:
+                return "Manual";
+            default:
+                return "Off";
             }
-            property string duckingModeName: {
-                switch (this.value) {
-                case MicrophoneDuckingPanel.DuckingMode.Auto:
-                    return "Auto";
-                case MicrophoneDuckingPanel.DuckingMode.Manual:
-                    return "Manual";
-                default:
-                    return "Off";
-                }
-            }
-
-            function nextMode() {
-                this.value = (this.value + 1) % MicrophoneDuckingPanel.DuckingMode.NumModes;
-            }
-
-            group: "[Master]"
-            key: "talkoverDucking"
         }
+
+        function nextMode() {
+            value = (value + 1) % MicrophoneDuckingPanel.DuckingMode.NumModes;
+        }
+
+        group: root.group
+        key: root.duckingModeKey
     }
 }

--- a/res/qml/MicrophoneUnit.qml
+++ b/res/qml/MicrophoneUnit.qml
@@ -1,115 +1,139 @@
+pragma ComponentBehavior: Bound
+
 import "." as Skin
+import Mixxx 1.0 as Mixxx
 import QtQuick 2.12
+import QtQuick.Layouts 1.12
 import "Theme"
 
 Row {
     id: root
 
     required property int unitNumber
+    property int fxUnitCount: 4
     property string group: unitNumber === 1 ? "[Microphone]" : "[Microphone" + unitNumber + "]"
+    readonly property bool inputConfigured: inputConfiguredControl.value > 0
+
+    signal fxAssignmentChanged(int unitNumber, bool enabled)
 
     spacing: 5
 
-    Skin.VuMeter {
-        id: vuMeter
+    Loader {
+        sourceComponent: root.inputConfigured ? configuredComponent : unconfiguredComponent
+    }
+    Mixxx.ControlProxy {
+        id: inputConfiguredControl
 
         group: root.group
-        key: "vu_meter"
-        width: 4
-        height: parent.height
+        key: "input_configured"
     }
+    Component {
+        id: configuredComponent
 
-    Rectangle {
-        id: gainKnobFrame
+        Row {
+            layoutDirection: root.layoutDirection
+            spacing: root.spacing
 
-        width: 52
-        height: width
-        color: Theme.knobBackgroundColor
-        radius: 5
+            Skin.VuMeter {
+                group: root.group
+                height: parent.height
+                key: "vu_meter"
+                width: 4
+            }
+            Rectangle {
+                color: Theme.knobBackgroundColor
+                height: 52
+                radius: 5
+                width: 52
 
-        Skin.ControlKnob {
-            id: gainKnob
+                Skin.ControlKnob {
+                    anchors.centerIn: parent
+                    arcStart: Knob.ArcStart.Minimum
+                    color: Theme.gainKnobColor
+                    group: root.group
+                    height: 48
+                    key: "pregain"
+                    width: 48
+                }
+            }
+            Column {
+                Skin.SectionText {
+                    height: 26
+                    text: "MIC " + root.unitNumber
+                    width: 52
+                }
+                Skin.ControlButton {
+                    activeColor: Theme.pflActiveButtonColor
+                    group: root.group
+                    key: "pfl"
+                    text: "PFL"
+                    toggleable: true
+                }
+            }
+            Skin.EmbeddedBackground {
+                height: parent.height
+                width: Math.max(56, fxAssignments.implicitWidth)
 
-            anchors.centerIn: parent
-            width: 48
-            height: width
-            arcStart: Knob.ArcStart.Minimum
-            group: root.group
-            key: "pregain"
-            color: Theme.gainKnobColor
-        }
-    }
+                ColumnLayout {
+                    anchors.fill: parent
+                    spacing: 0
 
-    Column {
-        SectionText {
-            width: parent.width
-            height: root.height / 2
-            text: "MIC " + root.unitNumber
-        }
+                    Skin.ControlButton {
+                        Layout.fillHeight: true
+                        Layout.fillWidth: true
+                        activeColor: Theme.deckActiveColor
+                        group: root.group
+                        key: "talkover"
+                        text: "Talk"
+                        toggleable: true
+                    }
+                    RowLayout {
+                        id: fxAssignments
 
-        Skin.ControlButton {
-            id: pflButton
+                        Layout.fillHeight: true
+                        Layout.fillWidth: true
+                        spacing: 0
 
-            group: root.group
-            key: "pfl"
-            text: "PFL"
-            activeColor: Theme.pflActiveButtonColor
-            toggleable: true
-        }
-    }
+                        Repeater {
+                            model: Math.max(0, root.fxUnitCount)
 
-    Skin.EmbeddedBackground {
-        id: embedded
+                            Skin.ControlButton {
+                                required property int index
 
-        height: parent.height
-        width: 56
+                                Layout.fillHeight: true
+                                Layout.fillWidth: true
+                                activeColor: Theme.effectUnitColor
+                                group: "[EffectRack1_EffectUnit" + (index + 1) + "]"
+                                implicitWidth: 28
+                                key: "group_" + root.group + "_enable"
+                                text: "FX" + (index + 1)
+                                toggleable: true
 
-        Skin.InfoBarButton {
-            id: talkButton
-
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            anchors.bottom: parent.verticalCenter
-            group: root.group
-            key: "talkover"
-            activeColor: Theme.deckActiveColor
-
-            foreground: Skin.EmbeddedText {
-                anchors.centerIn: parent
-                text: "TALK"
+                                onHighlightChanged: root.fxAssignmentChanged(index + 1, highlight)
+                            }
+                        }
+                    }
+                }
             }
         }
+    }
+    Component {
+        id: unconfiguredComponent
 
-        Skin.InfoBarButton {
-            id: fx1Button
+        Column {
+            spacing: 2
 
-            anchors.left: parent.left
-            anchors.right: parent.horizontalCenter
-            anchors.top: parent.verticalCenter
-            anchors.bottom: parent.bottom
-            group: "[EffectRack1_EffectUnit1]"
-            key: "group_" + root.group + "_enable"
-            activeColor: Theme.deckActiveColor
-
-            foreground: Skin.EmbeddedText {
-                anchors.centerIn: parent
-                text: "FX1"
+            Skin.SectionText {
+                color: Theme.darkGray3
+                height: 21
+                text: "mic " + root.unitNumber
+                width: 80
             }
-        }
-
-        Skin.InfoBarButton {
-            group: "[EffectRack1_EffectUnit2]"
-            anchors.left: parent.horizontalCenter
-            anchors.right: parent.right
-            anchors.top: parent.verticalCenter
-            anchors.bottom: parent.bottom
-            key: "group_" + root.group + "_enable"
-            activeColor: Theme.deckActiveColor
-
-            foreground: Skin.EmbeddedText {
-                anchors.centerIn: parent
-                text: "FX2"
+            Skin.ControlButton {
+                group: root.group
+                key: "talkover"
+                text: "Configure"
+                width: 80
             }
         }
     }

--- a/res/qml/Mixxx/Controls/WaveformOverview.qml
+++ b/res/qml/Mixxx/Controls/WaveformOverview.qml
@@ -5,7 +5,11 @@ import QtQuick 2.12
 Mixxx.WaveformOverview {
     id: root
 
+    property color cueMarkerColor: "red"
     required property string group
+    property color introOutroMarkerColor: "blue"
+    property color loopMarkerColor: "green"
+    property string playPositionMarkerColor: "white"
     readonly property var player: Mixxx.PlayerManager.getPlayer(root.group)
 
     track: player?.currentTrack
@@ -34,13 +38,13 @@ Mixxx.WaveformOverview {
 
         MixxxControls.WaveformOverviewMarkerLayer {
             anchors.fill: parent
-            cueColor: "red"
+            cueColor: root.cueMarkerColor
             cueText: "C"
             group: root.group
-            introOutroColor: "blue"
+            introOutroColor: root.introOutroMarkerColor
             introStartText: "IN"
             labelColor: "white"
-            loopColor: "green"
+            loopColor: root.loopMarkerColor
             loopStartText: "LOOP"
             outroStartText: "OUT"
             showHotcueLabels: false
@@ -51,6 +55,7 @@ Mixxx.WaveformOverview {
             id: playPositionMarker
 
             anchors.fill: parent
+            color: root.playPositionMarkerColor
             group: root.group
             key: "playposition"
         }

--- a/res/qml/Sampler.qml
+++ b/res/qml/Sampler.qml
@@ -1,6 +1,9 @@
+pragma ComponentBehavior: Bound
+
 import "." as Skin
 import Mixxx 1.0 as Mixxx
 import QtQuick 2.12
+import QtQuick.Layouts 1.12
 import "Theme"
 
 Rectangle {
@@ -8,14 +11,24 @@ Rectangle {
 
     property var currentTrack: deckPlayer.currentTrack
     property var deckPlayer: Mixxx.PlayerManager.getPlayer(group)
+    property int fxUnitCount: 4
     required property string group
+    property int hotcueCount: 8
+    readonly property bool loaded: trackLoadedControl.value > 0
     property bool minimized: false
+    readonly property bool playing: playControl.value > 0
+    property bool showFxAssignments: true
+    property bool showHotcues: true
+    property bool showRateControl: true
+    readonly property real visualBpm: visualBpmControl.value
+
+    signal fxAssignmentChanged(int unitNumber, bool enabled)
 
     Drag.active: dragArea.drag.active
     Drag.dragType: Drag.Automatic
     Drag.mimeData: {
         let data = {
-            "mixxx/player": group
+            "mixxx/player": root.group
         };
         const trackLocationUrl = root.currentTrack?.trackLocationUrl;
         if (trackLocationUrl)
@@ -25,131 +38,259 @@ Rectangle {
     Drag.supportedActions: Qt.CopyAction
     color: {
         const trackColor = root.currentTrack?.color;
-        if (!trackColor.valid)
+        if (!trackColor?.valid)
             return Theme.backgroundColor;
-        return Qt.darker(root.currentTrack?.color, 2);
+        return Qt.darker(trackColor, 2);
     }
-    implicitHeight: gainKnob.height + 10
+    implicitHeight: root.minimized ? 50 : 170
+    implicitWidth: 230
 
-    MouseArea {
-        id: dragArea
-
-        anchors.fill: root
-        drag.target: root
-    }
     Skin.SectionBackground {
         anchors.fill: parent
     }
-    Skin.EmbeddedBackground {
-        id: embedded
+    MouseArea {
+        id: dragArea
+
+        anchors.fill: parent
+        drag.target: root
+    }
+    Item {
+        id: summary
+
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: 50
+
+        Skin.EmbeddedBackground {
+            id: embedded
+
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.margins: 5
+            anchors.right: vuMeter.left
+            anchors.top: parent.top
+        }
+        Skin.ControlMiniKnob {
+            id: gainKnob
+
+            anchors.margins: 5
+            anchors.right: parent.right
+            anchors.top: parent.top
+            color: Theme.samplerColor
+            group: root.group
+            height: 40
+            key: "pregain"
+            width: 40
+        }
+        Skin.ControlButton {
+            id: playButton
+
+            activeColor: Theme.samplerColor
+            anchors.left: embedded.left
+            anchors.top: embedded.top
+            group: root.group
+            height: 40
+            highlight: playLatchedControl.value > 0 || root.playing
+            key: "cue_gotoandplay"
+            text: "Play"
+            width: 40
+
+            MouseArea {
+                acceptedButtons: Qt.RightButton
+                anchors.fill: parent
+
+                onCanceled: cueDefaultControl.value = 0
+                onPressed: cueDefaultControl.value = 1
+                onReleased: cueDefaultControl.value = 0
+            }
+        }
+        Text {
+            id: label
+
+            anchors.left: playButton.right
+            anchors.leftMargin: 5
+            anchors.right: bpmLabel.left
+            anchors.rightMargin: 5
+            anchors.top: embedded.top
+            color: Theme.deckTextColor
+            elide: Text.ElideRight
+            font.family: Theme.fontFamily
+            font.pixelSize: Theme.textFontPixelSize
+            text: root.currentTrack?.title ?? ""
+        }
+        Text {
+            id: bpmLabel
+
+            anchors.right: embedded.right
+            anchors.top: embedded.top
+            color: Theme.deckTextColor
+            font.family: Theme.fontFamily
+            font.pixelSize: Theme.buttonFontPixelSize
+            text: root.loaded && root.visualBpm > 0 ? root.visualBpm.toFixed(1) : ""
+        }
+        Skin.WaveformOverview {
+            anchors.bottom: embedded.bottom
+            anchors.left: playButton.right
+            anchors.leftMargin: 5
+            anchors.right: embedded.right
+            anchors.top: label.bottom
+            anchors.topMargin: 2
+            group: root.group
+        }
+        Skin.VuMeter {
+            id: vuMeter
+
+            anchors.bottom: parent.bottom
+            anchors.margins: 5
+            anchors.right: gainKnob.left
+            anchors.top: parent.top
+            group: root.group
+            key: "vu_meter"
+            width: 4
+        }
+    }
+    ColumnLayout {
+        id: expandedControls
 
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.margins: 5
-        anchors.right: vuMeter.left
-        anchors.top: parent.top
-    }
-    Skin.ControlMiniKnob {
-        id: gainKnob
-
-        anchors.margins: 5
         anchors.right: parent.right
-        anchors.top: parent.top
-        color: Theme.samplerColor
-        group: root.group
-        height: 40
-        key: "pregain"
-        width: 40
-    }
-    Skin.ControlButton {
-        id: playButton
+        anchors.top: summary.bottom
+        spacing: 3
+        visible: !root.minimized
 
-        activeColor: Theme.samplerColor
-        anchors.left: embedded.left
-        anchors.top: embedded.top
-        group: root.group
-        height: 40
-        highlight: playControl.playing
-        key: "cue_gotoandplay"
-        text: "Play"
-        width: 40
-    }
-    Text {
-        id: label
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 2
 
-        anchors.left: playButton.right
-        anchors.margins: 5
-        anchors.right: embedded.right
-        anchors.top: embedded.top
-        color: Theme.deckTextColor
-        elide: Text.ElideRight
-        font.family: Theme.fontFamily
-        font.pixelSize: Theme.textFontPixelSize
-        text: root.currentTrack?.title
-    }
-    Rectangle {
-        id: progressContainer
-
-        anchors.bottom: embedded.bottom
-        anchors.left: playButton.right
-        anchors.margins: 5
-        anchors.right: embedded.right
-        border.color: Theme.deckLineColor
-        border.width: 1
-        color: "transparent"
-        height: 5
-        radius: height / 2
-
-        Rectangle {
-            antialiasing: false // for performance reasons
-            color: Theme.samplerColor
-            height: parent.height
-            radius: height / 2
-            width: playPositionControl.value * parent.width
-
-            Mixxx.ControlProxy {
-                id: playPositionControl
-
+            Skin.ControlButton {
+                Layout.fillWidth: true
                 group: root.group
-                key: "playposition"
+                key: "sync_enabled"
+                text: "Sync"
+                toggleable: true
+            }
+            Skin.ControlButton {
+                Layout.fillWidth: true
+                group: root.group
+                key: "keylock"
+                text: "Key"
+                toggleable: true
+            }
+            Skin.ControlButton {
+                Layout.fillWidth: true
+                group: root.group
+                key: "repeat"
+                text: "Loop"
+                toggleable: true
+            }
+            Skin.ControlButton {
+                Layout.fillWidth: true
+                group: root.group
+                key: "pfl"
+                text: "PFL"
+                toggleable: true
+            }
+            Skin.OrientationToggleButton {
+                Layout.fillWidth: true
+                color: Theme.crossfaderOrientationColor
+                group: root.group
+                key: "orientation"
+            }
+            Skin.ControlButton {
+                Layout.fillWidth: true
+                group: root.group
+                key: "eject"
+                text: "Eject"
             }
         }
-        MouseArea {
-            anchors.fill: progressContainer
-            cursorShape: Qt.PointingHandCursor
-            hoverEnabled: true
+        Skin.ControlFader {
+            Layout.fillWidth: true
+            bar.color: Theme.bpmSliderBarColor
+            bar.start: 0.5
+            bg: Theme.imgBpmSliderBackground
+            group: root.group
+            key: "rate"
+            orientation: Qt.Horizontal
+            visible: root.showRateControl
+        }
+        GridLayout {
+            Layout.fillWidth: true
+            columnSpacing: 2
+            columns: 4
+            rowSpacing: 2
+            visible: root.showHotcues && root.hotcueCount > 0
 
-            onPositionChanged: mouse => {
-                if (containsPress)
-                    playPositionControl.value = mouse.x / width;
+            Repeater {
+                model: Math.min(8, Math.max(0, root.hotcueCount))
+
+                Skin.HotcueButton {
+                    required property int index
+
+                    Layout.fillWidth: true
+                    group: root.group
+                    hotcueNumber: index + 1
+                    implicitHeight: 22
+                }
             }
-            onPressed: mouse => {
-                playPositionControl.value = mouse.x / width;
+        }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 2
+            visible: root.showFxAssignments && root.fxUnitCount > 0
+
+            Repeater {
+                model: Math.max(0, root.fxUnitCount)
+
+                Skin.ControlButton {
+                    id: fxButton
+
+                    required property int index
+
+                    Layout.fillWidth: true
+                    activeColor: Theme.effectUnitColor
+                    group: "[EffectRack1_EffectUnit" + (index + 1) + "]"
+                    implicitHeight: 22
+                    key: "group_" + root.group + "_enable"
+                    text: "FX" + (index + 1)
+                    toggleable: true
+
+                    onHighlightChanged: root.fxAssignmentChanged(index + 1, highlight)
+                }
             }
         }
     }
-    Skin.VuMeter {
-        id: vuMeter
+    Mixxx.ControlProxy {
+        id: trackLoadedControl
 
-        anchors.bottom: parent.bottom
-        anchors.margins: 5
-        anchors.right: gainKnob.left
-        anchors.top: parent.top
         group: root.group
-        key: "vu_meter"
-        width: 4
+        key: "track_loaded"
+    }
+    Mixxx.ControlProxy {
+        id: visualBpmControl
+
+        group: root.group
+        key: "visual_bpm"
     }
     Mixxx.ControlProxy {
         id: playControl
 
-        readonly property bool playing: this.value !== 0
-
-        function stop() {
-            this.value = 0;
-        }
-
         group: root.group
         key: "play"
+    }
+    Mixxx.ControlProxy {
+        id: playLatchedControl
+
+        group: root.group
+        key: "play_latched"
+    }
+    Mixxx.ControlProxy {
+        id: cueDefaultControl
+
+        group: root.group
+        key: "cue_default"
     }
     Mixxx.ControlProxy {
         id: ejectControl
@@ -159,8 +300,8 @@ Rectangle {
     }
     TapHandler {
         onDoubleTapped: {
-            if (playControl.playing)
-                playControl.stop();
+            if (root.playing)
+                playControl.value = 0;
             else
                 ejectControl.trigger();
         }

--- a/res/qml/SamplerRow.qml
+++ b/res/qml/SamplerRow.qml
@@ -1,18 +1,39 @@
+pragma ComponentBehavior: Bound
+
 import "." as Skin
 import QtQuick 2.12
 import QtQuick.Layouts 1.12
 
-RowLayout {
-    spacing: 0
+GridLayout {
+    id: root
+
+    property int firstSampler: 1
+    property int fxUnitCount: 4
+    property int hotcueCount: 8
+    property bool minimized: false
+    property int samplerCount: 8
+    property bool showFxAssignments: true
+    property bool showHotcues: true
+    property bool showRateControl: true
+
+    columnSpacing: 0
+    columns: Math.max(1, root.samplerCount)
+    rowSpacing: 0
 
     Repeater {
-        model: 8
+        model: Math.max(0, root.samplerCount)
 
         Skin.Sampler {
             required property int index
 
             Layout.fillWidth: true
-            group: "[Sampler" + (index + 1) + "]"
+            fxUnitCount: root.fxUnitCount
+            group: "[Sampler" + (root.firstSampler + index) + "]"
+            hotcueCount: root.hotcueCount
+            minimized: root.minimized
+            showFxAssignments: root.showFxAssignments
+            showHotcues: root.showHotcues
+            showRateControl: root.showRateControl
         }
     }
 }


### PR DESCRIPTION
This PR adds reusable QML components for implementing sampler, microphone, auxiliary-input, and microphone-ducking interfaces in QML skins.

## Scope of Changes

* Adds reusable `Sampler` and `SamplerRow` components.
* Adds reusable microphone and auxiliary-input channel components.
* Adds a reusable microphone-ducking control panel.
* Exposes sampler controls for playback, hotcues, repeat, keylock, crossfader orientation, gain, PFL, effects routing, pitch, sync, waveform overview, and level metering.
* Exposes microphone and auxiliary-input controls for gain, routing, effects assignments, PFL, orientation, ducking, and level metering.
* Keeps the shared components independent of any particular skin layout or color scheme.

These components provide the shared foundation for the LateNightQML sampler and Mic/Aux implementation.