### PR TITLE
If the booth buffer is not being filled, clear it

### DIFF
--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -770,29 +770,27 @@ void EngineMixer::process(const int iBufferSize) {
         if (m_pVumeter != nullptr) {
             m_pVumeter->process(m_main.data(), iBufferSize);
         }
-    }
 
-    // Handle mono mixdown for the main output and booth.
-    // Headphone mixdown is handled separately since they have more complicated
-    // processing.
-    if (m_pMainMonoMixdown->toBool()) {
-        SampleUtil::mixStereoToMono(m_main.data(), iBufferSize);
-        if (boothEnabled) {
-            SampleUtil::mixStereoToMono(m_booth.data(), iBufferSize);
+        // Handle mono mixdown for the main output and booth.
+        // Headphone mixdown is handled separately since they have more
+        // complicated processing.
+        if (m_pMainMonoMixdown->toBool()) {
+            SampleUtil::mixStereoToMono(m_main.data(), iBufferSize);
+            if (boothEnabled) {
+                SampleUtil::mixStereoToMono(m_booth.data(), iBufferSize);
+            }
         }
-    }
-
-    if (mainEnabled) {
         m_pMainDelay->process(m_main.data(), iBufferSize);
+
+        if (boothEnabled) {
+            m_pBoothDelay->process(m_booth.data(), iBufferSize);
+        }
     } else {
         m_main.clear(iBufferSize);
         m_booth.clear(iBufferSize);
     }
     if (headphoneEnabled) {
         m_pHeadDelay->process(m_head.data(), iBufferSize);
-    }
-    if (boothEnabled) {
-        m_pBoothDelay->process(m_booth.data(), iBufferSize);
     }
 
     // We're close to the end of the callback. Wake up the engine worker

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -786,6 +786,7 @@ void EngineMixer::process(const int iBufferSize) {
         m_pMainDelay->process(m_main.data(), iBufferSize);
     } else {
         m_main.clear(iBufferSize);
+        m_booth.clear(iBufferSize);
     }
     if (headphoneEnabled) {
         m_pHeadDelay->process(m_head.data(), iBufferSize);


### PR DESCRIPTION
This patch clears the booth buffer when the main mix is disabled, otherwise if there were already samples in the buffer they will be played over and over again since no new samples are being written to the buffer.

This bug was pointed out by @daschuer in #17013 but does not appear to be related to the patch there, it exists in the currently released 2.5.6.

To reproduce the issue on a current build, configure a booth output and load a track into a deck and play it. Open the preferences and change the "Main Mix" setting to "Disabled". The last few samples will begin to loop.