### PR TITLE
[GSoC] LateNightQML: add sampler count options up to 64 samplers

### DIFF
--- a/res/skins/LateNightQML/Toolbar/Toolbar.qml
+++ b/res/skins/LateNightQML/Toolbar/Toolbar.qml
@@ -1571,6 +1571,7 @@ Rectangle {
             Item {
                 id: samplersHeader
                 property bool checked: showSamplersControl.value > 0
+                readonly property bool samplerCountChoiceStripHovered: samplersHeaderMouseArea.containsMouse && samplersHeaderMouseArea.mouseX >= sampler4Choice.x && samplersHeaderMouseArea.mouseX <= sampler64Choice.x + sampler64Choice.width
 
                 Layout.fillWidth: true
                 Layout.minimumWidth: implicitWidth
@@ -1579,7 +1580,7 @@ Rectangle {
 
                 Rectangle {
                     anchors.fill: parent
-                    color: root.menuHoverColor(samplersHeaderMouseArea.containsMouse, samplersHeader.enabled)
+                    color: root.menuHoverColor(samplersHeaderMouseArea.containsMouse && !samplersHeader.samplerCountChoiceStripHovered, samplersHeader.enabled)
                     radius: 1
                 }
 
@@ -1598,19 +1599,23 @@ Rectangle {
                     id: samplersHeaderContent
 
                     anchors.fill: parent
-                    spacing: 5
+                    spacing: 0
 
                     Image {
                         Layout.leftMargin: 2
                         Layout.preferredHeight: 14
                         Layout.preferredWidth: 14
+                        Layout.rightMargin: 5
                         fillMode: Image.PreserveAspectFit
                         source: samplersHeader.checked ? LateNightTheme.lateNightAsset("buttons", "btn__lib_checkmark_ivory.svg") : LateNightTheme.lateNightAsset("buttons", "btn__menu_checkbox.svg")
                     }
 
                     ToolbarMenuInlineChoice {
+                        id: sampler4Choice
+
                         checked: samplerRowsControl.value === 0.0
                         enabled: showSamplersControl.value > 0
+                        minimumWidth: 33
                         text: "4"
 
                         onClicked: {
@@ -1619,8 +1624,11 @@ Rectangle {
                     }
 
                     ToolbarMenuInlineChoice {
+                        id: sampler8Choice
+
                         checked: samplerRowsControl.value === 1.0
                         enabled: showSamplersControl.value > 0
+                        minimumWidth: 33
                         text: "8"
 
                         onClicked: {
@@ -1629,9 +1637,11 @@ Rectangle {
                     }
 
                     ToolbarMenuInlineChoice {
+                        id: sampler16Choice
+
                         checked: samplerRowsControl.value === 2.0
                         enabled: showSamplersControl.value > 0
-                        minimumWidth: 32
+                        minimumWidth: 37
                         text: "16"
 
                         onClicked: {
@@ -1640,17 +1650,46 @@ Rectangle {
                     }
 
                     ToolbarMenuInlineChoice {
+                        id: sampler32Choice
+
+                        checked: samplerRowsControl.value === 3.0
+                        enabled: showSamplersControl.value > 0
+                        minimumWidth: 37
+                        text: "32"
+
+                        onClicked: {
+                            samplerRowsControl.value = 3.0;
+                        }
+                    }
+
+                    ToolbarMenuInlineChoice {
+                        id: sampler48Choice
+
                         checked: samplerRowsControl.value === 4.0
                         enabled: showSamplersControl.value > 0
-                        minimumWidth: 32
-                        text: "64"
+                        minimumWidth: 37
+                        text: "48"
 
                         onClicked: {
                             samplerRowsControl.value = 4.0;
                         }
                     }
+
+                    ToolbarMenuInlineChoice {
+                        id: sampler64Choice
+
+                        checked: samplerRowsControl.value === 5.0
+                        enabled: showSamplersControl.value > 0
+                        minimumWidth: 37
+                        text: "64"
+
+                        onClicked: {
+                            samplerRowsControl.value = 5.0;
+                        }
+                    }
                     Text {
-                        color: samplersHeaderMouseArea.containsMouse ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
+                        Layout.leftMargin: 5
+                        color: samplersHeaderMouseArea.containsMouse && !samplersHeader.samplerCountChoiceStripHovered ? LateNightTheme.toolbarMenuHoverTextColor : LateNightTheme.toolbarMenuTextColor
                         font.family: "Open Sans"
                         font.pixelSize: 13
                         text: "sample decks"


### PR DESCRIPTION
This PR extends the LateNightQML sampler toolbar menu with the complete set of sampler-count options used by the LateNight skin.

## Scope of Changes

* Adds 32- and 48-sampler options alongside the existing 4, 8, 16, and 64 options.
* Maps the choices to sampler-row modes 0 through 5.
* Preserves the existing sampler visibility toggle and toolbar menu styling.