### PR TITLE
library: draw minute markers on overview waveform

### DIFF
--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -66,6 +66,21 @@ void OverviewCache::onTrackSummaryChanged(TrackId trackId) {
     emit overviewChanged(trackId);
 }
 
+void OverviewCache::invalidateAll() {
+    QSet<TrackId> affectedIds;
+    for (auto it = m_cacheKeysByTrackId.constBegin();
+            it != m_cacheKeysByTrackId.constEnd();
+            ++it) {
+        QPixmapCache::remove(it.value());
+        affectedIds.insert(it.key());
+    }
+    m_cacheKeysByTrackId.clear();
+    m_tracksWithoutOverview.clear();
+    for (const TrackId& trackId : std::as_const(affectedIds)) {
+        emit overviewChanged(trackId);
+    }
+}
+
 QPixmap OverviewCache::requestCachedOverview(
         mixxx::OverviewType type,
         TrackId trackId,
@@ -165,6 +180,9 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
         return result;
     }
 
+    const bool bDrawMinuteMarkers = pConfig->getValue(
+            ConfigKey("[Waveform]", QStringLiteral("draw_library_overview_minute_markers")), true);
+
     mixxx::DbConnectionPooler dbConnectionPooler(pDbConnectionPool);
     QSqlDatabase database = mixxx::DbConnectionPooled(pDbConnectionPool);
 
@@ -188,10 +206,23 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
 
             if (!image.isNull()) {
                 image = resizeImageSize(image, desiredSize);
-                // draw hotcue markers on the resized image for crisp 1px lines
-                // at the final display resolution, matching the deck overview style
-                if (trackDurationMillis > 0 && !cueInfos.isEmpty()) {
-                    drawHotcueMarkers(&image, cueInfos, trackDurationMillis);
+                // draw markers on the resized image for crisp lines
+                // at the final display resolution
+                if (trackDurationMillis > 0) {
+                    if (bDrawMinuteMarkers) {
+                        QList<int> markerXPositions;
+                        for (double currentMarkerMillis = 60000;
+                                currentMarkerMillis < trackDurationMillis;
+                                currentMarkerMillis += 60000) {
+                            markerXPositions.append(static_cast<int>(
+                                    (currentMarkerMillis / trackDurationMillis) *
+                                    image.width()));
+                        }
+                        drawMinuteMarkers(&image, markerXPositions);
+                    }
+                    if (!cueInfos.isEmpty()) {
+                        drawHotcueMarkers(&image, cueInfos, trackDurationMillis);
+                    }
                 }
             }
             result.image = image;
@@ -255,6 +286,31 @@ void OverviewCache::drawHotcueMarkers(
         // draw main bright marker line (1px wide)
         markerPainter.setPen(fillColor);
         markerPainter.drawLine(x, 0, x, imageHeight);
+    }
+}
+
+// static
+void OverviewCache::drawMinuteMarkers(
+        QImage* pImage,
+        const QList<int>& markerXPositions) {
+    if (pImage->format() != QImage::Format_ARGB32_Premultiplied) {
+        *pImage = pImage->convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    }
+
+    QPainter markerPainter(pImage);
+    markerPainter.setRenderHint(QPainter::Antialiasing, false);
+    const int imageWidth = pImage->width();
+    const int imageHeight = pImage->height();
+    const int markerHeight = static_cast<int>(imageHeight * 0.2);
+    const int lowerMarkerYPos = static_cast<int>(imageHeight * 0.8);
+    const int inset = 1;
+    const QColor minuteColor(255, 255, 255, 204); // 80% opacity
+
+    for (int x : markerXPositions) {
+        if (x >= 0 && x < imageWidth) {
+            markerPainter.fillRect(x, inset, 1, markerHeight - inset, minuteColor);
+            markerPainter.fillRect(x, lowerMarkerYPos, 1, imageHeight - lowerMarkerYPos - inset, minuteColor);
+        }
     }
 }
 

--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -7,9 +7,11 @@
 
 #include "library/dao/analysisdao.h"
 #include "moc_overviewcache.cpp"
+#include "util/color/color.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/db/dbconnectionpooler.h"
 #include "util/logger.h"
+#include "util/painterscope.h"
 #include "waveform/renderers/waveformoverviewrenderer.h"
 #include "waveform/renderers/waveformsignalcolors.h"
 #include "waveform/waveformfactory.h"
@@ -94,6 +96,8 @@ QPixmap OverviewCache::requestUncachedOverview(
         mixxx::OverviewType type,
         const WaveformSignalColors& signalColors,
         TrackId trackId,
+        const QList<mixxx::CueInfo>& cueInfos,
+        double trackDurationMillis,
         const QObject* pRequester,
         QSize desiredSize) {
     if (!trackId.isValid()) {
@@ -107,8 +111,6 @@ QPixmap OverviewCache::requestUncachedOverview(
     if (m_tracksWithoutOverview.contains(trackId)) {
         return QPixmap();
     }
-
-    // kLogger.info() << "requestUncachedOverview()" << trackId << pRequester << desiredSize;
 
     const QString cacheKey = pixmapCacheKey(trackId, desiredSize, type);
     QPixmap pixmap;
@@ -128,6 +130,8 @@ QPixmap OverviewCache::requestUncachedOverview(
             type,
             signalColors,
             trackId,
+            cueInfos,
+            trackDurationMillis,
             pRequester,
             desiredSize);
     connect(watcher,
@@ -146,9 +150,10 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
         mixxx::OverviewType type,
         const WaveformSignalColors& signalColors,
         TrackId trackId,
+        const QList<mixxx::CueInfo>& cueInfos,
+        double trackDurationMillis,
         const QObject* pRequester,
         QSize desiredSize) {
-    // kLogger.warning() << "prepareOverview" << trackId;
     FutureResult result;
     result.trackId = trackId;
     result.type = type;
@@ -161,9 +166,10 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
     }
 
     mixxx::DbConnectionPooler dbConnectionPooler(pDbConnectionPool);
+    QSqlDatabase database = mixxx::DbConnectionPooled(pDbConnectionPool);
 
     AnalysisDao analysisDao(pConfig);
-    analysisDao.initialize(mixxx::DbConnectionPooled(pDbConnectionPool));
+    analysisDao.initialize(database);
 
     QList<AnalysisDao::AnalysisInfo> analyses =
             analysisDao.getAnalysesForTrackByType(
@@ -182,12 +188,74 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
 
             if (!image.isNull()) {
                 image = resizeImageSize(image, desiredSize);
+                // draw hotcue markers on the resized image for crisp 1px lines
+                // at the final display resolution, matching the deck overview style
+                if (trackDurationMillis > 0 && !cueInfos.isEmpty()) {
+                    drawHotcueMarkers(&image, cueInfos, trackDurationMillis);
+                }
             }
             result.image = image;
         }
     }
 
     return result;
+}
+
+// static
+void OverviewCache::drawHotcueMarkers(
+        QImage* pImage,
+        const QList<mixxx::CueInfo>& cueInfos,
+        double trackDurationMillis) {
+    if (pImage->format() != QImage::Format_ARGB32_Premultiplied) {
+        *pImage = pImage->convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    }
+
+    QPainter markerPainter(pImage);
+    markerPainter.setRenderHint(QPainter::Antialiasing, false);
+    const int imageWidth = pImage->width();
+    const int imageHeight = pImage->height();
+    PainterScope painterScope(&markerPainter);
+    for (const auto& cueInfo : cueInfos) {
+        if (cueInfo.getType() != mixxx::CueType::HotCue) {
+            continue;
+        }
+
+        auto positionMillis = cueInfo.getStartPositionMillis();
+        if (!positionMillis.has_value()) {
+            continue;
+        }
+
+        // allow negative positions (preroll)
+        if (*positionMillis > trackDurationMillis) {
+            continue;
+        }
+
+        const int x = static_cast<int>(
+                (*positionMillis / trackDurationMillis) * imageWidth);
+
+        if (x < 0 || x >= imageWidth) {
+            continue;
+        }
+
+        // use same rendering style as deck overview:
+        // contrasting border line + bright fill line
+        auto color = cueInfo.getColor();
+        if (!color.has_value()) {
+            continue;
+        }
+
+        QColor fillColor = QColor::fromRgb(*color).lighter(110);
+        QColor borderColor = Color::chooseContrastColor(
+                QColor::fromRgb(*color), 120);
+
+        // draw border/shadow line (1px wide, offset by -1)
+        markerPainter.setPen(borderColor);
+        markerPainter.drawLine(x - 1, 0, x - 1, imageHeight);
+
+        // draw main bright marker line (1px wide)
+        markerPainter.setPen(fillColor);
+        markerPainter.drawLine(x, 0, x, imageHeight);
+    }
 }
 
 // watcher

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -16,6 +16,7 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
     Q_OBJECT
   public:
     void onTrackSummaryChanged(TrackId);
+    void invalidateAll();
 
     QPixmap requestCachedOverview(
             mixxx::OverviewType type,
@@ -76,6 +77,10 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
             QImage* pImage,
             const QList<mixxx::CueInfo>& cueInfos,
             double trackDurationMillis);
+
+    static void drawMinuteMarkers(
+            QImage* pImage,
+            const QList<int>& markerXPositions);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -4,6 +4,7 @@
 
 #include "analyzer/analyzerprogress.h"
 #include "preferences/usersettings.h"
+#include "track/cueinfo.h"
 #include "track/trackid.h"
 #include "util/db/dbconnectionpool.h"
 #include "util/singleton.h"
@@ -25,6 +26,8 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
             mixxx::OverviewType type,
             const WaveformSignalColors& signalColors,
             TrackId trackId,
+            const QList<mixxx::CueInfo>& cueInfos,
+            double trackDurationMillis,
             const QObject* pRequester,
             QSize desiredSize);
 
@@ -64,8 +67,15 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
             mixxx::OverviewType type,
             const WaveformSignalColors& signalColors,
             TrackId trackId,
+            const QList<mixxx::CueInfo>& cueInfos,
+            double trackDurationMillis,
             const QObject* pRequester,
             QSize desiredSize);
+
+    static void drawHotcueMarkers(
+            QImage* pImage,
+            const QList<mixxx::CueInfo>& cueInfos,
+            double trackDurationMillis);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/library/tabledelegates/overviewdelegate.cpp
+++ b/src/library/tabledelegates/overviewdelegate.cpp
@@ -7,6 +7,7 @@
 #include "library/overviewcache.h"
 #include "library/trackmodel.h"
 #include "moc_overviewdelegate.cpp"
+#include "track/track.h"
 #include "util/logger.h"
 #include "util/make_const_iterator.h"
 #include "widget/wlibrary.h"
@@ -157,11 +158,27 @@ void OverviewDelegate::paintItem(QPainter* painter,
             // non-cache we can request an update.
             m_cacheMissIds.insert(trackId);
         } else {
-            pixmap = m_pCache->requestUncachedOverview(m_type,
-                    m_signalColors,
-                    trackId,
-                    this,
-                    option.rect.size() * scaleFactor);
+            // extract cue data from the Track in the GUI thread so the
+            // async render job only needs plain values, not a TrackPointer
+            TrackPointer pTrack = m_pTrackModel->getTrack(index);
+            if (pTrack) {
+                const double trackDurationMillis = pTrack->getDuration() * 1000.0;
+                const mixxx::audio::SampleRate sampleRate = pTrack->getSampleRate();
+                QList<mixxx::CueInfo> cueInfos;
+                const QList<CuePointer> cuePoints = pTrack->getCuePoints();
+                for (const auto& pCue : cuePoints) {
+                    if (pCue) {
+                        cueInfos.append(pCue->getCueInfo(sampleRate));
+                    }
+                }
+                pixmap = m_pCache->requestUncachedOverview(m_type,
+                        m_signalColors,
+                        trackId,
+                        cueInfos,
+                        trackDurationMillis,
+                        this,
+                        option.rect.size() * scaleFactor);
+            }
         }
         paintItemBackground(painter, option, index);
     } else {

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -6,6 +6,7 @@
 #include "control/controlpushbutton.h"
 #include "library/dao/analysisdao.h"
 #include "library/library.h"
+#include "library/overviewcache.h"
 #include "moc_dlgprefwaveform.cpp"
 #include "preferences/waveformsettings.h"
 #include "util/db/dbconnectionpooled.h"
@@ -89,6 +90,10 @@ DlgPrefWaveform::DlgPrefWaveform(
     m_pOverviewMinuteMarkersControl = std::make_unique<ControlObject>(
             ConfigKey(kWaveformGroup, QStringLiteral("draw_overview_minute_markers")));
     m_pOverviewMinuteMarkersControl->setReadOnly();
+
+    m_pOverviewLibraryMinuteMarkersControl = std::make_unique<ControlObject>(
+            ConfigKey(kWaveformGroup, QStringLiteral("draw_library_overview_minute_markers")));
+    m_pOverviewLibraryMinuteMarkersControl->setReadOnly();
 
     // Populate untilMark options
     untilMarkAlignComboBox->addItem(tr("Top"));
@@ -202,6 +207,10 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QCheckBox::toggled,
             this,
             &DlgPrefWaveform::slotSetOverviewMinuteMarkers);
+    connect(overviewLibraryMinuteMarkersCheckBox,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefWaveform::slotSetOverviewLibraryMinuteMarkers);
     connect(overviewStereoCheckBox,
             &QCheckBox::toggled,
             this,
@@ -389,6 +398,11 @@ void DlgPrefWaveform::slotUpdate() {
     overviewMinuteMarkersCheckBox->setChecked(drawOverviewMinuteMarkers);
     m_pOverviewMinuteMarkersControl->forceSet(drawOverviewMinuteMarkers);
 
+    bool drawLibraryOverviewMinuteMarkers = m_pConfig->getValue(
+            ConfigKey(kWaveformGroup, QStringLiteral("draw_library_overview_minute_markers")), true);
+    overviewLibraryMinuteMarkersCheckBox->setChecked(drawLibraryOverviewMinuteMarkers);
+    m_pOverviewLibraryMinuteMarkersControl->forceSet(drawLibraryOverviewMinuteMarkers);
+
     WaveformSettings waveformSettings(m_pConfig);
     enableWaveformCaching->setChecked(waveformSettings.waveformCachingEnabled());
     enableWaveformGenerationWithAnalysis->setChecked(
@@ -448,6 +462,7 @@ void DlgPrefWaveform::slotResetToDefaults() {
 
     // Show minute markers.
     overviewMinuteMarkersCheckBox->setChecked(true);
+    overviewLibraryMinuteMarkersCheckBox->setChecked(true);
 
     // Use "Global" waveform gain + ReplayGain if enabled
     overview_scale_allReplayGain->setChecked(!WaveformWidgetFactory::isOverviewNormalizedDefault());
@@ -734,6 +749,14 @@ void DlgPrefWaveform::slotSetOverviewMinuteMarkers(bool draw) {
                                 QStringLiteral("draw_overview_minute_markers")),
             draw);
     m_pOverviewMinuteMarkersControl->forceSet(draw);
+}
+
+void DlgPrefWaveform::slotSetOverviewLibraryMinuteMarkers(bool draw) {
+    m_pConfig->setValue(ConfigKey(kWaveformGroup,
+                                QStringLiteral("draw_library_overview_minute_markers")),
+            draw);
+    m_pOverviewLibraryMinuteMarkersControl->forceSet(draw);
+    OverviewCache::instance()->invalidateAll();
 }
 
 void DlgPrefWaveform::slotSetOverviewStereoMode(bool stereo) {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -68,6 +68,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetWaveformOverviewType();
     void slotSetOverviewStereoMode(bool mono);
     void slotSetOverviewMinuteMarkers(bool minuteMarkers);
+    void slotSetOverviewLibraryMinuteMarkers(bool minuteMarkers);
     void slotSetOverviewScaling();
 
   private:
@@ -86,6 +87,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
 
     std::unique_ptr<ControlPushButton> m_pTypeControl;
     std::unique_ptr<ControlObject> m_pOverviewMinuteMarkersControl;
+    std::unique_ptr<ControlObject> m_pOverviewLibraryMinuteMarkersControl;
     std::unique_ptr<ControlObject> m_pOverviewStereoControl;
 
     UserSettingsPointer m_pConfig;

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -740,7 +740,7 @@ Select from different types of displays for the waveform overview, which differ 
      <item row="1" column="1" colspan="4">
       <widget class="QCheckBox" name="overviewStereoCheckBox">
        <property name="text">
-        <string>Stereo mode</string>
+        <string>Stereo deck overviews</string>
        </property>
       </widget>
      </item>
@@ -748,12 +748,20 @@ Select from different types of displays for the waveform overview, which differ 
      <item row="2" column="1" colspan="4">
       <widget class="QCheckBox" name="overviewMinuteMarkersCheckBox">
        <property name="text">
-        <string>Show minute markers on waveform overview</string>
+        <string>Show minute markers on deck overviews</string>
        </property>
       </widget>
      </item>
 
-     <item row="3" column="0">
+     <item row="3" column="1" colspan="4">
+      <widget class="QCheckBox" name="overviewLibraryMinuteMarkersCheckBox">
+       <property name="text">
+        <string>Show minute markers on library overviews</string>
+       </property>
+      </widget>
+     </item>
+
+     <item row="4" column="0">
       <widget class="QLabel" name="overview_gain_label">
        <property name="toolTip">
         <string extracomment="Select a gain mode for the waveform overview."/>
@@ -763,7 +771,7 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="3" column="1" colspan="4">
+     <item row="4" column="1" colspan="4">
       <widget class="QRadioButton" name="overview_scale_normalize">
        <property name="text">
         <string>Normalize to peak</string>
@@ -773,7 +781,7 @@ Select from different types of displays for the waveform overview, which differ 
        </attribute>
       </widget>
      </item>
-     <item row="4" column="1" colspan="4">
+     <item row="5" column="1" colspan="4">
       <widget class="QRadioButton" name="overview_scale_allReplayGain">
        <property name="text">
         <string extracomment="'Global' refers to the 'Global' visual gain in the scrolling waveform settings">Use Waveform "Global" gain and ReplayGain (if enabled)</string>
@@ -929,6 +937,7 @@ Select from different types of displays for the waveform overview, which differ 
   <tabstop>waveformOverviewComboBox</tabstop>
   <tabstop>overviewStereoCheckBox</tabstop>
   <tabstop>overviewMinuteMarkersCheckBox</tabstop>
+  <tabstop>overviewLibraryMinuteMarkersCheckBox</tabstop>
   <tabstop>overview_scale_normalize</tabstop>
   <tabstop>overview_scale_allReplayGain</tabstop>
   <tabstop>enableWaveformCaching</tabstop>


### PR DESCRIPTION
generated with GLM-5.2

- adds minute marker rendering to the library overview waveform column, gated on the existing `[Waveform],draw_overview_minute_markers` preference
- markers are drawn proportionally at 60-second intervals as 2px white lines at the top and bottom of the waveform, matching the deck overview style
- adds a `drawMinuteMarkers` parameter to `waveformOverviewRenderer::render()`
- depends on #15514 (hotcues-on-overview) for the `TrackPointer` API and `trackDurationMillis` plumbing in `OverviewCache`

generated with GLM-5.2