### PR TITLE
Skip beat grid creation when importing a BPM without a valid sample rate

### DIFF
--- a/src/test/trackupdate_test.cpp
+++ b/src/test/trackupdate_test.cpp
@@ -147,4 +147,21 @@ TEST_F(TrackUpdateTest, parseModifiedDirtyAgain) {
     EXPECT_EQ(coverInfoBefore, coverInfoAfter);
 }
 
+TEST_F(TrackUpdateTest, importBpmWithoutValidSampleRate) {
+    // Importing metadata that carries a valid BPM while the audio
+    // properties are unknown must neither crash nor create a beat grid.
+    // Seen with STEM files whose audio properties cannot be parsed
+    // (https://github.com/mixxxdj/mixxx/issues/16846).
+    auto pTrack = Track::newTemporary();
+    ASSERT_FALSE(pTrack->getSampleRate().isValid());
+
+    mixxx::TrackMetadata importedMetadata;
+    importedMetadata.refTrackInfo().setBpm(mixxx::Bpm(128.0));
+    pTrack->replaceMetadataFromSource(
+            std::move(importedMetadata),
+            QDateTime::currentDateTimeUtc());
+
+    EXPECT_EQ(nullptr, pTrack->getBeats());
+}
+
 // TODO: Add tests for SoundSourceProxy::UpdateTrackFromSourceMode::Newer

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -394,6 +394,20 @@ bool Track::trySetBpmWhileLocked(mixxx::Bpm bpm) {
         // they want to clear the beatgrid.
         return trySetBeatsWhileLocked(nullptr);
     } else if (!m_pBeats) {
+        if (!getSampleRate().isValid()) {
+            // The sample rate might still be unknown here, e.g. when
+            // importing a BPM from file tags while the audio properties
+            // could not be determined (seen with STEM files, #16846).
+            // A beat grid cannot be created without a valid sample rate,
+            // so keep the beat grid empty. The BPM will be set once the
+            // track has been analyzed or the stream info becomes known.
+            kLogger.warning()
+                    << "Cannot create beat grid for imported BPM"
+                    << bpm
+                    << "without a valid sample rate:"
+                    << getLocation();
+            return false;
+        }
         // No beat grid available -> create and initialize
         mixxx::audio::FramePos cuePosition = m_record.getMainCuePosition();
         if (!cuePosition.isValid()) {


### PR DESCRIPTION
Importing file metadata that carries a valid BPM while the audio properties are unknown crashed the library scanner on debug builds: `Track::replaceMetadataFromSource` → `trySetBpmWhileLocked` → `Beats::fromConstTempo` with an invalid sample rate → the `VERIFY_OR_DEBUG_ASSERT` reported in the issue (the x64debug "out of memory" is the assert reporter's artifact). Release builds already failed silently at the same spot (`fromConstTempo` returns `nullptr`).

Observed triggers: STEM files whose audio properties cannot be parsed by the reporter's TagLib build, an MP3 case seen by @daschuer, and (reproduced live here) file contention — a second Mixxx instance holding the library files makes TagLib log `Cannot read audio properties from inaccessible/unreadable/invalid file` while tags still parse, yielding exactly valid-BPM + invalid-samplerate.

**Fix:** guard the beat grid creation in `Track::trySetBpmWhileLocked` — log a warning and keep the beat grid empty; the analyzer sets the BPM once the track is loaded. This matches the existing release behavior, minus the debug-build crash.

**Verified** on Windows 11:
- New regression test `TrackUpdateTest.importBpmWithoutValidSampleRate`: on a `DEBUG_ASSERTIONS_FATAL=ON` build it aborts **pre-fix with the exact assert from the report** (`beats.cpp` `fromConstTempo`) and passes post-fix; passes on regular builds too.
- Full `TrackUpdateTest` (5 tests) passes; `BeatsTest`/`TrackTest` pass under fatal assertions.
- clang-format / codespell / end-of-file-fixer pass.

**Branch target:** `main`, where the regression was reported. ronso0 reproduced the assert on 2.6 as well — happy to open a 2.6 backport if wanted.

Fixes #16846

🤖 Generated with [Claude Code](https://claude.com/claude-code)