### PR TITLE
(performance) Hotcue button: create menu only on demand (reduce skin loading time)

### DIFF
--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -73,10 +73,8 @@ void WHotcueButton::setup(const QDomNode& node, const SkinContext& context) {
         m_dndRectMargins = QMargins(dndMargin, dndMargin, dndMargin, dndMargin);
     }
 
-    m_pCueMenuPopup = make_parented<WCueMenuPopup>(context.getConfig(), this);
-    ColorPaletteSettings colorPaletteSettings(context.getConfig());
-    auto colorPalette = colorPaletteSettings.getHotcueColorPalette();
-    m_pCueMenuPopup->setColorPalette(colorPalette);
+    // Store config pointer in case we need to create a cue menu later on
+    m_pConfig = context.getConfig();
 
     setFocusPolicy(Qt::NoFocus);
 
@@ -147,9 +145,10 @@ void WHotcueButton::mousePressEvent(QMouseEvent* pEvent) {
                 pTrack->removeCue(pHotCue);
                 return;
             }
-            m_pCueMenuPopup->setTrackCueGroup(pTrack, pHotCue, m_group);
+            auto* pCueMenuPopup = getCueMenuPopup();
+            pCueMenuPopup->setTrackCueGroup(pTrack, pHotCue, m_group);
             // use the bottom left corner as starting point for popup
-            m_pCueMenuPopup->popup(mapToGlobal(QPoint(0, height())));
+            pCueMenuPopup->popup(mapToGlobal(QPoint(0, height())));
         }
         return;
     }
@@ -237,6 +236,13 @@ void WHotcueButton::dropEvent(QDropEvent* pEvent) {
     } else {
         pEvent->ignore();
     }
+}
+
+WCueMenuPopup* WHotcueButton::getCueMenuPopup() {
+    if (m_pCueMenuPopup.get() == nullptr) {
+        m_pCueMenuPopup = make_parented<WCueMenuPopup>(m_pConfig, this);
+    }
+    return m_pCueMenuPopup.get();
 }
 
 ConfigKey WHotcueButton::createConfigKey(const QString& name) {

--- a/src/widget/whotcuebutton.h
+++ b/src/widget/whotcuebutton.h
@@ -44,11 +44,18 @@ class WHotcueButton : public WPushButton {
     ConfigKey createConfigKey(const QString& name);
     void updateStyleSheet();
 
+    /// getCueMenuPopup lazy-loads the popup menu to speed up skin load time.
+    /// On skins with many hotcue buttons, popup menu creation time is a
+    /// significant source of load latency.
+    WCueMenuPopup* getCueMenuPopup();
+
     const QString m_group;
     int m_hotcue;
     bool m_hoverCueColor;
     parented_ptr<ControlProxy> m_pCoColor;
     parented_ptr<ControlProxy> m_pCoType;
+    /// Callers should not use m_pCueMenuPopup directly because it is lazy-loaded.
+    /// Use getCueMenuPopup() instead to ensure the menu is populated.
     parented_ptr<WCueMenuPopup> m_pCueMenuPopup;
     int m_cueColorDimThreshold;
     bool m_bCueColorDimmed;
@@ -56,4 +63,6 @@ class WHotcueButton : public WPushButton {
     bool m_bCueColorIsDark;
     QString m_type;
     QMargins m_dndRectMargins;
+
+    UserSettingsPointer m_pConfig;
 };


### PR DESCRIPTION
This reduces `SkinLoader::loadConfiguredSkin` from 2.5 to 1.7 seconds for me (~30 % !!)
Especially helpful for #16934 

(measured with #16940 on top of 2.6, hence included that commit here, too)

### TODO
- [x] revert `--stats` commit