### PR TITLE
Controllers: stems for DJ2GO2 Touch

### DIFF
--- a/res/controllers/Numark_DJ2GO2_Touch.midi.xml
+++ b/res/controllers/Numark_DJ2GO2_Touch.midi.xml
@@ -295,7 +295,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.loopIn.input</key>
+        <key>DJ2GO2Touch.leftDeck.stemMuteButtons[1].input</key>
         <status>0x84</status>
         <midino>0x21</midino>
         <options>
@@ -304,7 +304,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.loopIn.input</key>
+        <key>DJ2GO2Touch.leftDeck.stemMuteButtons[1].input</key>
         <status>0x94</status>
         <midino>0x21</midino>
         <options>
@@ -313,7 +313,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.loopOut.input</key>
+        <key>DJ2GO2Touch.leftDeck.stemMuteButtons[2].input</key>
         <status>0x84</status>
         <midino>0x22</midino>
         <options>
@@ -322,7 +322,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.loopOut.input</key>
+        <key>DJ2GO2Touch.leftDeck.stemMuteButtons[2].input</key>
         <status>0x94</status>
         <midino>0x22</midino>
         <options>
@@ -331,7 +331,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.reLoopStop.input</key>
+        <key>DJ2GO2Touch.leftDeck.stemMuteButtons[4].input</key>
         <status>0x84</status>
         <midino>0x24</midino>
         <options>
@@ -340,7 +340,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.reLoopStop.input</key>
+        <key>DJ2GO2Touch.leftDeck.stemMuteButtons[4].input</key>
         <status>0x94</status>
         <midino>0x24</midino>
         <options>
@@ -394,7 +394,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.LoopToggleButton.input</key>
+        <key>DJ2GO2Touch.leftDeck.stemMuteButtons[3].input</key>
         <status>0x84</status>
         <midino>0x23</midino>
         <options>
@@ -403,7 +403,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DJ2GO2Touch.leftDeck.LoopToggleButton.input</key>
+        <key>DJ2GO2Touch.leftDeck.stemMuteButtons[3].input</key>
         <status>0x94</status>
         <midino>0x23</midino>
         <options>
@@ -718,7 +718,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.loopIn.input</key>
+        <key>DJ2GO2Touch.rightDeck.stemMuteButtons[1].input</key>
         <status>0x85</status>
         <midino>0x21</midino>
         <options>
@@ -727,7 +727,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.loopIn.input</key>
+        <key>DJ2GO2Touch.rightDeck.stemMuteButtons[1].input</key>
         <status>0x95</status>
         <midino>0x21</midino>
         <options>
@@ -736,7 +736,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.loopOut.input</key>
+        <key>DJ2GO2Touch.rightDeck.stemMuteButtons[2].input</key>
         <status>0x85</status>
         <midino>0x22</midino>
         <options>
@@ -745,7 +745,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.loopOut.input</key>
+        <key>DJ2GO2Touch.rightDeck.stemMuteButtons[2].input</key>
         <status>0x95</status>
         <midino>0x22</midino>
         <options>
@@ -754,8 +754,8 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.reLoopStop.input</key>
-        <status>0x95</status>
+        <key>DJ2GO2Touch.rightDeck.stemMuteButtons[4].input</key>
+        <status>0x85</status>
         <midino>0x24</midino>
         <options>
           <script-binding/>
@@ -763,7 +763,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.reLoopStop.input</key>
+        <key>DJ2GO2Touch.rightDeck.stemMuteButtons[4].input</key>
         <status>0x95</status>
         <midino>0x24</midino>
         <options>
@@ -817,7 +817,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.LoopToggleButton.input</key>
+        <key>DJ2GO2Touch.rightDeck.stemMuteButtons[3].input</key>
         <status>0x85</status>
         <midino>0x23</midino>
         <options>
@@ -826,7 +826,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DJ2GO2Touch.rightDeck.LoopToggleButton.input</key>
+        <key>DJ2GO2Touch.rightDeck.stemMuteButtons[3].input</key>
         <status>0x95</status>
         <midino>0x23</midino>
         <options>

--- a/res/controllers/Numark_DJ2GO2_Touch_scripts.js
+++ b/res/controllers/Numark_DJ2GO2_Touch_scripts.js
@@ -87,6 +87,7 @@ DJ2GO2Touch.Deck = function(deckNumbers, midiChannel) {
     this.hotcueButtons = [];
     this.samplerButtons = [];
     this.beatloopButtons = [];
+    this.stemMuteButtons = [];
     for (var i = 1; i <= 4; i++) {
         this.hotcueButtons[i] = new components.HotcueButton({
             group: "[Channel" + script.deckFromGroup(this.currentDeck) + "]",
@@ -118,24 +119,13 @@ DJ2GO2Touch.Deck = function(deckNumbers, midiChannel) {
             number: i,
             key: "beatloop_" + Math.pow(2, i-1) + "_toggle"
         });
+        this.stemMuteButtons[i] = new components.Button({
+            group: "[Channel" + script.deckFromGroup(this.currentDeck) + "_Stem" + i + "]",
+            type: components.Button.prototype.types.powerWindow,
+            midi: [0x94 + midiChannel, 0x20 + i],
+            key: "mute",
+        });
     }
-
-    this.loopIn = new components.Button({
-        midi: [0x94 + midiChannel, 0x21],
-        key: "loop_in",
-    });
-
-    this.loopOut = new components.Button({
-        midi: [0x94 + midiChannel, 0x22],
-        key: "loop_out",
-    });
-
-    this.LoopToggleButton = new components.LoopToggleButton([0x94 + midiChannel, 0x23]);
-
-    this.reLoopStop = new components.Button({
-        midi: [0x94 + midiChannel, 0x24],
-        key: "reloop_andstop",
-    });
 
     this.wheelTouch = function(channel, control, value, status, _group) {
         if ((status & 0xF0) === 0x90) {


### PR DESCRIPTION
Replaces the Manual Loop Pads mode with stem mute pads.

I don't believe that the manual loop pads mode on this controller is widely used with mixxx, on the basis that one of the pads on the right deck used the wrong MIDI code and no-one seems to have complained about it.