### PR TITLE
fix(LateNightQML): Menu Bar Preferences don't open the dialog and Enabled Start inFull Screen Mode

### DIFF
--- a/res/qml/ApplicationMenuActions.qml
+++ b/res/qml/ApplicationMenuActions.qml
@@ -398,7 +398,7 @@ Item {
 
         // Qt Quick Controls does not expose native menu roles. Prevent
         // macOS from treating this action as the application Preferences action.
-        text: qsTranslate("WMainMenuBar", "&Settings directory") + "\u200c"
+        text: "\u200c" + qsTranslate("WMainMenuBar", "&Settings directory")
 
         onTriggered: Qt.openUrlExternally(Mixxx.Application.settingsDirectoryUrl)
     }

--- a/res/skins/LateNightQML/main.qml
+++ b/res/skins/LateNightQML/main.qml
@@ -10,6 +10,7 @@ import Mixxx 1.0 as Mixxx
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Window
 
 ApplicationWindow {
     id: root
@@ -42,6 +43,7 @@ ApplicationWindow {
     minimumHeight: 668
     minimumWidth: 1280
     visible: true
+    visibility: Mixxx.Config.configStartInFullscreenKey ? Window.FullScreen : Window.Windowed
     width: 1792
 
     Loader {


### PR DESCRIPTION
Fixes two LateNightQML issues:
- Prevents macOS from treating “Settings directory” as the application Preferences action.
- Applies the saved “Start in full-screen mode” preference when launching LateNightQML.
