### PR TITLE
(fix) respect `repeat` in slip mode when enabled before slip, like looping

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -50,7 +50,7 @@ LoopingControl::LoopingControl(const QString& group,
         : EngineControl(group, pConfig),
           m_bLoopingEnabled(false),
           m_bLoopRollActive(false),
-          m_bLoopWasEnabledBeforeSlipEnable(false),
+          m_bloopOrRepeatWasEnabledBeforeSlipEnable(false),
           m_bAdjustingLoopIn(false),
           m_bAdjustingLoopOut(false),
           m_bAdjustingLoopInOld(false),
@@ -246,6 +246,10 @@ LoopingControl::LoopingControl(const QString& group,
     m_pPlayButton = ControlObject::getControl(ConfigKey(group, "play"));
 
     m_pRepeatButton = ControlObject::getControl(ConfigKey(group, "repeat"));
+    connect(m_pRepeatButton,
+            &ControlObject::valueChanged,
+            this,
+            &LoopingControl::repeatToggled);
 }
 
 LoopingControl::~LoopingControl() {
@@ -1226,7 +1230,7 @@ void LoopingControl::notifySeek(mixxx::audio::FramePos newPosition) {
 }
 
 void LoopingControl::setLoopingEnabled(bool enabled) {
-    m_bLoopWasEnabledBeforeSlipEnable =
+    m_bloopOrRepeatWasEnabledBeforeSlipEnable =
             !m_pSlipEnabled->toBool() && enabled && !m_bLoopRollActive;
     if (m_bLoopingEnabled == enabled) {
         return;
@@ -1244,6 +1248,18 @@ void LoopingControl::setLoopingEnabled(bool enabled) {
     }
 
     emit loopEnabledChanged(enabled);
+}
+
+/// Update m_bloopOrRepeatWasEnabledBeforeSlipEnable for use in
+/// EngineBuffer::processSlip()
+void LoopingControl::repeatToggled(double value) {
+    if (m_bLoopingEnabled) {
+        // m_bloopOrRepeatWasEnabledBeforeSlipEnable has been set in
+        // setLoopingEnabled(), nothing to do
+        return;
+    }
+    m_bloopOrRepeatWasEnabledBeforeSlipEnable =
+            value > 0 && !m_pSlipEnabled->toBool() && !m_bLoopRollActive;
 }
 
 void LoopingControl::trackLoaded(TrackPointer pNewTrack) {
@@ -1845,14 +1861,20 @@ void LoopingControl::slotLoopMove(double beats) {
     }
 }
 
-// Used to simulate looping while slip mode is enabled
-mixxx::audio::FramePos LoopingControl::adjustedPositionForCurrentLoop(
+/// Used to simulate looping while slip mode is enabled
+mixxx::audio::FramePos LoopingControl::adjustedPositionForCurrentLoopOrRepeat(
         mixxx::audio::FramePos currentPosition,
         bool reverse) {
-    if (!m_bLoopingEnabled) {
+    if (!m_bLoopingEnabled && !m_pRepeatButton->toBool()) {
         return currentPosition;
     }
-    LoopInfo loopInfo = m_loopInfo.getValue();
+    LoopInfo loopInfo;
+    if (m_bLoopingEnabled) {
+        loopInfo = m_loopInfo.getValue();
+    } else {
+        loopInfo.startPosition = mixxx::audio::kStartFramePos;
+        loopInfo.endPosition = frameInfo().trackEndPosition;
+    }
     const auto targetPosition = adjustedPositionInsideAdjustedLoop(
             currentPosition,
             reverse,

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -49,7 +49,7 @@ class LoopingControl : public EngineControl {
 
     // Wrapper to use adjustedPositionInsideAdjustedLoop() with the current loop.
     // Called from EngineBuffer while slip mode is enabled
-    mixxx::audio::FramePos adjustedPositionForCurrentLoop(
+    mixxx::audio::FramePos adjustedPositionForCurrentLoopOrRepeat(
             mixxx::audio::FramePos newPosition,
             bool reverse);
 
@@ -96,8 +96,8 @@ class LoopingControl : public EngineControl {
     bool isLoopRollActive() {
         return m_bLoopRollActive;
     }
-    bool loopWasEnabledBeforeSlipEnable() {
-        return m_bLoopWasEnabledBeforeSlipEnable;
+    bool loopOrRepeatWasEnabledBeforeSlipEnable() {
+        return m_bloopOrRepeatWasEnabledBeforeSlipEnable;
     }
 
     void trackLoaded(TrackPointer pNewTrack) override;
@@ -161,6 +161,7 @@ class LoopingControl : public EngineControl {
 
   private:
     void setLoopingEnabled(bool enabled);
+    void repeatToggled(double value);
     void setLoopInToCurrentPosition();
     void setLoopOutToCurrentPosition();
 
@@ -226,7 +227,7 @@ class LoopingControl : public EngineControl {
 
     bool m_bLoopingEnabled;
     bool m_bLoopRollActive;
-    bool m_bLoopWasEnabledBeforeSlipEnable;
+    bool m_bloopOrRepeatWasEnabledBeforeSlipEnable;
     bool m_bAdjustingLoopIn;
     bool m_bAdjustingLoopOut;
     bool m_bAdjustingLoopInOld;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1258,15 +1258,20 @@ void EngineBuffer::processSlip(int iBufferSize) {
         DEBUG_ASSERT(bufferFrameCount * mixxx::kEngineChannelCount == iBufferSize);
         const mixxx::audio::FrameDiff_t slipDelta =
                 static_cast<mixxx::audio::FrameDiff_t>(bufferFrameCount) * m_dSlipRate;
-        // Simulate looping if a regular loop is active
-        if (m_pLoopingControl->isLoopingEnabled() &&
-                m_pLoopingControl->loopWasEnabledBeforeSlipEnable() &&
+        // Simulate looping if a regular loop is active or repeat is enabled
+        bool looping = m_pLoopingControl->isLoopingEnabled();
+        if ((looping || m_pRepeat->toBool()) &&
+                m_pLoopingControl->loopOrRepeatWasEnabledBeforeSlipEnable() &&
                 !m_pLoopingControl->isLoopRollActive()) {
             const mixxx::audio::FramePos newPos = m_slipPos + slipDelta;
-            m_slipPos = m_pLoopingControl->adjustedPositionForCurrentLoop(
+            m_slipPos = m_pLoopingControl->adjustedPositionForCurrentLoopOrRepeat(
                     newPos,
                     m_dSlipRate < 0);
-            m_slipModeState = SlipModeState::Armed;
+            if (looping) {
+                m_slipModeState = SlipModeState::Armed;
+            } else { // repeat
+                m_slipModeState = SlipModeState::Running;
+            }
         } else {
             m_slipPos += slipDelta;
             m_slipModeState = SlipModeState::Running;


### PR DESCRIPTION
I noticed this slip bug when testing with a short Stem on repeat:
1. play a track, enable `repeat`
2. enable slip mode
3. let the track play till the end and wrap around
-> background playback stops -> **Fix:** treat like loop
4. quit slip mode
-> deck should continue (previously it was stopped already)

This is essentially a follow-up for #11435/#11848