### PR TITLE
Mixdown headphone and booth outputs in mono mode

### DIFF
--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -774,6 +774,12 @@ void EngineMixer::process(const int iBufferSize) {
 
     if (m_pMainMonoMixdown->toBool()) {
         SampleUtil::mixStereoToMono(m_main.data(), iBufferSize);
+        if (headphoneEnabled) {
+            SampleUtil::mixStereoToMono(m_head.data(), iBufferSize);
+        }
+        if (boothEnabled) {
+            SampleUtil::mixStereoToMono(m_booth.data(), iBufferSize);
+        }
     }
 
     if (mainEnabled) {

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -772,11 +772,11 @@ void EngineMixer::process(const int iBufferSize) {
         }
     }
 
+    // Handle mono mixdown for the main output and booth.
+    // Headphone mixdown is handled separately since they have more complicated
+    // processing.
     if (m_pMainMonoMixdown->toBool()) {
         SampleUtil::mixStereoToMono(m_main.data(), iBufferSize);
-        if (headphoneEnabled) {
-            SampleUtil::mixStereoToMono(m_head.data(), iBufferSize);
-        }
         if (boothEnabled) {
             SampleUtil::mixStereoToMono(m_booth.data(), iBufferSize);
         }
@@ -839,6 +839,8 @@ void EngineMixer::processHeadphones(
             ph[i] = (ph[i] + ph[i + 1]) / 2;
             ph[i + 1] = (pm[i] + pm[i + 1]) / 2;
         }
+    } else if (m_pMainMonoMixdown->toBool()) {
+        SampleUtil::mixStereoToMono(m_head.data(), iBufferSize);
     }
 
     // Apply headphone gain


### PR DESCRIPTION
Updates #16942

This ensures that in mono mode the headphone and booth outputs are also mono, but does not complete the larger UI changes that were requested in the issue. This solves the immediate problem and I'm hoping we can at least get this in and then tackle the larger UI change later since I ran into this issue again at my set last Tuesday.

Thanks for your consideration.