### PR TITLE
(fix) Search: correct `location` shortcut "loc" -> "lo"

### DIFF
--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -347,7 +347,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             const QString locationPathWithTerminator =
                     locationPath + QChar('/');
             const QString searchQuery =
-                    QStringLiteral("loc:") +
+                    QStringLiteral("lo:") +
                     quoteSearchQueryText(locationPathWithTerminator);
             addTriggerSearchAction(
                     &addSeparatorBeforeNextAction,


### PR DESCRIPTION
Closes #16968 

Fixes the regression I caused with #16920 