### PR TITLE
QML library: debounce the search field and add keyboard handling

### DIFF
--- a/res/qml/Library.qml
+++ b/res/qml/Library.qml
@@ -16,6 +16,7 @@ Item {
     property var sidebar: librarySources.sidebar()
 
     function applySearch() {
+        searchDebounce.stop();
         if (root.sidebar && root.sidebar.tracklist) {
             root.sidebar.tracklist.search(searchField.text);
         }
@@ -37,7 +38,36 @@ Item {
         anchors.top: parent.top
         placeholderText: qsTranslate("WSearchLineEdit", "Search...")
 
-        onTextChanged: root.applySearch()
+        Keys.onPressed: event => {
+            switch (event.key) {
+            case Qt.Key_Escape:
+                searchField.clear();
+                root.applySearch();
+                trackList.focusView();
+                event.accepted = true;
+                break;
+            case Qt.Key_Down:
+            case Qt.Key_Enter:
+            case Qt.Key_Return:
+                root.applySearch();
+                trackList.focusView();
+                event.accepted = true;
+                break;
+            }
+        }
+
+        // Every search runs a real SQL query against the library, so wait for
+        // a pause in typing rather than querying on each keystroke. Same
+        // default delay as the legacy WSearchLineEdit.
+        onTextChanged: searchDebounce.restart()
+
+        Timer {
+            id: searchDebounce
+
+            interval: 300
+
+            onTriggered: root.applySearch()
+        }
     }
     SplitView {
         id: librarySplitView
@@ -135,6 +165,8 @@ Item {
             }
         }
         LibraryComponent.TrackList {
+            id: trackList
+
             SplitView.fillHeight: true
 
             // FIXME: this is necessary to prevent the header label to render outside of the table when horizontally scrolling: https://github.com/mixxxdj/mixxx/pull/14514#issuecomment-3311914346

--- a/res/qml/Library/TrackList.qml
+++ b/res/qml/Library/TrackList.qml
@@ -14,6 +14,10 @@ Rectangle {
 
     required property var model
 
+    function focusView() {
+        view.forceActiveFocus();
+    }
+
     color: Theme.darkGray
 
     LibraryComponent.Control {


### PR DESCRIPTION
> _This description was drafted by an AI assistant (Claude) and reviewed by me before submitting._

The New UI library search field (`res/qml/Library.qml`) calls `LibraryTableModel::search()` from `onTextChanged`, so every keystroke runs a SQL query against the library. This adds the same 300 ms debounce the legacy `WSearchLineEdit` uses, plus the keyboard behaviour the legacy box has:

- **Escape** clears the field and returns focus to the track list
- **Enter / Down** apply a pending search immediately and move focus to the track list
- **Ctrl+F** (`focusSearch`, from #16849) also flushes a pending search before selecting the text

`TrackList` gains a two-line `focusView()` so `Library.qml` can hand focus to the `TableView` without reaching into its internals.

**Tested** on Windows 11, `--new-ui`: <!-- fill in after testing on the real rig: typing a multi-word query, Escape, Enter/Down into the list, Ctrl+F, and that the debounce doesn't drop the final keystroke -->

Refs #14534. Independent of #16686, which builds a criteria-chip search pane on the same `tracklist.search()` call and would layer on top of this.

> _End of AI-drafted text._
