### PR TITLE
SoundSource: do not warn when .m4a is sniffed as video/mp4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [2.7.0](https://github.com/mixxxdj/mixxx/milestone/47) (Unreleased)
 
+### Library
+
+* Do not warn when .m4a files are sniffed as video/mp4
+
 ## [2.6.0](https://github.com/mixxxdj/mixxx/milestone/44) (Unreleased)
 
 ### STEM file support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Library
 
-* Do not warn when .m4a files are sniffed as video/mp4
+* Do not warn when .m4a files are sniffed as video/mp4 [#16976](https://github.com/mixxxdj/mixxx/pull/16976)
 
 ## [2.6.0](https://github.com/mixxxdj/mixxx/milestone/44) (Unreleased)
 

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -23,6 +23,25 @@ inline QUrl validateLocalFileUrl(QUrl url) {
     return url;
 }
 
+// audio/mp4 (.m4a) and video/mp4 (.mp4) are the same ISO BMFF / MPEG-4
+// Part 14 container. Qt's content sniffer picks one or the other from the
+// ftyp brand, so a valid audio-only .m4a is often reported as video/mp4.
+bool isIsoBmffMpeg4MimeType(const QMimeType& mimeType) {
+    return mimeType.inherits(QStringLiteral("audio/mp4")) ||
+            mimeType.inherits(QStringLiteral("video/mp4"));
+}
+
+bool fileSuffixIsCompatibleWithMimeType(
+        const QString& fileSuffix, const QMimeType& mimeType) {
+    if (mimeType.suffixes().contains(fileSuffix)) {
+        return true;
+    }
+    const QMimeType suffixMimeType = QMimeDatabase().mimeTypeForFile(
+            QStringLiteral("x.") + fileSuffix, QMimeDatabase::MatchExtension);
+    return isIsoBmffMpeg4MimeType(mimeType) &&
+            isIsoBmffMpeg4MimeType(suffixMimeType);
+}
+
 } // anonymous namespace
 
 //static
@@ -87,7 +106,8 @@ QString SoundSource::getTypeFromFile(const QFileInfo& fileInfo) {
         qWarning() << "No file type registered for MIME type" << mimeType;
         return fileSuffix;
     }
-    if (fileType != fileSuffix && !mimeType.suffixes().contains(fileSuffix)) {
+    if (fileType != fileSuffix &&
+            !fileSuffixIsCompatibleWithMimeType(fileSuffix, mimeType)) {
         qWarning()
                 << "Using type" << fileType
                 << "instead of" << fileSuffix

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -1,3 +1,4 @@
+#include <QFile>
 #include <QTemporaryDir>
 #include <QTemporaryFile>
 #include <QtDebug>
@@ -981,6 +982,59 @@ TEST_F(SoundSourceProxyTest, getTypeFromAiffFile) {
     EXPECT_STREQ(qPrintable("aiff"),
             qPrintable(mixxx::SoundSource::getTypeFromFile(
                     QFileInfo(aiffFilePathWithShortenedSuffix))));
+}
+
+TEST_F(SoundSourceProxyTest, getTypeFromMpeg4AudioFile) {
+    // .m4a and .mp4 are the same ISO BMFF container. Qt may sniff the
+    // contents as audio/mp4 or video/mp4 depending on the ftyp brand,
+    // which Mixxx maps to file types "m4a" and "mp4" respectively.
+    // Either result is correct; a mismatched suffix must not matter.
+    if (!SoundSourceProxy::isFileTypeSupported(QStringLiteral("m4a")) &&
+            !SoundSourceProxy::isFileTypeSupported(QStringLiteral("mp4"))) {
+        return;
+    }
+
+    const QString m4aFilePath = getTestDir().filePath(
+            QStringLiteral("id3-test-data/cover-test-itunes-12.3.0-aac.m4a"));
+    ASSERT_TRUE(QFileInfo::exists(m4aFilePath));
+
+    const QString typeFromM4aSuffix =
+            mixxx::SoundSource::getTypeFromFile(QFileInfo(m4aFilePath));
+    EXPECT_TRUE(typeFromM4aSuffix == QLatin1String("m4a") ||
+            typeFromM4aSuffix == QLatin1String("mp4"))
+            << qPrintable(typeFromM4aSuffix);
+
+    QTemporaryDir tempDir;
+    ASSERT_TRUE(tempDir.isValid());
+    const QString mp4FilePath = tempDir.filePath(QStringLiteral("cover-test.mp4"));
+    mixxxtest::copyFile(m4aFilePath, mp4FilePath);
+
+    const QString typeFromMp4Suffix =
+            mixxx::SoundSource::getTypeFromFile(QFileInfo(mp4FilePath));
+    EXPECT_EQ(typeFromM4aSuffix, typeFromMp4Suffix);
+
+    // Streaming downloads often use a generic ISO BMFF ftyp (isom/mp42)
+    // instead of Apple's "M4A " brand. Qt then reports video/mp4 for a
+    // .m4a file. Mixxx should still accept that without treating it as a
+    // mismatched suffix.
+    QFile srcFile(m4aFilePath);
+    ASSERT_TRUE(srcFile.open(QIODevice::ReadOnly));
+    QByteArray bytes = srcFile.readAll();
+    srcFile.close();
+    const int ftypOffset = bytes.indexOf("ftyp");
+    ASSERT_GE(ftypOffset, 0);
+    bytes.replace(ftypOffset + 4, 4, "isom");
+    const QString isomM4aPath = tempDir.filePath(QStringLiteral("generic-isom.m4a"));
+    QFile destFile(isomM4aPath);
+    ASSERT_TRUE(destFile.open(QIODevice::WriteOnly));
+    ASSERT_EQ(destFile.write(bytes), bytes.size());
+    destFile.close();
+
+    const QString typeFromIsomM4a =
+            mixxx::SoundSource::getTypeFromFile(QFileInfo(isomM4aPath));
+    EXPECT_TRUE(typeFromIsomM4a == QLatin1String("m4a") ||
+            typeFromIsomM4a == QLatin1String("mp4"))
+            << qPrintable(typeFromIsomM4a);
 }
 
 TEST_F(SoundSourceProxyTest, updateTrackFromSourceFileMissing) {


### PR DESCRIPTION
Library scans of AAC/M4A collections (Tidal downloads in particular) flood `mixxx.log` with one warning per track:

    warning [Thread (pooled)] Using type "mp4" instead of "m4a" according to the detected MIME type QMimeType("video/mp4") of file ".../track.m4a"

`.m4a` and `.mp4` are the same ISO BMFF / MPEG-4 Part 14 container. Qt's content sniffer picks `audio/mp4` or `video/mp4` from the `ftyp` brand:

* Apple/iTunes files use `M4A ` → `audio/mp4` → Mixxx type `m4a`
* Tidal and other downloaders often use generic `isom` / `mp42` → `video/mp4` → Mixxx type `mp4`

Both types use the same decoder. The warning is a false positive.

This keeps using the content-based Mixxx type (`mp4` when Qt reports `video/mp4`). It only skips the warning when the file suffix's MIME type and the sniffed MIME type are both MPEG-4 (`audio/mp4` or `video/mp4`). Real mismatches, such as an MP3 named `.aiff`, still warn.

I did **not**:

* Register `.m4a` as a `video/mp4` suffix (wrong semantically, and Mixxx maps each MIME type to one file type).
* Early-return `"m4a"` the way we do for `.flac` / `.opus` (that would skip STEM detection for `.m4a` stems).

Tested with `SoundSourceProxyTest.getTypeFromMpeg4AudioFile` (including an `ftyp` rewrite to `isom`) and `handleWrongFileSuffix`.

This is a logging-only change and could be backported to 2.6 if desired.