### PR TITLE
Library: defer opening audio files until playback or analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [2.7.0](https://github.com/mixxxdj/mixxx/milestone/47) (Unreleased)
 
+### Library
+
+* Defer opening audio files until playback or analysis so library menus and
+  track loads stay fast on remote filesystems
+
 ## [2.6.0](https://github.com/mixxxdj/mixxx/milestone/44) (Unreleased)
 
 ### STEM file support

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1591,28 +1591,36 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
                 SoundSourceProxy::UpdateTrackFromSourceMode::Newer;
     }
     DEBUG_ASSERT(!pTrack->isDirty());
-    const auto sourceSynchronizedAtBefore = pTrack->getSourceSynchronizedAt();
-    const auto result =
-            SoundSourceProxy(pTrack).updateTrackFromSource(
-                    updateTrackFromSourceMode,
-                    SyncTrackMetadataParams::readFromUserSettings(*m_pConfig));
-    if (result == SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated) {
-        // At least the source synchronization time stamp must have changed
-        DEBUG_ASSERT(pTrack->isDirty());
-        const auto sourceSynchronizedAtAfter = pTrack->getSourceSynchronizedAt();
-        DEBUG_ASSERT(sourceSynchronizedAtAfter.isValid());
-        if (sourceSynchronizedAtBefore.isValid()) {
-            // Only log subsequent re-imports but not the initial import of metadata
-            DEBUG_ASSERT(updateTrackFromSourceMode ==
-                    SoundSourceProxy::UpdateTrackFromSourceMode::Newer);
-            DEBUG_ASSERT(sourceSynchronizedAtBefore < sourceSynchronizedAtAfter);
-            kLogger.info()
-                    << "Re-imported and updated outdated track metadata in library ("
-                    << sourceSynchronizedAtBefore.toString(Qt::ISODateWithMs)
-                    << ") with tags from modified file ("
-                    << sourceSynchronizedAtAfter.toString(Qt::ISODateWithMs)
-                    << "):"
-                    << pTrack->getMetadata();
+    // Skip constructing SoundSourceProxy (which may sniff file contents)
+    // when Once-mode has nothing to do.
+    const bool skipUpdateFromSource =
+            updateTrackFromSourceMode ==
+                    SoundSourceProxy::UpdateTrackFromSourceMode::Once &&
+            pTrack->hasImportedMetadataFromSource();
+    if (!skipUpdateFromSource) {
+        const auto sourceSynchronizedAtBefore = pTrack->getSourceSynchronizedAt();
+        const auto result =
+                SoundSourceProxy(pTrack).updateTrackFromSource(
+                        updateTrackFromSourceMode,
+                        SyncTrackMetadataParams::readFromUserSettings(*m_pConfig));
+        if (result == SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated) {
+            // At least the source synchronization time stamp must have changed
+            DEBUG_ASSERT(pTrack->isDirty());
+            const auto sourceSynchronizedAtAfter = pTrack->getSourceSynchronizedAt();
+            DEBUG_ASSERT(sourceSynchronizedAtAfter.isValid());
+            if (sourceSynchronizedAtBefore.isValid()) {
+                // Only log subsequent re-imports but not the initial import of metadata
+                DEBUG_ASSERT(updateTrackFromSourceMode ==
+                        SoundSourceProxy::UpdateTrackFromSourceMode::Newer);
+                DEBUG_ASSERT(sourceSynchronizedAtBefore < sourceSynchronizedAtAfter);
+                kLogger.info()
+                        << "Re-imported and updated outdated track metadata in library ("
+                        << sourceSynchronizedAtBefore.toString(Qt::ISODateWithMs)
+                        << ") with tags from modified file ("
+                        << sourceSynchronizedAtAfter.toString(Qt::ISODateWithMs)
+                        << "):"
+                        << pTrack->getMetadata();
+            }
         }
     }
 

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -436,10 +436,29 @@ SoundSourceProxy::SoundSourceProxy(
     initSoundSourceWithProvider(std::move(pProvider));
 }
 
+namespace {
+
+QList<mixxx::SoundSourceProviderRegistration> providerRegistrationsForTrack(
+        const TrackPointer& pTrack,
+        const QUrl& url) {
+    if (!pTrack) {
+        return {};
+    }
+    // Tracks already in the library know their file type. Trust that
+    // instead of sniffing file contents (MatchContent opens the file).
+    const QString fileType = pTrack->getType();
+    if (!fileType.isEmpty() && SoundSourceProxy::isFileTypeSupported(fileType)) {
+        return SoundSourceProxy::allProviderRegistrationsForFileType(fileType);
+    }
+    return SoundSourceProxy::allProviderRegistrationsForUrl(url);
+}
+
+} // namespace
+
 SoundSourceProxy::SoundSourceProxy(TrackPointer pTrack)
         : m_pTrack(std::move(pTrack)),
           m_url(m_pTrack ? m_pTrack->getFileInfo().toQUrl() : QUrl()),
-          m_providerRegistrations(allProviderRegistrationsForUrl(m_url)) {
+          m_providerRegistrations(providerRegistrationsForTrack(m_pTrack, m_url)) {
     findProviderAndInitSoundSource();
 }
 
@@ -641,6 +660,12 @@ SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromS
 
     if (getUrl().isEmpty()) {
         // Silently skip tracks without a corresponding file
+        return UpdateTrackFromSourceResult::NotUpdated;
+    }
+    // Once = import file tags only if Mixxx has never done so. Do not stat or
+    // parse the file on every library load just to merge "extra" tag fields.
+    if (mode == UpdateTrackFromSourceMode::Once &&
+            m_pTrack->hasImportedMetadataFromSource()) {
         return UpdateTrackFromSourceResult::NotUpdated;
     }
     if (!m_pSoundSource) {

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -1022,19 +1022,15 @@ TEST_F(SoundSourceProxyTest, handleWrongFileSuffix) {
             SoundSourceProxy::UpdateTrackFromSourceResult::MetadataImportedAndUpdated);
     EXPECT_STREQ(qPrintable(contentFileType), qPrintable(pTrack->getType()));
 
-    // Change the file type back to the wrong file type after the initial import
-    // and update from source once again to verify that the wrong type gets updated
-    // to the correct type.
+    // Change the file type back to the wrong file type after the initial import.
     pTrack->setType(wrongFileType);
-    // The re-import of metadata should be skipped with UpdateTrackFromSourceMode::Once
-    // and updateTrackFromSource() is supposed to return false.
+    // Once-mode must not reopen the file after a successful import. That
+    // keeps library operations fast on remote filesystems.
     ASSERT_EQ(SoundSourceProxy(pTrack).updateTrackFromSource(
                       SoundSourceProxy::UpdateTrackFromSourceMode::Once,
                       SyncTrackMetadataParams{}),
             SoundSourceProxy::UpdateTrackFromSourceResult::NotUpdated);
-    // But even though updateTrackFromSource() returned false the wrong file type
-    // should have been fixed.
-    EXPECT_STREQ(qPrintable(contentFileType), qPrintable(pTrack->getType()));
+    EXPECT_STREQ(qPrintable(wrongFileType), qPrintable(pTrack->getType()));
 }
 
 TEST_F(SoundSourceProxyTest, fileTypeWithCorrespondingSuffix) {

--- a/src/test/trackreftest.cpp
+++ b/src/test/trackreftest.cpp
@@ -71,6 +71,17 @@ TEST_F(TrackRefTest, FromFileInfoWithoutId) {
     EXPECT_EQ(m_invalidTrackId, actual.getId());
 }
 
+TEST_F(TrackRefTest, FromLocationAndIdDoesNotRequireCanonicalPath) {
+    const TrackRef actual(TrackRef::fromLocationAndId(
+            m_tempFileInfo.location(), m_validTrackId));
+
+    EXPECT_EQ(m_tempFileInfo.location(), actual.getLocation());
+    EXPECT_FALSE(actual.hasCanonicalLocation());
+    EXPECT_TRUE(actual.hasId());
+    EXPECT_EQ(m_validTrackId, actual.getId());
+    EXPECT_TRUE(actual.isValid());
+}
+
 TEST_F(TrackRefTest, CopyAndSetId) {
     const TrackRef withoutId(
             TrackRef::fromFileInfo(m_tempFileInfo));

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -32,6 +32,12 @@ constexpr bool kLogStats = false;
 
 inline
 TrackRef createTrackRef(const Track& track) {
+    // Tracks already in the library are identified by database id. Resolving
+    // the canonical path would hit the file system (costly on remote mounts)
+    // and is only required to detect duplicate files not yet stored in the DB.
+    if (track.getId().isValid()) {
+        return TrackRef::fromLocationAndId(track.getLocation(), track.getId());
+    }
     return TrackRef::fromFileInfo(track.getFileInfo(), track.getId());
 }
 
@@ -215,7 +221,8 @@ void GlobalTrackCacheResolver::initTrackIdAndUnlockCache(TrackId trackId) {
         DEBUG_ASSERT(m_trackRef.getId() == trackId);
     }
     unlockCache();
-    DEBUG_ASSERT(m_trackRef == createTrackRef(*m_strongPtr));
+    DEBUG_ASSERT(m_trackRef.getId() == m_strongPtr->getId());
+    DEBUG_ASSERT(m_trackRef.getLocation() == m_strongPtr->getLocation());
 }
 
 //static
@@ -594,6 +601,17 @@ void GlobalTrackCache::resolve(
                     std::move(trackRef));
             return;
         }
+        // Known library track, not yet in the cache. Identify it by database
+        // id and stored location without resolving the canonical path.
+        TrackRef trackRef = TrackRef::fromLocationAndId(
+                fileAccess.info().location(), trackId);
+        if (debugLogEnabled()) {
+            kLogger.debug()
+                    << "Cache miss - allocating library track without canonical path"
+                    << trackRef;
+        }
+        allocateNewTrack(pCacheResolver, std::move(fileAccess), std::move(trackRef));
+        return;
     }
     // Secondary lookup by canonical location
     // The TrackRef is constructed now after the lookup by ID failed to
@@ -638,6 +656,13 @@ void GlobalTrackCache::resolve(
             return;
         }
     }
+    allocateNewTrack(pCacheResolver, std::move(fileAccess), std::move(trackRef));
+}
+
+void GlobalTrackCache::allocateNewTrack(
+        GlobalTrackCacheResolver* pCacheResolver,
+        mixxx::FileAccess fileAccess,
+        TrackRef trackRef) {
     if (!m_pSaver) {
         // Do not allocate any new tracks once the cache
         // has been deactivated
@@ -652,10 +677,11 @@ void GlobalTrackCache::resolve(
                 << "Cache miss - allocating track"
                 << trackRef;
     }
+    const TrackId trackId = trackRef.getId();
     auto deletingPtr = std::unique_ptr<Track, GlobalTrackCacheEntry::TrackDeleter>(
             new Track(
                     std::move(fileAccess),
-                    std::move(trackId)),
+                    trackId),
             GlobalTrackCacheEntry::TrackDeleter(m_deleteTrackFn));
 
     auto cacheEntryPtr = std::make_shared<GlobalTrackCacheEntry>(
@@ -787,7 +813,10 @@ TrackRef GlobalTrackCache::initTrackId(
             pDel->getCacheEntryPointer()));
 
     strongPtr->initId(trackId);
-    DEBUG_ASSERT(createTrackRef(*strongPtr) == trackRefWithId);
+    // Library tracks are identified by id + location. Canonical path is
+    // not required after the id has been assigned.
+    DEBUG_ASSERT(strongPtr->getId() == trackId);
+    DEBUG_ASSERT(strongPtr->getLocation() == trackRefWithId.getLocation());
     DEBUG_ASSERT(m_tracksById.find(trackId) != m_tracksById.end());
 
     return trackRefWithId;
@@ -892,6 +921,19 @@ bool GlobalTrackCache::tryEvict(Track* plainPtr) {
                 evicted = true;
             } else {
                 notEvicted = true;
+            }
+        }
+    } else {
+        // Library tracks may have been inserted into the canonical-location
+        // index before they received a database id. createTrackRef() no longer
+        // resolves that path for id-based tracks, so fall back to a pointer scan.
+        for (auto it = m_tracksByCanonicalLocation.begin();
+                it != m_tracksByCanonicalLocation.end();
+                ++it) {
+            if (it->second->getPlainPtr() == plainPtr) {
+                m_tracksByCanonicalLocation.erase(it);
+                evicted = true;
+                break;
             }
         }
     }

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -250,6 +250,11 @@ class GlobalTrackCache : public QObject {
             mixxx::FileAccess fileAccess,
             TrackId trackId);
 
+    void allocateNewTrack(
+            GlobalTrackCacheResolver* pCacheResolver,
+            mixxx::FileAccess fileAccess,
+            TrackRef trackRef);
+
     void resolveTemporary(
             GlobalTrackCacheResolver* /*in/out*/ pCacheResolver,
             mixxx::FileAccess fileAccess);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -551,6 +551,11 @@ bool Track::checkSourceSynchronized() const {
             mixxx::TrackRecord::SourceSyncStatus::Synchronized;
 }
 
+bool Track::hasImportedMetadataFromSource() const {
+    const auto locked = lockMutex(&m_qMutex);
+    return m_record.hasImportedMetadataFromSource();
+}
+
 void Track::setSourceSynchronizedAt(const QDateTime& sourceSynchronizedAt) {
     DEBUG_ASSERT(!sourceSynchronizedAt.isValid() ||
             sourceSynchronizedAt.timeSpec() == Qt::UTC);

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -171,7 +171,12 @@ class Track : public QObject {
 
     /// Checks if the internal metadata is in-sync with the
     /// metadata stored in file tags.
+    /// Accesses the file system (mtime / exists).
     bool checkSourceSynchronized() const;
+
+    /// True if file tags have been imported at least once.
+    /// Does not access the file system.
+    bool hasImportedMetadataFromSource() const;
 
     // The date/time of the last import or export of metadata
     void setSourceSynchronizedAt(const QDateTime& sourceSynchronizedAt);

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -122,6 +122,12 @@ class TrackRecord final {
     };
     SourceSyncStatus checkSourceSyncStatus(
             const FileInfo& fileInfo) const;
+
+    /// True if Mixxx has imported file tags at least once.
+    /// Does not access the file system.
+    bool hasImportedMetadataFromSource() const {
+        return m_headerParsed || getSourceSynchronizedAt().isValid();
+    }
     bool replaceMetadataFromSource(
             TrackMetadata&& importedMetadata,
             const QDateTime& sourceSynchronizedAt);

--- a/src/track/trackref.h
+++ b/src/track/trackref.h
@@ -12,6 +12,16 @@
 // value object. Only the id can be set once.
 class TrackRef final {
   public:
+    /// Identify a library track by its stored location and database id
+    /// without resolving the canonical path. Does not access the file system.
+    static TrackRef fromLocationAndId(
+            QString location,
+            TrackId id) {
+        DEBUG_ASSERT(!location.isEmpty());
+        DEBUG_ASSERT(id.isValid());
+        return TrackRef(std::move(location), QString(), std::move(id));
+    }
+
     /// Converts a file path and an optional TrackId into a TrackRef.
     ///
     /// This involves and intermediate creation of mixxx::FileInfo

--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -242,6 +242,12 @@ SecurityTokenPointer Sandbox::openSecurityToken(mixxx::FileInfo* pFileInfo, bool
     VERIFY_OR_DEBUG_ASSERT(pFileInfo) {
         return nullptr;
     }
+    // Canonical path resolution hits the file system. Skip it when the
+    // process is not sandboxed (Linux/Windows) so library operations on
+    // remote mounts do not block on stat/realpath.
+    if (!enabled()) {
+        return nullptr;
+    }
     const auto canonicalLocation = pFileInfo->resolveCanonicalLocation();
     if (canonicalLocation.isEmpty()) {
         return nullptr;
@@ -253,10 +259,6 @@ SecurityTokenPointer Sandbox::openSecurityToken(mixxx::FileInfo* pFileInfo, bool
 
     if (sDebug) {
         qDebug() << "openSecurityToken for file" << canonicalLocation << create;
-    }
-
-    if (!enabled()) {
-        return nullptr;
     }
 
     const auto locker = lockMutex(&s_mutex);

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -119,6 +119,7 @@ WTrackMenu::WTrackMenu(
           m_bFindOnWebMenuLoaded(false),
           m_bPlaylistMenuLoaded(false),
           m_bCrateMenuLoaded(false),
+          m_bLoadToMenuLoaded(false),
           m_eActiveFeatures(flags),
           m_eTrackModelFeatures(Feature::TrackModelFeatures) {
     // Warn if any of the chosen features depend on a TrackModel
@@ -178,6 +179,7 @@ void WTrackMenu::createMenus() {
         m_pDeckMenu->setTitle(tr("Deck"));
         m_pSamplerMenu = make_parented<QMenu>(m_pLoadToMenu);
         m_pSamplerMenu->setTitle(tr("Sampler"));
+        connect(m_pLoadToMenu, &QMenu::aboutToShow, this, &WTrackMenu::slotPopulateLoadToMenu);
     }
 
     if (featureIsEnabled(Feature::Playlist)) {
@@ -1002,17 +1004,12 @@ void WTrackMenu::updateMenus() {
         return;
     }
 
-    if (m_pLoadToMenu) {
-        m_pLoadToMenu->clear();
-    }
-
     // Gray out some stuff if multiple songs were selected.
     const bool singleTrackSelected = getTrackCount() == 1;
 
-    auto pTrack = getFirstTrackPointer();
-    VERIFY_OR_DEBUG_ASSERT(pTrack) {
-        return;
-    }
+    // Do not load a Track (which may open the audio file) just to show this
+    // menu. Playlist/crate actions only need TrackIds from the table model.
+    // Load-to, Search Related, and Find on Web populate on hover.
 
     if (featureIsEnabled(Feature::SearchRelated)) {
         m_bSearchRelatedMenuLoaded = false;
@@ -1023,86 +1020,7 @@ void WTrackMenu::updateMenus() {
     }
 
     if (featureIsEnabled(Feature::LoadTo)) {
-        // Enable menus only for single track
-        int iNumDecks = static_cast<int>(m_pNumDecks.get());
-        m_pDeckMenu->clear();
-        m_pDeckMenu->setEnabled(singleTrackSelected);
-        if (singleTrackSelected && iNumDecks > 0) {
-            for (int i = 1; i <= iNumDecks; ++i) {
-                // PlayerManager::groupForDeck is 0-indexed.
-                QString deckGroup = PlayerManager::groupForDeck(i - 1);
-                bool deckPlaying = ControlObject::get(
-                                           ConfigKey(deckGroup, "play")) > 0.0;
-                bool allowLoadTrackIntoPlayingDeck = false;
-                if (m_pConfig->exists(kConfigKeyLoadWhenDeckPlaying)) {
-                    int loadWhenDeckPlaying =
-                            m_pConfig->getValueString(kConfigKeyLoadWhenDeckPlaying).toInt();
-                    switch (static_cast<LoadWhenDeckPlaying>(loadWhenDeckPlaying)) {
-                    case LoadWhenDeckPlaying::Allow:
-                    case LoadWhenDeckPlaying::AllowButStopDeck:
-                        allowLoadTrackIntoPlayingDeck = true;
-                        break;
-                    case LoadWhenDeckPlaying::Reject:
-                        break;
-                    }
-                } else {
-                    // support older version of this flag
-                    allowLoadTrackIntoPlayingDeck = m_pConfig->getValue<bool>(
-                            ConfigKey("[Controls]", "AllowTrackLoadToPlayingDeck"));
-                }
-                bool deckEnabled =
-                        (!deckPlaying || allowLoadTrackIntoPlayingDeck) &&
-                        singleTrackSelected;
-                generateTrackLoadMenu(deckGroup,
-                        tr("Deck %1").arg(i),
-                        pTrack,
-                        m_pDeckMenu,
-                        true,
-                        deckEnabled);
-            }
-        }
-        m_pLoadToMenu->addMenu(m_pDeckMenu);
-
-        int iNumSamplers = static_cast<int>(m_pNumSamplers.get());
-        const int maxSamplersPerMenu = 16;
-        m_pSamplerMenu->clear();
-        m_pSamplerMenu->setEnabled(singleTrackSelected);
-        if (singleTrackSelected && iNumSamplers > 0) {
-            QMenu* pMenu = m_pSamplerMenu;
-            int samplersInMenu = 0;
-            for (int i = 1; i <= iNumSamplers; ++i) {
-                if (samplersInMenu == maxSamplersPerMenu) {
-                    samplersInMenu = 0;
-                    int limit = iNumSamplers > i + 15 ? i + 15 : iNumSamplers;
-                    const QString label = samplerTrString(i) + QStringLiteral("- %1").arg(limit);
-                    pMenu = make_parented<QMenu>(label, m_pSamplerMenu);
-                    m_pSamplerMenu->addMenu(pMenu);
-                }
-                samplersInMenu++;
-                // PlayerManager::groupForSampler is 0-indexed.
-                QString samplerGroup = PlayerManager::groupForSampler(i - 1);
-                bool samplerPlaying = ControlObject::get(
-                                              ConfigKey(samplerGroup, "play")) > 0.0;
-                bool samplerEnabled = !samplerPlaying && singleTrackSelected;
-
-                generateTrackLoadMenu(samplerGroup,
-                        samplerTrString(i),
-                        pTrack,
-                        pMenu,
-                        false,
-                        samplerEnabled);
-            }
-        }
-        m_pLoadToMenu->addMenu(m_pSamplerMenu);
-
-        if (m_pNumPreviewDecks.get() > 0.0) {
-            // currently there is only one preview deck so just map it here.
-            generateTrackLoadMenu(PlayerManager::groupForPreviewDeck(0),
-                    tr("Preview Deck"),
-                    pTrack,
-                    m_pLoadToMenu,
-                    false);
-        }
+        m_bLoadToMenuLoaded = false;
     }
 
     if (featureIsEnabled(Feature::Playlist)) {
@@ -1168,13 +1086,25 @@ void WTrackMenu::updateMenus() {
             m_pBpmThreeHalvesAction->setEnabled(!anyBpmLocked);
             m_pBpmDoubleAction->setEnabled(!anyBpmLocked);
             m_pBpmResetAction->setEnabled(!anyBpmLocked);
-            m_pBpmUndoAction->setEnabled(!anyBpmLocked && canUndoBeatsChange());
+            // Skip canUndoBeatsChange() for library tables: it loads Track
+            // objects and may open files. Enable Undo whenever BPM is unlocked.
+            m_pBpmUndoAction->setEnabled(!anyBpmLocked &&
+                    (m_pTrackModel || canUndoBeatsChange()));
 
             // Append scaled BPM preview for single selection
             // TODO ... and multiple tracks with same BPM.
             // See DlgTrackInfoMulti
             if (singleTrackSelected) {
-                const double bpm = pTrack->getBpm();
+                double bpm = 0;
+                if (m_pTrackModel) {
+                    const int column = m_pTrackModel->fieldIndex(LIBRARYTABLE_BPM);
+                    bpm = m_trackIndexList.first()
+                                  .sibling(m_trackIndexList.first().row(), column)
+                                  .data(Qt::EditRole)
+                                  .toDouble();
+                } else if (m_pTrack) {
+                    bpm = m_pTrack->getBpm();
+                }
                 appendBpmPreviewtoBpmAction(m_pBpmHalveAction, bpm);
                 appendBpmPreviewtoBpmAction(m_pBpmTwoThirdsAction, bpm);
                 appendBpmPreviewtoBpmAction(m_pBpmThreeFourthsAction, bpm);
@@ -1255,17 +1185,10 @@ void WTrackMenu::updateMenus() {
         m_pPropertiesAct->setEnabled(true);
     }
 
+    // Find on Web is populated on hover so we do not load a Track object
+    // just to enable the menu.
     if (featureIsEnabled(Feature::FindOnWeb)) {
-        m_pFindOnWebMenu->clear();
-        m_pFindOnWebLastAct->setVisible(false);
-        const bool enableMenu = WFindOnWebMenu::hasEntriesForTrack(*pTrack);
-        if (enableMenu) {
-            mixxx::library::createFindOnWebSubmenus(
-                    m_pFindOnWebMenu.toWeakRef(),
-                    m_pFindOnWebLastAct.toWeakRef(),
-                    *pTrack);
-        }
-        m_pFindOnWebMenu->setEnabled(!m_pFindOnWebMenu->isEmpty());
+        m_pFindOnWebMenu->setEnabled(true);
     }
 }
 
@@ -1561,6 +1484,98 @@ void WTrackMenu::slotUpdateExternalTrackCollection(
     }
 
     externalTrackCollection->updateTracks(getTrackRefs());
+}
+
+void WTrackMenu::slotPopulateLoadToMenu() {
+    if (m_bLoadToMenuLoaded || !m_pLoadToMenu) {
+        return;
+    }
+    m_pLoadToMenu->clear();
+
+    const bool singleTrackSelected = getTrackCount() == 1;
+    // Loading a Track may open the audio file (STEM detection). Only do this
+    // when the user actually opens the Load to submenu.
+    const auto pTrack = getFirstTrackPointer();
+
+    int iNumDecks = static_cast<int>(m_pNumDecks.get());
+    m_pDeckMenu->clear();
+    m_pDeckMenu->setEnabled(singleTrackSelected);
+    if (singleTrackSelected && iNumDecks > 0) {
+        for (int i = 1; i <= iNumDecks; ++i) {
+            // PlayerManager::groupForDeck is 0-indexed.
+            QString deckGroup = PlayerManager::groupForDeck(i - 1);
+            bool deckPlaying = ControlObject::get(
+                    ConfigKey(deckGroup, "play")) > 0.0;
+            bool allowLoadTrackIntoPlayingDeck = false;
+            if (m_pConfig->exists(kConfigKeyLoadWhenDeckPlaying)) {
+                int loadWhenDeckPlaying =
+                        m_pConfig->getValueString(kConfigKeyLoadWhenDeckPlaying).toInt();
+                switch (static_cast<LoadWhenDeckPlaying>(loadWhenDeckPlaying)) {
+                case LoadWhenDeckPlaying::Allow:
+                case LoadWhenDeckPlaying::AllowButStopDeck:
+                    allowLoadTrackIntoPlayingDeck = true;
+                    break;
+                case LoadWhenDeckPlaying::Reject:
+                    break;
+                }
+            } else {
+                // support older version of this flag
+                allowLoadTrackIntoPlayingDeck = m_pConfig->getValue<bool>(
+                        ConfigKey("[Controls]", "AllowTrackLoadToPlayingDeck"));
+            }
+            bool deckEnabled =
+                    (!deckPlaying || allowLoadTrackIntoPlayingDeck) &&
+                    singleTrackSelected;
+            generateTrackLoadMenu(deckGroup,
+                    tr("Deck %1").arg(i),
+                    pTrack,
+                    m_pDeckMenu,
+                    true,
+                    deckEnabled);
+        }
+    }
+    m_pLoadToMenu->addMenu(m_pDeckMenu);
+
+    int iNumSamplers = static_cast<int>(m_pNumSamplers.get());
+    const int maxSamplersPerMenu = 16;
+    m_pSamplerMenu->clear();
+    m_pSamplerMenu->setEnabled(singleTrackSelected);
+    if (singleTrackSelected && iNumSamplers > 0) {
+        QMenu* pMenu = m_pSamplerMenu;
+        int samplersInMenu = 0;
+        for (int i = 1; i <= iNumSamplers; ++i) {
+            if (samplersInMenu == maxSamplersPerMenu) {
+                samplersInMenu = 0;
+                int limit = iNumSamplers > i + 15 ? i + 15 : iNumSamplers;
+                const QString label = samplerTrString(i) + QStringLiteral("- %1").arg(limit);
+                pMenu = make_parented<QMenu>(label, m_pSamplerMenu);
+                m_pSamplerMenu->addMenu(pMenu);
+            }
+            samplersInMenu++;
+            // PlayerManager::groupForSampler is 0-indexed.
+            QString samplerGroup = PlayerManager::groupForSampler(i - 1);
+            bool samplerPlaying = ControlObject::get(
+                    ConfigKey(samplerGroup, "play")) > 0.0;
+            bool samplerEnabled = !samplerPlaying && singleTrackSelected;
+
+            generateTrackLoadMenu(samplerGroup,
+                    samplerTrString(i),
+                    pTrack,
+                    pMenu,
+                    false,
+                    samplerEnabled);
+        }
+    }
+    m_pLoadToMenu->addMenu(m_pSamplerMenu);
+
+    if (m_pNumPreviewDecks.get() > 0.0) {
+        generateTrackLoadMenu(PlayerManager::groupForPreviewDeck(0),
+                tr("Preview Deck"),
+                pTrack,
+                m_pLoadToMenu,
+                false);
+    }
+    m_bLoadToMenuLoaded = true;
 }
 
 void WTrackMenu::slotPopulatePlaylistMenu() {

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -183,6 +183,7 @@ class WTrackMenu : public QMenu {
     // Playlist and crate
     void slotPopulatePlaylistMenu();
     void slotPopulateCrateMenu();
+    void slotPopulateLoadToMenu();
     void addSelectionToNewCrate();
 
     // Auto DJ
@@ -401,6 +402,7 @@ class WTrackMenu : public QMenu {
     bool m_bFindOnWebMenuLoaded;
     bool m_bPlaylistMenuLoaded;
     bool m_bCrateMenuLoaded;
+    bool m_bLoadToMenuLoaded;
 
     Features m_eActiveFeatures;
     const Features m_eTrackModelFeatures;


### PR DESCRIPTION
Right-click and other library actions loaded a Track object, which resolved the canonical path, sniffed MIME contents, and re-parsed tags on every first load. On remote filesystems that blocked the UI for seconds per click.

- Show the track context menu from table-model data; load-to and related submenus populate on hover.
- Skip Once-mode tag reimport when metadata was already imported.
- Prefer the stored file type over MatchContent sniffing.
- Identify cached library tracks by database id without realpath.