### PR TITLE
CmdLineArgs: add `--stats` flag

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -367,8 +367,8 @@ CoreServices::CoreServices(const CmdlineArgs& args, QApplication* pApp)
     // called after the GUI is initialized
     initializeSettings();
     initializeLogging();
-    // Only record stats in developer mode.
-    if (m_cmdlineArgs.getDeveloper()) {
+    // Only record stats in developer mode or when --stats is specified.
+    if (m_cmdlineArgs.getStats()) {
         StatsManager::createInstance();
     }
     mixxx::Translations::initializeTranslations(
@@ -386,7 +386,7 @@ CoreServices::~CoreServices() {
     CLEAR_AND_CHECK_DELETED(m_pKbdConfig);
     CLEAR_AND_CHECK_DELETED(m_pKbdConfigEmpty);
 
-    if (m_cmdlineArgs.getDeveloper()) {
+    if (m_cmdlineArgs.getStats()) {
         StatsManager::destroy();
     }
 

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -54,6 +54,7 @@ CmdlineArgs::CmdlineArgs()
           m_controllerDebug(false),
           m_controllerAbortOnWarning(false),
           m_developer(false),
+          m_stats(false),
 #ifdef MIXXX_USE_QML
           m_qml(false),
 #endif
@@ -279,6 +280,12 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                             : QString());
     parser.addOption(developer);
 
+    const QCommandLineOption stats(QStringLiteral("stats"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Enables collection of performance statistics.")
+                            : QString());
+    parser.addOption(stats);
+
 #ifdef MIXXX_USE_QML
     const QCommandLineOption qml(QStringLiteral("qml"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -457,6 +464,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     m_controllerPreviewScreens = parser.isSet(controllerPreviewScreens);
     m_controllerAbortOnWarning = parser.isSet(controllerAbortOnWarning);
     m_developer = parser.isSet(developer);
+    m_stats = parser.isSet(stats);
 #ifdef MIXXX_USE_QML
     m_qml = parser.isSet(qml);
 #endif

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -46,6 +46,9 @@ class CmdlineArgs final {
         return m_controllerAbortOnWarning;
     }
     bool getDeveloper() const { return m_developer; }
+    bool getStats() const {
+        return m_developer || m_stats;
+    }
 #ifdef MIXXX_USE_QML
     bool isQml() const {
         return m_qml;
@@ -104,6 +107,7 @@ class CmdlineArgs final {
     bool m_controllerPreviewScreens;
     bool m_controllerAbortOnWarning; // Controller Engine will be stricter
     bool m_developer; // Developer Mode
+    bool m_stats;     // Enable stats collection
 #ifdef MIXXX_USE_QML
     bool m_qml;
 #endif

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -55,7 +55,7 @@ class ScopedTimer {
                 "_s or QStringLiteral() "
                 "to avoid runtime UTF-16 conversion.");
         // we can now assume that T is a QString.
-        if (!CmdlineArgs::Instance().getDeveloper()) {
+        if (!CmdlineArgs::Instance().getStats()) {
             return; // leave timer in cancelled state
         }
         DEBUG_ASSERT(key.capacity() == 0);


### PR DESCRIPTION
This allows to collect statistics without enabling other dev features which affect performance.