### PR TITLE
[GSoC] LateNightQML: Mic/Aux

### DIFF
--- a/res/qml/ControlProxyButtonBehavior.qml
+++ b/res/qml/ControlProxyButtonBehavior.qml
@@ -12,6 +12,7 @@ Item {
     property bool toggleable: false
     property bool activateOnClick: false
     property bool ignoreActivePresses: false
+    property bool powerWindow: false
     property bool releaseToZero: true
     property bool longPressLatching: false
     property bool handlePointerInput: true
@@ -67,7 +68,13 @@ Item {
     function pressPrimary() {
         root.pressAndHoldTriggered = false;
         root.primaryPressed(displayControl.value);
-        if (root.longPressLatching) {
+        if (root.powerWindow) {
+            root.pressStartValue = displayControl.value;
+            root.pressTargetValue = root.nextState(root.pressStartValue);
+            powerWindowTimer.stop();
+            control.value = root.pressTargetValue;
+            powerWindowTimer.start();
+        } else if (root.longPressLatching) {
             root.pressStartValue = displayControl.value;
             root.pressTargetValue = root.nextState(root.pressStartValue);
             longPressTimer.stop();
@@ -90,7 +97,12 @@ Item {
     }
 
     function releasePrimary() {
-        if (root.longPressLatching) {
+        if (root.powerWindow) {
+            if (!powerWindowTimer.running) {
+                control.value = 0;
+            }
+            powerWindowTimer.stop();
+        } else if (root.longPressLatching) {
             if (longPressTimer.running &&
                     root.pressTargetValue > root.activeDisplayThreshold) {
                 control.value = root.pressStartValue;
@@ -190,6 +202,13 @@ Item {
         onTriggered: {
             root.longPressAnimationRunning = false;
         }
+    }
+
+    Timer {
+        id: powerWindowTimer
+
+        interval: root.longPressDuration
+        repeat: false
     }
 
     NumberAnimation {

--- a/res/skins/LateNightQML/Controls/ImageVuMeter.qml
+++ b/res/skins/LateNightQML/Controls/ImageVuMeter.qml
@@ -10,66 +10,68 @@ Item {
     readonly property bool clipping: peakIndicatorControl.value > 0 || levelControl.value >= clipThreshold
     property bool drawGroove: true
     required property string group
+    property bool micAux: false
     readonly property real level: Math.max(0, Math.min(1, levelControl.value))
     property string levelKey: "vu_meter"
     property string peakKey: "peak_indicator"
     readonly property string variantName: backgroundVariant === 0 ? "dark" : "light"
 
     clip: true
-    implicitHeight: 96
+    implicitHeight: root.micAux ? 55 : 96
     implicitWidth: 8
 
     Rectangle {
         anchors.horizontalCenter: parent.horizontalCenter
         color: "#040404"
-        height: parent.height
+        height: root.micAux ? 50 : parent.height
         visible: root.drawGroove
         width: 8
+        y: root.micAux ? 2 : 0
     }
     Image {
         anchors.horizontalCenter: parent.horizontalCenter
         fillMode: Image.PreserveAspectFit
-        height: 11
+        height: root.micAux ? 9 : 11
         smooth: false
-        source: LateNightTheme.mixerVuClipBackground(root.variantName)
+        source: root.micAux ? LateNightTheme.assetMicAuxVuClippingBackground : LateNightTheme.mixerVuClipBackground(root.variantName)
         width: 6
-        y: 1
+        y: root.micAux ? 2 : 1
     }
     Image {
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: 1
+        anchors.bottomMargin: root.micAux ? 3 : 1
         anchors.horizontalCenter: parent.horizontalCenter
         fillMode: Image.PreserveAspectFit
-        height: 81
+        height: root.micAux ? 41 : 81
         smooth: false
-        source: LateNightTheme.mixerVuLevelBackground(root.variantName)
+        source: root.micAux ? LateNightTheme.assetMicAuxVuLevelBackground : LateNightTheme.mixerVuLevelBackground(root.variantName)
         width: 6
     }
     Image {
         anchors.horizontalCenter: parent.horizontalCenter
         fillMode: Image.PreserveAspectFit
-        height: 11
+        height: root.micAux ? 9 : 11
         opacity: root.clipping ? 1 : 0
         smooth: false
-        source: LateNightTheme.lateNightAsset("style", "vu_deck_clipping_active.png")
+        source: root.micAux ? LateNightTheme.assetMicAuxVuClippingActive : LateNightTheme.lateNightAsset("style", "vu_deck_clipping_active.png")
         width: 6
-        y: 1
+        y: root.micAux ? 2 : 1
     }
     Item {
         anchors.bottom: parent.bottom
-        anchors.bottomMargin: 1
+        anchors.bottomMargin: root.micAux ? 3 : 1
         anchors.horizontalCenter: parent.horizontalCenter
         clip: true
-        height: 81 * root.level
+        height: (root.micAux ? 41 : 81) * root.level
         width: 6
 
         Image {
             anchors.bottom: parent.bottom
             anchors.horizontalCenter: parent.horizontalCenter
             fillMode: Image.PreserveAspectFit
-            height: 81
+            height: root.micAux ? 41 : 81
             smooth: false
-            source: LateNightTheme.lateNightAsset("style", "vu_deck_level_active.png")
+            source: root.micAux ? LateNightTheme.assetMicAuxVuLevelActive : LateNightTheme.lateNightAsset("style", "vu_deck_level_active.png")
             width: 6
         }
     }

--- a/res/skins/LateNightQML/Controls/RackFiller.qml
+++ b/res/skins/LateNightQML/Controls/RackFiller.qml
@@ -1,0 +1,31 @@
+import QtQuick
+import "../LateNightTheme"
+
+Rectangle {
+    border.color: LateNightTheme.rackFillerBorderColor
+    border.width: 1
+    color: LateNightTheme.effectsFillerColor
+    radius: LateNightTheme.isClassic ? 2 : 1
+
+    Rectangle {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        color: LateNightTheme.rackFillerTopBorderColor
+        height: 1
+    }
+    Rectangle {
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.top: parent.top
+        color: LateNightTheme.rackFillerLeftBorderColor
+        width: 1
+    }
+    Rectangle {
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        color: LateNightTheme.rackFillerBottomBorderColor
+        height: 1
+    }
+}

--- a/res/skins/LateNightQML/Deck/LateNightControlButton.qml
+++ b/res/skins/LateNightQML/Deck/LateNightControlButton.qml
@@ -13,6 +13,7 @@ LateNightIconButton {
     property bool toggleable: false
     property bool activateOnClick: false
     property bool ignoreActivePresses: false
+    property bool powerWindow: false
     property bool releaseToZero: true
     property bool longPressLatching: false
     property int numberStates: 2
@@ -79,6 +80,7 @@ LateNightIconButton {
         toggleable: root.toggleable
         activateOnClick: root.activateOnClick
         ignoreActivePresses: root.ignoreActivePresses
+        powerWindow: root.powerWindow
         releaseToZero: root.releaseToZero
         longPressLatching: root.longPressLatching
         numberStates: root.numberStates

--- a/res/skins/LateNightQML/Effects/EffectsRack.qml
+++ b/res/skins/LateNightQML/Effects/EffectsRack.qml
@@ -1,5 +1,6 @@
 import Mixxx 1.0 as Mixxx
 import QtQuick
+import "../Controls" as Controls
 import "../LateNightTheme"
 
 Rectangle {
@@ -8,8 +9,8 @@ Rectangle {
     readonly property bool compactDiagonal: showFourUnits && ((unit1.expanded && !unit2.expanded && !unit3.expanded && unit4.expanded) || (!unit1.expanded && unit2.expanded && unit3.expanded && !unit4.expanded))
     readonly property real firstPairHeight: Math.max(unit1.implicitHeight, unit2.implicitHeight)
     readonly property int rowSpacing: LateNightTheme.isClassic ? 4 : 3
-    readonly property real secondRowTop: rowSpacing + firstPairHeight + rowSpacing
     readonly property real secondPairHeight: showFourUnits ? Math.max(unit3.implicitHeight, unit4.implicitHeight) : 0
+    readonly property real secondRowTop: rowSpacing + firstPairHeight + rowSpacing
     readonly property bool showFourUnits: showFourUnitsControl.value > 0
     readonly property real unit3Top: compactDiagonal ? unit1.y + unit1.height + rowSpacing : secondRowTop
     readonly property real unit4Top: compactDiagonal ? unit2.y + unit2.height + rowSpacing : secondRowTop
@@ -26,7 +27,7 @@ Rectangle {
         x: 0
         y: root.rowSpacing
     }
-    RackFiller {
+    Controls.RackFiller {
         height: Math.max(0, root.firstPairHeight - unit1.height - root.rowSpacing)
         visible: !root.compactDiagonal && height > 0
         width: unit1.width - 1
@@ -42,7 +43,7 @@ Rectangle {
         x: unit1.width + 4
         y: root.rowSpacing
     }
-    RackFiller {
+    Controls.RackFiller {
         height: Math.max(0, root.firstPairHeight - unit2.height - root.rowSpacing)
         visible: !root.compactDiagonal && height > 0
         width: unit2.width - 1
@@ -59,7 +60,7 @@ Rectangle {
         x: 0
         y: root.unit3Top
     }
-    RackFiller {
+    Controls.RackFiller {
         height: Math.max(0, root.secondPairHeight - unit3.height - root.rowSpacing)
         visible: root.showFourUnits && !root.compactDiagonal && height > 0
         width: unit3.width - 1
@@ -76,7 +77,7 @@ Rectangle {
         x: unit3.width + 4
         y: root.unit4Top
     }
-    RackFiller {
+    Controls.RackFiller {
         height: Math.max(0, root.secondPairHeight - unit4.height - root.rowSpacing)
         visible: root.showFourUnits && !root.compactDiagonal && height > 0
         width: unit4.width - 1
@@ -88,34 +89,5 @@ Rectangle {
 
         group: "[Skin]"
         key: "show_4effectunits"
-    }
-
-    component RackFiller: Rectangle {
-        border.color: "#111111"
-        border.width: 1
-        color: LateNightTheme.effectsFillerColor
-        radius: LateNightTheme.isClassic ? 2 : 1
-
-        Rectangle {
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.top: parent.top
-            color: LateNightTheme.isClassic ? "#222222" : "#1c1c1c"
-            height: 1
-        }
-        Rectangle {
-            anchors.bottom: parent.bottom
-            anchors.left: parent.left
-            anchors.top: parent.top
-            color: LateNightTheme.isClassic ? "#222222" : "#191919"
-            width: 1
-        }
-        Rectangle {
-            anchors.bottom: parent.bottom
-            anchors.left: parent.left
-            anchors.right: parent.right
-            color: LateNightTheme.isClassic ? "#111111" : "#020202"
-            height: 1
-        }
     }
 }

--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -76,6 +76,10 @@ QtObject {
     readonly property url assetDeckVinylControl3: lateNightAsset("style", "vinyl_control_3.svg")
     readonly property url assetDeckVolumeSliderBackground: lateNightAsset("sliders", "slider_volume_deck.svg")
     readonly property url assetDeckVolumeSliderHandle: lateNightAsset("sliders", "knob_volume_deck.svg")
+    readonly property url assetAuxMainMixButton: lateNightAsset("buttons", "btn__aux_play.svg")
+    readonly property url assetAuxXfaderLeft: lateNightAsset("buttons", "btn__xfader_deck_left_default.svg")
+    readonly property url assetAuxXfaderMain: lateNightAsset("buttons", "btn__xfader_deck_mid_default.svg")
+    readonly property url assetAuxXfaderRight: lateNightAsset("buttons", "btn__xfader_deck_right_default.svg")
     readonly property url assetFxCollapseButton: lateNightAsset("buttons", isClassic ? "btn__collapse.svg" : "btn__collapse_dim.svg")
     readonly property url assetFxExpandButton: lateNightAsset("buttons", isClassic ? "btn__expand.svg" : "btn__expand_dim.svg")
     readonly property url assetFxFlowHorizontal: lateNightAsset("style", isClassic ? "fx_separator.svg" : "fx_flow_horizontal.svg")
@@ -97,6 +101,17 @@ QtObject {
     readonly property url assetFxToggleActiveButton: lateNightAsset("buttons", "btn__fx_toggle_active.svg")
     readonly property url assetFxToggleButton: lateNightAsset("buttons", "btn__fx_toggle.svg")
     readonly property url assetMainKnobBackground: lateNightAsset("knobs", "knob_bg_main.svg")
+    readonly property url assetMicAuxAddButton: lateNightAsset("buttons", "btn__plus_flat.svg")
+    readonly property url assetMicAuxGainKnobBackground: lateNightAsset("knobs", "knob_bg_small.svg")
+    readonly property url assetMicAuxUnconfiguredBackground: lateNightAsset("buttons", "btn_flat_square.svg")
+    readonly property url assetMicAuxVuClippingActive: lateNightAsset("style", "vu_micaux_clipping_active.png")
+    readonly property url assetMicAuxVuClippingBackground: lateNightAsset("style", "vu_micaux_clipping_bg_.png")
+    readonly property url assetMicAuxVuLevelActive: lateNightAsset("style", "vu_micaux_level_active.png")
+    readonly property url assetMicAuxVuLevelBackground: lateNightAsset("style", "vu_micaux_level_bg_.png")
+    readonly property url assetMicDuckAutoButton: lateNightAsset("buttons", "btn__mic_duck_auto.svg")
+    readonly property url assetMicDuckManualButton: lateNightAsset("buttons", "btn__mic_duck_manual.svg")
+    readonly property url assetMicDuckOffButton: lateNightAsset("buttons", "btn__mic_duck_off.svg")
+    readonly property url assetMicTalkButton: lateNightAsset("buttons", "btn__mic_talk.svg")
     readonly property url assetMixerCrossfaderBackground: lateNightAsset("sliders", "slider_crossfader.svg")
     readonly property url assetMixerCrossfaderHandle: lateNightAsset("sliders", "knob_crossfader.svg")
     readonly property url assetMixerCrossfaderSmallBackground: lateNightAsset("sliders", "slider_crossfader_small.svg")
@@ -202,8 +217,8 @@ QtObject {
     readonly property color mixerControlTextColor: isClassic ? "#d2d2d1" : "#a7998b"
     readonly property color mixerDimTextColor: "#696969"
     readonly property color mixerEqKillActiveColor: isClassic ? "#db0000" : "#a80000"
-    readonly property color mixerFxAssignInactiveColor: isClassic ? deckEmbeddedButtonInactiveColor : "#151517"
-    readonly property color mixerFxAssignInactiveTextColor: isClassic ? mixerDimTextColor : "#555555"
+    readonly property color mixerFxAssignInactiveColor: deckEmbeddedButtonInactiveColor
+    readonly property color mixerFxAssignInactiveTextColor: isClassic ? effectsAssignmentInactiveTextColor : "#666666"
     readonly property color mixerMainSeparatorDarkColor: isPaleMoon ? "#0c0c0c" : mixerPanelBorderDark
     readonly property color mixerMainSeparatorLightColor: isPaleMoon ? "#222222" : mixerPanelBorderLight
     readonly property color mixerSplitActiveColor: isClassic ? "#888888" : "#555555"
@@ -221,6 +236,13 @@ QtObject {
     readonly property color mixerSliderBarColor: "#257b82"
     readonly property color mixerVuClipColor: mixerAccentRed
     readonly property color mixerVuLevelColor: mixerAccentRed
+    readonly property color micAuxDuckingArcColor: "#a00000"
+    readonly property color micAuxGainColor: isClassic ? "#db7700" : "#b24c12"
+    readonly property color micAuxLabelTextColor: primaryDeckTextColor
+    readonly property color micAuxPanelColor: isClassic ? "#1e1e1e" : "#1e1e20"
+    readonly property color micAuxRackGutterColor: isClassic ? "#0f0f0f" : "#080808"
+    readonly property color micAuxUnconfiguredTextColor: isClassic ? "#666666" : "#686666"
+    readonly property string micTalkActiveIconSuffix: isPaleMoon ? "active" : ""
     readonly property url optionalDeckControlsBackgroundTile: isClassic ? lateNightAsset("style", "background_tile.png") : ""
     readonly property url optionalDeckRateCenterActive: isPaleMoon ? lateNightAsset("buttons", "btn__rate_center_cyan.svg") : ""
     readonly property url optionalDeckRateCenterInactive: isPaleMoon ? lateNightAsset("buttons", "btn__rate_center_off.svg") : ""
@@ -243,6 +265,10 @@ QtObject {
     readonly property color primaryDeckTextColor: isClassic ? "#f0bb2b" : "#c2b3a5"
     readonly property color primaryOverviewBackgroundColor: isClassic ? "#0f0f0f" : "#19191a"
     readonly property color primaryWaveformSignalColor: isClassic ? "#e7c413" : "#d9b28c"
+    readonly property color rackFillerBorderColor: "#111111"
+    readonly property color rackFillerBottomBorderColor: isClassic ? "#111111" : "#020202"
+    readonly property color rackFillerLeftBorderColor: isClassic ? "#222222" : "#191919"
+    readonly property color rackFillerTopBorderColor: isClassic ? "#222222" : "#1c1c1c"
     readonly property color samplerBpmColor: isClassic ? "#f0bb2b" : "#766b65"
     readonly property color samplerBpmSeparatorLightColor: "#292929"
     readonly property color samplerColor: accentColor

--- a/res/skins/LateNightQML/MainWindow.qml
+++ b/res/skins/LateNightQML/MainWindow.qml
@@ -2,6 +2,7 @@ import "../../qml" as Skin
 import "LateNightTheme"
 import "Deck" as LateNightDeck
 import "Effects" as LateNightEffects
+import "MicAux" as LateNightMicAux
 import "Mixer" as LateNightMixer
 import "Samplers" as LateNightSamplers
 import "Toolbar" as LateNightToolbar
@@ -26,6 +27,7 @@ Item {
     readonly property int numSamplers: 64
     readonly property bool show4decks: toolbar.show4decks
     property alias showEffects: toolbar.showEffects
+    property alias showMicAux: toolbar.showMicAux
     readonly property bool showMaximizedDecks: toolbar.showMaximizedDecks
     readonly property bool showMixer: toolbar.showMixer
     property alias showSamplers: toolbar.showSamplers
@@ -401,7 +403,7 @@ Item {
 
                 readonly property real basePaneHeight: Math.max(deckRowsHeight, mixer.visible ? mixer.implicitHeight : 0)
                 readonly property real deckRowsHeight: root.show4decks ? visibleDeckHeight * 2 : visibleDeckHeight
-                readonly property real requiredPaneHeight: basePaneHeight + effectsSection.height + samplersSection.height
+                readonly property real requiredPaneHeight: basePaneHeight + effectsSection.height + samplersSection.height + micAuxSection.height
                 readonly property real visibleDeckHeight: root.maximizeLibrary ? (root.showMaximizedDecks ? root.minimizedDeckHeight : 0) : root.fullDeckHeight
 
                 SplitView.fillHeight: library.active
@@ -735,6 +737,37 @@ Item {
                         anchors.top: parent.top
                     }
                 }
+                Item {
+                    id: micAuxSection
+
+                    clip: true
+                    height: root.showMicAux && !root.maximizeLibrary ? micAuxRack.implicitHeight : 0
+                    opacity: root.showMicAux && !root.maximizeLibrary ? 1 : 0
+                    visible: height > 0
+                    width: parent.width
+                    y: samplersSection.y + samplersSection.height
+                    z: 2
+
+                    Behavior on height {
+                        NumberAnimation {
+                            duration: 150
+                            easing.type: Easing.OutCubic
+                        }
+                    }
+                    Behavior on opacity {
+                        NumberAnimation {
+                            duration: 120
+                        }
+                    }
+
+                    LateNightMicAux.MicAuxRack {
+                        id: micAuxRack
+
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                    }
+                }
                 Loader {
                     id: library
 
@@ -775,7 +808,7 @@ Item {
 
                     anchors {
                         bottom: parent.bottom
-                        top: samplersSection.bottom
+                        top: micAuxSection.bottom
                     }
                 }
             }

--- a/res/skins/LateNightQML/MicAux/AuxOrientationButton.qml
+++ b/res/skins/LateNightQML/MicAux/AuxOrientationButton.qml
@@ -1,0 +1,62 @@
+pragma ComponentBehavior: Bound
+
+import Mixxx 1.0 as Mixxx
+import QtQuick
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    required property string group
+
+    implicitHeight: 15
+    implicitWidth: 33
+
+    Image {
+        anchors.fill: parent
+        fillMode: Image.PreserveAspectFit
+        source: {
+            switch (Math.round(orientationControl.value)) {
+            case 0:
+                return LateNightTheme.assetAuxXfaderLeft;
+            case 2:
+                return LateNightTheme.assetAuxXfaderRight;
+            default:
+                return LateNightTheme.assetAuxXfaderMain;
+            }
+        }
+    }
+    Row {
+        anchors.fill: parent
+
+        Repeater {
+            model: ["orientation_left", "orientation_center", "orientation_right"]
+
+            Item {
+                id: assignButton
+
+                required property int index
+                required property string modelData
+
+                height: parent.height
+                width: 11
+
+                TapHandler {
+                    onPressedChanged: assignControl.value = pressed ? 1 : 0
+                }
+                Mixxx.ControlProxy {
+                    id: assignControl
+
+                    group: root.group
+                    key: assignButton.modelData
+                }
+            }
+        }
+    }
+    Mixxx.ControlProxy {
+        id: orientationControl
+
+        group: root.group
+        key: "orientation"
+    }
+}

--- a/res/skins/LateNightQML/MicAux/AuxUnit.qml
+++ b/res/skins/LateNightQML/MicAux/AuxUnit.qml
@@ -1,0 +1,180 @@
+pragma ComponentBehavior: Bound
+
+import "../Controls" as Controls
+import "../Deck" as DeckControls
+import "../LateNightTheme"
+import "../Mixer" as MixerControls
+import Mixxx 1.0 as Mixxx
+import QtQuick
+import QtQuick.Layouts
+
+Item {
+    id: root
+
+    property string group: "[Auxiliary" + unitNumber + "]"
+    readonly property bool inputConfigured: inputConfiguredControl.value > 0
+    readonly property Item loadedUnit: unitLoader.item as Item
+    required property int unitNumber
+
+    implicitHeight: loadedUnit?.implicitHeight ?? 0
+    implicitWidth: loadedUnit?.implicitWidth ?? 0
+
+    Loader {
+        id: unitLoader
+
+        anchors.fill: parent
+        sourceComponent: root.inputConfigured ? configuredUnit : unconfiguredUnit
+    }
+    Mixxx.ControlProxy {
+        id: inputConfiguredControl
+
+        group: root.group
+        key: "input_configured"
+    }
+    Component {
+        id: configuredUnit
+
+        Controls.Panel {
+            color: LateNightTheme.micAuxPanelColor
+            implicitHeight: 68
+            implicitWidth: contentLayout.implicitWidth + contentLayout.anchors.leftMargin + contentLayout.anchors.rightMargin
+
+            RowLayout {
+                id: contentLayout
+
+                anchors.fill: parent
+                anchors.margins: 2
+                spacing: 2
+
+                ColumnLayout {
+                    Layout.fillHeight: true
+                    Layout.preferredWidth: 43
+                    spacing: 1
+
+                    Text {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 18
+                        color: LateNightTheme.micAuxLabelTextColor
+                        font.bold: true
+                        font.family: "Open Sans"
+                        font.pixelSize: 14
+                        horizontalAlignment: Text.AlignHCenter
+                        text: "AUX " + root.unitNumber
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    AuxOrientationButton {
+                        Layout.alignment: Qt.AlignHCenter
+                        group: root.group
+                    }
+                    DeckControls.LateNightControlButton {
+                        Layout.alignment: Qt.AlignHCenter
+                        Layout.preferredHeight: 26
+                        Layout.preferredWidth: 42
+                        activeColor: LateNightTheme.activePlayCueColor
+                        activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                        group: root.group
+                        iconSource: LateNightTheme.assetAuxMainMixButton
+                        key: "main_mix"
+                        powerWindow: true
+                        stretchIcon: true
+                    }
+                }
+                Controls.ImageVuMeter {
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredHeight: 55
+                    Layout.preferredWidth: 8
+                    group: root.group
+                    levelKey: "vu_meter"
+                    micAux: true
+                }
+                ColumnLayout {
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 3
+                    Layout.rightMargin: 3
+                    spacing: 1
+
+                    RowLayout {
+                        Layout.alignment: Qt.AlignHCenter
+                        Layout.preferredHeight: 30
+                        spacing: 4
+
+                        Controls.Knob {
+                            Layout.preferredHeight: 30
+                            Layout.preferredWidth: 35
+                            backgroundSource: LateNightTheme.assetMicAuxGainKnobBackground
+                            displayArc: true
+                            displayArcColor: LateNightTheme.micAuxGainColor
+                            displayArcStart: Controls.Knob.ArcStart.Minimum
+                            group: root.group
+                            indicatorColor: "orange"
+                            indicatorKind: "small"
+                            key: "pregain"
+                        }
+                        MixerControls.PflButton {
+                            group: root.group
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 22
+                        spacing: 1
+
+                        MixerControls.FxAssignButtons {
+                            id: fxAssignments
+
+                            Layout.alignment: Qt.AlignHCenter
+                            Layout.preferredHeight: 20
+                            groupName: root.group
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Component {
+        id: unconfiguredUnit
+
+        Controls.Panel {
+            color: LateNightTheme.micAuxPanelColor
+            implicitHeight: 57
+            implicitWidth: 47
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.bottomMargin: 4
+                anchors.leftMargin: 4
+                anchors.rightMargin: 4
+                anchors.topMargin: 2
+                spacing: 2
+
+                Text {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 21
+                    color: LateNightTheme.micAuxUnconfiguredTextColor
+                    font.bold: true
+                    font.family: "Open Sans"
+                    font.pixelSize: 14
+                    horizontalAlignment: Text.AlignHCenter
+                    text: "AUX " + root.unitNumber
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Item {
+                    Layout.fillHeight: true
+                }
+                DeckControls.LateNightControlButton {
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredHeight: 26
+                    Layout.preferredWidth: 26
+                    backgroundSource: LateNightTheme.assetMicAuxUnconfiguredBackground
+                    contentOpacity: 1.0
+                    group: root.group
+                    iconSource: LateNightTheme.assetMicAuxAddButton
+                    inactiveFillEnabled: false
+                    key: "main_mix"
+                    stretchIcon: true
+                }
+            }
+        }
+    }
+}

--- a/res/skins/LateNightQML/MicAux/MicAuxRack.qml
+++ b/res/skins/LateNightQML/MicAux/MicAuxRack.qml
@@ -1,0 +1,89 @@
+pragma ComponentBehavior: Bound
+
+import "../Controls" as Controls
+import "../LateNightTheme"
+import Mixxx 1.0 as Mixxx
+import QtQuick
+import QtQuick.Layouts
+
+Rectangle {
+    id: root
+
+    readonly property int legacyBottomMargin: LateNightTheme.isClassic ? 4 : 3
+
+    color: LateNightTheme.micAuxRackGutterColor
+    implicitHeight: Math.max(micRack.implicitHeight, auxRack.implicitHeight) + legacyBottomMargin
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.bottomMargin: root.legacyBottomMargin
+        anchors.topMargin: 0
+        spacing: 0
+
+        Controls.RackFiller {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+        }
+        RowLayout {
+            id: micRack
+
+            Layout.alignment: Qt.AlignTop
+            Layout.fillHeight: true
+            Layout.leftMargin: 2
+            Layout.rightMargin: 2
+            spacing: 3
+
+            MicrophoneDuckingPanel {
+                Layout.alignment: Qt.AlignTop
+                Layout.fillHeight: true
+                visible: numMicrophonesControl.value > 0
+            }
+            Repeater {
+                model: 4
+
+                MicUnit {
+                    required property int index
+
+                    Layout.alignment: Qt.AlignTop
+                    Layout.fillHeight: true
+                    unitNumber: index + 1
+                }
+            }
+        }
+        Controls.RackFiller {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+        }
+        RowLayout {
+            id: auxRack
+
+            Layout.alignment: Qt.AlignTop
+            Layout.fillHeight: true
+            Layout.leftMargin: 2
+            Layout.rightMargin: 2
+            spacing: 3
+
+            Repeater {
+                model: 4
+
+                AuxUnit {
+                    required property int index
+
+                    Layout.alignment: Qt.AlignTop
+                    Layout.fillHeight: true
+                    unitNumber: index + 1
+                }
+            }
+        }
+        Controls.RackFiller {
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+        }
+    }
+    Mixxx.ControlProxy {
+        id: numMicrophonesControl
+
+        group: "[App]"
+        key: "num_microphones"
+    }
+}

--- a/res/skins/LateNightQML/MicAux/MicUnit.qml
+++ b/res/skins/LateNightQML/MicAux/MicUnit.qml
@@ -1,0 +1,183 @@
+pragma ComponentBehavior: Bound
+
+import "../Controls" as Controls
+import "../Deck" as DeckControls
+import "../LateNightTheme"
+import "../Mixer" as MixerControls
+import Mixxx 1.0 as Mixxx
+import QtQuick
+import QtQuick.Layouts
+
+Item {
+    id: root
+
+    property string group: unitNumber === 1 ? "[Microphone]" : "[Microphone" + unitNumber + "]"
+    readonly property bool inputConfigured: inputConfiguredControl.value > 0
+    readonly property Item loadedUnit: unitLoader.item as Item
+    required property int unitNumber
+
+    implicitHeight: loadedUnit?.implicitHeight ?? 0
+    implicitWidth: loadedUnit?.implicitWidth ?? 0
+
+    Loader {
+        id: unitLoader
+
+        anchors.fill: parent
+        sourceComponent: root.inputConfigured ? configuredUnit : unconfiguredUnit
+    }
+    Mixxx.ControlProxy {
+        id: inputConfiguredControl
+
+        group: root.group
+        key: "input_configured"
+    }
+    Component {
+        id: configuredUnit
+
+        Controls.Panel {
+            color: LateNightTheme.micAuxPanelColor
+            implicitHeight: 59
+            implicitWidth: contentLayout.implicitWidth + contentLayout.anchors.leftMargin + contentLayout.anchors.rightMargin
+
+            RowLayout {
+                id: contentLayout
+
+                anchors.fill: parent
+                anchors.margins: 2
+                spacing: 2
+
+                ColumnLayout {
+                    Layout.fillHeight: true
+                    Layout.preferredWidth: 43
+                    spacing: 1
+
+                    Text {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 20
+                        color: LateNightTheme.micAuxLabelTextColor
+                        font.bold: true
+                        font.family: "Open Sans"
+                        font.pixelSize: 14
+                        horizontalAlignment: Text.AlignHCenter
+                        text: "MIC " + root.unitNumber
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    Item {
+                        Layout.fillHeight: true
+                    }
+                    DeckControls.LateNightControlButton {
+                        Layout.alignment: Qt.AlignHCenter
+                        Layout.preferredHeight: 26
+                        Layout.preferredWidth: 42
+                        activeBackgroundSuffix: "active"
+                        activeColor: LateNightTheme.activePlayCueColor
+                        activeIconSuffix: LateNightTheme.micTalkActiveIconSuffix
+                        activeOpacity: 1
+                        backgroundSource: LateNightTheme.lateNightTopRegionButton("medium")
+                        group: root.group
+                        iconSource: LateNightTheme.assetMicTalkButton
+                        inactiveOpacity: 1
+                        key: "talkover"
+                        powerWindow: true
+                        stretchIcon: true
+                    }
+                }
+                Controls.ImageVuMeter {
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.preferredHeight: 55
+                    Layout.preferredWidth: 8
+                    group: root.group
+                    levelKey: "vu_meter"
+                    micAux: true
+                }
+                ColumnLayout {
+                    Layout.fillHeight: true
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 3
+                    Layout.rightMargin: 3
+                    spacing: 1
+
+                    RowLayout {
+                        Layout.alignment: Qt.AlignHCenter
+                        Layout.preferredHeight: 30
+                        spacing: 4
+
+                        Controls.Knob {
+                            Layout.preferredHeight: 30
+                            Layout.preferredWidth: 35
+                            backgroundSource: LateNightTheme.assetMicAuxGainKnobBackground
+                            displayArc: true
+                            displayArcColor: LateNightTheme.micAuxGainColor
+                            displayArcStart: Controls.Knob.ArcStart.Minimum
+                            group: root.group
+                            indicatorColor: "orange"
+                            indicatorKind: "small"
+                            key: "pregain"
+                        }
+                        MixerControls.PflButton {
+                            group: root.group
+                        }
+                    }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: 22
+                        spacing: 1
+
+                        MixerControls.FxAssignButtons {
+                            id: fxAssignments
+
+                            Layout.alignment: Qt.AlignHCenter
+                            Layout.preferredHeight: 20
+                            groupName: root.group
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Component {
+        id: unconfiguredUnit
+
+        Controls.Panel {
+            color: LateNightTheme.micAuxPanelColor
+            implicitHeight: 57
+            implicitWidth: 47
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.bottomMargin: 4
+                anchors.leftMargin: 4
+                anchors.rightMargin: 4
+                anchors.topMargin: 2
+                spacing: 2
+
+                Text {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 21
+                    color: LateNightTheme.micAuxUnconfiguredTextColor
+                    font.bold: true
+                    font.family: "Open Sans"
+                    font.pixelSize: 14
+                    horizontalAlignment: Text.AlignHCenter
+                    text: "MIC " + root.unitNumber
+                    verticalAlignment: Text.AlignVCenter
+                }
+                Item {
+                    Layout.fillHeight: true
+                }
+                DeckControls.LateNightControlButton {
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredHeight: 26
+                    Layout.preferredWidth: 26
+                    backgroundSource: LateNightTheme.assetMicAuxUnconfiguredBackground
+                    contentOpacity: 1.0
+                    group: root.group
+                    iconSource: LateNightTheme.assetMicAuxAddButton
+                    inactiveFillEnabled: false
+                    key: "talkover"
+                    stretchIcon: true
+                }
+            }
+        }
+    }
+}

--- a/res/skins/LateNightQML/MicAux/MicrophoneDuckingPanel.qml
+++ b/res/skins/LateNightQML/MicAux/MicrophoneDuckingPanel.qml
@@ -1,0 +1,65 @@
+import "../Controls" as Controls
+import "../Deck" as DeckControls
+import "../LateNightTheme"
+import "../../../qml" as Shared
+import QtQuick
+import QtQuick.Layouts
+
+Controls.Panel {
+    id: root
+
+    color: LateNightTheme.micAuxPanelColor
+    implicitHeight: 59
+    implicitWidth: 48
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 2
+        spacing: 2
+
+        DeckControls.LateNightIconButton {
+            id: duckModeButton
+
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredHeight: 24
+            Layout.preferredWidth: 42
+            activeBackgroundSuffix: "active"
+            activeColor: LateNightTheme.activePlayCueColor
+            activeState: duckModeBehavior.currentState > 0
+            backgroundSource: LateNightTheme.lateNightTopRegionButton("medium")
+            contentOpacity: 1
+            iconSource: {
+                switch (duckModeBehavior.currentState) {
+                case 1:
+                    return LateNightTheme.assetMicDuckAutoButton;
+                case 2:
+                    return LateNightTheme.assetMicDuckManualButton;
+                default:
+                    return LateNightTheme.assetMicDuckOffButton;
+                }
+            }
+            stretchIcon: true
+
+            Shared.ControlCycleButtonBehavior {
+                id: duckModeBehavior
+
+                anchors.fill: parent
+                group: "[Master]"
+                key: "talkoverDucking"
+            }
+        }
+        Controls.Knob {
+            Layout.alignment: Qt.AlignHCenter
+            Layout.preferredHeight: 30
+            Layout.preferredWidth: 35
+            backgroundSource: LateNightTheme.assetMicAuxGainKnobBackground
+            displayArc: true
+            displayArcColor: LateNightTheme.micAuxDuckingArcColor
+            displayArcStart: Controls.Knob.ArcStart.Maximum
+            group: "[Master]"
+            indicatorColor: "red"
+            indicatorKind: "small"
+            key: "duckStrength"
+        }
+    }
+}

--- a/res/skins/LateNightQML/Mixer/FxAssignButtons.qml
+++ b/res/skins/LateNightQML/Mixer/FxAssignButtons.qml
@@ -5,17 +5,24 @@ import "../LateNightTheme"
 Row {
     id: root
 
+    readonly property int assignmentWidth: root.effectUnitCount === 4 ? 86 : 52
+    readonly property int effectUnitCount: showFourEffectUnitsControl.value > 0 ? 4 : 2
     required property string groupName
 
     spacing: 0
 
     Repeater {
-        model: 4
+        model: root.effectUnitCount
 
         Item {
             id: cell
 
-            readonly property int buttonWidth: cell.index === 0 ? 26 : 20
+            readonly property bool active: assignControl.value > 0
+            readonly property color activeColor: cell.index < 2
+                    ? (LateNightTheme.isClassic ? LateNightTheme.effectsUnitColor12 : LateNightTheme.effectsUnitDimColor12)
+                    : (LateNightTheme.isClassic ? LateNightTheme.effectsUnitColor34 : LateNightTheme.effectsUnitDimColor34)
+            readonly property int buttonWidth: root.effectUnitCount === 4 && cell.index > 0 ? 20 : 26
+            readonly property color fillColor: cell.active ? cell.activeColor : LateNightTheme.mixerFxAssignInactiveColor
             required property int index
 
             height: 20
@@ -25,22 +32,30 @@ Row {
 
             Rectangle {
                 anchors.fill: parent
-                color: assignControl.value > 0 ? "#333335" : LateNightTheme.mixerFxAssignInactiveColor
+                color: cell.fillColor
             }
+
+            // TODO(xARSENICx): Reuse the border-sliced FX assignment component after
+            // LateNightQML/layouts merges.
             Image {
                 anchors.fill: parent
                 fillMode: Image.Stretch
                 source: {
-                    const suffix = assignControl.value > 0 ? "_active" : "";
-                    return LateNightTheme.lateNightAsset("buttons", cell.index === 0 ? "btn_embedded_library" + suffix + ".svg" : "btn_embedded_grid" + suffix + ".svg");
+                    const suffix = cell.active ? "_active" : "";
+                    return LateNightTheme.lateNightButton(cell.index === 0 ? "btn_embedded_library" + suffix + ".svg" : "btn_embedded_grid" + suffix + ".svg");
                 }
             }
             Text {
                 anchors.centerIn: parent
-                color: assignControl.value > 0 ? LateNightTheme.mixerControlTextColor : LateNightTheme.mixerFxAssignInactiveTextColor
+                color: cell.active
+                        ? (LateNightTheme.isClassic ? LateNightTheme.deckActiveButtonTextColor : LateNightTheme.mixerControlTextColor)
+                        : LateNightTheme.mixerFxAssignInactiveTextColor
                 font.bold: true
-                font.pixelSize: 12
-                text: cell.index === 0 ? "FX1" : cell.index + 1
+                font.family: "Open Sans"
+                font.pixelSize: 10
+                text: root.effectUnitCount === 4
+                        ? (cell.index === 0 ? "FX1" : cell.index + 1)
+                        : "FX" + (cell.index + 1)
             }
             TapHandler {
                 onTapped: assignControl.value = assignControl.value > 0 ? 0 : 1
@@ -52,5 +67,12 @@ Row {
                 key: "group_" + root.groupName + "_enable"
             }
         }
+    }
+
+    Mixxx.ControlProxy {
+        id: showFourEffectUnitsControl
+
+        group: "[Skin]"
+        key: "show_4effectunits"
     }
 }

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -321,6 +321,10 @@ void DlgPreferences::showSoundHardwarePage(
     }
 }
 
+void DlgPreferences::showSoundHardwareInputPage() {
+    showSoundHardwarePage(mixxx::preferences::SoundHardwareTab::Input);
+}
+
 bool DlgPreferences::eventFilter(QObject* o, QEvent* e) {
     // Send a close signal if dialog is closing
     if (e->type() == QEvent::Hide) {

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -68,6 +68,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     void showSoundHardwarePage(
             std::optional<mixxx::preferences::SoundHardwareTab> tab =
                     std::nullopt);
+    void showSoundHardwareInputPage();
     void slotButtonPressed(QAbstractButton* pButton);
   signals:
     void closeDlg();

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -9,6 +9,7 @@
 #include <QQuickStyle>
 #include <QQuickWindow>
 #include <QTextDocument>
+#include <memory>
 #include <utility>
 
 #include "control/controlproxy.h"
@@ -226,24 +227,38 @@ QmlApplication::QmlApplication(
     // the QQmlApplicationEngine.
     pDlgPreferences->setAttribute(Qt::WA_QuitOnClose, false);
 
-    auto showNoInputConfiguredWarning = [pDlgPreferences](
-                                                const QString& message) {
-        QMessageBox msgBox(QMessageBox::Warning,
-                VersionStore::applicationName(),
-                message,
-                QMessageBox::Ok | QMessageBox::Cancel);
+    auto inputWarningVisible = std::make_shared<bool>(false);
+    auto showNoInputConfiguredWarning =
+            [pDlgPreferences, inputWarningVisible](const QString& message) {
+                if (*inputWarningVisible) {
+                    return;
+                }
+                *inputWarningVisible = true;
+
+                QMessageBox msgBox(QMessageBox::Warning,
+                        VersionStore::applicationName(),
+                        message,
+                        QMessageBox::Ok | QMessageBox::Cancel);
 #if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
-        msgBox.setOption(QMessageBox::Option::DontUseNativeDialog);
+                msgBox.setOption(QMessageBox::Option::DontUseNativeDialog);
 #endif
-        msgBox.setWindowModality(Qt::ApplicationModal);
-        msgBox.setDefaultButton(QMessageBox::Cancel);
-        msgBox.exec();
-        if (msgBox.clickedButton() == msgBox.button(QMessageBox::Ok)) {
-            pDlgPreferences->show();
-            pDlgPreferences->raise();
-            pDlgPreferences->activateWindow();
-        }
-    };
+                msgBox.setWindowModality(Qt::ApplicationModal);
+                msgBox.setDefaultButton(QMessageBox::Cancel);
+                msgBox.exec();
+
+                const bool accepted = msgBox.clickedButton() == msgBox.button(QMessageBox::Ok);
+                *inputWarningVisible = false;
+                if (accepted) {
+                    pDlgPreferences->show();
+                    if (!QMetaObject::invokeMethod(pDlgPreferences.get(),
+                                "showSoundHardwareInputPage",
+                                Qt::DirectConnection)) {
+                        qWarning() << "QML input warning could not open Sound Hardware preferences";
+                    }
+                    pDlgPreferences->raise();
+                    pDlgPreferences->activateWindow();
+                }
+            };
 
     connect(m_pCoreServices->getPlayerManager().get(),
             &PlayerManager::noDeckPassthroughInputConfigured,
@@ -264,6 +279,22 @@ QmlApplication::QmlApplication(
                            "control.\n"
                            "Please select an input device in the sound "
                            "hardware preferences first."));
+            });
+    connect(m_pCoreServices->getPlayerManager().get(),
+            &PlayerManager::noMicrophoneInputConfigured,
+            this,
+            [showNoInputConfiguredWarning]() {
+                showNoInputConfiguredWarning(
+                        tr("There is no input device selected for this microphone.\n"
+                           "Do you want to select an input device?"));
+            });
+    connect(m_pCoreServices->getPlayerManager().get(),
+            &PlayerManager::noAuxiliaryInputConfigured,
+            this,
+            [showNoInputConfiguredWarning]() {
+                showNoInputConfiguredWarning(
+                        tr("There is no input device selected for this auxiliary.\n"
+                           "Do you want to select an input device?"));
             });
 
     // Since DlgPreferences is only meant to be used in the main QML engine, it


### PR DESCRIPTION
This PR continues the LateNightQML skin work by implementing the microphone and auxiliary-input rack with feature and visual parity with the legacy LateNight skin for both Classic and PaleMoon color schemes.

## Testing the Experimental Skin

Since this is an early experimental milestone, you must first run Mixxx with the developer flag:

    ./build/mixxx --developer

Once Mixxx is open, switch to the experimental skin:

    Preferences -> Interface -> LateNight QML (Experimental)

You can dynamically toggle between the Classic and PaleMoon color schemes under preferences.

## Previews

### Classic

### PaleMoon

## Scope of Changes

- Adds the LateNightQML microphone and auxiliary-input rack.
- Supports up to four microphone and four auxiliary-input channels.
- Adds configured and unconfigured states for each unit.
- Implements microphone talkover and ducking controls.
- Adds pregain, PFL, effects assignments, VU metering, and main-mix routing.
- Implements auxiliary crossfader assignment using the mixer’s three-zone selection behavior.
- Integrates the rack with the toolbar and responsive library layout.

## Dependencies

Depends on #16935.

## Tracking

GSoC: LateNightQML PR-11