### PR TITLE
Fix 17026 cue and intro/outro markers in slip mode with stacked stem 

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -70,11 +70,11 @@ class WaveformMarkNode : public rendergraph::GeometryNode {
         for (int boxIdx = 0; boxIdx < numBoxes; ++boxIdx) {
             const float y = boxIdx * boxBreadth + yOffset;
             if (boxIdx == labelBoxIdx) {
-        vertexUpdater.addRectangle({x, y},
-                {x + m_textureWidth / devicePixelRatio,
-                        y + m_textureHeight / devicePixelRatio},
-                {0.f, 0.f},
-                {1.f, 1.f});
+                vertexUpdater.addRectangle({x, y},
+                        {x + m_textureWidth / devicePixelRatio,
+                                y + m_textureHeight / devicePixelRatio},
+                        {0.f, 0.f},
+                        {1.f, 1.f});
             } else {
                 const float lineX = x + m_pOwner->m_linePosition;
                 vertexUpdater.addRectangle({lineX - 1.5f, y},

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -2,6 +2,7 @@
 
 #include <QPainterPath>
 
+#include "engine/engine.h"
 #include "moc_waveformrendermark.cpp"
 #include "rendergraph/context.h"
 #include "rendergraph/geometry.h"
@@ -16,6 +17,7 @@
 #include "util/roundtopixel.h"
 #include "waveform/renderers/allshader/digitsrenderer.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
 
 using namespace rendergraph;
@@ -46,20 +48,42 @@ class WaveformMarkNode : public rendergraph::GeometryNode {
         m_textureWidth = image.width();
         m_textureHeight = image.height();
     }
-    void update(float x, float y, float devicePixelRatio) {
+    void update(float x,
+            int numBoxes,
+            float boxBreadth,
+            float yOffset,
+            int labelBoxIdx,
+            float devicePixelRatio) {
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
         const float epsilon = 1e-6f;
         auto roundToPixel = createFunctionRoundToPixel(devicePixelRatio);
         DEBUG_ASSERT(std::abs(x - roundToPixel(x)) < epsilon);
-        DEBUG_ASSERT(std::abs(y - roundToPixel(y)) < epsilon);
+        DEBUG_ASSERT(std::abs(yOffset - roundToPixel(yOffset)) < epsilon);
 #endif
+        const int numVerticesPerRectangle = 6;
+        geometry().allocate(numVerticesPerRectangle * numBoxes);
         TexturedVertexUpdater vertexUpdater{
                 geometry().vertexDataAs<Geometry::TexturedPoint2D>()};
+        const float u1 = (m_pOwner->m_linePosition - 1.5f) / (m_textureWidth / devicePixelRatio);
+        const float u2 = (m_pOwner->m_linePosition + 1.5f) / (m_textureWidth / devicePixelRatio);
+        const float vLine = (labelBoxIdx == 0) ? 0.9f : 0.1f;
+        for (int boxIdx = 0; boxIdx < numBoxes; ++boxIdx) {
+            const float y = boxIdx * boxBreadth + yOffset;
+            if (boxIdx == labelBoxIdx) {
         vertexUpdater.addRectangle({x, y},
                 {x + m_textureWidth / devicePixelRatio,
                         y + m_textureHeight / devicePixelRatio},
                 {0.f, 0.f},
                 {1.f, 1.f});
+            } else {
+                const float lineX = x + m_pOwner->m_linePosition;
+                vertexUpdater.addRectangle({lineX - 1.5f, y},
+                        {lineX + 1.5f, y + m_textureHeight / devicePixelRatio},
+                        {u1, vLine},
+                        {u2, vLine});
+            }
+        }
+        markDirtyGeometry();
     }
     float textureWidth() const {
         return m_textureWidth;
@@ -84,8 +108,13 @@ class WaveformMarkNodeGraphics : public WaveformMark::Graphics {
     void updateTexture(rendergraph::Context* pContext, const QImage& image) {
         waveformMarkNode()->updateTexture(pContext, image);
     }
-    void update(float x, float y, float devicePixelRatio) {
-        waveformMarkNode()->update(x, y, devicePixelRatio);
+    void update(float x,
+            int numBoxes,
+            float boxBreadth,
+            float yOffset,
+            int labelBoxIdx,
+            float devicePixelRatio) {
+        waveformMarkNode()->update(x, numBoxes, boxBreadth, yOffset, labelBoxIdx, devicePixelRatio);
     }
     float textureWidth() const {
         return waveformMarkNode()->textureWidth();
@@ -233,26 +262,36 @@ bool allshader::WaveformRenderMark::init() {
 
 void allshader::WaveformRenderMark::updateRangeNode(GeometryNode* pNode,
         const QRectF& rect,
+        int numBoxes,
+        float boxBreadth,
+        float yOffset,
         QColor color) {
     // draw a gradient towards transparency at the upper and lower 25% of the waveform view
 
     const float qh = static_cast<float>(std::floor(rect.height() * 0.25));
     const float posx1 = static_cast<float>(rect.x());
     const float posx2 = static_cast<float>(rect.x() + rect.width());
-    const float posy1 = static_cast<float>(rect.y());
-    const float posy2 = static_cast<float>(rect.y()) + qh;
-    const float posy3 = static_cast<float>(rect.y() + rect.height()) - qh;
-    const float posy4 = static_cast<float>(rect.y() + rect.height());
 
     float r, g, b, a;
 
     getRgbF(color, &r, &g, &b, &a);
 
+    const int numVerticesPerRectangle = 6;
+    pNode->geometry().allocate(numVerticesPerRectangle * 2 * numBoxes);
     RGBAVertexUpdater vertexUpdater{pNode->geometry().vertexDataAs<Geometry::RGBAColoredPoint2D>()};
+    for (int boxIdx = 0; boxIdx < numBoxes; ++boxIdx) {
+        const float posy1 = boxIdx * boxBreadth + yOffset;
+        const float posy2 = posy1 + qh;
+        const float posy3 = posy1 + static_cast<float>(rect.height()) - qh;
+        const float posy4 = posy1 + static_cast<float>(rect.height());
+
     vertexUpdater.addRectangleVGradient(
             {posx1, posy1}, {posx2, posy2}, {r, g, b, a}, {r, g, b, 0.f});
     vertexUpdater.addRectangleVGradient(
             {posx1, posy4}, {posx2, posy3}, {r, g, b, a}, {r, g, b, 0.f});
+    }
+    pNode->markDirtyGeometry();
+    pNode->markDirtyMaterial();
 }
 
 bool allshader::WaveformRenderMark::isSubtreeBlocked() const {
@@ -287,14 +326,28 @@ void allshader::WaveformRenderMark::update() {
                                          : ::WaveformRendererAbstract::Play;
     bool slipActive = m_waveformRenderer->isSlipActive();
 
+    const TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
+    const bool isStemTrack = trackInfo && trackInfo->hasStem() &&
+            trackInfo->getWaveform() && trackInfo->getWaveform()->hasStem();
+    const bool splitStemTracks = isStemTrack &&
+            WaveformWidgetFactory::instance()->isStemSplitTracks();
+
+    const float breadth = m_waveformRenderer->getBreadth();
+    const int numBoxes = (splitStemTracks && slipActive) ? mixxx::kMaxSupportedStems : 1;
+    const float boxBreadth = breadth / static_cast<float>(numBoxes);
+    const float markBreadth = slipActive ? (boxBreadth / 2.f) : boxBreadth;
+    const float yOffset = !m_isSlipRenderer && slipActive
+            ? (boxBreadth / 2.f)
+            : 0.f;
+    const int labelBoxIdx = m_isSlipRenderer ? 0 : numBoxes - 1;
+
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     QList<WaveformWidgetRenderer::WaveformMarkOnScreen> marksOnScreen;
 
     auto roundToPixel = createFunctionRoundToPixel(devicePixelRatio);
 
     for (const auto& pMark : std::as_const(m_marks)) {
-        pMark->setBreadth(slipActive ? m_waveformRenderer->getBreadth() / 2
-                                     : m_waveformRenderer->getBreadth());
+        pMark->setBreadth(markBreadth);
     }
 
     updatePlayPosMarkTexture(m_waveformRenderer->getContext());
@@ -345,9 +398,10 @@ void allshader::WaveformRenderMark::update() {
                 drawOffset < m_waveformRenderer->getLength()) {
             pMarkNodeGraphics->update(
                     roundToPixel(drawOffset),
-                    !m_isSlipRenderer && slipActive
-                            ? roundToPixel(m_waveformRenderer->getBreadth() / 2.f)
-                            : 0,
+                    numBoxes,
+                    boxBreadth,
+                    roundToPixel(yOffset),
+                    labelBoxIdx,
                     devicePixelRatio);
 
             // transfer back to m_pMarkNodesParent children, for rendering
@@ -369,7 +423,7 @@ void allshader::WaveformRenderMark::update() {
                 // Reuse, or create new when needed
                 if (!pRangeChild) {
                     auto pNode = std::make_unique<GeometryNode>();
-                    pNode->initForRectangles<RGBAMaterial>(2);
+                    pNode->initForRectangles<RGBAMaterial>(2 * numBoxes);
                     pRangeChild = pNode.get();
                     m_pRangeNodesParent->appendChildNode(std::move(pNode));
                 }
@@ -377,7 +431,10 @@ void allshader::WaveformRenderMark::update() {
                 updateRangeNode(pRangeChild,
                         QRectF(QPointF(roundToPixel(currentMarkPos), 0.f),
                                 QPointF(roundToPixel(currentMarkEndPos),
-                                        roundToPixel(m_waveformRenderer->getBreadth()))),
+                                        roundToPixel(markBreadth))),
+                        numBoxes,
+                        boxBreadth,
+                        roundToPixel(yOffset),
                         color);
 
                 visible = true;

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -285,10 +285,10 @@ void allshader::WaveformRenderMark::updateRangeNode(GeometryNode* pNode,
         const float posy3 = posy1 + static_cast<float>(rect.height()) - qh;
         const float posy4 = posy1 + static_cast<float>(rect.height());
 
-    vertexUpdater.addRectangleVGradient(
-            {posx1, posy1}, {posx2, posy2}, {r, g, b, a}, {r, g, b, 0.f});
-    vertexUpdater.addRectangleVGradient(
-            {posx1, posy4}, {posx2, posy3}, {r, g, b, a}, {r, g, b, 0.f});
+        vertexUpdater.addRectangleVGradient(
+                {posx1, posy1}, {posx2, posy2}, {r, g, b, a}, {r, g, b, 0.f});
+        vertexUpdater.addRectangleVGradient(
+                {posx1, posy4}, {posx2, posy3}, {r, g, b, a}, {r, g, b, 0.f});
     }
     pNode->markDirtyGeometry();
     pNode->markDirtyMaterial();

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -76,6 +76,9 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
     float getMaxHeightForText(float proportion) const;
     void updateRangeNode(rendergraph::GeometryNode* pNode,
             const QRectF& rect,
+            int numBoxes,
+            float boxBreadth,
+            float yOffset,
             QColor color);
 
     int m_beatsUntilMark;


### PR DESCRIPTION
<img width="1259" height="410" alt="image" src="https://github.com/user-attachments/assets/ae7249e8-d697-404e-8ccb-078359c967eb" />

This PR is to fix the incosistencies in how the markers are displayed in slip mode with stacked stems