### PR TITLE
Fix gcc 15.2.0 warning Wstrngop-overflow

### DIFF
--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -39,7 +39,9 @@ struct WaveformStride {
             m_averageOverallData[i] = 0.0f;
             SampleUtil::clear(m_filteredData[i], BandCount);
             SampleUtil::clear(m_averageFilteredData[i], BandCount);
-            SampleUtil::clear(m_stemData[i], m_stemCount);
+            if (m_stemCount > 0) {
+                SampleUtil::clear(m_stemData[i], m_stemCount);
+            }
         }
     }
 

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -41,6 +41,8 @@ struct WaveformStride {
             SampleUtil::clear(m_averageFilteredData[i], BandCount);
             if (m_stemCount > 0) {
                 SampleUtil::clear(m_stemData[i], m_stemCount);
+            } else {
+                DEBUG_ASSERT(m_stemCount == 0);
             }
         }
     }


### PR DESCRIPTION
For some reson it assumes that stem count can become negative.