### PR TITLE
Perceptual 3-band waveform mode

### DIFF
--- a/res/mixxx.qrc
+++ b/res/mixxx.qrc
@@ -105,5 +105,6 @@
         <file>shaders/passthrough.vert</file>
         <file>shaders/rgbsignal.frag</file>
         <file>shaders/stackedsignal.frag</file>
+        <file>shaders/perceptual3bandsignal.frag</file>
     </qresource>
 </RCC>

--- a/res/shaders/perceptual3bandsignal.frag
+++ b/res/shaders/perceptual3bandsignal.frag
@@ -1,0 +1,88 @@
+uniform highp vec2 framebufferSize;
+uniform highp vec4 axesColor;
+uniform highp vec4 lowColor;
+uniform highp vec4 midColor;
+uniform highp vec4 highColor;
+uniform highp vec4 overlapColor;
+
+uniform int waveformLength;
+uniform int textureSize;
+uniform int textureStride;
+
+uniform highp float allGain;
+uniform highp float lowGain;
+uniform highp float midGain;
+uniform highp float highGain;
+uniform highp float perceptualValueScale;
+uniform highp float firstVisualIndex;
+uniform highp float lastVisualIndex;
+
+uniform sampler2D waveformDataTexture;
+
+highp vec4 getWaveformData(highp float index) {
+    highp vec2 uv_data;
+    uv_data.y = floor(index / float(textureStride));
+    uv_data.x = floor(index - uv_data.y * float(textureStride));
+    return texture2D(waveformDataTexture, uv_data / float(textureStride));
+}
+
+highp vec4 getInterpolatedWaveformData(highp float visualIndex, highp float channelOffset) {
+    highp float currentIndex = floor(visualIndex) * 2.0 + channelOffset;
+    highp float lastIndexForChannel = float(waveformLength - 2) + channelOffset;
+    highp float nextIndex = min(currentIndex + 2.0, lastIndexForChannel);
+    return mix(getWaveformData(currentIndex),
+            getWaveformData(nextIndex),
+            fract(visualIndex));
+}
+
+void main(void) {
+    highp vec2 uv = gl_TexCoord[0].st;
+    highp vec4 pixel = gl_FragCoord;
+
+    highp float currentVisualIndex =
+            firstVisualIndex + uv.x * (lastVisualIndex - firstVisualIndex);
+    highp float channelOffset = uv.y < 0.5 ? 1.0 : 0.0;
+    highp float currentIndex = floor(currentVisualIndex) * 2.0 + channelOffset;
+
+    highp vec4 outputColor = vec4(0.0, 0.0, 0.0, 0.0);
+    bool showing = false;
+    highp vec4 showingColor = vec4(0.0, 0.0, 0.0, 0.0);
+
+    if (currentIndex >= 0.0 && currentIndex <= float(waveformLength - 1)) {
+        highp vec4 currentData = clamp(getInterpolatedWaveformData(
+                                               currentVisualIndex, channelOffset),
+                                         0.0,
+                                         1.0) *
+                allGain * perceptualValueScale;
+        currentData.x *= lowGain;
+        currentData.y *= midGain;
+        currentData.z *= highGain;
+
+        highp float distanceFromCenter = abs((uv.y - 0.5) * 2.0);
+        if (distanceFromCenter <= currentData.z) {
+            showingColor = highColor;
+            showing = true;
+        } else if (distanceFromCenter <= min(currentData.x, currentData.y)) {
+            showingColor = overlapColor;
+            showing = true;
+        } else if (distanceFromCenter <= currentData.x) {
+            showingColor = lowColor;
+            showing = true;
+        } else if (distanceFromCenter <= currentData.y) {
+            showingColor = midColor;
+            showing = true;
+        }
+    }
+
+    if (abs(framebufferSize.y / 2.0 - pixel.y) <= 4.0) {
+        outputColor.xyz = mix(outputColor.xyz, axesColor.xyz, axesColor.w);
+        outputColor.w = 1.0;
+    }
+
+    if (showing) {
+        outputColor.xyz = showingColor.xyz;
+        outputColor.w = 1.0;
+    }
+
+    gl_FragColor = outputColor;
+}

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -282,9 +282,12 @@ bool AnalyzerWaveform::processSamples(const CSAMPLE* pIn, SINT count) {
 
                 m_perceptualStride.m_summaryOverallData[channel] +=
                         overall[channel] * overall[channel];
-                m_perceptualStride.m_summaryFilteredData[channel][Low] += low[channel] * low[channel];
-                m_perceptualStride.m_summaryFilteredData[channel][Mid] += mid[channel] * mid[channel];
-                m_perceptualStride.m_summaryFilteredData[channel][High] += high[channel] * high[channel];
+                m_perceptualStride.m_summaryFilteredData[channel][Low] +=
+                        low[channel] * low[channel];
+                m_perceptualStride.m_summaryFilteredData[channel][Mid] +=
+                        mid[channel] * mid[channel];
+                m_perceptualStride.m_summaryFilteredData[channel][High] +=
+                        high[channel] * high[channel];
             }
             ++m_perceptualStride.m_sampleCount;
             ++m_perceptualStride.m_summarySampleCount;
@@ -325,7 +328,7 @@ bool AnalyzerWaveform::processSamples(const CSAMPLE* pIn, SINT count) {
         const double strideLength =
                 isPerceptual ? m_perceptualStride.m_length : m_legacyStride.m_length;
         const double summaryStrideLength = isPerceptual ? m_perceptualStride.m_averageLength
-                                                         : m_legacyStride.m_averageLength;
+                                                        : m_legacyStride.m_averageLength;
         ++position;
 
         if (std::fmod(position, strideLength) < 1) {

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -1,5 +1,6 @@
 #include "analyzer/analyzerwaveform.h"
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -10,24 +11,36 @@
 #include "util/logger.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformfactory.h"
+#include "waveform/widgets/waveformwidgettype.h"
 
 namespace {
 
 mixxx::Logger kLogger("AnalyzerWaveform");
 
-constexpr double kLowMidFreqHz = 600.0;
+const ConfigKey kWaveformTypeKey(
+        QStringLiteral("[Waveform]"), QStringLiteral("WaveformType"));
 
-constexpr double kMidHighFreqHz = 4000.0;
+constexpr double kLegacyLowMidFreqHz = 600.0;
+constexpr double kLegacyMidHighFreqHz = 4000.0;
+
+constexpr double kPerceptualLowHighFreqHz = 300.0;
+constexpr double kPerceptualMidLowFreqHz = 230.0;
+constexpr double kPerceptualMidHighFreqHz = 1320.0;
+constexpr double kPerceptualHighLowFreqHz = 3340.0;
+constexpr double kPerceptualHighHighFreqHz = 8420.0;
 
 } // namespace
 
 AnalyzerWaveform::AnalyzerWaveform(
         UserSettingsPointer pConfig,
         const QSqlDatabase& dbConnection)
-        : m_analysisDao(pConfig),
+        : m_pConfig(pConfig),
+          m_analysisProfile(mixxx::WaveformAnalysisProfile::Legacy),
+          m_analysisDao(pConfig),
           m_waveformData(nullptr),
           m_waveformSummaryData(nullptr),
-          m_stride(0, 0, 0),
+          m_legacyStride(0, 0, 0),
+          m_perceptualStride(0, 0, 0, 0),
           m_currentStride(0),
           m_currentSummaryStride(0) {
     m_analysisDao.initialize(dbConnection);
@@ -47,6 +60,11 @@ bool AnalyzerWaveform::initialize(const AnalyzerTrack& track,
         return false;
     }
 
+    const auto waveformType = static_cast<WaveformWidgetType::Type>(m_pConfig->getValue(
+            kWaveformTypeKey,
+            static_cast<int>(WaveformWidgetType::RGB)));
+    m_analysisProfile = WaveformWidgetType::analysisProfile(waveformType);
+
     // If we don't need to calculate the waveform/wavesummary, skip.
     if (!shouldAnalyze(track.getTrack())) {
         return false;
@@ -54,13 +72,10 @@ bool AnalyzerWaveform::initialize(const AnalyzerTrack& track,
 
     m_timer.start();
 
-    // Now actually initialize the AnalyzerWaveform:
     destroyFilters();
     createFilters(sampleRate);
 
-    //TODO (vrince) Do we want to expose this as settings or whatever ?
     constexpr int mainWaveformSampleRate = 441;
-    // two visual sample per pixel in full width overview in full hd
     constexpr int summaryWaveformSamples = 2 * 1920;
 
     int stemCount = channelCount == mixxx::kAnalysisChannels
@@ -70,7 +85,6 @@ bool AnalyzerWaveform::initialize(const AnalyzerTrack& track,
             sampleRate, frameLength, mainWaveformSampleRate, -1, stemCount));
     m_waveformSummary = WaveformPointer(new Waveform(
             sampleRate, frameLength, mainWaveformSampleRate, summaryWaveformSamples, stemCount));
-
     // Now, that the Waveform memory is initialized, we can set set them to
     // the track. Be aware that other threads of Mixxx can touch them from
     // now.
@@ -80,17 +94,20 @@ bool AnalyzerWaveform::initialize(const AnalyzerTrack& track,
     m_waveformData = m_waveform->data();
     m_waveformSummaryData = m_waveformSummary->data();
 
-    m_stride = WaveformStride(m_waveform->getAudioVisualRatio(),
-            m_waveformSummary->getAudioVisualRatio(),
-            stemCount);
+    if (m_analysisProfile == mixxx::WaveformAnalysisProfile::Perceptual3Band) {
+        m_perceptualStride = PerceptualWaveformStride(m_waveform->getAudioVisualRatio(),
+                m_waveformSummary->getAudioVisualRatio(),
+                sampleRate,
+                stemCount);
+    } else {
+        m_legacyStride = WaveformStride(m_waveform->getAudioVisualRatio(),
+                m_waveformSummary->getAudioVisualRatio(),
+                stemCount);
+    }
 
     m_currentStride = 0;
     m_currentSummaryStride = 0;
     m_channelCount = channelCount;
-
-    //debug
-    //m_waveform->dump();
-    //m_waveformSummary->dump();
 
 #ifdef TEST_HEAT_MAP
     test_heatMap = new QImage(256, 256, QImage::Format_RGB32);
@@ -108,38 +125,48 @@ bool AnalyzerWaveform::shouldAnalyze(TrackPointer pTrack) const {
     bool isStemTrack = !pTrack->getStemInfo().isEmpty();
 #endif
 
-    TrackId trackId = pTrack->getId();
-    bool missingWaveform = pTrackWaveform.isNull();
-    bool missingWavesummary = pTrackWaveformSummary.isNull();
+    bool missingWaveform = pTrackWaveform.isNull() ||
+            WaveformFactory::waveformVersionToVersionClass(
+                    pTrackWaveform->getVersion(), m_analysisProfile) !=
+                    WaveformFactory::VC_USE;
+    bool missingWavesummary = pTrackWaveformSummary.isNull() ||
+            WaveformFactory::waveformSummaryVersionToVersionClass(
+                    pTrackWaveformSummary->getVersion(), m_analysisProfile) !=
+                    WaveformFactory::VC_USE;
+    if (missingWaveform && !pTrackWaveform.isNull()) {
+        pTrack->setWaveform(WaveformPointer());
+        pTrackWaveform.clear();
+    }
+    if (missingWavesummary && !pTrackWaveformSummary.isNull()) {
+        pTrack->setWaveformSummary(WaveformPointer());
+        pTrackWaveformSummary.clear();
+    }
 
+    const TrackId trackId = pTrack->getId();
     if (trackId.isValid() && (missingWaveform || missingWavesummary)) {
-        QList<AnalysisDao::AnalysisInfo> analyses =
+        const QList<AnalysisDao::AnalysisInfo> analyses =
                 m_analysisDao.getAnalysesForTrack(trackId);
 
-        QListIterator<AnalysisDao::AnalysisInfo> it(analyses);
-        while (it.hasNext()) {
-            const AnalysisDao::AnalysisInfo& analysis = it.next();
-            WaveformFactory::VersionClass vc;
-
+        for (const AnalysisDao::AnalysisInfo& analysis : analyses) {
             if (analysis.type == AnalysisDao::TYPE_WAVEFORM) {
-                vc = WaveformFactory::waveformVersionToVersionClass(analysis.version);
-                if (missingWaveform && vc == WaveformFactory::VC_USE) {
+                const auto versionClass = WaveformFactory::waveformVersionToVersionClass(
+                        analysis.version, m_analysisProfile);
+                if (missingWaveform && versionClass == WaveformFactory::VC_USE) {
                     pLoadedTrackWaveform = ConstWaveformPointer(
                             WaveformFactory::loadWaveformFromAnalysis(analysis));
                     missingWaveform = false;
-                } else if (vc != WaveformFactory::VC_KEEP) {
-                    // remove all other Analysis except that one we should keep
+                } else if (versionClass != WaveformFactory::VC_KEEP) {
                     m_analysisDao.deleteAnalysis(analysis.analysisId);
                 }
             }
             if (analysis.type == AnalysisDao::TYPE_WAVESUMMARY) {
-                vc = WaveformFactory::waveformSummaryVersionToVersionClass(analysis.version);
-                if (missingWavesummary && vc == WaveformFactory::VC_USE) {
+                const auto versionClass = WaveformFactory::waveformSummaryVersionToVersionClass(
+                        analysis.version, m_analysisProfile);
+                if (missingWavesummary && versionClass == WaveformFactory::VC_USE) {
                     pLoadedTrackWaveformSummary = ConstWaveformPointer(
                             WaveformFactory::loadWaveformFromAnalysis(analysis));
                     missingWavesummary = false;
-                } else if (vc != WaveformFactory::VC_KEEP) {
-                    // remove all other Analysis except that one we should keep
+                } else if (versionClass != WaveformFactory::VC_KEEP) {
                     m_analysisDao.deleteAnalysis(analysis.analysisId);
                 }
             }
@@ -158,7 +185,6 @@ bool AnalyzerWaveform::shouldAnalyze(TrackPointer pTrack) const {
     }
 #endif
 
-    // If we don't need to calculate the waveform/wavesummary, skip.
     if (!missingWaveform && !missingWavesummary) {
         kLogger.debug() << "loadStored - Stored waveform loaded";
         if (pLoadedTrackWaveform) {
@@ -173,13 +199,20 @@ bool AnalyzerWaveform::shouldAnalyze(TrackPointer pTrack) const {
 }
 
 void AnalyzerWaveform::createFilters(mixxx::audio::SampleRate sampleRate) {
-    // m_filter[Low] = new EngineFilterButterworth8Low(sampleRate, kLowMidFreqHz);
-    // m_filter[Mid] = new EngineFilterButterworth8Band(sampleRate, kLowMidFreqHz, kMidHighFreqHz);
-    // m_filter[High] = new EngineFilterButterworth8High(sampleRate, kMidHighFreqHz);
-    m_filters = {
-            std::make_unique<EngineFilterBessel4Low>(sampleRate, kLowMidFreqHz),
-            std::make_unique<EngineFilterBessel4Band>(sampleRate, kLowMidFreqHz, kMidHighFreqHz),
-            std::make_unique<EngineFilterBessel4High>(sampleRate, kMidHighFreqHz)};
+    if (m_analysisProfile == mixxx::WaveformAnalysisProfile::Perceptual3Band) {
+        m_filters = {
+                std::make_unique<EngineFilterBessel4Low>(sampleRate, kPerceptualLowHighFreqHz),
+                std::make_unique<EngineFilterBessel4Band>(
+                        sampleRate, kPerceptualMidLowFreqHz, kPerceptualMidHighFreqHz),
+                std::make_unique<EngineFilterBessel4Band>(
+                        sampleRate, kPerceptualHighLowFreqHz, kPerceptualHighHighFreqHz)};
+    } else {
+        m_filters = {
+                std::make_unique<EngineFilterBessel4Low>(sampleRate, kLegacyLowMidFreqHz),
+                std::make_unique<EngineFilterBessel4Band>(
+                        sampleRate, kLegacyLowMidFreqHz, kLegacyMidHighFreqHz),
+                std::make_unique<EngineFilterBessel4High>(sampleRate, kLegacyMidHighFreqHz)};
+    }
 
     // settle filters for silence in preroll to avoids ramping (Issue #7776)
     m_filters.low->assumeSettled();
@@ -218,7 +251,6 @@ bool AnalyzerWaveform::processSamples(const CSAMPLE* pIn, SINT count) {
         pWaveformInput = pMixedChannel;
     }
 
-    // This should only append once if count is constant
     if (count > m_buffers.size) {
         m_buffers.low.resize(count);
         m_buffers.mid.resize(count);
@@ -233,79 +265,99 @@ bool AnalyzerWaveform::processSamples(const CSAMPLE* pIn, SINT count) {
     m_waveform->setSaveState(Waveform::SaveState::NotSaved);
     m_waveformSummary->setSaveState(Waveform::SaveState::NotSaved);
 
+    const bool isPerceptual =
+            m_analysisProfile == mixxx::WaveformAnalysisProfile::Perceptual3Band;
     for (SINT i = 0; i < count; i += 2) {
-        // Take max value, not average of data
-        CSAMPLE cover[2] = {fabs(pWaveformInput[i]), fabs(pWaveformInput[i + 1])};
-        CSAMPLE clow[2] = {fabs(m_buffers.low[i]), fabs(m_buffers.low[i + 1])};
-        CSAMPLE cmid[2] = {fabs(m_buffers.mid[i]), fabs(m_buffers.mid[i + 1])};
-        CSAMPLE chigh[2] = {fabs(m_buffers.high[i]), fabs(m_buffers.high[i + 1])};
+        if (isPerceptual) {
+            const CSAMPLE overall[ChannelCount] = {pWaveformInput[i], pWaveformInput[i + 1]};
+            const CSAMPLE low[ChannelCount] = {m_buffers.low[i], m_buffers.low[i + 1]};
+            const CSAMPLE mid[ChannelCount] = {m_buffers.mid[i], m_buffers.mid[i + 1]};
+            const CSAMPLE high[ChannelCount] = {m_buffers.high[i], m_buffers.high[i + 1]};
 
-        // This is for if you want to experiment with averaging instead of
-        // maxing.
-        // m_stride.m_overallData[Right] += buffer[i]*buffer[i];
-        // m_stride.m_overallData[Left] += buffer[i + 1]*buffer[i + 1];
-        // m_stride.m_filteredData[Right][Low] += m_buffers.low[i]*m_buffers.low[i];
-        // m_stride.m_filteredData[Left][Low] += m_buffers.low[i + 1]*m_buffers.low[i + 1];
-        // m_stride.m_filteredData[Right][Mid] += m_buffers.mid[i]*m_buffers.mid[i];
-        // m_stride.m_filteredData[Left][Mid] += m_buffers.mid[i + 1]*m_buffers.mid[i + 1];
-        // m_stride.m_filteredData[Right][High] += m_buffers.high[i]*m_buffers.high[i];
-        // m_stride.m_filteredData[Left][High] += m_buffers.high[i + 1]*m_buffers.high[i + 1];
+            for (int channel = 0; channel < ChannelCount; ++channel) {
+                m_perceptualStride.m_overallData[channel] += overall[channel] * overall[channel];
+                m_perceptualStride.m_filteredData[channel][Low] += low[channel] * low[channel];
+                m_perceptualStride.m_filteredData[channel][Mid] += mid[channel] * mid[channel];
+                m_perceptualStride.m_filteredData[channel][High] += high[channel] * high[channel];
 
-        // Record the max across this stride.
-        storeIfGreater(&m_stride.m_overallData[Left], cover[Left]);
-        storeIfGreater(&m_stride.m_overallData[Right], cover[Right]);
-        storeIfGreater(&m_stride.m_filteredData[Left][Low], clow[Left]);
-        storeIfGreater(&m_stride.m_filteredData[Right][Low], clow[Right]);
-        storeIfGreater(&m_stride.m_filteredData[Left][Mid], cmid[Left]);
-        storeIfGreater(&m_stride.m_filteredData[Right][Mid], cmid[Right]);
-        storeIfGreater(&m_stride.m_filteredData[Left][High], chigh[Left]);
-        storeIfGreater(&m_stride.m_filteredData[Right][High], chigh[Right]);
+                m_perceptualStride.m_summaryOverallData[channel] +=
+                        overall[channel] * overall[channel];
+                m_perceptualStride.m_summaryFilteredData[channel][Low] += low[channel] * low[channel];
+                m_perceptualStride.m_summaryFilteredData[channel][Mid] += mid[channel] * mid[channel];
+                m_perceptualStride.m_summaryFilteredData[channel][High] += high[channel] * high[channel];
+            }
+            ++m_perceptualStride.m_sampleCount;
+            ++m_perceptualStride.m_summarySampleCount;
+        } else {
+            const CSAMPLE cover[ChannelCount] = {
+                    std::fabs(pWaveformInput[i]), std::fabs(pWaveformInput[i + 1])};
+            const CSAMPLE low[ChannelCount] = {
+                    std::fabs(m_buffers.low[i]), std::fabs(m_buffers.low[i + 1])};
+            const CSAMPLE mid[ChannelCount] = {
+                    std::fabs(m_buffers.mid[i]), std::fabs(m_buffers.mid[i + 1])};
+            const CSAMPLE high[ChannelCount] = {
+                    std::fabs(m_buffers.high[i]), std::fabs(m_buffers.high[i + 1])};
 
-        for (int s = 0; s < stemCount; s++) {
-            CSAMPLE cstem[2] = {
-                    fabs(pIn[i * stemCount + s * mixxx::kAnalysisChannels]),
-                    fabs(pIn[i * stemCount + s * mixxx::kAnalysisChannels +
-                            1])};
-            storeIfGreater(&m_stride.m_stemData[Left][s], cstem[Left]);
-            storeIfGreater(&m_stride.m_stemData[Right][s], cstem[Right]);
+            storeIfGreater(&m_legacyStride.m_overallData[Left], cover[Left]);
+            storeIfGreater(&m_legacyStride.m_overallData[Right], cover[Right]);
+            storeIfGreater(&m_legacyStride.m_filteredData[Left][Low], low[Left]);
+            storeIfGreater(&m_legacyStride.m_filteredData[Right][Low], low[Right]);
+            storeIfGreater(&m_legacyStride.m_filteredData[Left][Mid], mid[Left]);
+            storeIfGreater(&m_legacyStride.m_filteredData[Right][Mid], mid[Right]);
+            storeIfGreater(&m_legacyStride.m_filteredData[Left][High], high[Left]);
+            storeIfGreater(&m_legacyStride.m_filteredData[Right][High], high[Right]);
         }
 
-        m_stride.m_position++;
+        for (int stemIndex = 0; stemIndex < stemCount; ++stemIndex) {
+            const CSAMPLE stem[ChannelCount] = {
+                    std::fabs(pIn[i * stemCount + stemIndex * mixxx::kAnalysisChannels]),
+                    std::fabs(pIn[i * stemCount + stemIndex * mixxx::kAnalysisChannels + 1])};
+            if (isPerceptual) {
+                storeIfGreater(&m_perceptualStride.m_stemData[Left][stemIndex], stem[Left]);
+                storeIfGreater(&m_perceptualStride.m_stemData[Right][stemIndex], stem[Right]);
+            } else {
+                storeIfGreater(&m_legacyStride.m_stemData[Left][stemIndex], stem[Left]);
+                storeIfGreater(&m_legacyStride.m_stemData[Right][stemIndex], stem[Right]);
+            }
+        }
 
-        if (fmod(m_stride.m_position, m_stride.m_length) < 1) {
+        int& position = isPerceptual ? m_perceptualStride.m_position : m_legacyStride.m_position;
+        const double strideLength =
+                isPerceptual ? m_perceptualStride.m_length : m_legacyStride.m_length;
+        const double summaryStrideLength = isPerceptual ? m_perceptualStride.m_averageLength
+                                                         : m_legacyStride.m_averageLength;
+        ++position;
+
+        if (std::fmod(position, strideLength) < 1) {
             VERIFY_OR_DEBUG_ASSERT(m_currentStride + ChannelCount <= m_waveform->getDataSize()) {
                 qWarning() << "AnalyzerWaveform::process - currentStride > waveform size";
                 return false;
             }
-            m_stride.store(m_waveformData + m_currentStride);
+            if (isPerceptual) {
+                m_perceptualStride.store(m_waveformData + m_currentStride);
+            } else {
+                m_legacyStride.store(m_waveformData + m_currentStride);
+            }
             m_currentStride += ChannelCount;
             m_waveform->setCompletion(m_currentStride);
         }
 
-        if (fmod(m_stride.m_position, m_stride.m_averageLength) < 1) {
-            VERIFY_OR_DEBUG_ASSERT(m_currentSummaryStride + ChannelCount <= m_waveformSummary->getDataSize()) {
+        if (std::fmod(position, summaryStrideLength) < 1) {
+            VERIFY_OR_DEBUG_ASSERT(m_currentSummaryStride + ChannelCount <=
+                    m_waveformSummary->getDataSize()) {
                 qWarning() << "AnalyzerWaveform::process - current summary stride > waveform summary size";
                 return false;
             }
-            m_stride.averageStore(m_waveformSummaryData + m_currentSummaryStride);
+            if (isPerceptual) {
+                m_perceptualStride.averageStore(m_waveformSummaryData + m_currentSummaryStride);
+            } else {
+                m_legacyStride.averageStore(m_waveformSummaryData + m_currentSummaryStride);
+            }
             m_currentSummaryStride += ChannelCount;
             m_waveformSummary->setCompletion(m_currentSummaryStride);
-
-#ifdef TEST_HEAT_MAP
-            QPointF point(m_stride.m_filteredData[Right][High],
-                    m_stride.m_filteredData[Right][Mid]);
-
-            float norm = sqrt(point.x() * point.x() + point.y() * point.y());
-            point /= norm;
-
-            point *= m_stride.m_filteredData[Right][Low];
-            test_heatMap->setPixel(point.toPoint(), 0xFF0000FF);
-#endif
         }
     }
 
-    //kLogger.debug() << "process - m_waveform->getCompletion()" << m_waveform->getCompletion() << "off" << m_waveform->getDataSize();
-    //kLogger.debug() << "process - m_waveformSummary->getCompletion()" << m_waveformSummary->getCompletion() << "off" << m_waveformSummary->getDataSize();
     if (pMixedChannel) {
         SampleUtil::free(pMixedChannel);
     }
@@ -320,20 +372,20 @@ void AnalyzerWaveform::cleanup() {
 }
 
 void AnalyzerWaveform::storeResults(TrackPointer pTrack) {
-    // Force completion to waveform size
     if (m_waveform) {
         m_waveform->setSaveState(Waveform::SaveState::SavePending);
         m_waveform->setCompletion(m_waveform->getDataSize());
-        m_waveform->setVersion(WaveformFactory::currentWaveformVersion());
-        m_waveform->setDescription(WaveformFactory::currentWaveformDescription());
+        m_waveform->setVersion(WaveformFactory::currentWaveformVersion(m_analysisProfile));
+        m_waveform->setDescription(WaveformFactory::currentWaveformDescription(m_analysisProfile));
     }
 
-    // Force completion to waveform size
     if (m_waveformSummary) {
         m_waveformSummary->setSaveState(Waveform::SaveState::SavePending);
         m_waveformSummary->setCompletion(m_waveformSummary->getDataSize());
-        m_waveformSummary->setVersion(WaveformFactory::currentWaveformSummaryVersion());
-        m_waveformSummary->setDescription(WaveformFactory::currentWaveformSummaryDescription());
+        m_waveformSummary->setVersion(
+                WaveformFactory::currentWaveformSummaryVersion(m_analysisProfile));
+        m_waveformSummary->setDescription(
+                WaveformFactory::currentWaveformSummaryDescription(m_analysisProfile));
     }
 
 #ifdef TEST_HEAT_MAP
@@ -344,10 +396,7 @@ void AnalyzerWaveform::storeResults(TrackPointer pTrack) {
     // waveforms (i.e. if the config setting was disabled in a previous scan)
     // and then it is not called. The other analyzers have signals which control
     // the update of their data.
-    m_analysisDao.saveTrackAnalyses(
-            pTrack->getId(),
-            m_waveform,
-            m_waveformSummary);
+    m_analysisDao.saveTrackAnalyses(pTrack->getId(), m_waveform, m_waveformSummary);
 
     // Set waveforms on track AFTER they'been written to disk in order to have
     // a consistency when OverviewCache asks AnalysisDAO for a waveform summary.

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -2,12 +2,15 @@
 
 #include <cmath>
 #include <limits>
+#include <vector>
 
 #include "analyzer/analyzer.h"
+#include "analyzer/perceptualwaveformlut.h"
 #include "library/dao/analysisdao.h"
 #include "util/performancetimer.h"
 #include "util/sample.h"
 #include "waveform/waveform.h"
+#include "waveform/waveformanalysisprofile.h"
 
 //NOTS vrince some test to segment sound, to apply color in the waveform
 //#define TEST_HEAT_MAP
@@ -60,7 +63,6 @@ struct WaveformStride {
             }
         }
         m_averageDivisor++;
-        // Reset the stride counters
         for (int i = 0; i < ChannelCount; ++i) {
             m_averageOverallData[i] += m_overallData[i];
             m_overallData[i] = 0.0f;
@@ -79,7 +81,8 @@ struct WaveformStride {
             for (int i = 0; i < ChannelCount; ++i) {
                 WaveformData& datum = *(data + i);
                 datum.filtered.all = static_cast<unsigned char>(std::min(255.0,
-                        m_postScaleConversion * m_averageOverallData[i] / m_averageDivisor + 0.5));
+                        m_postScaleConversion * m_averageOverallData[i] / m_averageDivisor +
+                                0.5));
                 datum.filtered.low = static_cast<unsigned char>(std::min(255.0,
                         m_postScaleConversion * m_averageFilteredData[i][Low] /
                                         m_averageDivisor +
@@ -134,6 +137,148 @@ struct WaveformStride {
     float m_postScaleConversion;
 };
 
+struct PerceptualWaveformStride {
+    PerceptualWaveformStride(double samples,
+            double averageSamples,
+            double sampleRate,
+            int stemCount)
+            : m_position(0),
+              m_stemCount(stemCount),
+              m_length(samples),
+              m_averageLength(averageSamples),
+              m_sampleRate(sampleRate),
+              m_averagePosition(0),
+              m_sampleCount(0),
+              m_summarySampleCount(0),
+              m_postScaleConversion(static_cast<float>(
+                      std::numeric_limits<unsigned char>::max())) {
+        reset();
+    }
+
+    inline void reset() {
+        m_position = 0;
+        m_sampleCount = 0;
+        m_summarySampleCount = 0;
+        for (int i = 0; i < ChannelCount; ++i) {
+            m_overallData[i] = 0.0f;
+            m_summaryOverallData[i] = 0.0f;
+            SampleUtil::clear(m_filteredData[i], BandCount);
+            SampleUtil::clear(m_summaryFilteredData[i], BandCount);
+            SampleUtil::clear(m_filteredEnvelope[i], BandCount);
+            SampleUtil::clear(m_summaryFilteredEnvelope[i], BandCount);
+            SampleUtil::clear(m_stemData[i], m_stemCount);
+        }
+    }
+
+    inline void store(WaveformData* data) {
+        for (int i = 0; i < ChannelCount; ++i) {
+            WaveformData& datum = *(data + i);
+            datum.filtered.all = rmsToByte(m_overallData[i], m_sampleCount);
+            datum.filtered.low = rmsEnvelopeToByte(
+                    m_filteredData[i][Low], m_sampleCount, &m_filteredEnvelope[i][Low], Low);
+            datum.filtered.mid = rmsEnvelopeToByte(
+                    m_filteredData[i][Mid], m_sampleCount, &m_filteredEnvelope[i][Mid], Mid);
+            datum.filtered.high = rmsEnvelopeToByte(m_filteredData[i][High],
+                    m_sampleCount,
+                    &m_filteredEnvelope[i][High],
+                    High);
+            for (int stemIdx = 0; stemIdx < m_stemCount; stemIdx++) {
+                datum.stems[stemIdx] = static_cast<unsigned char>(std::min(255.0,
+                        m_postScaleConversion * m_stemData[i][stemIdx] + 0.5));
+            }
+        }
+        m_sampleCount = 0;
+        for (int i = 0; i < ChannelCount; ++i) {
+            m_overallData[i] = 0.0f;
+            for (int f = 0; f < BandCount; ++f) {
+                m_filteredData[i][f] = 0.0f;
+            }
+            for (int stemIdx = 0; stemIdx < m_stemCount; ++stemIdx) {
+                m_stemData[i][stemIdx] = 0.0f;
+            }
+        }
+    }
+
+    inline void averageStore(WaveformData* data) {
+        for (int i = 0; i < ChannelCount; ++i) {
+            WaveformData& datum = *(data + i);
+            datum.filtered.all = rmsToByte(m_summaryOverallData[i], m_summarySampleCount);
+            datum.filtered.low = rmsEnvelopeToByte(m_summaryFilteredData[i][Low],
+                    m_summarySampleCount,
+                    &m_summaryFilteredEnvelope[i][Low],
+                    Low);
+            datum.filtered.mid = rmsEnvelopeToByte(m_summaryFilteredData[i][Mid],
+                    m_summarySampleCount,
+                    &m_summaryFilteredEnvelope[i][Mid],
+                    Mid);
+            datum.filtered.high = rmsEnvelopeToByte(m_summaryFilteredData[i][High],
+                    m_summarySampleCount,
+                    &m_summaryFilteredEnvelope[i][High],
+                    High);
+        }
+
+        m_summarySampleCount = 0;
+        for (int i = 0; i < ChannelCount; ++i) {
+            m_summaryOverallData[i] = 0.0f;
+            for (int f = 0; f < BandCount; ++f) {
+                m_summaryFilteredData[i][f] = 0.0f;
+            }
+        }
+    }
+
+  private:
+    inline float rms(float sumSquares, int sampleCount) const {
+        return sampleCount > 0
+                ? std::sqrt(sumSquares / static_cast<float>(sampleCount))
+                : 0.0f;
+    }
+
+    inline unsigned char valueToByte(float value) const {
+        return static_cast<unsigned char>(
+                std::min(255.0f, m_postScaleConversion * value + 0.5f));
+    }
+
+    inline unsigned char rmsToByte(float sumSquares, int sampleCount) const {
+        return valueToByte(rms(sumSquares, sampleCount));
+    }
+
+    inline unsigned char rmsEnvelopeToByte(float sumSquares,
+            int sampleCount,
+            float* envelope,
+            int band) const {
+        const float releaseTimeSeconds = band == Low
+                ? 0.097816f
+                : band == Mid ? 0.048390f : 0.017013f;
+        const float releaseFactor = std::exp(-static_cast<float>(sampleCount) /
+                static_cast<float>(m_sampleRate * releaseTimeSeconds));
+        *envelope = std::max(rms(sumSquares, sampleCount), *envelope * releaseFactor);
+        const float normalizedEnvelope = std::clamp(*envelope, 0.0f, 1.0f);
+        return valueToByte(mixxx::analyzer::PerceptualWaveformLut::applyNormalized(
+                normalizedEnvelope, band));
+    }
+
+  public:
+    int m_position;
+    int m_stemCount;
+    double m_length;
+    double m_averageLength;
+    double m_sampleRate;
+    int m_averagePosition;
+    int m_sampleCount;
+    int m_summarySampleCount;
+
+    float m_overallData[ChannelCount];
+    float m_filteredData[ChannelCount][BandCount];
+    float m_filteredEnvelope[ChannelCount][BandCount];
+    float m_stemData[ChannelCount][mixxx::kMaxSupportedStems];
+
+    float m_summaryOverallData[ChannelCount];
+    float m_summaryFilteredData[ChannelCount][BandCount];
+    float m_summaryFilteredEnvelope[ChannelCount][BandCount];
+
+    float m_postScaleConversion;
+};
+
 class AnalyzerWaveform : public Analyzer {
   public:
     AnalyzerWaveform(
@@ -152,21 +297,20 @@ class AnalyzerWaveform : public Analyzer {
   private:
     bool shouldAnalyze(TrackPointer tio) const;
 
-    void storeCurrentStridePower();
-    void resetCurrentStride();
-
     void createFilters(mixxx::audio::SampleRate sampleRate);
     void destroyFilters();
     void storeIfGreater(float* pDest, float source);
 
+    UserSettingsPointer m_pConfig;
+    mixxx::WaveformAnalysisProfile m_analysisProfile;
     mutable AnalysisDao m_analysisDao;
 
     WaveformPointer m_waveform;
     WaveformPointer m_waveformSummary;
     WaveformData* m_waveformData;
     WaveformData* m_waveformSummaryData;
-
-    WaveformStride m_stride;
+    WaveformStride m_legacyStride;
+    PerceptualWaveformStride m_perceptualStride;
 
     int m_currentStride;
     int m_currentSummaryStride;

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -248,7 +248,8 @@ struct PerceptualWaveformStride {
             int band) const {
         const float releaseTimeSeconds = band == Low
                 ? 0.097816f
-                : band == Mid ? 0.048390f : 0.017013f;
+                : band == Mid ? 0.048390f
+                              : 0.017013f;
         const float releaseFactor = std::exp(-static_cast<float>(sampleCount) /
                 static_cast<float>(m_sampleRate * releaseTimeSeconds));
         *envelope = std::max(rms(sumSquares, sampleCount), *envelope * releaseFactor);

--- a/src/analyzer/perceptualwaveformlut.h
+++ b/src/analyzer/perceptualwaveformlut.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+
+#include "waveform/waveform.h"
+#include "waveform/waveformanalysisprofile.h"
+
+namespace mixxx::analyzer {
+
+class PerceptualWaveformLut {
+  public:
+    static float applyNormalized(float value, int band) {
+        value = std::clamp(value, 0.0f, 1.0f);
+        if (value == 0.0f) {
+            return 0.0f;
+        }
+        return interpolate(value * 255.0f, band) / 255.0f;
+    }
+
+  private:
+    struct Knot {
+        float input;
+        float output;
+    };
+
+    static constexpr float kLowTailSlope = 0.136f;
+    static constexpr float kMaximumOutput = mixxx::kPerceptual3BandMaximumValue;
+
+    static const std::array<Knot, 10>& lowKnots() {
+        static constexpr std::array knots{
+                Knot{0.0f, 0.0f},
+                Knot{8.0f, 8.5f},
+                Knot{16.0f, 16.0f},
+                Knot{32.0f, 27.0f},
+                Knot{48.0f, 37.0f},
+                Knot{64.0f, 44.0f},
+                Knot{80.0f, 53.0f},
+                Knot{96.0f, 58.0f},
+                Knot{112.0f, 67.5f},
+                Knot{128.0f, 77.0f}};
+        return knots;
+    }
+
+    static const std::array<Knot, 11>& midKnots() {
+        static constexpr std::array knots{
+                Knot{0.0f, 0.0f},
+                Knot{8.0f, 4.0f},
+                Knot{16.0f, 15.0f},
+                Knot{32.0f, 26.0f},
+                Knot{48.0f, 35.0f},
+                Knot{64.0f, 46.0f},
+                Knot{80.0f, 57.0f},
+                Knot{96.0f, 66.0f},
+                Knot{112.0f, 74.0f},
+                Knot{128.0f, 81.0f},
+                Knot{160.0f, 92.0f}};
+        return knots;
+    }
+
+    static const std::array<Knot, 9>& highKnots() {
+        static constexpr std::array knots{
+                Knot{0.0f, 0.0f},
+                Knot{8.0f, 4.0f},
+                Knot{16.0f, 13.0f},
+                Knot{32.0f, 29.0f},
+                Knot{48.0f, 58.0f},
+                Knot{64.0f, 77.0f},
+                Knot{80.0f, 90.0f},
+                Knot{96.0f, 97.0f},
+                Knot{112.0f, 100.0f}};
+        return knots;
+    }
+
+    template<std::size_t Size>
+    static float interpolate(float value, const std::array<Knot, Size>& knots) {
+        if (value <= knots.front().input) {
+            return knots.front().output;
+        }
+        for (std::size_t index = 1; index < knots.size(); ++index) {
+            if (value <= knots[index].input) {
+                const Knot& lower = knots[index - 1];
+                const Knot& upper = knots[index];
+                const float factor = (value - lower.input) / (upper.input - lower.input);
+                return lower.output + factor * (upper.output - lower.output);
+            }
+        }
+        return knots.back().output;
+    }
+
+    static float interpolateLow(float value) {
+        const auto& knots = lowKnots();
+        if (value <= knots.back().input) {
+            return interpolate(value, knots);
+        }
+        return std::min(
+                kMaximumOutput,
+                knots.back().output + kLowTailSlope * (value - knots.back().input));
+    }
+
+    static float interpolate(float value, int band) {
+        switch (band) {
+        case Low:
+            return interpolateLow(value);
+        case Mid:
+            return interpolate(value, midKnots());
+        case High:
+            return interpolate(value, highKnots());
+        default:
+            return 0.0f;
+        }
+    }
+};
+
+} // namespace mixxx::analyzer

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -1,6 +1,8 @@
 #include "mixer/playermanager.h"
 
 #include <QRegularExpression>
+#include <QSet>
+#include <utility>
 
 #include "audio/types.h"
 #include "control/controlobject.h"
@@ -783,6 +785,24 @@ void PlayerManager::slotLoadTrackIntoNextAvailableSampler(TrackPointer pTrack) {
 #else
     pSampler->slotLoadTrack(pTrack, false);
 #endif
+}
+
+void PlayerManager::slotReanalyzeLoadedTracks() {
+    QSet<TrackId> scheduledTrackIds;
+    for (BaseTrackPlayer* pPlayer : std::as_const(m_players)) {
+        if (pPlayer == nullptr) {
+            continue;
+        }
+        const TrackPointer pTrack = pPlayer->getLoadedTrack();
+        if (!pTrack || !pTrack->getId().isValid() ||
+                scheduledTrackIds.contains(pTrack->getId())) {
+            continue;
+        }
+        scheduledTrackIds.insert(pTrack->getId());
+        pTrack->setWaveform(WaveformPointer());
+        pTrack->setWaveformSummary(WaveformPointer());
+        slotAnalyzeTrack(pTrack);
+    }
 }
 
 void PlayerManager::slotAnalyzeTrack(TrackPointer track) {

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -220,6 +220,7 @@ class PlayerManager : public PlayerManagerInterface {
     void slotLoadToPreviewDeck(const QString& location, int previewDeckNumber);
     // Slots for loading tracks to samplers
     void slotLoadTrackIntoNextAvailableSampler(TrackPointer pTrack);
+    void slotReanalyzeLoadedTracks();
     // Loads the location to the sampler. samplerNumber is 1-indexed
     void slotLoadToSampler(const QString& location, int samplerNumber);
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -306,6 +306,10 @@ void MixxxMainWindow::initialize() {
     WaveformWidgetFactory::createInstance(); // takes a long time
     WaveformWidgetFactory::instance()->setConfig(m_pCoreServices->getSettings());
     WaveformWidgetFactory::instance()->startVSync(m_pGuiTick, m_pVisualsManager, false);
+    connect(WaveformWidgetFactory::instance(),
+            &WaveformWidgetFactory::waveformAnalysisProfileChanged,
+            pPlayerManager.get(),
+            &PlayerManager::slotReanalyzeLoadedTracks);
 
     connect(this,
             &MixxxMainWindow::skinLoaded,

--- a/src/qml/qmlwaveformrenderer.cpp
+++ b/src/qml/qmlwaveformrenderer.cpp
@@ -188,7 +188,10 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererFiltered::create(
         options ^= allshader::WaveformRendererSignalBase::Option::HighDetail;
     }
     pRenderer.reset(new allshader::WaveformRendererFiltered(
-            waveformWidget, m_stacked, options));
+            waveformWidget,
+            m_stacked ? allshader::WaveformRendererFiltered::Mode::Stacked
+                      : allshader::WaveformRendererFiltered::Mode::Filtered,
+            options));
     setup(dynamic_cast<allshader::WaveformRendererSignalBase*>(pRenderer.get()));
 
     return QmlWaveformRendererFactory::Renderer{

--- a/src/test/analyserwaveformtest.cpp
+++ b/src/test/analyserwaveformtest.cpp
@@ -12,7 +12,9 @@
 #include "analyzer/analyzerwaveform.h"
 #include "analyzer/perceptualwaveformlut.h"
 #include "library/dao/analysisdao.h"
+#ifdef MIXXX_USE_QML
 #include "qml/qmlwaveformdisplay.h"
+#endif
 #include "test/mixxxtest.h"
 #include "track/track.h"
 #include "waveform/waveformfactory.h"
@@ -312,6 +314,7 @@ TEST(WaveformWidgetTypeTest, mapsOnlyPerceptualThreeBandToThePerceptualProfile) 
             mixxx::WaveformAnalysisProfile::Perceptual3Band);
 }
 
+#ifdef MIXXX_USE_QML
 TEST(QmlWaveformDisplayTest, doesNotExposePerceptualThreeBand) {
     const QMetaObject& metaObject = mixxx::qml::QmlWaveformDisplay::staticMetaObject;
     const int enumIndex = metaObject.indexOfEnumerator("Type");
@@ -320,5 +323,6 @@ TEST(QmlWaveformDisplayTest, doesNotExposePerceptualThreeBand) {
     const QMetaEnum waveformType = metaObject.enumerator(enumIndex);
     EXPECT_EQ(waveformType.keyToValue("Perceptual3Band"), -1);
 }
+#endif
 
 } // namespace

--- a/src/test/analyserwaveformtest.cpp
+++ b/src/test/analyserwaveformtest.cpp
@@ -229,7 +229,8 @@ TEST(PerceptualWaveformLutTest, interpolatesKnotsAndUsesLowTail) {
             if (value <= knots[index].first) {
                 const auto [lowerInput, lowerOutput] = knots[index - 1];
                 const auto [upperInput, upperOutput] = knots[index];
-                return lowerOutput + (value - lowerInput) * (upperOutput - lowerOutput) /
+                return lowerOutput +
+                        (value - lowerInput) * (upperOutput - lowerOutput) /
                         (upperInput - lowerInput);
             }
         }
@@ -258,7 +259,8 @@ TEST(PerceptualWaveformLutTest, interpolatesKnotsAndUsesLowTail) {
             0.000001f);
 
     for (int input = 0; input <= 128; ++input) {
-        EXPECT_NEAR(legacyLow(static_cast<float>(input)), transform(static_cast<float>(input), Low),
+        EXPECT_NEAR(legacyLow(static_cast<float>(input)),
+                transform(static_cast<float>(input), Low),
                 0.00001f);
     }
 

--- a/src/test/analyserwaveformtest.cpp
+++ b/src/test/analyserwaveformtest.cpp
@@ -1,14 +1,22 @@
 #include <gtest/gtest.h>
 
 #include <QDir>
+#include <QFile>
+#include <QMetaEnum>
 #include <QtDebug>
+#include <array>
+#include <utility>
 #include <vector>
 
 #include "analyzer/analyzertrack.h"
 #include "analyzer/analyzerwaveform.h"
+#include "analyzer/perceptualwaveformlut.h"
 #include "library/dao/analysisdao.h"
+#include "qml/qmlwaveformdisplay.h"
 #include "test/mixxxtest.h"
 #include "track/track.h"
+#include "waveform/waveformfactory.h"
+#include "waveform/widgets/waveformwidgettype.h"
 
 namespace {
 
@@ -128,6 +136,187 @@ TEST_F(AnalyzerWaveformTest, canary) {
     EXPECT_EQ(pWaveformSummary->getDataSize(), 3842);
     EXPECT_EQ(pWaveformSummary->getCompletion(), 3842);
     EXPECT_DOUBLE_EQ(pWaveformSummary->getAudioVisualRatio(), 1.0);
+}
+
+TEST(PerceptualWaveformStrideTest, storesDetailAndSummaryWithPerceptualLut) {
+    PerceptualWaveformStride stride(1.0, 1.0, 44100.0, 0);
+    std::array<WaveformData, ChannelCount> data{};
+
+    stride.m_sampleCount = 4;
+    stride.m_overallData[Left] = 1.0f;
+    stride.m_filteredData[Left][Low] = 4.0f;
+    stride.m_filteredData[Left][Mid] = 0.25f;
+    stride.m_filteredData[Left][High] = 0.0f;
+    stride.m_overallData[Right] = 0.25f;
+    stride.m_filteredData[Right][Low] = 0.0f;
+    stride.m_filteredData[Right][Mid] = 1.0f;
+    stride.m_filteredData[Right][High] = 4.0f;
+    stride.store(data.data());
+
+    EXPECT_EQ(data[Left].filtered.all, 128);
+    EXPECT_EQ(data[Left].filtered.low, 94);
+    EXPECT_EQ(data[Left].filtered.mid, 46);
+    EXPECT_EQ(data[Left].filtered.high, 0);
+    EXPECT_EQ(data[Right].filtered.all, 64);
+    EXPECT_EQ(data[Right].filtered.low, 0);
+    EXPECT_EQ(data[Right].filtered.mid, 81);
+    EXPECT_EQ(data[Right].filtered.high, 100);
+    EXPECT_EQ(stride.m_sampleCount, 0);
+
+    stride.m_summarySampleCount = 8;
+    stride.m_summaryOverallData[Left] = 4.0f;
+    stride.m_summaryFilteredData[Left][Low] = 0.0f;
+    stride.m_summaryFilteredData[Left][Mid] = 8.0f;
+    stride.m_summaryFilteredData[Left][High] = 0.5f;
+    stride.m_summaryOverallData[Right] = 0.5f;
+    stride.m_summaryFilteredData[Right][Low] = 2.0f;
+    stride.m_summaryFilteredData[Right][Mid] = 0.0f;
+    stride.m_summaryFilteredData[Right][High] = 8.0f;
+    stride.averageStore(data.data());
+
+    EXPECT_EQ(data[Left].filtered.all, 180);
+    EXPECT_EQ(data[Left].filtered.low, 0);
+    EXPECT_EQ(data[Left].filtered.mid, 92);
+    EXPECT_EQ(data[Left].filtered.high, 77);
+    EXPECT_EQ(data[Right].filtered.all, 64);
+    EXPECT_EQ(data[Right].filtered.low, 77);
+    EXPECT_EQ(data[Right].filtered.mid, 0);
+    EXPECT_EQ(data[Right].filtered.high, 100);
+    EXPECT_EQ(stride.m_summarySampleCount, 0);
+}
+
+TEST(PerceptualWaveformStrideTest, appliesBandSpecificExponentialRelease) {
+    PerceptualWaveformStride stride(1.0, 1.0, 44100.0, 0);
+    std::array<WaveformData, ChannelCount> data{};
+
+    stride.m_sampleCount = 441;
+    for (int band = Low; band < BandCount; ++band) {
+        stride.m_filteredData[Left][band] = 110.25f;
+    }
+    stride.store(data.data());
+
+    EXPECT_EQ(data[Left].filtered.low, 77);
+    EXPECT_EQ(data[Left].filtered.mid, 81);
+    EXPECT_EQ(data[Left].filtered.high, 100);
+
+    stride.m_sampleCount = 441;
+    stride.store(data.data());
+
+    EXPECT_EQ(data[Left].filtered.low, 69);
+    EXPECT_EQ(data[Left].filtered.mid, 70);
+    EXPECT_EQ(data[Left].filtered.high, 83);
+}
+
+TEST(PerceptualWaveformLutTest, interpolatesKnotsAndUsesLowTail) {
+    using mixxx::analyzer::PerceptualWaveformLut;
+
+    const auto transform = [](float value, int band) {
+        return 255.0f * PerceptualWaveformLut::applyNormalized(value / 255.0f, band);
+    };
+    const auto legacyLow = [](float value) {
+        constexpr std::array knots{
+                std::pair{0.0f, 0.0f},
+                std::pair{8.0f, 8.5f},
+                std::pair{16.0f, 16.0f},
+                std::pair{32.0f, 27.0f},
+                std::pair{48.0f, 37.0f},
+                std::pair{64.0f, 44.0f},
+                std::pair{80.0f, 53.0f},
+                std::pair{96.0f, 58.0f},
+                std::pair{112.0f, 67.5f},
+                std::pair{128.0f, 77.0f}};
+        for (std::size_t index = 1; index < knots.size(); ++index) {
+            if (value <= knots[index].first) {
+                const auto [lowerInput, lowerOutput] = knots[index - 1];
+                const auto [upperInput, upperOutput] = knots[index];
+                return lowerOutput + (value - lowerInput) * (upperOutput - lowerOutput) /
+                        (upperInput - lowerInput);
+            }
+        }
+        return knots.back().second;
+    };
+
+    EXPECT_FLOAT_EQ(0.0f, PerceptualWaveformLut::applyNormalized(0.0f, Low));
+    EXPECT_NEAR(8.5f / 255.0f,
+            PerceptualWaveformLut::applyNormalized(8.0f / 255.0f, Low),
+            0.000001f);
+    EXPECT_NEAR(30.5f / 255.0f,
+            PerceptualWaveformLut::applyNormalized(40.0f / 255.0f, Mid),
+            0.000001f);
+    EXPECT_NEAR(67.5f / 255.0f,
+            PerceptualWaveformLut::applyNormalized(56.0f / 255.0f, High),
+            0.000001f);
+    EXPECT_NEAR(77.0f, transform(128.0f, Low), 0.00001f);
+    EXPECT_NEAR(77.136f, transform(129.0f, Low), 0.00001f);
+    EXPECT_NEAR(81.352f, transform(160.0f, Low), 0.00001f);
+    EXPECT_NEAR(94.272f, transform(255.0f, Low), 0.00001f);
+    EXPECT_NEAR(92.0f / 255.0f,
+            PerceptualWaveformLut::applyNormalized(1.0f, Mid),
+            0.000001f);
+    EXPECT_NEAR(100.0f / 255.0f,
+            PerceptualWaveformLut::applyNormalized(1.0f, High),
+            0.000001f);
+
+    for (int input = 0; input <= 128; ++input) {
+        EXPECT_NEAR(legacyLow(static_cast<float>(input)), transform(static_cast<float>(input), Low),
+                0.00001f);
+    }
+
+    for (const int band : {Low, Mid, High}) {
+        float previous = 0.0f;
+        for (int input = 0; input <= 255; ++input) {
+            const float transformed = PerceptualWaveformLut::applyNormalized(
+                    static_cast<float>(input) / 255.0f, band);
+            EXPECT_GE(transformed, previous);
+            previous = transformed;
+        }
+    }
+}
+
+TEST(WaveformFactoryTest, separatesLegacyAndPerceptualCacheProfiles) {
+    EXPECT_EQ(WaveformFactory::waveformVersionToVersionClass(
+                      WAVEFORM_LEGACY_CURRENT_VERSION,
+                      mixxx::WaveformAnalysisProfile::Legacy),
+            WaveformFactory::VC_USE);
+    EXPECT_EQ(WaveformFactory::waveformSummaryVersionToVersionClass(
+                      WAVEFORMSUMMARY_LEGACY_CURRENT_VERSION,
+                      mixxx::WaveformAnalysisProfile::Legacy),
+            WaveformFactory::VC_USE);
+    EXPECT_EQ(WaveformFactory::waveformVersionToVersionClass(
+                      WAVEFORM_PERCEPTUAL_3BAND_VERSION,
+                      mixxx::WaveformAnalysisProfile::Perceptual3Band),
+            WaveformFactory::VC_USE);
+    EXPECT_EQ(WaveformFactory::waveformSummaryVersionToVersionClass(
+                      WAVEFORMSUMMARY_PERCEPTUAL_3BAND_VERSION,
+                      mixxx::WaveformAnalysisProfile::Perceptual3Band),
+            WaveformFactory::VC_USE);
+
+    EXPECT_EQ(WaveformFactory::waveformVersionToVersionClass(
+                      WAVEFORM_LEGACY_CURRENT_VERSION,
+                      mixxx::WaveformAnalysisProfile::Perceptual3Band),
+            WaveformFactory::VC_REMOVE);
+    EXPECT_EQ(WaveformFactory::waveformVersionToVersionClass(
+                      WAVEFORM_PERCEPTUAL_3BAND_VERSION,
+                      mixxx::WaveformAnalysisProfile::Legacy),
+            WaveformFactory::VC_REMOVE);
+}
+
+TEST(WaveformWidgetTypeTest, mapsOnlyPerceptualThreeBandToThePerceptualProfile) {
+    EXPECT_EQ(WaveformWidgetType::analysisProfile(WaveformWidgetType::RGB),
+            mixxx::WaveformAnalysisProfile::Legacy);
+    EXPECT_EQ(WaveformWidgetType::analysisProfile(WaveformWidgetType::Stacked),
+            mixxx::WaveformAnalysisProfile::Legacy);
+    EXPECT_EQ(WaveformWidgetType::analysisProfile(WaveformWidgetType::Perceptual3Band),
+            mixxx::WaveformAnalysisProfile::Perceptual3Band);
+}
+
+TEST(QmlWaveformDisplayTest, doesNotExposePerceptualThreeBand) {
+    const QMetaObject& metaObject = mixxx::qml::QmlWaveformDisplay::staticMetaObject;
+    const int enumIndex = metaObject.indexOfEnumerator("Type");
+    ASSERT_NE(enumIndex, -1);
+
+    const QMetaEnum waveformType = metaObject.enumerator(enumIndex);
+    EXPECT_EQ(waveformType.keyToValue("Perceptual3Band"), -1);
 }
 
 } // namespace

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <QSignalSpy>
 #include <QTest>
 #include <gsl/pointers>
 
@@ -21,6 +22,8 @@
 #include "test/soundsourceproviderregistration.h"
 #include "track/track.h"
 #include "util/cmdlineargs.h"
+#include "waveform/waveform.h"
+#include "waveform/waveformwidgetfactory.h"
 #ifdef __RUBBERBAND__
 #include "engine/bufferscalers/rubberbandworkerpool.h"
 #endif
@@ -105,6 +108,9 @@ class PlayerManagerTest : public MixxxDbTest, SoundSourceProviderRegistration {
     }
 
     void TearDown() override {
+        if (WaveformWidgetFactory::isCreated()) {
+            WaveformWidgetFactory::destroy();
+        }
         CoverArtCache::destroy();
 #ifdef __RUBBERBAND__
         RubberBandWorkerPool::destroy();
@@ -236,6 +242,108 @@ TEST_F(PlayerManagerTest, UnEjectInvalidTrackIdTest) {
     QTest::qSleep(kUnreplaceDelay);
     deck1->slotEjectTrack(1.0);
     ASSERT_EQ(nullptr, deck1->getLoadedTrack());
+}
+
+TEST_F(PlayerManagerTest, ReanalyzeLoadedTracks) {
+    auto deck1 = m_pPlayerManager->getDeck(0);
+    auto deck2 = m_pPlayerManager->getDeck(1);
+    ASSERT_NE(nullptr, deck1);
+    ASSERT_NE(nullptr, deck2);
+
+    TrackPointer pTrack = getOrAddTrackByLocation(
+            getTestDir().filePath(kTrackLocationTest1));
+    ASSERT_NE(nullptr, pTrack);
+    ASSERT_TRUE(pTrack->getId().isValid());
+
+    deck1->slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            false);
+    deck2->slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            false);
+    m_pEngine->process(1024);
+    waitForTrackToBeLoaded(deck1);
+    waitForTrackToBeLoaded(deck2);
+    ASSERT_EQ(pTrack, deck1->getLoadedTrack());
+    ASSERT_EQ(pTrack, deck2->getLoadedTrack());
+
+    pTrack->setWaveform(ConstWaveformPointer(new Waveform()));
+    pTrack->setWaveformSummary(ConstWaveformPointer(new Waveform()));
+    QSignalSpy progressSpy(
+            m_pPlayerManager.get(), SIGNAL(trackAnalyzerProgress(TrackId, AnalyzerProgress)));
+
+    m_pPlayerManager->slotReanalyzeLoadedTracks();
+
+    EXPECT_TRUE(pTrack->getWaveform().isNull());
+    EXPECT_TRUE(pTrack->getWaveformSummary().isNull());
+    EXPECT_EQ(progressSpy.count(), 1);
+}
+
+TEST_F(PlayerManagerTest, WaveformProfileChangeReanalyzesLoadedTracks) {
+    ASSERT_FALSE(WaveformWidgetFactory::isCreated());
+    auto* pWaveformWidgetFactory = WaveformWidgetFactory::createInstance();
+    ASSERT_NE(nullptr, pWaveformWidgetFactory);
+    ASSERT_TRUE(pWaveformWidgetFactory->setConfig(m_pConfig));
+    QObject::connect(pWaveformWidgetFactory,
+            &WaveformWidgetFactory::waveformAnalysisProfileChanged,
+            m_pPlayerManager.get(),
+            &PlayerManager::slotReanalyzeLoadedTracks);
+    if (!pWaveformWidgetFactory->widgetTypeSupportsAcceleration(
+                WaveformWidgetType::Perceptual3Band)) {
+        GTEST_SKIP() << "Perceptual 3-band requires the accelerated waveform backend";
+    }
+
+    auto deck1 = m_pPlayerManager->getDeck(0);
+    auto deck2 = m_pPlayerManager->getDeck(1);
+    ASSERT_NE(nullptr, deck1);
+    ASSERT_NE(nullptr, deck2);
+
+    TrackPointer pTrack = getOrAddTrackByLocation(
+            getTestDir().filePath(kTrackLocationTest1));
+    ASSERT_NE(nullptr, pTrack);
+    ASSERT_TRUE(pTrack->getId().isValid());
+
+    deck1->slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            false);
+    deck2->slotLoadTrack(pTrack,
+#ifdef __STEM__
+            mixxx::StemChannelSelection(),
+#endif
+            false);
+    m_pEngine->process(1024);
+    waitForTrackToBeLoaded(deck1);
+    waitForTrackToBeLoaded(deck2);
+    ASSERT_EQ(pTrack, deck1->getLoadedTrack());
+    ASSERT_EQ(pTrack, deck2->getLoadedTrack());
+
+    ASSERT_TRUE(pWaveformWidgetFactory->setWidgetType(WaveformWidgetType::RGB));
+    QSignalSpy progressSpy(
+            m_pPlayerManager.get(), SIGNAL(trackAnalyzerProgress(TrackId, AnalyzerProgress)));
+
+    pTrack->setWaveform(ConstWaveformPointer(new Waveform()));
+    pTrack->setWaveformSummary(ConstWaveformPointer(new Waveform()));
+    ASSERT_TRUE(pWaveformWidgetFactory->setWidgetType(
+            WaveformWidgetType::Perceptual3Band));
+
+    EXPECT_TRUE(pTrack->getWaveform().isNull());
+    EXPECT_TRUE(pTrack->getWaveformSummary().isNull());
+    EXPECT_EQ(progressSpy.count(), 1);
+
+    progressSpy.clear();
+    pTrack->setWaveform(ConstWaveformPointer(new Waveform()));
+    pTrack->setWaveformSummary(ConstWaveformPointer(new Waveform()));
+    ASSERT_TRUE(pWaveformWidgetFactory->setWidgetType(WaveformWidgetType::Stacked));
+
+    EXPECT_TRUE(pTrack->getWaveform().isNull());
+    EXPECT_TRUE(pTrack->getWaveformSummary().isNull());
+    EXPECT_EQ(progressSpy.count(), 1);
 }
 
 TEST_F(PlayerManagerTest, UnReplaceTest) {

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -274,7 +274,7 @@ TEST_F(PlayerManagerTest, ReanalyzeLoadedTracks) {
     pTrack->setWaveform(ConstWaveformPointer(new Waveform()));
     pTrack->setWaveformSummary(ConstWaveformPointer(new Waveform()));
     QSignalSpy progressSpy(
-            m_pPlayerManager.get(), SIGNAL(trackAnalyzerProgress(TrackId, AnalyzerProgress)));
+            m_pPlayerManager.get(), &PlayerManager::trackAnalyzerProgress);
 
     m_pPlayerManager->slotReanalyzeLoadedTracks();
 
@@ -325,7 +325,7 @@ TEST_F(PlayerManagerTest, WaveformProfileChangeReanalyzesLoadedTracks) {
 
     ASSERT_TRUE(pWaveformWidgetFactory->setWidgetType(WaveformWidgetType::RGB));
     QSignalSpy progressSpy(
-            m_pPlayerManager.get(), SIGNAL(trackAnalyzerProgress(TrackId, AnalyzerProgress)));
+            m_pPlayerManager.get(), &PlayerManager::trackAnalyzerProgress);
 
     pTrack->setWaveform(ConstWaveformPointer(new Waveform()));
     pTrack->setWaveformSummary(ConstWaveformPointer(new Waveform()));

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -1,11 +1,14 @@
 #include "waveform/renderers/allshader/waveformrendererfiltered.h"
 
+#include <algorithm>
+
 #include "rendergraph/material/rgbmaterial.h"
 #include "rendergraph/vertexupdaters/rgbvertexupdater.h"
 #include "track/track.h"
 #include "util/math.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
+#include "waveform/waveformanalysisprofile.h"
 
 using namespace rendergraph;
 
@@ -13,10 +16,10 @@ namespace allshader {
 
 WaveformRendererFiltered::WaveformRendererFiltered(
         WaveformWidgetRenderer* waveformWidget,
-        bool bRgbStacked,
+        Mode mode,
         ::WaveformRendererSignalBase::Options options)
         : WaveformRendererSignalBase(waveformWidget, options),
-          m_bRgbStacked(bRgbStacked) {
+          m_mode(mode) {
     initForRectangles<RGBMaterial>(0);
     setUsePreprocess(true);
 }
@@ -86,8 +89,14 @@ bool WaveformRendererFiltered::preprocessInner() {
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;
+    const bool useRgbColors = m_mode != Mode::Filtered;
+    const bool usePerceptualThreeBand = m_mode == Mode::Perceptual3Band;
+    const int layerCount = usePerceptualThreeBand ? 4 : 3;
 
-    const float heightFactor = allGain * halfBreadth / m_maxValue;
+    const float maximumValue = usePerceptualThreeBand
+            ? mixxx::kPerceptual3BandMaximumValue
+            : m_maxValue;
+    const float heightFactor = allGain * halfBreadth / maximumValue;
 
     // Effective visual frame for x
     double xVisualFrame = qRound(firstVisualFrame / visualIncrementPerPixel) *
@@ -95,15 +104,19 @@ bool WaveformRendererFiltered::preprocessInner() {
 
     const int numVerticesPerLine = 6; // 2 triangles
 
-    // low, mid, high + horizontal axis
-    int reserved = numVerticesPerLine * (pixelLength * 3 + 1);
+    int reserved = numVerticesPerLine * (pixelLength * layerCount + 1);
 
     geometry().setDrawingMode(Geometry::DrawingMode::Triangles);
     geometry().allocate(reserved);
     markDirtyGeometry();
 
-    QVector3D rgb[3];
-    if (m_bRgbStacked) {
+    QVector3D rgb[4];
+    if (usePerceptualThreeBand) {
+        rgb[0] = QVector3D(32.0f / 255.0f, 83.0f / 255.0f, 217.0f / 255.0f);
+        rgb[1] = QVector3D(242.0f / 255.0f, 170.0f / 255.0f, 60.0f / 255.0f);
+        rgb[2] = QVector3D(169.0f / 255.0f, 107.0f / 255.0f, 39.0f / 255.0f);
+        rgb[3] = QVector3D(1.0f, 1.0f, 1.0f);
+    } else if (useRgbColors) {
         rgb[0] = QVector3D(static_cast<float>(m_rgbLowColor_r),
                 static_cast<float>(m_rgbLowColor_g),
                 static_cast<float>(m_rgbLowColor_b));
@@ -134,14 +147,17 @@ bool WaveformRendererFiltered::preprocessInner() {
                     static_cast<float>(m_axesColor_g),
                     static_cast<float>(m_axesColor_b)});
 
-    RGBVertexUpdater vertexUpdater[3]{
+    RGBVertexUpdater vertexUpdater[4]{
             {geometry().vertexDataAs<Geometry::RGBColoredPoint2D>() +
                     numVerticesPerLine},
             {geometry().vertexDataAs<Geometry::RGBColoredPoint2D>() +
                     numVerticesPerLine * (1 + pixelLength)},
             {geometry().vertexDataAs<Geometry::RGBColoredPoint2D>() +
-                    numVerticesPerLine * (1 + pixelLength * 2)}};
+                    numVerticesPerLine * (1 + pixelLength * 2)},
+            {geometry().vertexDataAs<Geometry::RGBColoredPoint2D>() +
+                    numVerticesPerLine * (1 + pixelLength * 3)}};
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
+    float previousHeight[4][2]{};
 
     for (int pos = 0; pos < pixelLength; ++pos) {
         const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
@@ -164,7 +180,8 @@ bool WaveformRendererFiltered::preprocessInner() {
                 u8max[1][chn] = math_max(u8max[1][chn], waveformData.filtered.mid);
                 u8max[2][chn] = math_max(u8max[2][chn], waveformData.filtered.high);
             }
-            // Cast to float
+        }
+        for (int chn = 0; chn < 2; ++chn) {
             max[0][chn] = static_cast<float>(u8max[0][chn]);
             max[1][chn] = static_cast<float>(u8max[1][chn]);
             max[2][chn] = static_cast<float>(u8max[2][chn]);
@@ -177,23 +194,55 @@ bool WaveformRendererFiltered::preprocessInner() {
         for (int bandIndex = 0; bandIndex < 3; bandIndex++) {
             max[bandIndex][0] *= bandGain[bandIndex];
             max[bandIndex][1] *= bandGain[bandIndex];
+        }
 
-            vertexUpdater[bandIndex].addRectangle(
-                    {fpos - halfPixelSize,
-                            halfBreadth - heightFactor * max[bandIndex][0]},
-                    {fpos + halfPixelSize,
-                            halfBreadth + heightFactor * max[bandIndex][1]},
-                    {rgb[bandIndex]});
+        float height[4][2]{};
+        if (usePerceptualThreeBand) {
+            for (int channelIndex = 0; channelIndex < 2; channelIndex++) {
+                const float lowHeight = heightFactor * max[0][channelIndex];
+                const float midHeight = heightFactor * max[1][channelIndex];
+                height[0][channelIndex] = lowHeight > midHeight ? lowHeight : 0.0f;
+                height[1][channelIndex] = midHeight > lowHeight ? midHeight : 0.0f;
+                height[2][channelIndex] = std::min(lowHeight, midHeight);
+                height[3][channelIndex] = heightFactor * max[2][channelIndex];
+            }
+        } else {
+            for (int bandIndex = 0; bandIndex < 3; bandIndex++) {
+                height[bandIndex][0] = heightFactor * max[bandIndex][0];
+                height[bandIndex][1] = heightFactor * max[bandIndex][1];
+            }
+        }
+
+        for (int layerIndex = 0; layerIndex < layerCount; layerIndex++) {
+            if (usePerceptualThreeBand && pos > 0) {
+                const float x0 = fpos - halfPixelSize;
+                const float x1 = fpos + halfPixelSize;
+                const float top0 = halfBreadth - previousHeight[layerIndex][0];
+                const float top1 = halfBreadth - height[layerIndex][0];
+                const float bottom0 = halfBreadth + previousHeight[layerIndex][1];
+                const float bottom1 = halfBreadth + height[layerIndex][1];
+                vertexUpdater[layerIndex].addTriangle(
+                        {x0, top0}, {x1, top1}, {x0, bottom0}, rgb[layerIndex]);
+                vertexUpdater[layerIndex].addTriangle(
+                        {x0, bottom0}, {x1, bottom1}, {x1, top1}, rgb[layerIndex]);
+            } else {
+                vertexUpdater[layerIndex].addRectangle(
+                        {fpos - halfPixelSize, halfBreadth - height[layerIndex][0]},
+                        {fpos + halfPixelSize, halfBreadth + height[layerIndex][1]},
+                        {rgb[layerIndex]});
+            }
+            previousHeight[layerIndex][0] = height[layerIndex][0];
+            previousHeight[layerIndex][1] = height[layerIndex][1];
         }
 
         xVisualFrame += visualIncrementPerPixel;
     }
 
-    DEBUG_ASSERT(reserved ==
-            vertexUpdater[0].index() + vertexUpdater[1].index() +
-                    vertexUpdater[2].index() +
-                    numVerticesPerLine); // all lines on the three channels and
-                                         // the axis
+    int writtenVertices = numVerticesPerLine;
+    for (int layerIndex = 0; layerIndex < layerCount; layerIndex++) {
+        writtenVertices += vertexUpdater[layerIndex].index();
+    }
+    DEBUG_ASSERT(reserved == writtenVertices);
 
     markDirtyMaterial();
 

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.h
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.h
@@ -12,8 +12,14 @@ class allshader::WaveformRendererFiltered final
         : public allshader::WaveformRendererSignalBase,
           public rendergraph::GeometryNode {
   public:
+    enum class Mode {
+        Filtered,
+        Stacked,
+        Perceptual3Band,
+    };
+
     explicit WaveformRendererFiltered(WaveformWidgetRenderer* waveformWidget,
-            bool rgbStacked,
+            Mode mode,
             ::WaveformRendererSignalBase::Options options);
 
     // Pure virtual from WaveformRendererSignalBase, not used
@@ -23,7 +29,7 @@ class allshader::WaveformRendererFiltered final
     void preprocess() override;
 
   private:
-    const bool m_bRgbStacked;
+    const Mode m_mode;
     bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererFiltered);

--- a/src/waveform/renderers/allshader/waveformrenderertextured.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.cpp
@@ -8,6 +8,7 @@
 #include "moc_waveformrenderertextured.cpp"
 #include "track/track.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/waveformanalysisprofile.h"
 
 namespace {
 const QString kPassthroughShaderPath = QStringLiteral(":/shaders/passthrough.vert");
@@ -24,6 +25,8 @@ QString WaveformRendererTextured::fragShaderForType(::WaveformWidgetType::Type t
         return QStringLiteral(":/shaders/rgbsignal.frag");
     case ::WaveformWidgetType::Stacked:
         return QStringLiteral(":/shaders/stackedsignal.frag");
+    case ::WaveformWidgetType::Perceptual3Band:
+        return QStringLiteral(":/shaders/perceptual3bandsignal.frag");
     default:
         break;
     }
@@ -275,11 +278,6 @@ void WaveformRendererTextured::resizeGL(int, int) {
 
 void WaveformRendererTextured::slotWaveformUpdated() {
     m_textureRenderedWaveformCompletion = 0;
-    // initializeGL not called yet
-    if (!m_frameShaderProgram) {
-        return;
-    }
-    loadTexture();
 }
 
 void WaveformRendererTextured::paintGL() {
@@ -333,6 +331,8 @@ void WaveformRendererTextured::paintGL() {
     // Per-band gain from the EQ knobs.
     float lowGain(1.0), midGain(1.0), highGain(1.0), allGain(1.0);
     getGains(&allGain, &lowGain, &midGain, &highGain);
+    const bool usePerceptualThreeBand =
+            m_type == ::WaveformWidgetType::Perceptual3Band;
 
     const auto firstVisualIndex = static_cast<GLfloat>(
             m_waveformRenderer->getFirstDisplayedPosition(positionType) * trackSamples /
@@ -383,6 +383,11 @@ void WaveformRendererTextured::paintGL() {
         m_frameShaderProgram->setUniformValue("midGain", midGain);
         m_frameShaderProgram->setUniformValue("highGain", highGain);
 
+        if (usePerceptualThreeBand) {
+            m_frameShaderProgram->setUniformValue("perceptualValueScale",
+                    m_maxValue / mixxx::kPerceptual3BandMaximumValue);
+        }
+
         if (m_type == ::WaveformWidgetType::RGB) {
             m_frameShaderProgram->setUniformValue("splitStereoSignal",
                     m_options & ::WaveformRendererSignalBase::Option::SplitStereoSignal);
@@ -411,22 +416,43 @@ void WaveformRendererTextured::paintGL() {
                             static_cast<GLfloat>(m_rgbHighFilteredColor_b),
                             1.0));
         }
-        if (m_type == ::WaveformWidgetType::RGB || m_type == ::WaveformWidgetType::Stacked) {
-            m_frameShaderProgram->setUniformValue("lowColor",
-                    QVector4D(static_cast<GLfloat>(m_rgbLowColor_r),
+        if (m_type == ::WaveformWidgetType::RGB ||
+                m_type == ::WaveformWidgetType::Stacked ||
+                usePerceptualThreeBand) {
+            const QVector4D lowColor = usePerceptualThreeBand
+                    ? QVector4D(32.0f / 255.0f,
+                            83.0f / 255.0f,
+                            217.0f / 255.0f,
+                            1.0f)
+                    : QVector4D(static_cast<GLfloat>(m_rgbLowColor_r),
                             static_cast<GLfloat>(m_rgbLowColor_g),
                             static_cast<GLfloat>(m_rgbLowColor_b),
-                            1.0));
-            m_frameShaderProgram->setUniformValue("midColor",
-                    QVector4D(static_cast<GLfloat>(m_rgbMidColor_r),
+                            1.0f);
+            const QVector4D midColor = usePerceptualThreeBand
+                    ? QVector4D(242.0f / 255.0f,
+                            170.0f / 255.0f,
+                            60.0f / 255.0f,
+                            1.0f)
+                    : QVector4D(static_cast<GLfloat>(m_rgbMidColor_r),
                             static_cast<GLfloat>(m_rgbMidColor_g),
                             static_cast<GLfloat>(m_rgbMidColor_b),
-                            1.0));
-            m_frameShaderProgram->setUniformValue("highColor",
-                    QVector4D(static_cast<GLfloat>(m_rgbHighColor_r),
+                            1.0f);
+            const QVector4D highColor = usePerceptualThreeBand
+                    ? QVector4D(1.0f, 1.0f, 1.0f, 1.0f)
+                    : QVector4D(static_cast<GLfloat>(m_rgbHighColor_r),
                             static_cast<GLfloat>(m_rgbHighColor_g),
                             static_cast<GLfloat>(m_rgbHighColor_b),
-                            1.0));
+                            1.0f);
+            m_frameShaderProgram->setUniformValue("lowColor", lowColor);
+            m_frameShaderProgram->setUniformValue("midColor", midColor);
+            m_frameShaderProgram->setUniformValue("highColor", highColor);
+            if (usePerceptualThreeBand) {
+                m_frameShaderProgram->setUniformValue("overlapColor",
+                        QVector4D(169.0f / 255.0f,
+                                107.0f / 255.0f,
+                                39.0f / 255.0f,
+                                1.0f));
+            }
         } else {
             m_frameShaderProgram->setUniformValue("lowColor",
                     QVector4D(static_cast<GLfloat>(m_lowColor_r),

--- a/src/waveform/renderers/allshader/waveformrenderertextured.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.cpp
@@ -426,28 +426,28 @@ void WaveformRendererTextured::paintGL() {
                 usePerceptualThreeBand) {
             const QVector4D lowColor = usePerceptualThreeBand
                     ? QVector4D(32.0f / 255.0f,
-                            83.0f / 255.0f,
-                            217.0f / 255.0f,
-                            1.0f)
+                              83.0f / 255.0f,
+                              217.0f / 255.0f,
+                              1.0f)
                     : QVector4D(static_cast<GLfloat>(m_rgbLowColor_r),
-                            static_cast<GLfloat>(m_rgbLowColor_g),
-                            static_cast<GLfloat>(m_rgbLowColor_b),
-                            1.0f);
+                              static_cast<GLfloat>(m_rgbLowColor_g),
+                              static_cast<GLfloat>(m_rgbLowColor_b),
+                              1.0f);
             const QVector4D midColor = usePerceptualThreeBand
                     ? QVector4D(242.0f / 255.0f,
-                            170.0f / 255.0f,
-                            60.0f / 255.0f,
-                            1.0f)
+                              170.0f / 255.0f,
+                              60.0f / 255.0f,
+                              1.0f)
                     : QVector4D(static_cast<GLfloat>(m_rgbMidColor_r),
-                            static_cast<GLfloat>(m_rgbMidColor_g),
-                            static_cast<GLfloat>(m_rgbMidColor_b),
-                            1.0f);
+                              static_cast<GLfloat>(m_rgbMidColor_g),
+                              static_cast<GLfloat>(m_rgbMidColor_b),
+                              1.0f);
             const QVector4D highColor = usePerceptualThreeBand
                     ? QVector4D(1.0f, 1.0f, 1.0f, 1.0f)
                     : QVector4D(static_cast<GLfloat>(m_rgbHighColor_r),
-                            static_cast<GLfloat>(m_rgbHighColor_g),
-                            static_cast<GLfloat>(m_rgbHighColor_b),
-                            1.0f);
+                              static_cast<GLfloat>(m_rgbHighColor_g),
+                              static_cast<GLfloat>(m_rgbHighColor_b),
+                              1.0f);
             m_frameShaderProgram->setUniformValue("lowColor", lowColor);
             m_frameShaderProgram->setUniformValue("midColor", midColor);
             m_frameShaderProgram->setUniformValue("highColor", highColor);

--- a/src/waveform/renderers/allshader/waveformrenderertextured.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.cpp
@@ -278,6 +278,11 @@ void WaveformRendererTextured::resizeGL(int, int) {
 
 void WaveformRendererTextured::slotWaveformUpdated() {
     m_textureRenderedWaveformCompletion = 0;
+    // initializeGL not called yet
+    if (!m_frameShaderProgram) {
+        return;
+    }
+    loadTexture();
 }
 
 void WaveformRendererTextured::paintGL() {

--- a/src/waveform/waveformanalysisprofile.h
+++ b/src/waveform/waveformanalysisprofile.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace mixxx {
+
+enum class WaveformAnalysisProfile {
+    Legacy,
+    Perceptual3Band,
+};
+
+inline constexpr float kPerceptual3BandMaximumValue = 127.0f;
+
+} // namespace mixxx

--- a/src/waveform/waveformfactory.cpp
+++ b/src/waveform/waveformfactory.cpp
@@ -1,4 +1,5 @@
 #include "waveform/waveformfactory.h"
+
 #include "waveform/waveform.h"
 
 // static
@@ -12,10 +13,17 @@ Waveform* WaveformFactory::loadWaveformFromAnalysis(
 }
 
 // static
-WaveformFactory::VersionClass WaveformFactory::waveformVersionToVersionClass(const QString& version) {
-    if (version == WAVEFORM_CURRENT_VERSION) {
-        // use, since is our version
+WaveformFactory::VersionClass WaveformFactory::waveformVersionToVersionClass(
+        const QString& version,
+        mixxx::WaveformAnalysisProfile profile) {
+    if (version == currentWaveformVersion(profile)) {
         return VC_USE;
+    }
+
+    if (version == WAVEFORM_LEGACY_CURRENT_VERSION ||
+            version == WAVEFORM_PERCEPTUAL_3BAND_VERSION ||
+            version == WAVEFORM_5_VERSION) {
+        return VC_REMOVE;
     }
 
     if (version == WAVEFORM_4_VERSION) {
@@ -34,9 +42,7 @@ WaveformFactory::VersionClass WaveformFactory::waveformVersionToVersionClass(con
     }
 
 #ifdef __STEM__
-    if (version == WAVEFORM_6_0_VERSION) {
-        // Used in Mixxx 2.6 beta, introducing stem data but later replaced with
-        // the signal scale removal
+    if (version == WAVEFORM_6_VERSION || version == WAVEFORM_6_0_VERSION) {
         return VC_REMOVE;
     }
 #endif
@@ -46,10 +52,16 @@ WaveformFactory::VersionClass WaveformFactory::waveformVersionToVersionClass(con
 }
 
 // static
-WaveformFactory::VersionClass WaveformFactory::waveformSummaryVersionToVersionClass(const QString& version) {
-    if (version == WAVEFORMSUMMARY_CURRENT_VERSION) {
-        // use, since is our version
+WaveformFactory::VersionClass WaveformFactory::waveformSummaryVersionToVersionClass(
+        const QString& version,
+        mixxx::WaveformAnalysisProfile profile) {
+    if (version == currentWaveformSummaryVersion(profile)) {
         return VC_USE;
+    }
+
+    if (version == WAVEFORMSUMMARY_LEGACY_CURRENT_VERSION ||
+            version == WAVEFORMSUMMARY_PERCEPTUAL_3BAND_VERSION) {
+        return VC_REMOVE;
     }
 
     if (version == WAVEFORMSUMMARY_4_VERSION) {
@@ -72,21 +84,33 @@ WaveformFactory::VersionClass WaveformFactory::waveformSummaryVersionToVersionCl
 }
 
 // static
-QString WaveformFactory::currentWaveformVersion() {
-    return WAVEFORM_CURRENT_VERSION;
+QString WaveformFactory::currentWaveformVersion(
+        mixxx::WaveformAnalysisProfile profile) {
+    return profile == mixxx::WaveformAnalysisProfile::Perceptual3Band
+            ? QStringLiteral(WAVEFORM_PERCEPTUAL_3BAND_VERSION)
+            : QStringLiteral(WAVEFORM_LEGACY_CURRENT_VERSION);
 }
 
 // static
-QString WaveformFactory::currentWaveformSummaryVersion() {
-    return WAVEFORMSUMMARY_CURRENT_VERSION;
+QString WaveformFactory::currentWaveformDescription(
+        mixxx::WaveformAnalysisProfile profile) {
+    return profile == mixxx::WaveformAnalysisProfile::Perceptual3Band
+            ? QStringLiteral(WAVEFORM_PERCEPTUAL_3BAND_DESCRIPTION)
+            : QStringLiteral(WAVEFORM_LEGACY_CURRENT_DESCRIPTION);
 }
 
 // static
-QString WaveformFactory::currentWaveformDescription() {
-    return WAVEFORM_CURRENT_DESCRIPTION;
+QString WaveformFactory::currentWaveformSummaryVersion(
+        mixxx::WaveformAnalysisProfile profile) {
+    return profile == mixxx::WaveformAnalysisProfile::Perceptual3Band
+            ? QStringLiteral(WAVEFORMSUMMARY_PERCEPTUAL_3BAND_VERSION)
+            : QStringLiteral(WAVEFORMSUMMARY_LEGACY_CURRENT_VERSION);
 }
 
 // static
-QString WaveformFactory::currentWaveformSummaryDescription() {
-    return WAVEFORMSUMMARY_CURRENT_DESCRIPTION;
+QString WaveformFactory::currentWaveformSummaryDescription(
+        mixxx::WaveformAnalysisProfile profile) {
+    return profile == mixxx::WaveformAnalysisProfile::Perceptual3Band
+            ? QStringLiteral(WAVEFORMSUMMARY_PERCEPTUAL_3BAND_DESCRIPTION)
+            : QStringLiteral(WAVEFORMSUMMARY_LEGACY_CURRENT_DESCRIPTION);
 }

--- a/src/waveform/waveformfactory.h
+++ b/src/waveform/waveformfactory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "library/dao/analysisdao.h"
+#include "waveform/waveformanalysisprofile.h"
 
 class Waveform;
 
@@ -35,15 +36,23 @@ class Waveform;
 #define WAVEFORMSUMMARY_6_VERSION "WaveformSummary-6.1"
 #define WAVEFORM_6_DESCRIPTION "Waveform 6.1"
 #define WAVEFORMSUMMARY_6_DESCRIPTION "WaveformSummary 6.1"
-
-#define WAVEFORM_CURRENT_VERSION WAVEFORM_6_VERSION
-#define WAVEFORM_CURRENT_DESCRIPTION WAVEFORM_6_DESCRIPTION
-#else
-#define WAVEFORM_CURRENT_VERSION WAVEFORM_5_VERSION
-#define WAVEFORM_CURRENT_DESCRIPTION WAVEFORM_5_DESCRIPTION
 #endif
-#define WAVEFORMSUMMARY_CURRENT_VERSION WAVEFORMSUMMARY_5_VERSION
-#define WAVEFORMSUMMARY_CURRENT_DESCRIPTION WAVEFORMSUMMARY_5_DESCRIPTION
+
+#ifdef __STEM__
+#define WAVEFORM_LEGACY_CURRENT_VERSION WAVEFORM_6_VERSION
+#define WAVEFORM_LEGACY_CURRENT_DESCRIPTION WAVEFORM_6_DESCRIPTION
+#else
+#define WAVEFORM_LEGACY_CURRENT_VERSION WAVEFORM_5_VERSION
+#define WAVEFORM_LEGACY_CURRENT_DESCRIPTION WAVEFORM_5_DESCRIPTION
+#endif
+#define WAVEFORMSUMMARY_LEGACY_CURRENT_VERSION WAVEFORMSUMMARY_5_VERSION
+#define WAVEFORMSUMMARY_LEGACY_CURRENT_DESCRIPTION WAVEFORMSUMMARY_5_DESCRIPTION
+
+#define WAVEFORM_PERCEPTUAL_3BAND_VERSION "Waveform-Perceptual3Band-1"
+#define WAVEFORM_PERCEPTUAL_3BAND_DESCRIPTION "Perceptual 3-band waveform 1"
+#define WAVEFORMSUMMARY_PERCEPTUAL_3BAND_VERSION "WaveformSummary-Perceptual3Band-1"
+#define WAVEFORMSUMMARY_PERCEPTUAL_3BAND_DESCRIPTION \
+    "Perceptual 3-band waveform summary 1"
 
 class WaveformFactory {
   public:
@@ -55,10 +64,18 @@ class WaveformFactory {
 
     static Waveform* loadWaveformFromAnalysis(
             const AnalysisDao::AnalysisInfo& analysis);
-    static VersionClass waveformVersionToVersionClass(const QString& version);
-    static VersionClass waveformSummaryVersionToVersionClass(const QString& version);
-    static QString currentWaveformVersion();
-    static QString currentWaveformDescription();
-    static QString currentWaveformSummaryVersion();
-    static QString currentWaveformSummaryDescription();
+    static VersionClass waveformVersionToVersionClass(
+            const QString& version,
+            mixxx::WaveformAnalysisProfile profile);
+    static VersionClass waveformSummaryVersionToVersionClass(
+            const QString& version,
+            mixxx::WaveformAnalysisProfile profile);
+    static QString currentWaveformVersion(
+            mixxx::WaveformAnalysisProfile profile);
+    static QString currentWaveformDescription(
+            mixxx::WaveformAnalysisProfile profile);
+    static QString currentWaveformSummaryVersion(
+            mixxx::WaveformAnalysisProfile profile);
+    static QString currentWaveformSummaryDescription(
+            mixxx::WaveformAnalysisProfile profile);
 };

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -587,7 +587,14 @@ void WaveformWidgetFactory::setEndOfTrackWarningTime(int endTime) {
 }
 
 bool WaveformWidgetFactory::setWidgetType(WaveformWidgetType::Type type) {
-    return setWidgetType(type, &m_type);
+    const mixxx::WaveformAnalysisProfile previousProfile =
+            WaveformWidgetType::analysisProfile(m_type);
+    const bool isAcceptable = setWidgetType(type, &m_type);
+    if (isAcceptable &&
+            previousProfile != WaveformWidgetType::analysisProfile(m_type)) {
+        emit waveformAnalysisProfileChanged();
+    }
+    return isAcceptable;
 }
 
 bool WaveformWidgetFactory::setWidgetType(
@@ -616,6 +623,7 @@ bool WaveformWidgetFactory::widgetTypeSupportsUntilMark() const {
     case WaveformWidgetType::Simple:
     case WaveformWidgetType::HSV:
     case WaveformWidgetType::Stacked:
+    case WaveformWidgetType::Perceptual3Band:
         return true;
     default:
         break;
@@ -630,6 +638,7 @@ bool WaveformWidgetFactory::widgetTypeSupportsStems() const {
     case WaveformWidgetType::Simple:
     case WaveformWidgetType::HSV:
     case WaveformWidgetType::Stacked:
+    case WaveformWidgetType::Perceptual3Band:
         return true;
     default:
         break;
@@ -1085,6 +1094,13 @@ void WaveformWidgetFactory::evaluateWidgets() {
                             type, useGles);
 #endif
             break;
+        case WaveformWidgetType::Perceptual3Band:
+#ifdef MIXXX_USE_QOPENGL
+            addHandle(collectedHandles, type, allshader::WaveformWidget::vars());
+            supportedOptions[type] =
+                    allshader::WaveformWidget::supportedOptions(type, useGles);
+#endif
+            break;
         default:
             DEBUG_ASSERT(!"Unexpected WaveformWidgetType");
             continue;
@@ -1173,6 +1189,18 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createStackedWaveformWidget(
     }
 }
 
+WaveformWidgetAbstract* WaveformWidgetFactory::createPerceptual3BandWaveformWidget(
+        WWaveformViewer* viewer,
+        WaveformRendererSignalBase::Options options) {
+#ifdef MIXXX_USE_QOPENGL
+    if (getBackendFromConfig() == WaveformWidgetBackend::AllShader) {
+        return createAllshaderWaveformWidget(
+                WaveformWidgetType::Perceptual3Band, viewer, options);
+    }
+#endif
+    return new EmptyWaveformWidget(viewer->getGroup(), viewer);
+}
+
 WaveformWidgetAbstract* WaveformWidgetFactory::createSimpleWaveformWidget(
         WWaveformViewer* viewer, WaveformRendererSignalBase::Options options) {
     WaveformWidgetBackend backend = getBackendFromConfig();
@@ -1226,6 +1254,9 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createWaveformWidget(
             break;
         case WaveformWidgetType::Stacked:
             pWidget = createStackedWaveformWidget(pViewer, options);
+            break;
+        case WaveformWidgetType::Perceptual3Band:
+            pWidget = createPerceptual3BandWaveformWidget(pViewer, options);
             break;
         default:
             pWidget = new EmptyWaveformWidget(pViewer->getGroup(), pViewer);
@@ -1388,6 +1419,8 @@ QString WaveformWidgetAbstractHandle::getDisplayName(WaveformWidgetType::Type ty
         return QObject::tr("RGB");
     case WaveformWidgetType::Stacked:
         return QObject::tr("Stacked");
+    case WaveformWidgetType::Perceptual3Band:
+        return QObject::tr("Perceptual 3-band");
     default:
         return QObject::tr("Unknown");
     }

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -266,6 +266,7 @@ class WaveformWidgetFactory : public QObject,
 
     void overviewScalingChanged();
     void visualGainChanged(double allChannelGain, double lowGain, double midGain, double highGain);
+    void waveformAnalysisProfileChanged();
 
     void untilMarkShowBeatsChanged(bool value);
     void untilMarkShowTimeChanged(bool value);
@@ -366,6 +367,9 @@ class WaveformWidgetFactory : public QObject,
     WaveformWidgetAbstract* createRGBWaveformWidget(WWaveformViewer* viewer,
             WaveformRendererSignalBase::Options option);
     WaveformWidgetAbstract* createStackedWaveformWidget(WWaveformViewer* viewer,
+            WaveformRendererSignalBase::Options option);
+    WaveformWidgetAbstract* createPerceptual3BandWaveformWidget(
+            WWaveformViewer* viewer,
             WaveformRendererSignalBase::Options option);
     WaveformWidgetAbstract* createSimpleWaveformWidget(WWaveformViewer* viewer,
             WaveformRendererSignalBase::Options option);

--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -113,6 +113,7 @@ WaveformWidget::addWaveformSignalRenderer(WaveformWidgetType::Type type,
         case ::WaveformWidgetType::RGB:
         case ::WaveformWidgetType::Filtered:
         case ::WaveformWidgetType::Stacked:
+        case ::WaveformWidgetType::Perceptual3Band:
             return addWaveformSignalRenderer<WaveformRendererTextured>(
                     type, positionSource, options);
         default:
@@ -129,10 +130,14 @@ WaveformWidget::addWaveformSignalRenderer(WaveformWidgetType::Type type,
     case ::WaveformWidgetType::HSV:
         return addWaveformSignalRenderer<WaveformRendererHSV>(options);
     case ::WaveformWidgetType::Filtered:
-        return addWaveformSignalRenderer<WaveformRendererFiltered>(false, options);
+        return addWaveformSignalRenderer<WaveformRendererFiltered>(
+                WaveformRendererFiltered::Mode::Filtered, options);
     case ::WaveformWidgetType::Stacked:
         return addWaveformSignalRenderer<WaveformRendererFiltered>(
-                true, options); // true for RGB Stacked
+                WaveformRendererFiltered::Mode::Stacked, options);
+    case ::WaveformWidgetType::Perceptual3Band:
+        return addWaveformSignalRenderer<WaveformRendererFiltered>(
+                WaveformRendererFiltered::Mode::Perceptual3Band, options);
     default:
         break;
     }

--- a/src/waveform/widgets/allshader/waveformwidget.h
+++ b/src/waveform/widgets/allshader/waveformwidget.h
@@ -54,6 +54,7 @@ class allshader::WaveformWidget final : public ::WGLWidget,
             options = ::WaveformRendererSignalBase::Option::HighDetail;
             break;
         case WaveformWidgetType::Type::Stacked:
+        case WaveformWidgetType::Type::Perceptual3Band:
             options = ::WaveformRendererSignalBase::Option::HighDetail;
             break;
         default:

--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -20,8 +20,8 @@ class WaveformWidgetType {
         RGB = 12,      // 12 RGB GLSL
         Stacked = 16,  // 16 RGB Stacked
         Perceptual3Band = 17,
-        Invalid,       // Don't use! Used to indicate invalid/unknown type, as
-                       // Count_WaveformWidgetType used to.
+        Invalid, // Don't use! Used to indicate invalid/unknown type, as
+                 // Count_WaveformWidgetType used to.
     };
     static constexpr std::array kValues = {
             WaveformWidgetType::Empty,

--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -5,6 +5,8 @@
 // required for Qt-Macros
 #include <qobjectdefs.h>
 
+#include "waveform/waveformanalysisprofile.h"
+
 class WaveformWidgetType {
   public:
     enum Type {
@@ -17,6 +19,7 @@ class WaveformWidgetType {
         VSyncTest = 9, // 9  VSync GL
         RGB = 12,      // 12 RGB GLSL
         Stacked = 16,  // 16 RGB Stacked
+        Perceptual3Band = 17,
         Invalid,       // Don't use! Used to indicate invalid/unknown type, as
                        // Count_WaveformWidgetType used to.
     };
@@ -28,7 +31,14 @@ class WaveformWidgetType {
             WaveformWidgetType::VSyncTest,
             WaveformWidgetType::RGB,
             WaveformWidgetType::Stacked,
+            WaveformWidgetType::Perceptual3Band,
     };
+
+    static constexpr mixxx::WaveformAnalysisProfile analysisProfile(Type type) {
+        return type == Perceptual3Band
+                ? mixxx::WaveformAnalysisProfile::Perceptual3Band
+                : mixxx::WaveformAnalysisProfile::Legacy;
+    }
 };
 
 enum class WaveformWidgetBackend {


### PR DESCRIPTION
## Summary

Adds a new optional **Perceptual 3-band** waveform mode designed to make low-, mid-, and high-frequency structure easier to distinguish while DJing.

The new mode has its own waveform analysis profile and accelerated waveform renderer. Existing waveform types continue to use the legacy analysis and rendering paths unchanged.

### Analysis

Perceptual 3-band uses:

- RMS-based energy measurement for three frequency bands
- band-specific instant-attack, exponential-release temporal envelopes
- per-band piecewise-linear transfer LUTs for display
- a separate waveform cache profile/version from legacy waveform modes

The analysis parameters and transfer mappings were derived empirically using controlled tone and burst tests, followed by validation across real tracks, using Rekordbox's 3-band waveform as a visual reference.

Because the analysis data is not compatible with the legacy waveform profile, switching between Perceptual 3-band and legacy waveform modes invalidates the currently loaded incompatible waveforms and queues them for reanalysis.

### Rendering

The accelerated renderer displays:

- low frequencies in blue
- mid frequencies in amber
- low/mid overlap separately
- high-frequency detail in white
- interpolated geometry when High Details is enabled

Perceptual 3-band is currently not exposed by the QML waveform backend.

## Existing behavior

RGB, Stacked, and the other existing waveform types retain their previous analysis and rendering behavior.

The existing legacy waveform golden test still passes byte-for-byte unchanged.

## Screenshot

<img width="1323" height="287" alt="comparison Rekordbox vs Stacked vs Perceptual 3-band" src="https://github.com/user-attachments/assets/55e92eb3-789e-46d2-a1ce-d7ada783192b" />

Rekordbox 3-band waveform (top) vs. Stacked waveform (middle) vs. Perceptual 3-band waveform (bottom).

## Testing

- Built `mixxx` successfully
- Built `mixxx-test` successfully
- Legacy waveform golden test passes byte-for-byte unchanged
- 8 focused analyzer/profile tests pass
- 1 accelerated-backend integration test is skipped when the accelerated waveform backend is unavailable in the test configuration
- Manually tested:
  - loading and analyzing tracks
  - switching between Stacked and Perceptual 3-band
  - cache invalidation and reanalysis
  - High Details enabled and disabled
  - multiple tracks and zoom levels
- `pre-commit` passes
- `git diff --check` passes

## Notes

This is my first contribution to an open-source project on GitHub, and I made extensive use of Codex while writing the code, investigating the existing waveform implementation, and reviewing the changes.

My original goal was to create a waveform view that felt closer to Rekordbox's 3-band waveform, which I found very helpful while learning to DJ.

The Perceptual 3-band mode is intentionally not meant to be a more literal representation of the underlying audio signal than the existing waveform modes. Instead, the RMS-based analysis and temporal envelopes produce a more stable representation of energy within each frequency band, making rhythmic structure and the relative prominence of low, mid, and high frequencies easier to read, particularly for someone learning to DJ.