### PR TITLE
Fix QML crash on stem track load: null WaveformWidgetFactory

### DIFF
--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -21,7 +21,13 @@ namespace allshader {
 WaveformRenderBeat::WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget,
         ::WaveformRendererAbstract::PositionSource type)
         : ::WaveformRendererAbstract(waveformWidget),
-          m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip) {
+          m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip),
+          // Singleton::instance() itself trips a VERIFY_OR_DEBUG_ASSERT when
+          // the singleton was never created, which is fatal in builds with
+          // MIXXX_DEBUG_ASSERTIONS_FATAL. Ask isCreated() first.
+          m_pWaveformWidgetFactory(WaveformWidgetFactory::isCreated()
+                          ? WaveformWidgetFactory::instance()
+                          : nullptr) {
     initForRectangles<UniColorMaterial>(0);
     setUsePreprocess(true);
 }
@@ -53,8 +59,12 @@ bool WaveformRenderBeat::preprocessInner() {
 
     const bool isStemTrack = trackInfo && trackInfo->hasStem() &&
             trackInfo->getWaveform() && trackInfo->getWaveform()->hasStem();
-    const bool splitStemTracks = isStemTrack &&
-            WaveformWidgetFactory::instance()->isStemSplitTracks();
+    // WaveformWidgetFactory is only created by the QWidget main window, so
+    // under --qml / --new-ui it is null and dereferencing it crashed on
+    // every stem track load. Plain tracks were unaffected because the
+    // deref sits behind the isStemTrack short-circuit.
+    const bool splitStemTracks = isStemTrack && m_pWaveformWidgetFactory &&
+            m_pWaveformWidgetFactory->isStemSplitTracks();
 
     auto positionType = m_isSlipRenderer ? ::WaveformRendererAbstract::Slip
                                          : ::WaveformRendererAbstract::Play;

--- a/src/waveform/renderers/allshader/waveformrenderbeat.h
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.h
@@ -8,6 +8,7 @@
 
 class QDomNode;
 class SkinContext;
+class WaveformWidgetFactory;
 
 namespace allshader {
 class WaveformRenderBeat;
@@ -39,6 +40,10 @@ class allshader::WaveformRenderBeat final
   private:
     QColor m_color;
     bool m_isSlipRenderer;
+    // Resolved once at construction: the factory singleton only exists in the
+    // QWidget UI, in the QML UI this stays null. Looking it up per frame would
+    // spam the log from Singleton::instance().
+    WaveformWidgetFactory* m_pWaveformWidgetFactory;
 
     bool preprocessInner();
 

--- a/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
@@ -33,7 +33,13 @@ WaveformRendererSlipMode::WaveformRendererSlipMode(
         WaveformWidgetRenderer* waveformWidget)
         : ::WaveformRendererAbstract(waveformWidget),
           m_slipBorderTopOutlineSize(10.f),
-          m_slipBorderBottomOutlineSize(10.f) {
+          m_slipBorderBottomOutlineSize(10.f),
+          // Singleton::instance() itself trips a VERIFY_OR_DEBUG_ASSERT when
+          // the singleton was never created, which is fatal in builds with
+          // MIXXX_DEBUG_ASSERTIONS_FATAL. Ask isCreated() first.
+          m_pWaveformWidgetFactory(WaveformWidgetFactory::isCreated()
+                          ? WaveformWidgetFactory::instance()
+                          : nullptr) {
     initForRectangles<RGBAMaterial>(0);
     setUsePreprocess(true);
 }
@@ -94,8 +100,9 @@ bool WaveformRendererSlipMode::preprocessInner() {
     TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
     const bool isStemTrack = pTrack && pTrack->hasStem() &&
             pTrack->getWaveform() && pTrack->getWaveform()->hasStem();
-    const bool splitStemTracks = isStemTrack &&
-            WaveformWidgetFactory::instance()->isStemSplitTracks();
+    // The factory singleton only exists in the QWidget UI; null in the QML UI.
+    const bool splitStemTracks = isStemTrack && m_pWaveformWidgetFactory &&
+            m_pWaveformWidgetFactory->isStemSplitTracks();
 
     const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
 

--- a/src/waveform/renderers/allshader/waveformrendererslipmode.h
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.h
@@ -11,6 +11,7 @@
 class ControlProxy;
 class QDomNode;
 class SkinContext;
+class WaveformWidgetFactory;
 
 namespace allshader {
 class WaveformRendererSlipMode;
@@ -41,6 +42,10 @@ class allshader::WaveformRendererSlipMode final
 
     QColor m_color;
     PerformanceTimer m_timer;
+    // Resolved once at construction: the factory singleton only exists in the
+    // QWidget UI, in the QML UI this stays null. Looking it up per frame would
+    // spam the log from Singleton::instance().
+    WaveformWidgetFactory* m_pWaveformWidgetFactory;
 
     bool preprocessInner();
 


### PR DESCRIPTION
Fixes #17011.

### What happens

Loading any stem file in the QML UI (`--qml` / `--new-ui`) kills Mixxx. On a build with
`MIXXX_DEBUG_ASSERTIONS_FATAL` it terminates on the assert @Eve00000 captured in #17011:

```
DEBUG ASSERT: "m_instance" in function Singleton<WaveformWidgetFactory>::instance()
at src/util/singleton.h:22
```

with the stack, on the scene graph render thread:

```
allshader_sg::WaveformRenderBeat::preprocess+12
allshader_sg::WaveformRenderBeat::preprocessInner+179
```

On a release build there is no assert, so `instance()` returns `nullptr`, the very next
dereference runs, and it is an access violation in the same function instead.

### Why

`WaveformWidgetFactory::createInstance()` has exactly one call site in the tree,
`src/mixxxmainwindow.cpp`, which is the QWidget main window. The QML UI never constructs
it, so the singleton is null for the whole session.

`WaveformRenderBeat::preprocessInner()` and `WaveformRendererSlipMode::preprocessInner()`
both do:

```cpp
const bool splitStemTracks = isStemTrack &&
        WaveformWidgetFactory::instance()->isStemSplitTracks();
```

The dereference sits behind the `isStemTrack &&` short-circuit, which is why the QML UI
looked healthy until the first stem track — plain tracks never evaluate the right-hand
side.

### The fix

Resolve the factory once at construction, and null-check it at the use site.

The construction-time lookup asks `isCreated()` instead of calling `instance()` directly.
That matters: `Singleton::instance()` runs a `VERIFY_OR_DEBUG_ASSERT(m_instance)` of its
own, so merely *asking* for the pointer is fatal under `MIXXX_DEBUG_ASSERTIONS_FATAL` and
logs `Singleton class has not been created yet, returning nullptr` otherwise — once per
renderer, per session. `dlgpreferences.cpp` already guards the same singleton this way.

With the factory absent, `splitStemTracks` is false and the renderers draw the unsplit
beat grid — the behaviour the QML UI had before stem support existed. Nothing changes for
the QWidget UI, where the factory always exists.

### Testing

Windows, `RelWithDebInfo`, `-DQML=ON`, `mixxx --new-ui --developer` with a `.stem.mp4`
passed on the command line so it loads straight into deck 1.

- Before: two `Singleton class has not been created yet, returning nullptr` warnings on
  the render thread; on a fatal-assert build this is #17011's crash.
- After: stem decodes (`SoundSourceSTEM` / `Track - Importing stem(s) info`), waveform
  renderers come up for both decks, zero singleton warnings, no assert, still running
  after 40s.

### Note for reviewers

In the QML UI this value is computed and then never used -- `splitStemTracks` only feeds the
slip beat renderer, which QML never builds (its beat renderer is fixed at
`PositionSource::Play`). That is why the crash surfaced on a plain non-slip renderer with no
interest in the answer.

An alternative would be to compute `splitStemTracks` inside the `m_isSlipRenderer` branch that
consumes it, removing the factory access by construction rather than by null check. Happy to
respin it that way if you prefer; as it stands the guard is the smaller, more backportable
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
