### PR TITLE
(performance) create more menus only on demand

### DIFF
--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -34,61 +34,72 @@ void WEffectPushButton::setup(const QDomNode& node, const SkinContext& context) 
             this,
             &WEffectPushButton::parameterUpdated);
 
-    m_pButtonMenu = new QMenu(this);
-    connect(m_pButtonMenu,
-            &QMenu::triggered,
-            this,
-            &WEffectPushButton::slotActionChosen);
     parameterUpdated();
 }
 
 void WEffectPushButton::onConnectedControlChanged(double dParameter, double dValue) {
-    const QList<QAction*> actions = m_pButtonMenu->actions();
-    for (const auto& action : actions) {
-        if (action->data().toDouble() == dValue) {
-            action->setChecked(true);
-            break;
-        }
-    }
+    setCheckedActionByValue(dValue);
     WPushButton::onConnectedControlChanged(dParameter, dValue);
 }
 
 void WEffectPushButton::mousePressEvent(QMouseEvent* e) {
-    const bool rightClick = e->button() == Qt::RightButton;
-    if (rightClick && !m_pButtonMenu->actions().isEmpty()) {
+    if (e->button() == Qt::RightButton) {
+        // Get or create and connect the menu
+        QMenu* pMenu = getMenu();
+        // Populate the menu if it hasn't been populated yet
+        if (pMenu->actions().isEmpty()) {
+            parameterUpdated();
+        }
+        if (!pMenu->actions().isEmpty()) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        m_pButtonMenu->exec(e->globalPosition().toPoint());
+            pMenu->exec(e->globalPosition().toPoint());
 #else
-        m_pButtonMenu->exec(e->globalPos());
+            pMenu->exec(e->globalPos());
 #endif
-        return;
+            return;
+        }
     }
 
     // Pass all other press events to the base class.
     WPushButton::mousePressEvent(e);
 
-    // The push handler may have set the left value. Check the corresponding
-    // QAction.
-    const double leftValue = getControlParameterLeft();
-    const QList<QAction*> actions = m_pButtonMenu->actions();
-    for (const auto& action : actions) {
-        if (action->data().toDouble() == leftValue) {
-            action->setChecked(true);
-            break;
-        }
-    }
+    // The push handler may have set the left value.
+    // Check the corresponding QAction.
+    setCheckedActionByValue(getControlParameterLeft());
 }
 
 void WEffectPushButton::mouseReleaseEvent(QMouseEvent* e) {
     // Pass all other release events to the base class.
     WPushButton::mouseReleaseEvent(e);
 
-    // The release handler may have set the left value. Check the corresponding
-    // QAction.
-    const double leftValue = getControlParameterLeft();
-    const QList<QAction*> actions = m_pButtonMenu->actions();
+    // The release handler may have set the left value.
+    // Check the corresponding QAction.
+    setCheckedActionByValue(getControlParameterLeft());
+}
+
+QMenu* WEffectPushButton::getMenu() {
+    if (m_pButtonMenu == nullptr) {
+        m_pButtonMenu = new QMenu(this);
+        connect(m_pButtonMenu,
+                &QMenu::triggered,
+                this,
+                &WEffectPushButton::slotActionChosen);
+    }
+    return m_pButtonMenu;
+}
+
+bool WEffectPushButton::menuIsCreated() {
+    return m_pButtonMenu != nullptr;
+}
+
+void WEffectPushButton::setCheckedActionByValue(double value) {
+    if (!menuIsCreated()) {
+        return;
+    }
+    QMenu* pMenu = getMenu();
+    const QList<QAction*> actions = pMenu->actions();
     for (QAction* action : actions) {
-        if (action->data().toDouble() == leftValue) {
+        if (action->data().toDouble() == value) {
             action->setChecked(true);
             break;
         }
@@ -112,7 +123,6 @@ void WEffectPushButton::parameterUpdated() {
         setBaseTooltip("");
     }
 
-    m_pButtonMenu->clear();
     EffectManifestParameterPointer pManifest = m_pEffectParameterSlot->getManifest();
     QList<QPair<QString, double>> options;
     if (pManifest) {
@@ -126,9 +136,17 @@ void WEffectPushButton::parameterUpdated() {
         m_iNoStates = 2;
         return;
     }
-    double value = getControlParameterLeft();
 
-    auto* actionGroup = new QActionGroup(m_pButtonMenu);
+    // Only populate menu if it exists (created on demand on right-click)
+    if (!menuIsCreated()) {
+        return;
+    }
+
+    QMenu* pMenu = getMenu();
+    pMenu->clear();
+    const double value = getControlParameterLeft();
+
+    auto* actionGroup = new QActionGroup(pMenu);
     actionGroup->setExclusive(true);
     for (const auto& option : std::as_const(options)) {
         // action is added automatically to actionGroup
@@ -141,11 +159,11 @@ void WEffectPushButton::parameterUpdated() {
         if (option.second == value) {
             action->setChecked(true);
         }
-        m_pButtonMenu->addAction(action);
+        pMenu->addAction(action);
     }
 }
 
-void WEffectPushButton::slotActionChosen(QAction* action) {
-    action->setChecked(true);
-    setControlParameterLeftDown(action->data().toDouble());
+void WEffectPushButton::slotActionChosen(QAction* pAction) {
+    pAction->setChecked(true);
+    setControlParameterLeftDown(pAction->data().toDouble());
 }

--- a/src/widget/weffectpushbutton.h
+++ b/src/widget/weffectpushbutton.h
@@ -26,7 +26,16 @@ class WEffectPushButton : public WPushButton {
     void slotActionChosen(QAction* action);
 
   private:
+    /// Returns the menu pointer.
+    /// Creates and connects the menu on first call
+    QMenu* getMenu();
+    bool menuIsCreated();
+    void setCheckedActionByValue(double value);
+
     EffectsManager* m_pEffectsManager;
     EffectParameterSlotBasePointer m_pEffectParameterSlot;
+    /// Note: the menu should not be used directly since it is created only on
+    /// demand to reduce skin loading time.
+    /// Use getMenu() menuIsCreated() instead.
     QMenu* m_pButtonMenu;
 };

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -53,7 +53,7 @@ WOverview::WOverview(
           m_devicePixelRatio(1.0),
           m_endOfTrack(false),
           m_bPassthroughEnabled(false),
-          m_pCueMenuPopup(make_parented<WCueMenuPopup>(pConfig, this)),
+          m_pCueMenuPopup(nullptr),
           m_bShowCueTimes(true),
           m_iPosSeconds(0),
           m_bLeftClickDragging(false),
@@ -134,8 +134,6 @@ WOverview::WOverview(
 
     connect(pPlayerManager, &PlayerManager::trackAnalyzerProgress,
             this, &WOverview::onTrackAnalyzerProgress);
-
-    connect(m_pCueMenuPopup.get(), &WCueMenuPopup::aboutToHide, this, &WOverview::slotCueMenuPopupAboutToHide);
 }
 
 void WOverview::setup(const QDomNode& node, const SkinContext& context) {
@@ -188,10 +186,6 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
 
     // setup hotcues and cue and loop(s)
     m_marks.setup(m_group, node, context, m_signalColors);
-
-    ColorPaletteSettings colorPaletteSettings(m_pConfig);
-    auto colorPalette = colorPaletteSettings.getHotcueColorPalette();
-    m_pCueMenuPopup->setColorPalette(colorPalette);
 
     m_marks.connectSamplePositionChanged(this, &WOverview::onMarkChanged);
     m_marks.connectSampleEndPositionChanged(this, &WOverview::onMarkChanged);
@@ -268,6 +262,21 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
     }
 
     setFocusPolicy(Qt::NoFocus);
+}
+
+WCueMenuPopup* WOverview::getMenu() {
+    if (m_pCueMenuPopup.get() == nullptr) {
+        m_pCueMenuPopup = make_parented<WCueMenuPopup>(m_pConfig, this);
+        connect(m_pCueMenuPopup.get(),
+                &WCueMenuPopup::aboutToHide,
+                this,
+                &WOverview::slotCueMenuPopupAboutToHide);
+    }
+    return m_pCueMenuPopup.get();
+}
+
+bool WOverview::menuIsCreated() {
+    return m_pCueMenuPopup.get() != nullptr;
 }
 
 void WOverview::initWithTrack(TrackPointer pTrack) {
@@ -651,11 +660,12 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
                 } else {
                     // Clear the pickup position display, we have all cue info in the menu.
                     leaveEvent(nullptr);
-                    m_pCueMenuPopup->setTrackCueGroup(m_pCurrentTrack, pHoveredCue, m_group);
+                    auto* pCueMenuPopup = getMenu();
+                    pCueMenuPopup->setTrackCueGroup(m_pCurrentTrack, pHoveredCue, m_group);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-                    m_pCueMenuPopup->popup(e->globalPosition().toPoint());
+                    pCueMenuPopup->popup(e->globalPosition().toPoint());
 #else
-                    m_pCueMenuPopup->popup(e->globalPos());
+                    pCueMenuPopup->popup(e->globalPos());
 #endif
                 }
             }
@@ -682,7 +692,7 @@ void WOverview::leaveEvent(QEvent* pEvent) {
     if (QGuiApplication::mouseButtons() & Qt::LeftButton) {
         return;
     }
-    if (!m_pCueMenuPopup->isVisible()) {
+    if (!menuIsCreated() || !getMenu()->isVisible()) {
         m_pHoveredMark.clear();
     }
     m_bLeftClickDragging = false;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -141,6 +141,10 @@ class WOverview : public WWidget, public TrackDropTarget {
         }
     }
 
+    /// Returns the menu pointer.
+    /// Creates and connects the menu on first call
+    WCueMenuPopup* getMenu();
+    bool menuIsCreated();
 
     const QString m_group;
     UserSettingsPointer m_pConfig;
@@ -155,7 +159,11 @@ class WOverview : public WWidget, public TrackDropTarget {
     bool m_endOfTrack;
     bool m_bPassthroughEnabled;
 
+    /// Note: the menu should not be used directly since it is created only on
+    /// demand to reduce skin loading time.
+    /// Use getMenu() menuIsCreated() instead.
     parented_ptr<WCueMenuPopup> m_pCueMenuPopup;
+
     bool m_bShowCueTimes;
 
     int m_iPosSeconds;


### PR DESCRIPTION
On top of #16941

* WEffectPushButton -> Options menu: creation only takes a few milliseconds and is only actually populated for LV2 (and AudioUnit?) effects with option buttons, but we have 96 of them (4 units x 3 slots x 8 buttons), so this is worth it IMO
* WOverview -> WCueMenuPopup: we have 21+ of them (4decks, 16+ samplers, preview deck)

Gives me another ~5% shorter skin load time.
|branch|skin load time|
|-|-|
|2.6| 2.5 s
|#16941| 1.6 s
|#16941 + this| 1.5