### PR TITLE
Only default to ASIO if a device can actually be opened

### DIFF
--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -38,6 +38,12 @@ class SoundDevice {
     virtual void writeProcess(SINT framesPerBuffer) = 0;
     virtual QString getError() const = 0;
     virtual mixxx::audio::SampleRate getDefaultSampleRate() const = 0;
+    /// Whether the device can plausibly be opened for output. Used to avoid
+    /// auto-selecting a sound API whose devices enumerate but are broken,
+    /// e.g. an ASIO driver that rejects every standard sample rate.
+    virtual bool isUsable() const {
+        return true;
+    }
     mixxx::audio::ChannelCount getNumOutputChannels() const;
     mixxx::audio::ChannelCount getNumInputChannels() const;
     SoundDeviceStatus addOutput(const AudioOutputBuffer& out);

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -411,6 +411,33 @@ bool SoundDevicePortAudio::isOpen() const {
     return m_pStream.load() != nullptr;
 }
 
+bool SoundDevicePortAudio::isUsable() const {
+    if (!m_deviceInfo || m_deviceInfo->maxOutputChannels < 1) {
+        return false;
+    }
+    PaStreamParameters outputParams;
+    outputParams.device = m_deviceId.portAudioIndex;
+    outputParams.channelCount = math_min(2, m_deviceInfo->maxOutputChannels);
+    outputParams.sampleFormat = paFloat32;
+    outputParams.suggestedLatency = m_deviceInfo->defaultHighOutputLatency;
+    outputParams.hostApiSpecificStreamInfo = nullptr;
+
+    // Accept the device if it supports its own default rate or any of the
+    // rates Mixxx offers. A device that rejects all of them (seen with the
+    // Realtek ASIO driver, which fails every open with "Invalid sample
+    // rate") would only produce a broken configuration.
+    const double candidateRates[] = {
+            m_deviceInfo->defaultSampleRate, 44100.0, 48000.0, 96000.0};
+    for (const double rate : candidateRates) {
+        if (rate > 0.0 &&
+                Pa_IsFormatSupported(nullptr, &outputParams, rate) ==
+                        paFormatIsSupported) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void paFinishedCallback(void* soundDevice) {
     // This callback is called by PortAudio when Pa_IsStreamStopped becomes true.
     // This is triggered when Mixxx sets the return value from the process callback

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -26,6 +26,7 @@ class SoundDevicePortAudio : public SoundDevice {
 
     SoundDeviceStatus open(bool isClkRefDevice, int syncBuffers) override;
     bool isOpen() const override;
+    bool isUsable() const override;
     SoundDeviceStatus close() override;
     void readProcess(SINT framesPerBuffer) override;
     void writeProcess(SINT framesPerBuffer) override;

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -485,13 +485,28 @@ void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int f
             }
 #endif
 #ifdef __WINDOWS__
-            //Existence of ASIO doesn't necessarily mean you've got ASIO devices
-            //Do something more advanced one day if you like - Adam
-            // hoping this counts as more advanced, tests if ASIO is an option
-            // and then that we have at least one ASIO output device -- bkgood
-            if (apiList.contains(MIXXX_PORTAUDIO_ASIO_STRING)
-                   && !soundManager->getDeviceList(
-                       MIXXX_PORTAUDIO_ASIO_STRING, true, false).isEmpty()) {
+            // Existence of ASIO doesn't necessarily mean you've got ASIO devices
+            // Do something more advanced one day if you like - Adam
+            //  hoping this counts as more advanced, tests if ASIO is an option
+            //  and then that we have at least one ASIO output device -- bkgood
+            //  A present ASIO device can still be unusable: e.g. the Realtek
+            //  ASIO driver enumerates but rejects every standard sample rate,
+            //  so defaulting to it leaves the user without sound. Only pick
+            //  ASIO if at least one of its output devices can actually be
+            //  opened.
+            bool usableAsioDevice = false;
+            if (apiList.contains(MIXXX_PORTAUDIO_ASIO_STRING)) {
+                const QList<SoundDevicePointer> asioDevices =
+                        soundManager->getDeviceList(
+                                MIXXX_PORTAUDIO_ASIO_STRING, true, false);
+                for (const auto& pDevice : asioDevices) {
+                    if (pDevice->isUsable()) {
+                        usableAsioDevice = true;
+                        break;
+                    }
+                }
+            }
+            if (usableAsioDevice) {
                 m_api = MIXXX_PORTAUDIO_ASIO_STRING;
             } else {
                 m_api = MIXXX_PORTAUDIO_DIRECTSOUND_STRING;


### PR DESCRIPTION
The Windows auto-config picks ASIO whenever the API reports at least one output device. But an enumerable ASIO device can still be broken: the Realtek ASIO driver rejects every standard sample rate, so a fresh Mixxx install defaulted to it and started without working sound (observed: 'Error opening stream: Invalid sample rate', ~20 seconds of failed opens before a fallback device was found).

Add SoundDevice::isUsable(), implemented for PortAudio devices with Pa_IsFormatSupported (no stream is opened) across the device's default rate and Mixxx's standard rates, and only select ASIO as the default API if at least one of its output devices passes.

Fixes first-run experience for #14905's underlying UX issue in its nastier form: ASIO devices that exist but do not work.