### PR TITLE
Fix flaky unittests 

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -381,25 +381,27 @@ void BaseTrackPlayerImpl::slotEjectTrack(double v) {
         return;
     }
 
-    mixxx::Duration elapsed = m_ejectTimer.restart();
+    if (m_pPlayerManager) {
+        mixxx::Duration elapsed = m_ejectTimer.restart();
 
-    // Double-click always restores the last replaced track, i.e. un-eject the second
-    // last track: the first click ejects or unejects, and the second click reloads.
-    if (elapsed < mixxx::Duration::fromMillis(kUnreplaceDelay)) {
-        TrackPointer lastEjected = m_pPlayerManager->getSecondLastEjectedTrack();
-        if (lastEjected) {
-            slotLoadTrack(lastEjected, false);
+        // Double-click always restores the last replaced track, i.e. un-eject the second
+        // last track: the first click ejects or unejects, and the second click reloads.
+        if (elapsed < mixxx::Duration::fromMillis(kUnreplaceDelay)) {
+            TrackPointer lastEjected = m_pPlayerManager->getSecondLastEjectedTrack();
+            if (lastEjected) {
+                slotLoadTrack(lastEjected, false);
+            }
+            return;
         }
-        return;
-    }
 
-    // With no loaded track a single click reloads the last ejected track.
-    if (!m_pLoadedTrack) {
-        TrackPointer lastEjected = m_pPlayerManager->getLastEjectedTrack();
-        if (lastEjected) {
-            slotLoadTrack(lastEjected, false);
+        // With no loaded track a single click reloads the last ejected track.
+        if (!m_pLoadedTrack) {
+            TrackPointer lastEjected = m_pPlayerManager->getLastEjectedTrack();
+            if (lastEjected) {
+                slotLoadTrack(lastEjected, false);
+            }
+            return;
         }
-        return;
     }
 
     m_pChannel->getEngineBuffer()->ejectTrack();

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -146,6 +146,8 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
 
     void loadTrack(Deck* pDeck, TrackPointer pTrack) {
         EngineDeck* pEngineDeck = pDeck->getEngineDeck();
+        pDeck->slotEjectTrack(1.0);
+        DEBUG_ASSERT(!pEngineDeck->getEngineBuffer()->isTrackLoaded());
         pDeck->slotLoadTrack(pTrack, false);
 
         // Wait for the track to load.


### PR DESCRIPTION
It happens that the test body is executed with an outdated track. This is caused by the waiting loop abort condition which is  still true after loading a new track. 

This change makes sure that isTrackLoaded() is false before waiting in a loop for the loop to become true. 
