### PR TITLE
Update common-controller-scripts.js

### DIFF
--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -197,7 +197,7 @@ script.midiDebug = function(channel, control, value, status, group) {
 // Returns the deck number of a "ChannelN" or "SamplerN" group
 script.deckFromGroup = function(group) {
     let deck = 0;
-    if (group.substring(2, 8) === "hannel") {
+    if (group.substring(2, 8) === "channel") {
         // Extract deck number from the group text
         deck = group.substring(8, group.length - 1);
     }


### PR DESCRIPTION
typo "hannel" should be "channel"

line 200       if (group.substring(2, 8) === "hannel") {