### PR TITLE
Fix flickering cue/hotcue marks caused by fragile slip-active check

### DIFF
--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -43,7 +43,8 @@ WaveformWidgetRenderer::WaveformWidgetRenderer(const QString& group)
           m_trackSamples(0),
           m_scaleFactor(1.0),
           m_playMarkerPosition(s_defaultPlayMarkerPosition),
-          m_passthroughEnabled(false) {
+          m_passthroughEnabled(false),
+          m_slipActive(false) {
     //qDebug() << "WaveformWidgetRenderer";
     for (int type = ::WaveformRendererAbstract::Play;
             type <= ::WaveformRendererAbstract::Slip;
@@ -114,6 +115,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
             m_pos[type] = -1.0;
             m_truePosSample[type] = -1.0;
         }
+        m_slipActive = false;
         return;
     }
 
@@ -146,7 +148,8 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     double truePos[2]{0};
     m_visualPlayPosition->getPlaySlipAtNextVSync(vsyncThread,
             truePos + ::WaveformRendererAbstract::Play,
-            truePos + ::WaveformRendererAbstract::Slip);
+            truePos + ::WaveformRendererAbstract::Slip,
+            &m_slipActive);
     // truePlayPos = -1 happens, when a new track is in buffer but m_visualPlayPosition was not updated
 
     if (m_audioSamplePerPixel > 0) {
@@ -185,6 +188,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
             m_pos[type] = -1.0; // disable renderers
             m_truePosSample[type] = -1.0;
         }
+        m_slipActive = false;
     }
 
     // qDebug() << "WaveformWidgetRenderer::onPreRender" <<

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -47,7 +47,7 @@ class WaveformWidgetRenderer {
     }
 
     bool isSlipActive() const {
-        return m_pos[::WaveformRendererAbstract::Play] != m_pos[::WaveformRendererAbstract::Slip];
+        return m_slipActive;
     }
 
     ConstWaveformPointer getWaveform() const;
@@ -252,4 +252,5 @@ private:
     bool m_passthroughEnabled;
     double m_pos[2];
     double m_truePosSample[2];
+    bool m_slipActive;
 };

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -173,7 +173,8 @@ double VisualPlayPosition::getAtNextVSync(VSyncThread* pVSyncThread) {
 
 void VisualPlayPosition::getPlaySlipAtNextVSync(VSyncThread* pVSyncThread,
         double* pPlayPosition,
-        double* pSlipPosition) {
+        double* pSlipPosition,
+        bool* pSlipActive) {
     if (m_valid.load()) {
         const VisualPlayPositionData data = m_data.getValue();
         const double offset = calcOffsetAtNextVSync(pVSyncThread, data);
@@ -181,10 +182,14 @@ void VisualPlayPosition::getPlaySlipAtNextVSync(VSyncThread* pVSyncThread,
         double interpolatedPlayPos = determinePlayPosInLoopBoundries(data, offset);
         *pPlayPosition = interpolatedPlayPos;
 
-        if (data.m_slipModeState == SlipModeState::Running) {
+        const bool slipRunning = data.m_slipModeState == SlipModeState::Running;
+        if (slipRunning) {
             *pSlipPosition = data.m_slipPos + offset * data.m_slipRate;
         } else {
             *pSlipPosition = interpolatedPlayPos;
+        }
+        if (pSlipActive) {
+            *pSlipActive = slipRunning;
         }
     }
 }

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -69,9 +69,19 @@ class VisualPlayPosition : public QObject {
             double audioBufferMicroS);
 
     double getAtNextVSync(VSyncThread* pVSyncThread);
+    // pSlipActive, if not null, is set to whether slip mode is actually
+    // running (i.e. whether slipPosition is expected to diverge from
+    // playPosition), read from the same snapshot as the two positions.
+    // Callers should prefer this over comparing *playPosition and
+    // *slipPosition for equality: the two are computed from the same value
+    // when slip is inactive, but code compiled with aggressive
+    // (non-IEEE-754-strict) floating point optimizations is not guaranteed
+    // to reproduce bit-identical results for the same formula evaluated
+    // twice, which can make such a comparison spuriously report a mismatch.
     void getPlaySlipAtNextVSync(VSyncThread* pVSyncThread,
             double* playPosition,
-            double* slipPosition);
+            double* slipPosition,
+            bool* pSlipActive = nullptr);
     double determinePlayPosInLoopBoundries(
             const VisualPlayPositionData& data, const double& offset);
     double getEnginePlayPos();


### PR DESCRIPTION
## Summary
- `WaveformWidgetRenderer::isSlipActive()` determined whether slip mode was active by comparing the Play and Slip visual positions for exact floating-point equality. When slip mode is genuinely inactive, both values are assigned from the same interpolated position in `VisualPlayPosition::getPlaySlipAtNextVSync()`, so this comparison is only reliable if evaluating the same formula twice, from the same input, is guaranteed to produce bit-identical results.
- `src/waveform/renderers/waveformwidgetrenderer.cpp` is compiled with `/fp:fast` (MSVC's non-IEEE-754-strict floating point mode), which does not guarantee that. In practice this let the equality check spuriously report slip mode as active for a frame at a time, roughly at random, causing `WaveformRenderMark` to intermittently draw cue/hotcue marks at the "slip active" vertical offset instead of their normal position — visible as marks flickering/jumping even with slip mode untouched.
- Thread the actual `SlipModeState` through from the same atomic snapshot already read for the two positions (a new optional out-parameter on `getPlaySlipAtNextVSync()`) instead of inferring it from a position comparison, and use that directly in `isSlipActive()`.

## Test plan
- [x] Reproduced cue/hotcue marks flickering between normal and slip-mode vertical offset during normal playback with slip mode off
- [x] Confirmed via logging that the two positions were being compared for exact equality and diverging by floating-point noise despite slip mode never being toggled
- [x] Confirmed flicker disappears entirely with this fix, while genuine slip mode activation/deactivation still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)