### PR TITLE
Table delegate: move paintItemBackground() to DefaultDelegate

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -346,8 +346,8 @@ CoreServices::CoreServices(const CmdlineArgs& args, QApplication* pApp)
     // called after the GUI is initialized
     initializeSettings();
     initializeLogging();
-    // Only record stats in developer mode.
-    if (m_cmdlineArgs.getDeveloper()) {
+    // Only record stats in developer mode or when --stats is specified.
+    if (m_cmdlineArgs.getStats()) {
         StatsManager::createInstance();
     }
     mixxx::Translations::initializeTranslations(
@@ -365,7 +365,7 @@ CoreServices::~CoreServices() {
     CLEAR_AND_CHECK_DELETED(m_pKbdConfig);
     CLEAR_AND_CHECK_DELETED(m_pKbdConfigEmpty);
 
-    if (m_cmdlineArgs.getDeveloper()) {
+    if (m_cmdlineArgs.getStats()) {
         StatsManager::destroy();
     }
 

--- a/src/library/tabledelegates/defaultdelegate.cpp
+++ b/src/library/tabledelegates/defaultdelegate.cpp
@@ -4,6 +4,7 @@
 
 #include "moc_defaultdelegate.cpp"
 #include "util/assert.h"
+#include "util/timer.h"
 
 DefaultDelegate::DefaultDelegate(QTableView* pTableView)
         : QStyledItemDelegate(pTableView) {
@@ -13,6 +14,8 @@ void DefaultDelegate::paint(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
+    ScopedTimer t(QStringLiteral("DefaultDelegate::paint"));
+
     QStyleOptionViewItem opt = option;
     initStyleOption(&opt, index);
 

--- a/src/library/tabledelegates/defaultdelegate.cpp
+++ b/src/library/tabledelegates/defaultdelegate.cpp
@@ -3,6 +3,7 @@
 #include <QPainter>
 
 #include "moc_defaultdelegate.cpp"
+#include "util/assert.h"
 
 DefaultDelegate::DefaultDelegate(QTableView* pTableView)
         : QStyledItemDelegate(pTableView) {
@@ -15,12 +16,39 @@ void DefaultDelegate::paint(
     QStyleOptionViewItem opt = option;
     initStyleOption(&opt, index);
 
+    // Workaround for a Qt6 bug occurring on Wayland (maybe also with other OS or
+    // compositors):
+    // Paint background color from model if available and not selected to
+    // ensure the alpha channel is respected.
+    paintItemBackground(painter, opt, index);
+    // Clear the background brush so QStyledItemDelegate doesn't paint it again
+    opt.backgroundBrush = QBrush();
+
     if (opt.state & QStyle::State_Selected) {
         setHighlightedTextColor(opt, index);
     }
     // TODO Guarantee font/bg contrast with ALL track colors
 
     QStyledItemDelegate::paint(painter, opt, index);
+}
+
+void DefaultDelegate::paintItemBackground(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) {
+    // If the row is not selected, paint the desired background color before
+    // painting the delegate item
+    if (option.showDecorationSelected &&
+            (option.state & QStyle::State_Selected)) {
+        return;
+    }
+    QVariant bgValue = index.data(Qt::BackgroundRole);
+    if (!bgValue.isValid()) {
+        return;
+    }
+    DEBUG_ASSERT(bgValue.canConvert<QBrush>());
+    const auto bgBrush = qvariant_cast<QBrush>(bgValue);
+    painter->fillRect(option.rect, bgBrush);
 }
 
 void DefaultDelegate::setHighlightedTextColor(

--- a/src/library/tabledelegates/defaultdelegate.h
+++ b/src/library/tabledelegates/defaultdelegate.h
@@ -17,4 +17,10 @@ class DefaultDelegate : public QStyledItemDelegate {
     void setHighlightedTextColor(
             QStyleOptionViewItem& option,
             const QModelIndex& index) const;
+
+  protected:
+    static void paintItemBackground(
+            QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index);
 };

--- a/src/library/tabledelegates/multilineeditdelegate.cpp
+++ b/src/library/tabledelegates/multilineeditdelegate.cpp
@@ -191,6 +191,17 @@ MultiLineEditDelegate::MultiLineEditDelegate(QTableView* pTableView)
         : TableItemDelegate(pTableView) {
 }
 
+void MultiLineEditDelegate::paint(
+        QPainter* pPainter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    // Workaround for a Qt6 bug occurring on Wayland (maybe also with other OS or
+    // compositors) https://github.com/mixxxdj/mixxx/issues/17037
+    // Paint background color from model if available and not selected to
+    // ensure the alpha channel is respected.
+    DefaultDelegate::paint(pPainter, option, index);
+}
+
 QWidget* MultiLineEditDelegate::createEditor(QWidget* pParent,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {

--- a/src/library/tabledelegates/multilineeditdelegate.h
+++ b/src/library/tabledelegates/multilineeditdelegate.h
@@ -38,6 +38,10 @@ class MultiLineEditDelegate : public TableItemDelegate {
     explicit MultiLineEditDelegate(QTableView* pTrackTable);
     ~MultiLineEditDelegate() override = default;
 
+    void paint(QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index) const override;
+
     // called when the user starts editing an item
     QWidget* createEditor(QWidget* parent,
             const QStyleOptionViewItem& option,

--- a/src/library/tabledelegates/tableitemdelegate.cpp
+++ b/src/library/tabledelegates/tableitemdelegate.cpp
@@ -76,25 +76,6 @@ int TableItemDelegate::columnWidth(const QModelIndex &index) const {
     return m_pTableView->columnWidth(index.column());
 }
 
-void TableItemDelegate::paintItemBackground(
-        QPainter* painter,
-        const QStyleOptionViewItem& option,
-        const QModelIndex& index) {
-    // If the row is not selected, paint the desired background color before
-    // painting the delegate item
-    if (option.showDecorationSelected &&
-            (option.state & QStyle::State_Selected)) {
-        return;
-    }
-    QVariant bgValue = index.data(Qt::BackgroundRole);
-    if (!bgValue.isValid()) {
-        return;
-    }
-    DEBUG_ASSERT(bgValue.canConvert<QBrush>());
-    const auto bgBrush = qvariant_cast<QBrush>(bgValue);
-    painter->fillRect(option.rect, bgBrush);
-}
-
 // static
 void TableItemDelegate::drawBorder(
         QPainter* painter,

--- a/src/library/tabledelegates/tableitemdelegate.h
+++ b/src/library/tabledelegates/tableitemdelegate.h
@@ -24,11 +24,6 @@ class TableItemDelegate : public DefaultDelegate {
             const QRect& rect);
 
   protected:
-    static void paintItemBackground(
-            QPainter* painter,
-            const QStyleOptionViewItem& option,
-            const QModelIndex& index);
-
     // Only used by LocationDelegate's text elide.
     // Having this here avoids including QTableView there.
     int columnWidth(const QModelIndex &index) const;

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -53,6 +53,7 @@ CmdlineArgs::CmdlineArgs()
           m_controllerDebug(false),
           m_controllerAbortOnWarning(false),
           m_developer(false),
+          m_stats(false),
 #ifdef MIXXX_USE_QML
           m_qml(false),
 #endif
@@ -272,6 +273,12 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                             : QString());
     parser.addOption(developer);
 
+    const QCommandLineOption stats(QStringLiteral("stats"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Enables collection of performance statistics.")
+                            : QString());
+    parser.addOption(stats);
+
 #ifdef MIXXX_USE_QML
     const QCommandLineOption qml(QStringLiteral("qml"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -439,6 +446,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     m_controllerDebug = parser.isSet(controllerDebug) || parser.isSet(controllerDebugDeprecated);
     m_controllerAbortOnWarning = parser.isSet(controllerAbortOnWarning);
     m_developer = parser.isSet(developer);
+    m_stats = parser.isSet(stats);
 #ifdef MIXXX_USE_QML
     m_qml = parser.isSet(qml);
 #endif

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -40,6 +40,9 @@ class CmdlineArgs final {
         return m_controllerAbortOnWarning;
     }
     bool getDeveloper() const { return m_developer; }
+    bool getStats() const {
+        return m_developer || m_stats;
+    }
 #ifdef MIXXX_USE_QML
     bool isQml() const {
         return m_qml;
@@ -96,6 +99,7 @@ class CmdlineArgs final {
     bool m_controllerDebug;
     bool m_controllerAbortOnWarning; // Controller Engine will be stricter
     bool m_developer; // Developer Mode
+    bool m_stats;     // Enable stats collection
 #ifdef MIXXX_USE_QML
     bool m_qml;
 #endif

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -47,7 +47,7 @@ class ScopedTimer {
             int i,
             Stat::ComputeFlags compute = kDefaultComputeFlags)
             : ScopedTimer(key,
-                      CmdlineArgs::Instance().getDeveloper()
+                      CmdlineArgs::Instance().getStats()
                               ? QString::number(i)
                               : QStringView(),
                       compute) {
@@ -55,7 +55,7 @@ class ScopedTimer {
 
     ScopedTimer(QStringView key, QStringView arg, Stat::ComputeFlags compute = kDefaultComputeFlags)
             : m_maybeTimer(std::nullopt) {
-        if (!CmdlineArgs::Instance().getDeveloper()) {
+        if (!CmdlineArgs::Instance().getStats()) {
             return;
         }
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)


### PR DESCRIPTION
Fixes #17037

Work around a Qt6 bug on Wayland where opacity of Qt::BackgroundRole is ignored.
Now every delegate uses the custom paintItemBackground() method and manually applies the track color incl. opacity.