### PR TITLE
Update CHANGELOG for Mixxx 2.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Allen & Heath Xone K3: Update midi mappings (backport [#16453](https://github.com/mixxxdj/mixxx/pull/16453)) [#16496](https://github.com/mixxxdj/mixxx/pull/16496)
 * Numark Mixtrack 3: fix settings bool evaluation [#16708](https://github.com/mixxxdj/mixxx/pull/16708)
+* Vestax VCI-400: fix VU meters, midi.sendShortMsg() [#16180](https://github.com/mixxxdj/mixxx/pull/16180)
 
 ### Library
 
@@ -20,9 +21,13 @@
 * Fixing last played time being wiped on history deletion
   [#16178](https://github.com/mixxxdj/mixxx/pull/16178)
   [#14427](https://github.com/mixxxdj/mixxx/issues/14427)
+  [#16911](https://github.com/mixxxdj/mixxx/pull/16911)
 * Fix false-positive missing tracks
   [#16685](https://github.com/mixxxdj/mixxx/pull/16685)
   [#13533](https://github.com/mixxxdj/mixxx/issues/13533)
+* Rekordbox: detect databases in hidden .PIONEER directory
+  [#16895](https://github.com/mixxxdj/mixxx/pull/16895)
+  [#16894](https://github.com/mixxxdj/mixxx/issues/16894)
 
 ### Target support
 
@@ -85,6 +90,14 @@
   [#16816](https://github.com/mixxxdj/mixxx/pull/16816)
   [#16783](https://github.com/mixxxdj/mixxx/issues/16783)
   [#16592](https://github.com/mixxxdj/mixxx/pull/16592)
+* Avoid spurious play control update
+  [#16912](https://github.com/mixxxdj/mixxx/pull/16912)
+  [#16910](https://github.com/mixxxdj/mixxx/issues/16910)
+* Respect `repeat` in slip mode when enabled before slip, like looping
+  [#16982](https://github.com/mixxxdj/mixxx/pull/16982)
+* Mixdown headphone and booth outputs in mono mode
+  [#17013](https://github.com/mixxxdj/mixxx/pull/17013)
+  [#16942](https://github.com/mixxxdj/mixxx/issues/16942)
 
 ## [2.5.6](https://github.com/mixxxdj/mixxx/milestone/53) (2026-03-25)
 

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -303,7 +303,7 @@
  </ul>
 </description>
     </release>
-    <release version="2.5.5" type="development" date="2026-08-18" timestamp="1787048362">
+    <release version="2.5.5" type="development" date="2026-09-06" timestamp="1788699229">
       <description>
  <p>
   Note: Version 2.5.5 has been skipped following an issue in the release workflow.


### PR DESCRIPTION
Another update. 

we have these open 
#17003 
#16990
#16981

all required for a smooth 2.5.7 release process.  