### PR TITLE
fix(engine): preserve repeat state when disabling a loop in slip mode

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1209,7 +1209,9 @@ void LoopingControl::notifySeek(mixxx::audio::FramePos newPosition) {
 
 void LoopingControl::setLoopingEnabled(bool enabled) {
     m_bloopOrRepeatWasEnabledBeforeSlipEnable =
-            !m_pSlipEnabled->toBool() && enabled && !m_bLoopRollActive;
+            !m_pSlipEnabled->toBool() &&
+            !m_bLoopRollActive &&
+            (enabled || m_pRepeatButton->toBool());
     if (m_bLoopingEnabled == enabled) {
         return;
     }

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -27,6 +27,7 @@ class LoopingControlTest : public MockedEngineBackendTest {
         m_pQuantizeEnabled = std::make_unique<PollingControlProxy>(m_sGroup1, "quantize");
         m_pQuantizeEnabled->set(1.0);
         m_pSlipEnabled = std::make_unique<PollingControlProxy>(m_sGroup1, "slip_enabled");
+        m_pRepeatEnabled = std::make_unique<PollingControlProxy>(m_sGroup1, "repeat");
         m_pNextBeat = std::make_unique<PollingControlProxy>(m_sGroup1, "beat_next");
 
         m_pNextBeat->set(-1);
@@ -92,6 +93,19 @@ class LoopingControlTest : public MockedEngineBackendTest {
         return m_pChannel1->getEngineBuffer()->m_pLoopingControl->frameInfo().currentPosition;
     }
 
+    bool loopOrRepeatWasEnabledBeforeSlipEnable() {
+        return m_pChannel1->getEngineBuffer()
+                ->m_pLoopingControl->loopOrRepeatWasEnabledBeforeSlipEnable();
+    }
+
+    mixxx::audio::FramePos adjustedPositionForCurrentLoopOrRepeat(
+            mixxx::audio::FramePos position,
+            bool reverse) {
+        return m_pChannel1->getEngineBuffer()
+                ->m_pLoopingControl->adjustedPositionForCurrentLoopOrRepeat(
+                        position, reverse);
+    }
+
     bool isLoopEnabled() {
         return m_pLoopEnabled->get() > 0.0;
     }
@@ -105,6 +119,7 @@ class LoopingControlTest : public MockedEngineBackendTest {
     std::unique_ptr<PollingControlProxy> m_pClosestBeat;
     std::unique_ptr<PollingControlProxy> m_pQuantizeEnabled;
     std::unique_ptr<PollingControlProxy> m_pSlipEnabled;
+    std::unique_ptr<PollingControlProxy> m_pRepeatEnabled;
     std::unique_ptr<PollingControlProxy> m_pTrackSamples;
     std::unique_ptr<PollingControlProxy> m_pButtonLoopIn;
     std::unique_ptr<PollingControlProxy> m_pButtonLoopOut;
@@ -1331,4 +1346,33 @@ TEST_F(LoopingControlTest, LoopBeatloopReverse) {
         EXPECT_FALSE(isLoopEnabled());
         EXPECT_EQ(0.0, m_pSlipEnabled->get());
     }
+}
+
+TEST_F(LoopingControlTest, RepeatPositionIsAdjustedWhileInSlipMode) {
+    m_pRepeatEnabled->set(1.0);
+    EXPECT_TRUE(loopOrRepeatWasEnabledBeforeSlipEnable());
+
+    m_pSlipEnabled->set(1.0);
+    EXPECT_FRAMEPOS_EQ(
+            mixxx::audio::FramePos{1},
+            adjustedPositionForCurrentLoopOrRepeat(kTrackEndPosition + 1, false));
+}
+
+TEST_F(LoopingControlTest, DisablingLoopPreservesRepeatForSlipMode) {
+    m_pTrack1->trySetBpm(120.0);
+    m_pBeatLoopSize->set(4.0);
+    m_pButtonBeatLoopActivate->set(1.0);
+    m_pButtonBeatLoopActivate->set(0.0);
+    ASSERT_TRUE(isLoopEnabled());
+
+    m_pRepeatEnabled->set(1.0);
+    m_pLoopEnabled->set(0.0);
+
+    EXPECT_FALSE(isLoopEnabled());
+    EXPECT_TRUE(loopOrRepeatWasEnabledBeforeSlipEnable());
+
+    m_pSlipEnabled->set(1.0);
+    EXPECT_FRAMEPOS_EQ(
+            mixxx::audio::FramePos{1},
+            adjustedPositionForCurrentLoopOrRepeat(kTrackEndPosition + 1, false));
 }


### PR DESCRIPTION
Preserves repeat wrapping when a regular loop is disabled while repeat remains enabled and slip mode is subsequently activated.

`LoopingControl::setLoopingEnabled(false)` now retains the state used for slip-mode position adjustment when repeat is active.

Adds focused regression tests for repeat position adjustment in slip mode and retaining repeat behaviour after disabling an active loop.