### PR TITLE
common-controllerscripts.js: improve performance of `deckFromGroup()`

### DIFF
--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -203,23 +203,23 @@ script.channelFromStem = function(stem) {
     return `${stem.substring(0, 9)}]`;
 };
 
-// Returns the deck number of a "ChannelN" or "SamplerN" group
+// Returns the deck number of a "[ChannelN]" group
 script.deckFromGroup = function(group) {
     let deck = 0;
     if (group === undefined) {
         return undefined;
     }
-    if (group.substring(2, 8) === "hannel") {
+    if (group.startsWith("[Channel")) {
         // Extract deck number from the group text
-        deck = group.substring(8, group.length - 1);
+        deck = group.slice(8, -1);
     }
     /*
-        else if (group.substring(2,8)=="ampler") {
+        else if (group.startsWith("[Sampler")) {
             // Extract sampler number from the group text
-            deck = group.substring(8,group.length-1);
+            deck = group.slice(8, -1);
         }
     */
-    return parseInt(deck);
+    return parseInt(deck, 10);
 };
 
 /* -------- ------------------------------------------------------


### PR DESCRIPTION
When looking at #16974 I remember that Qt's QString::startsWith() was reported to be faster that other methods, so I wondered if this applies to the js method, too.

-> Many scripts use `deckFromGroup()` to get the deck number for `engine.scratchTick()`, ie. for wheel turn mapping swhich get called at high rate, so make this more performant is welcome, no?

* `startswith("abc")` is apparently twice as fast as `substring(0, 3) === "abc"` since it checks the buffered string and doesn't create a copy
* with `slice(8, -1)` the engine doesn't need to compute `length - 1`

I only compared this in jsbench.me, not sure if this fully applies to QJSEngine, too.
If someone can verify we can change the other occurences of `substring()` as well.