### PR TITLE
Fix segfault in AdjustReplayGainTest.AdjustReplayGainUpdatesPregain

### DIFF
--- a/src/control/controlproxy.cpp
+++ b/src/control/controlproxy.cpp
@@ -18,7 +18,7 @@ ControlProxy::ControlProxy(const ConfigKey& key, QObject* pParent, ControlFlags 
 }
 
 ControlProxy::~ControlProxy() {
-    //qDebug() << "ControlProxy::~ControlProxy()";
+    // qDebug() << "ControlProxy::~ControlProxy()" << m_pControl->getKey() << this;
 }
 
 const ConfigKey& ControlProxy::getKey() const {

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -271,9 +271,6 @@ class EngineMixer : public QObject, public AudioSource {
     // non-owning. lifetime bound to EffectsManager
     EngineEffectsManager* m_pEngineEffectsManager;
 
-    // List of channels added to the engine.
-    QVarLengthArray<std::unique_ptr<ChannelInfo>, kPreallocatedChannels> m_channels;
-
     // The previous gain of each channel for each mixing output (main,
     // headphone, talkover).
     QVarLengthArray<GainCache, kPreallocatedChannels> m_channelMainGainCache;
@@ -298,6 +295,9 @@ class EngineMixer : public QObject, public AudioSource {
 
     parented_ptr<EngineWorkerScheduler> m_pWorkerScheduler;
     std::unique_ptr<EngineSync> m_pEngineSync;
+
+    // List of channels added to the engine. (depends on m_pEngineSync)
+    QVarLengthArray<std::unique_ptr<ChannelInfo>, kPreallocatedChannels> m_channels;
 
     std::unique_ptr<ControlObject> m_pMainGain;
     std::unique_ptr<ControlObject> m_pBoothGain;


### PR DESCRIPTION
The reason was a dangling pointer in m_pEngineSync in SyncControl. This PR takes care that m_pEngineSync outlives SyncControl. It deletes m_channels owning SyncControl early in the default EngineMixer destructor. 

Hopefully this was the final https://github.com/mixxxdj/mixxx/issues/10516 fix. 