### PR TITLE
Include file mtimes in library scan directory freshness hashes

### DIFF
--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -1,6 +1,7 @@
 #include "library/scanner/recursivescandirectorytask.h"
 
 #include <QCryptographicHash>
+#include <QDateTime>
 #include <QDir>
 #include <QFileInfo>
 
@@ -64,6 +65,11 @@ void RecursiveScanDirectoryTask::run() {
                     supportedExtensionsRegex.match(fileName);
             if (supportedExtensionsMatch.hasMatch()) {
                 hasher.addData(currentFile.toUtf8());
+                // Include the modification time so that files edited in place
+                // (e.g. tags updated without renaming the file) change the
+                // directory hash and trigger a rescan.
+                hasher.addData(QByteArray::number(
+                        currentFileInfo.lastModified().toMSecsSinceEpoch()));
                 filesToImport.push_back(currentFileInfo);
                 // Record the canonical track location used by track_locations
                 // so the unchanged-hash path can clear fs_deleted only for


### PR DESCRIPTION
The library scanner decides whether to rescan a directory by hashing its list of track file *names* and comparing against the stored hash (`recursivescandirectorytask.cpp`). A file modified in place — tags edited, or the file replaced by a different one with the same name — never changes the hash, so the scanner takes the `directoryUnchanged` path forever and the modification goes unnoticed.

**Fix:** fold each track file's `lastModified()` timestamp (msecs since epoch) into the directory hash. The `QFileInfo` objects come from `QDir::entryInfoList()`, so the mtime is already stat-cached — no extra filesystem I/O.

Effects:
- A directory whose files were modified in place is now rescanned, keeping the scanner's verified/`fs_deleted` bookkeeping honest.
- Together with the existing `UpdateTrackFromSourceMode::Newer` re-import (active when "Synchronize library track metadata from/to file tags" is enabled), tags edited in place are now picked up without renaming files.
- One-time cost: the hash input format changes, so every directory hash mismatches once after upgrading and each library folder gets a single full rescan on the first scan.

**Verified** on Windows 11:
- A/B mechanism test: an mtime-only touch of one file (no rename, no content change) followed by `--rescan-library` changes the stored `LibraryHashes` value on this branch, while an unpatched build of current `main` leaves it byte-for-byte identical.
- End to end with metadata sync enabled: a title tag rewritten in place (filename unchanged) is picked up after a rescan — the library row updates and `source_synchronized_ms` matches the file's post-edit mtime.
- `DirectoryDAOTest` (add/remove/loadAll/relocateDirectory) and `LibraryScannerTest.ScannerRoundtrip` pass.

**Branch target:** `main` rather than a stable/beta branch, deliberately — the hash format change forces a one-time full library rescan for every user, which seems wrong for a point release. Happy to retarget `2.6` if preferred.

Fixes #6187 (filed 2011; fix shape suggested by @rryan in the thread, same idea as bencoder's 2012 patch that never landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)