### PR TITLE
[GSoC] LateNightQML: Waveform Reskin 

### DIFF
--- a/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
+++ b/res/skins/LateNightQML/LateNightTheme/LateNightTheme.qml
@@ -12,6 +12,8 @@ QtObject {
     readonly property url assetDeckBeatSpinBoxBorder: isClassic ? lateNightAsset("buttons", "spinbox_elevated_border.svg") : lateNightSubRegionButton("wide")
     readonly property url assetDeckBeatSpinBoxDownButton: isClassic ? lateNightAsset("buttons", "spinbox_down.svg") : lateNightAsset("buttons", "btn__spinbox_down.svg")
     readonly property url assetDeckBeatSpinBoxUpButton: isClassic ? lateNightAsset("buttons", "spinbox_up.svg") : lateNightAsset("buttons", "btn__spinbox_up.svg")
+    readonly property url assetDeckBeatgridControlsCollapseButton: lateNightAsset("buttons", "btn__beatgrid_controls_collapse.svg")
+    readonly property url assetDeckBeatgridControlsExpandButton: lateNightAsset("buttons", "btn__beatgrid_controls_expand.svg")
     readonly property url assetDeckBeatjumpLeftButton: lateNightAsset("buttons", "btn__beatjump_left.svg")
     readonly property url assetDeckBeatjumpRightButton: lateNightAsset("buttons", "btn__beatjump_right.svg")
     readonly property url assetDeckBeatsEarlierButton: lateNightAsset("buttons", "btn__beats_earlier.svg")
@@ -70,6 +72,10 @@ QtObject {
     readonly property url assetDeckSpinnyIndicator: lateNightAsset("style", "spinny_indicator.svg")
     readonly property url assetDeckSpinnyMask12: lateNightAsset("style", "spinny_mask_12.svg")
     readonly property url assetDeckSpinnyMask34: lateNightAsset("style", "spinny_mask_34.svg")
+    readonly property url assetDeckStemControlsCollapseButton: lateNightAsset("buttons", "btn__stem_controls_collapse.svg")
+    readonly property url assetDeckStemControlsExpandButton: lateNightAsset("buttons", "btn__stem_controls_expand.svg")
+    readonly property url assetWaveformSplitterHandle: lateNightAsset("style", isClassic ? "splitter_handle_horizontal.png" : "splitter_handle_horizontal.svg")
+    readonly property url assetWaveformSplitterHandlePressed: lateNightAsset("style", isClassic ? "splitter_handle_horizontal_pressed.png" : "splitter_handle_horizontal_pressed.svg")
     readonly property url assetDeckSyncActiveButton: isPaleMoon ? lateNightAsset("buttons", "btn__sync_deck_active.svg") : lateNightAsset("buttons", "btn__sync_deck.svg")
     readonly property url assetDeckSyncBackground: lateNightAsset("buttons", "btn_embedded_library.svg")
     readonly property url assetDeckSyncButton: lateNightAsset("buttons", "btn__sync_deck.svg")
@@ -130,6 +136,7 @@ QtObject {
     readonly property url assetMixerQuickEffectIcon: lateNightAsset("buttons", "btn__star.svg")
     readonly property url assetMixerSplitActiveIcon: lateNightAsset("buttons", isClassic ? "btn_elevated_headsplit_active.svg" : "btn_embedded_headsplit_active.svg")
     readonly property url assetMixerSplitIcon: lateNightAsset("buttons", isClassic ? "btn_elevated_headsplit.svg" : "btn_embedded_headsplit.svg")
+    readonly property url assetMixerStemMuteIcon: lateNightAsset("buttons", "btn__stem_mute.svg")
     readonly property url assetMixerVolumeSliderBackground: lateNightAsset("sliders", "slider_volume_deck.svg")
     readonly property url assetMixerVolumeSliderHandle: lateNightAsset("sliders", "knob_volume_deck.svg")
     readonly property url assetRegularKnobBackground: lateNightAsset("knobs", "knob_bg_regular.svg")
@@ -228,7 +235,7 @@ QtObject {
     readonly property bool isPaleMoon: ColorScheme.name === "palemoon"
     readonly property color keyControlsPressedColor: isPaleMoon ? "#7d350d" : "#db0000"
     readonly property string keyControlsPressedIconSuffix: isPaleMoon ? "active" : ""
-    readonly property color libraryPanelSplitterBackground: "#1e1e1e"
+    readonly property color libraryPanelSplitterBackground: isPaleMoon ? "#080808" : "#0f0f0f"
     readonly property color libraryPanelSplitterHandle: "#5f5f5f"
     readonly property color libraryPanelSplitterHandleActive: "#7a7a7a"
     readonly property color mixerAccentCyan: "#0bd9d1"
@@ -249,8 +256,6 @@ QtObject {
     readonly property color mixerFxAssignInactiveTextColor: isClassic ? effectsAssignmentInactiveTextColor : "#666666"
     readonly property color mixerMainSeparatorDarkColor: isPaleMoon ? "#0c0c0c" : mixerPanelBorderDark
     readonly property color mixerMainSeparatorLightColor: isPaleMoon ? "#222222" : mixerPanelBorderLight
-    readonly property color mixerSplitActiveColor: isClassic ? "#888888" : "#555555"
-    readonly property color mixerSplitInactiveColor: isClassic ? deckEmbeddedButtonInactiveColor : "#222222"
     readonly property color mixerPanelBorderBottom: isPaleMoon ? "#0c0c0c" : "#0a0a0a"
     readonly property color mixerPanelBorderDark: "#080808"
     readonly property color mixerPanelBorderLeft: isPaleMoon ? "#282828" : "#333333"
@@ -260,8 +265,15 @@ QtObject {
     readonly property color mixerPanelColor: "#1d1d1f"
     readonly property color mixerPflActiveFillColor: isClassic ? "#db0000" : "#666666"
     readonly property color mixerQuickEffectActiveColor: isClassic ? "#659f08" : "#236b00"
-    readonly property color mixerQuickEffectSelectorTextColor: "#918273"
+    readonly property color mixerQuickEffectSelectorHighlightColor: isClassic ? "#5e4507" : "#2c454f"
+    readonly property color mixerQuickEffectSelectorPopupBackgroundColor: isClassic ? "#0f0f0f" : "#151517"
+    readonly property color mixerQuickEffectSelectorPopupBorderColor: isClassic ? "#888888" : "#333333"
+    readonly property color mixerQuickEffectSelectorHighlightTextColor: white
+    readonly property color mixerQuickEffectSelectorTextColor: isClassic ? "#888888" : "#918273"
     readonly property color mixerSliderBarColor: "#257b82"
+    readonly property color mixerSplitActiveColor: isClassic ? "#888888" : "#555555"
+    readonly property color mixerSplitInactiveColor: isClassic ? deckEmbeddedButtonInactiveColor : "#222222"
+    readonly property color mixerStemMuteInactiveColor: isClassic ? "#262626" : "#2a2a2c"
     readonly property color mixerVuClipColor: mixerAccentRed
     readonly property color mixerVuLevelColor: mixerAccentRed
     readonly property color micAuxDuckingArcColor: "#a00000"
@@ -278,17 +290,18 @@ QtObject {
     readonly property url optionalMixerEqKillDotActiveRed: isPaleMoon ? lateNightAsset("buttons", "btn__eq_kill_dot_active_red.svg") : ""
     readonly property url optionalMixerEqKillDotOff: isPaleMoon ? lateNightAsset("buttons", "btn__eq_kill_dot_off.svg") : ""
     readonly property url optionalMixerQuickEffectActiveIcon: isPaleMoon ? lateNightAsset("buttons", "btn__star_active.svg") : ""
+    readonly property color overviewBorderBottomColor: "#2a2a2a"
+    readonly property color overviewBorderLeftColor: "#121212"
+    readonly property color overviewBorderRightColor: "#252525"
+    readonly property color overviewBorderTopColor: "#0d0d0d"
     readonly property color overviewHotcueBrightTextColor: "#000000"
     readonly property int overviewHotcueBrightnessThreshold: 127
     readonly property color overviewMarkerTextColor: "#ffffff"
     readonly property color overviewRgbHighColor: "#ff0000"
     readonly property color overviewRgbLowColor: "#0000ff"
     readonly property color overviewRgbMidColor: "#00ff00"
-    readonly property color overviewBorderBottomColor: "#2a2a2a"
-    readonly property color overviewBorderLeftColor: "#121212"
-    readonly property color overviewBorderRightColor: "#252525"
-    readonly property color overviewBorderTopColor: "#0d0d0d"
     readonly property color overviewSettingsBackgroundColor: isClassic ? "#151515" : "#19191a"
+    readonly property color passthroughActiveColor: vinylStatusSpeedColor
     readonly property string playCueActiveIconSuffix: isPaleMoon ? "active" : ""
     readonly property color primaryDeckTextColor: isClassic ? "#f0bb2b" : "#c2b3a5"
     readonly property color primaryOverviewBackgroundColor: isClassic ? "#0f0f0f" : "#19191a"
@@ -336,9 +349,6 @@ QtObject {
     readonly property color syncInactiveBackgroundColor: "#1e1e1e"
     readonly property color textColor: white
     readonly property color textColorMuted: "#696969"
-    readonly property color trackPropertyHighlightColor: "#151515"
-    readonly property color trackPropertySelectedTextColor: "#111111"
-    readonly property color trackPropertySelectionColor: white
     readonly property color toolbarActiveColor: white
     readonly property color toolbarBackgroundColor: "#242424"
     readonly property color toolbarBottomBorderColor: "#020202"
@@ -368,7 +378,9 @@ QtObject {
     readonly property color toolbarStatusErrorColor: "#f856e7"
     readonly property color toolbarStatusOkColor: "#54c76a"
     readonly property color toolbarStatusWarnColor: "#d89124"
-    readonly property color passthroughActiveColor: vinylStatusSpeedColor
+    readonly property color trackPropertyHighlightColor: "#151515"
+    readonly property color trackPropertySelectedTextColor: "#111111"
+    readonly property color trackPropertySelectionColor: white
     readonly property color vinylCueingActiveColor: "#888888"
     readonly property color vinylStatusSignalAndSpeedColor: "#f856e7"
     readonly property color vinylStatusSignalColor: isClassic ? "#659f08" : "#438225"
@@ -380,16 +392,23 @@ QtObject {
     readonly property color waveformCueColor: isPaleMoon ? "#ff7a01" : "#ff001c"
     readonly property color waveformDefaultMarkColor: "#ff0000"
     readonly property color waveformDisabledMarkColor: "#ffffff"
-    readonly property color waveformEndOfTrackWarningColor: "#ff8872"
+    readonly property color waveformEndOfTrackWarningColor: "#f856e7"
     readonly property color waveformFilteredHighColor: "#d5c2a2"
     readonly property color waveformFilteredLowColor: "#2154d7"
     readonly property color waveformFilteredMidColor: "#97632d"
     readonly property color waveformIntroOutroColor: isPaleMoon ? "#2c5c9a" : "#0000ff"
     readonly property color waveformLoopColor: isPaleMoon ? "#00b400" : "#00ff00"
     readonly property color waveformMarkerTextColor: "#ffffff"
+    readonly property color waveformNoStemLabelColor: isPaleMoon ? "#444444" : "#f0bb2b"
+    readonly property color waveformContainerColor: isPaleMoon ? "#151517" : "#1e1e1e"
+    readonly property color waveformContainerBottomBorderColor: isPaleMoon ? "#0c0c0c" : "#0a0a0a"
+    readonly property color waveformDeckBottomBorderColor: isPaleMoon ? "#2a2a2a" : "#333333"
+    readonly property color waveformOverlayColor: isPaleMoon ? "#151517" : "#171717"
     readonly property color waveformPlayPositionColor: isPaleMoon ? "#00c6ff" : "#00c8ff"
     readonly property color waveformPrimaryBackgroundColor: "#0f0f0e"
+    readonly property color waveformPrimarySignalColor: isPaleMoon ? "#d9b28c" : "#e7c413"
     readonly property color waveformSecondaryBackgroundColor: "#001b23"
+    readonly property color waveformSecondarySignalColor: isPaleMoon ? "#7bc6c3" : "#09b2ae"
     readonly property color white: "#D9D9D9"
 
     function lateNightAsset(directory, fileName) {
@@ -421,9 +440,7 @@ QtObject {
         const green = hotcueColor.g * 255;
         const blue = hotcueColor.b * 255;
         const brightness = Math.sqrt(red * red * 0.241 + green * green * 0.691 + blue * blue * 0.068);
-        return brightness <= overviewHotcueBrightnessThreshold
-                ? overviewMarkerTextColor
-                : overviewHotcueBrightTextColor;
+        return brightness <= overviewHotcueBrightnessThreshold ? overviewMarkerTextColor : overviewHotcueBrightTextColor;
     }
     function sharedImage(fileName) {
         return Qt.resolvedUrl("../../../qml/images/" + fileName);

--- a/res/skins/LateNightQML/MainWindow.qml
+++ b/res/skins/LateNightQML/MainWindow.qml
@@ -11,6 +11,7 @@ import Mixxx 1.0 as Mixxx
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtQuick.Templates as T
 import QtQuick.Window
 
 Item {
@@ -153,33 +154,25 @@ Item {
             handle: Rectangle {
                 id: handleDelegate
 
-                property color handleColor: SplitHandle.pressed || SplitHandle.hovered ? LateNightTheme.libraryPanelSplitterHandleActive : LateNightTheme.libraryPanelSplitterHandle
-                property int handleSize: SplitHandle.pressed || SplitHandle.hovered ? 6 : 3
+                readonly property bool pressed: splitView.resizing || T.SplitHandle.pressed
 
                 clip: true
                 color: LateNightTheme.libraryPanelSplitterBackground
-                implicitHeight: 4
+                implicitHeight: 9
                 implicitWidth: 8
 
                 containmentMask: Item {
-                    height: 8
+                    height: 12
                     width: splitView.width
                     x: (handleDelegate.width - width) / 2
                 }
 
-                RowLayout {
+                Image {
                     anchors.centerIn: parent
-
-                    Repeater {
-                        model: 3
-
-                        Rectangle {
-                            color: handleColor
-                            height: handleSize
-                            radius: handleSize
-                            width: handleSize
-                        }
-                    }
+                    fillMode: Image.PreserveAspectFit
+                    source: handleDelegate.pressed
+                            ? LateNightTheme.assetWaveformSplitterHandlePressed
+                            : LateNightTheme.assetWaveformSplitterHandle
                 }
             }
 
@@ -187,6 +180,7 @@ Item {
                 id: waveforms
 
                 SplitView.fillHeight: !library.active
+                SplitView.minimumHeight: visible ? minimumContentHeight : 0
                 SplitView.preferredHeight: library.active ? 120 : undefined
                 show4decks: root.show4decks
                 visible: root.showWaveforms && !root.maximizeLibrary

--- a/res/skins/LateNightQML/Mixer/QuickEffectSelector.qml
+++ b/res/skins/LateNightQML/Mixer/QuickEffectSelector.qml
@@ -9,14 +9,27 @@ ComboBox {
     property bool arrowOnRight: false
     readonly property bool compact: width <= 40
     required property string group
-    property int popupMaxItem: 44
+    readonly property int popupMaxItem: count
     property int popupWidth: 160
     readonly property string quickEffectGroup: "[QuickEffectRack1_" + group + "]"
+    property bool textAlignRight: arrowOnRight
 
-    currentIndex: root.count > 0 ? Math.max(0, Math.min(root.count - 1, Math.round(presetControl.value))) : -1
+    function syncCurrentPreset() {
+        if (root.count === 0) {
+            root.currentIndex = -1
+            return
+        }
+
+        const presetIndex = presetControl && presetControl.initialized
+                ? Math.round(presetControl.value)
+                : -1
+        root.currentIndex = Math.max(-1, Math.min(root.count - 1, presetIndex))
+    }
+
+    currentIndex: -1
     font.family: "Open Sans"
-    font.pixelSize: 13
-    font.weight: Font.Medium
+    font.pixelSize: LateNightTheme.isClassic ? 12 : 14
+    font.weight: LateNightTheme.isClassic ? Font.Bold : Font.Medium
     implicitHeight: 18
     implicitWidth: 62
     model: Mixxx.EffectsManager.quickChainPresetModel
@@ -45,10 +58,10 @@ ComboBox {
             color: LateNightTheme.mixerQuickEffectSelectorTextColor
             elide: Text.ElideRight
             font: root.font
-            horizontalAlignment: root.arrowOnRight ? Text.AlignRight : Text.AlignLeft
+            horizontalAlignment: root.textAlignRight ? Text.AlignRight : Text.AlignLeft
             leftPadding: root.arrowOnRight ? 0 : (root.compact ? 10 : 13)
             rightPadding: root.arrowOnRight ? (root.compact ? 10 : 13) : 0
-            text: root.displayText || qsTr("Filter")
+            text: root.displayText
             verticalAlignment: Text.AlignVCenter
         }
     }
@@ -65,11 +78,13 @@ ComboBox {
         width: ListView.view ? ListView.view.width : root.popupWidth
 
         background: Rectangle {
-            color: presetDelegate.highlighted ? "#2c454f" : "transparent"
+            color: presetDelegate.highlighted ? LateNightTheme.mixerQuickEffectSelectorHighlightColor : "transparent"
             radius: presetDelegate.highlighted ? 1 : 0
         }
         contentItem: Text {
-            color: presetDelegate.checked || presetDelegate.highlighted ? "#ffffff" : LateNightTheme.mixerQuickEffectSelectorTextColor
+            color: presetDelegate.checked || presetDelegate.highlighted
+                    ? LateNightTheme.mixerQuickEffectSelectorHighlightTextColor
+                    : LateNightTheme.mixerQuickEffectSelectorTextColor
             elide: Text.ElideRight
             font: root.font
             leftPadding: 20
@@ -89,10 +104,10 @@ ComboBox {
         y: root.height
 
         background: Rectangle {
-            border.color: "#333333"
+            border.color: LateNightTheme.mixerQuickEffectSelectorPopupBorderColor
             border.width: 1
-            color: "#151517"
-            radius: 1
+            color: LateNightTheme.mixerQuickEffectSelectorPopupBackgroundColor
+            radius: LateNightTheme.isClassic ? 2 : 1
         }
         contentItem: ListView {
             id: presetList
@@ -110,7 +125,29 @@ ComboBox {
         onOpened: presetList.contentY = 0
     }
 
+    Component.onCompleted: root.syncCurrentPreset()
     onActivated: index => presetControl.value = index
+    onCountChanged: root.syncCurrentPreset()
+
+    Connections {
+        function onModelReset() {
+            root.syncCurrentPreset()
+        }
+
+        target: root.model
+    }
+
+    Connections {
+        function onValueChanged() {
+            root.syncCurrentPreset()
+        }
+
+        function onInitializedChanged() {
+            root.syncCurrentPreset()
+        }
+
+        target: presetControl
+    }
 
     Mixxx.ControlProxy {
         id: presetControl

--- a/res/skins/LateNightQML/SkinControlBootstrap.qml
+++ b/res/skins/LateNightQML/SkinControlBootstrap.qml
@@ -35,6 +35,8 @@ Item {
     Mixxx.SkinControlCreator { defaultValue: 1.0; group: "[Skin]"; key: "show_main_head_mixer"; persist: true }
     Mixxx.SkinControlCreator { group: "[Skin]"; key: "equal_4deck_waveforms"; persist: true }
     Mixxx.SkinControlCreator { group: "[Skin]"; key: "timing_shift_buttons"; persist: true }
+    Mixxx.SkinControlCreator { defaultValue: 1.0; group: "[Skin]"; key: "show_beatgrid_controls"; persist: true }
+    Mixxx.SkinControlCreator { defaultValue: 0.0; group: "[Skin]"; key: "show_stem_controls"; persist: true }
     Mixxx.SkinControlCreator { defaultValue: 0.0; group: "[Skin]"; key: "show_sampler_fx"; persist: true }
     Mixxx.SkinControlCreator { defaultValue: 1.0; group: "[Skin]"; key: "sampler_rows"; persist: true }
     Mixxx.SkinControlCreator { defaultValue: -1.0; group: "[Skin]"; key: "show_4samplers"; persist: true }

--- a/res/skins/LateNightQML/Waveforms/BeatgridControls.qml
+++ b/res/skins/LateNightQML/Waveforms/BeatgridControls.qml
@@ -2,268 +2,266 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
-import Mixxx 1.0 as Mixxx
 import "../LateNightTheme"
 import "../Deck"
+import "../Controls" as Controls
+import "../../../qml/Deck" as SharedDeck
 
-RowLayout {
+Controls.Panel {
     id: root
 
     required property string group
 
-    Mixxx.ControlProxy {
-        id: bpmlockProxy
+    clip: true
+    color: LateNightTheme.waveformOverlayColor
+    implicitHeight: 52
+    implicitWidth: beatgridBehavior.timingShiftButtonsVisible ? 130 : 104
+    bottomBorderColor: LateNightTheme.isPaleMoon ? "#020202" : "#111111"
+    leftBorderColor: LateNightTheme.isPaleMoon ? "#1c1c1c" : "#222222"
+    rightBorderColor: "#111111"
+    topBorderColor: LateNightTheme.isPaleMoon ? "#1c1c1c" : "#222222"
+
+    MouseArea {
+        acceptedButtons: Qt.AllButtons
+        anchors.fill: parent
+        z: -1
+
+        onWheel: wheel => wheel.accepted = true
+    }
+    SharedDeck.BeatgridControlsBehavior {
+        id: beatgridBehavior
+
         group: root.group
-        key: "bpmlock"
     }
-
-    Mixxx.ControlProxy {
-        id: timingShiftButtonsProxy
-        group: "[Skin]"
-        key: "timing_shift_buttons"
-    }
-
-    Mixxx.ControlProxy {
-        id: beatsUndoPossibleProxy
-        group: root.group
-        key: "beats_undo_possible"
-    }
-
-    spacing: 0
-    Layout.fillHeight: true
-
-    // Column 1: CurPos (26x52)
-    Item {
-        Layout.preferredWidth: 26
-        Layout.preferredHeight: 52
-
-        LateNightControlButton {
-            anchors.fill: parent
-            backgroundSource: LateNightTheme.lateNightTopRegionButton("library_tall")
-            iconSource: LateNightTheme.assetDeckBeatCurposLargeButton
-            group: root.group
-            key: "beats_translate_curpos"
-            rightClickKey: "beats_translate_match_alignment"
-            activeBackgroundSuffix: "active"
-            pressedBackgroundSuffix: "active"
-            activeOpacity: 1.0
-            inactiveOpacity: 0.82
-            activeColor: LateNightTheme.deckDimButtonInactiveColor
-            inactiveColor: LateNightTheme.deckDimButtonInactiveColor
-            enabled: bpmlockProxy.value === 0
-        }
-
-        Rectangle {
-            anchors.fill: parent
-            color: LateNightTheme.beatgridDisabledCoverColor
-            visible: bpmlockProxy.value > 0
-            radius: 2
-        }
-    }
-
-    // Column 2: BeatsEarlier / BeatsFaster
-    Item {
-        Layout.preferredWidth: 26
-        Layout.preferredHeight: 52
-
-        Column {
-            anchors.fill: parent
-            spacing: 0
-
-            LateNightControlButton {
-                width: 26
-                height: 26
-                backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
-                iconSource: LateNightTheme.assetDeckBeatsEarlierButton
-                group: root.group
-                key: "beats_translate_earlier"
-                rightClickKey: "beats_translate_half"
-                activeBackgroundSuffix: "active"
-                pressedBackgroundSuffix: "active"
-                activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                activeOpacity: 1.0
-                inactiveOpacity: 0.82
-                activeColor: LateNightTheme.deckDimButtonInactiveColor
-                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
-                enabled: bpmlockProxy.value === 0
-            }
-
-            LateNightControlButton {
-                width: 26
-                height: 26
-                backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
-                iconSource: LateNightTheme.assetDeckBeatsFasterButton
-                group: root.group
-                key: "beats_adjust_faster"
-                activeBackgroundSuffix: "active"
-                pressedBackgroundSuffix: "active"
-                activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                activeOpacity: 1.0
-                inactiveOpacity: 0.82
-                activeColor: LateNightTheme.deckDimButtonInactiveColor
-                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
-                enabled: bpmlockProxy.value === 0
-            }
-        }
-
-        Rectangle {
-            anchors.fill: parent
-            color: LateNightTheme.beatgridDisabledCoverColor
-            visible: bpmlockProxy.value > 0
-            radius: 2
-        }
-    }
-
-    // Column 3: BeatsLater / BeatsSlower
-    Item {
-        Layout.preferredWidth: 26
-        Layout.preferredHeight: 52
-
-        Column {
-            anchors.fill: parent
-            spacing: 0
-
-            LateNightControlButton {
-                width: 26
-                height: 26
-                backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
-                iconSource: LateNightTheme.assetDeckBeatsLaterButton
-                group: root.group
-                key: "beats_translate_later"
-                rightClickKey: "beats_translate_half"
-                activeBackgroundSuffix: "active"
-                pressedBackgroundSuffix: "active"
-                activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                activeOpacity: 1.0
-                inactiveOpacity: 0.82
-                activeColor: LateNightTheme.deckDimButtonInactiveColor
-                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
-                enabled: bpmlockProxy.value === 0
-            }
-
-            LateNightControlButton {
-                width: 26
-                height: 26
-                backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
-                iconSource: LateNightTheme.assetDeckBeatsSlowerButton
-                group: root.group
-                key: "beats_adjust_slower"
-                activeBackgroundSuffix: "active"
-                pressedBackgroundSuffix: "active"
-                activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                activeOpacity: 1.0
-                inactiveOpacity: 0.82
-                activeColor: LateNightTheme.deckDimButtonInactiveColor
-                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
-                enabled: bpmlockProxy.value === 0
-            }
-        }
-
-        Rectangle {
-            anchors.fill: parent
-            color: LateNightTheme.beatgridDisabledCoverColor
-            visible: bpmlockProxy.value > 0
-            radius: 2
-        }
-    }
-
-    // Column 4: Undo / BpmLockToggle
-    Column {
-        Layout.preferredWidth: 26
-        Layout.preferredHeight: 52
+    RowLayout {
+        anchors.centerIn: parent
         spacing: 0
 
+        // Column 1: CurPos (26x52)
         Item {
-            width: 26
-            height: 26
+            Layout.preferredHeight: 52
+            Layout.preferredWidth: 26
 
             LateNightControlButton {
-                anchors.fill: parent
-                backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
-                iconSource: LateNightTheme.assetDeckUndoButton
-                group: root.group
-                key: "beats_undo_adjustment"
                 activeBackgroundSuffix: "active"
-                pressedBackgroundSuffix: "active"
-                activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-                activeOpacity: 1.0
-                inactiveOpacity: 0.82
                 activeColor: LateNightTheme.deckDimButtonInactiveColor
+                activeOpacity: 1.0
+                anchors.fill: parent
+                backgroundSource: LateNightTheme.lateNightTopRegionButton("library_tall")
+                enabled: !beatgridBehavior.bpmLocked
+                group: root.group
+                iconSource: LateNightTheme.assetDeckBeatCurposLargeButton
                 inactiveColor: LateNightTheme.deckDimButtonInactiveColor
-                enabled: beatsUndoPossibleProxy.value > 0
+                inactiveOpacity: 0.82
+                key: "beats_translate_curpos"
+                pressedBackgroundSuffix: "active"
+                rightClickKey: "beats_translate_match_alignment"
             }
-
             Rectangle {
                 anchors.fill: parent
                 color: LateNightTheme.beatgridDisabledCoverColor
-                visible: beatsUndoPossibleProxy.value === 0
                 radius: 2
+                visible: beatgridBehavior.bpmLocked
             }
         }
 
-        LateNightControlButton {
-            width: 26
-            height: 26
-            backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
-            iconSource: isActive ? LateNightTheme.assetDeckBpmLockedButton : LateNightTheme.assetDeckBpmUnlockedButton
-            group: root.group
-            key: "bpmlock"
-            toggleable: true
-            activeBackgroundSuffix: "active"
-            pressedBackgroundSuffix: "active"
-            activeOpacity: 1.0
-            inactiveOpacity: 0.82
-            activeColor: LateNightTheme.deckDimButtonInactiveColor
-            inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+        // Column 2: BeatsEarlier / BeatsFaster
+        Item {
+            Layout.preferredHeight: 52
+            Layout.preferredWidth: 26
+
+            Column {
+                anchors.fill: parent
+                spacing: 0
+
+                LateNightControlButton {
+                    activeBackgroundSuffix: "active"
+                    activeColor: LateNightTheme.deckDimButtonInactiveColor
+                    activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                    activeOpacity: 1.0
+                    backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
+                    enabled: !beatgridBehavior.bpmLocked
+                    group: root.group
+                    height: 26
+                    iconSource: LateNightTheme.assetDeckBeatsEarlierButton
+                    inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+                    inactiveOpacity: 0.82
+                    key: "beats_translate_earlier"
+                    pressedBackgroundSuffix: "active"
+                    pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                    rightClickKey: "beats_translate_half"
+                    width: 26
+                }
+                LateNightControlButton {
+                    activeBackgroundSuffix: "active"
+                    activeColor: LateNightTheme.deckDimButtonInactiveColor
+                    activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                    activeOpacity: 1.0
+                    backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
+                    enabled: !beatgridBehavior.bpmLocked
+                    group: root.group
+                    height: 26
+                    iconSource: LateNightTheme.assetDeckBeatsFasterButton
+                    inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+                    inactiveOpacity: 0.82
+                    key: "beats_adjust_faster"
+                    pressedBackgroundSuffix: "active"
+                    pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                    width: 26
+                }
+            }
+            Rectangle {
+                anchors.fill: parent
+                color: LateNightTheme.beatgridDisabledCoverColor
+                radius: 2
+                visible: beatgridBehavior.bpmLocked
+            }
         }
-    }
 
-    // Column 5 (optional): HotcuesEarlier / HotcuesLater
-    Column {
-        Layout.preferredWidth: 26
-        Layout.preferredHeight: 52
-        spacing: 0
-        visible: timingShiftButtonsProxy.value > 0
+        // Column 3: BeatsLater / BeatsSlower
+        Item {
+            Layout.preferredHeight: 52
+            Layout.preferredWidth: 26
 
-        LateNightControlButton {
-            width: 26
-            height: 26
-            backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
-            iconSource: LateNightTheme.assetDeckBeatsHotcuesEarlierButton
-            group: root.group
-            key: "shift_cues_earlier"
-            rightClickKey: "shift_cues_earlier_small"
-            activeBackgroundSuffix: "active"
-            pressedBackgroundSuffix: "active"
-            activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-            pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-            activeOpacity: 1.0
-            inactiveOpacity: 0.82
-            activeColor: LateNightTheme.deckDimButtonInactiveColor
-            inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+            Column {
+                anchors.fill: parent
+                spacing: 0
+
+                LateNightControlButton {
+                    activeBackgroundSuffix: "active"
+                    activeColor: LateNightTheme.deckDimButtonInactiveColor
+                    activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                    activeOpacity: 1.0
+                    backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
+                    enabled: !beatgridBehavior.bpmLocked
+                    group: root.group
+                    height: 26
+                    iconSource: LateNightTheme.assetDeckBeatsLaterButton
+                    inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+                    inactiveOpacity: 0.82
+                    key: "beats_translate_later"
+                    pressedBackgroundSuffix: "active"
+                    pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                    rightClickKey: "beats_translate_half"
+                    width: 26
+                }
+                LateNightControlButton {
+                    activeBackgroundSuffix: "active"
+                    activeColor: LateNightTheme.deckDimButtonInactiveColor
+                    activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                    activeOpacity: 1.0
+                    backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
+                    enabled: !beatgridBehavior.bpmLocked
+                    group: root.group
+                    height: 26
+                    iconSource: LateNightTheme.assetDeckBeatsSlowerButton
+                    inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+                    inactiveOpacity: 0.82
+                    key: "beats_adjust_slower"
+                    pressedBackgroundSuffix: "active"
+                    pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                    width: 26
+                }
+            }
+            Rectangle {
+                anchors.fill: parent
+                color: LateNightTheme.beatgridDisabledCoverColor
+                radius: 2
+                visible: beatgridBehavior.bpmLocked
+            }
         }
 
-        LateNightControlButton {
-            width: 26
-            height: 26
-            backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
-            iconSource: LateNightTheme.assetDeckBeatsHotcuesLaterButton
-            group: root.group
-            key: "shift_cues_later"
-            rightClickKey: "shift_cues_later_small"
-            activeBackgroundSuffix: "active"
-            pressedBackgroundSuffix: "active"
-            activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-            pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
-            activeOpacity: 1.0
-            inactiveOpacity: 0.82
-            activeColor: LateNightTheme.deckDimButtonInactiveColor
-            inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+        // Column 4: Undo / BpmLockToggle
+        Column {
+            Layout.preferredHeight: 52
+            Layout.preferredWidth: 26
+            spacing: 0
+
+            Item {
+                height: 26
+                width: 26
+
+                LateNightControlButton {
+                    activeBackgroundSuffix: "active"
+                    activeColor: LateNightTheme.deckDimButtonInactiveColor
+                    activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                    activeOpacity: 1.0
+                    anchors.fill: parent
+                    backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
+                    enabled: beatgridBehavior.beatsUndoPossible
+                    group: root.group
+                    iconSource: LateNightTheme.assetDeckUndoButton
+                    inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+                    inactiveOpacity: 0.82
+                    key: "beats_undo_adjustment"
+                    pressedBackgroundSuffix: "active"
+                    pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                }
+                Rectangle {
+                    anchors.fill: parent
+                    color: LateNightTheme.beatgridDisabledCoverColor
+                    radius: 2
+                    visible: !beatgridBehavior.beatsUndoPossible
+                }
+            }
+            LateNightControlButton {
+                activeBackgroundSuffix: "active"
+                activeColor: LateNightTheme.deckDimButtonInactiveColor
+                activeOpacity: 1.0
+                backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
+                group: root.group
+                height: 26
+                iconSource: isActive ? LateNightTheme.assetDeckBpmLockedButton : LateNightTheme.assetDeckBpmUnlockedButton
+                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+                inactiveOpacity: 0.82
+                key: "bpmlock"
+                pressedBackgroundSuffix: "active"
+                toggleable: true
+                width: 26
+            }
+        }
+
+        // Column 5 (optional): HotcuesEarlier / HotcuesLater
+        Column {
+            Layout.preferredHeight: 52
+            Layout.preferredWidth: 26
+            spacing: 0
+            visible: beatgridBehavior.timingShiftButtonsVisible
+
+            LateNightControlButton {
+                activeBackgroundSuffix: "active"
+                activeColor: LateNightTheme.deckDimButtonInactiveColor
+                activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                activeOpacity: 1.0
+                backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
+                group: root.group
+                height: 26
+                iconSource: LateNightTheme.assetDeckBeatsHotcuesEarlierButton
+                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+                inactiveOpacity: 0.82
+                key: "shift_cues_earlier"
+                pressedBackgroundSuffix: "active"
+                pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                rightClickKey: "shift_cues_earlier_small"
+                width: 26
+            }
+            LateNightControlButton {
+                activeBackgroundSuffix: "active"
+                activeColor: LateNightTheme.deckDimButtonInactiveColor
+                activeIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                activeOpacity: 1.0
+                backgroundSource: LateNightTheme.lateNightSubRegionButton("square")
+                group: root.group
+                height: 26
+                iconSource: LateNightTheme.assetDeckBeatsHotcuesLaterButton
+                inactiveColor: LateNightTheme.deckDimButtonInactiveColor
+                inactiveOpacity: 0.82
+                key: "shift_cues_later"
+                pressedBackgroundSuffix: "active"
+                pressedIconSuffix: LateNightTheme.isPaleMoon ? "active" : ""
+                rightClickKey: "shift_cues_later_small"
+                width: 26
+            }
         }
     }
 }

--- a/res/skins/LateNightQML/Waveforms/DeckWaveform.qml
+++ b/res/skins/LateNightQML/Waveforms/DeckWaveform.qml
@@ -2,40 +2,72 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import Mixxx 1.0 as Mixxx
-import "../LateNightTheme"
 
 Item {
     id: root
 
+    readonly property int minimumHeight: Math.max(
+        30,
+        beatgridControls.visible ? beatgridControls.implicitHeight : 0,
+        stemControls.visible && stemControls.hasStems ? stemControls.implicitHeight : 0)
+    implicitHeight: root.minimumHeight
+    readonly property bool beatgridControlsVisible: beatgridControls.visible
+    readonly property real beatgridControlsWidth: beatgridControls.width
+    readonly property real beatgridControlsX: beatgridControls.x
     required property string group
+    readonly property bool stemControlsVisible: stemControls.visible
+    readonly property real stemControlsWidth: stemControls.width
+    readonly property real stemControlsX: stemControls.x
 
     Mixxx.ControlProxy {
         id: showBeatgridControlsProxy
+
         group: "[Skin]"
         key: "show_beatgrid_controls"
     }
-
     Mixxx.ControlProxy {
-        id: timingShiftButtonsProxy
-        group: "[Skin]"
-        key: "timing_shift_buttons"
-    }
+        id: showStemControlsProxy
 
+        group: "[Skin]"
+        key: "show_stem_controls"
+    }
+    Mixxx.ControlProxy {
+        id: splitStemTracksProxy
+
+        group: "[Waveform]"
+        key: "stem_split_tracks"
+    }
     LateNightWaveformDisplay {
         id: waveformDisplay
-        group: root.group
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        anchors.right: beatgridControls.visible ? beatgridControls.left : parent.right
-    }
 
+        anchors.fill: parent
+        group: root.group
+        splitStemTracks: splitStemTracksProxy.value > 0
+
+        onSplitStemTracksToggleRequested: splitStemTracksProxy.value = splitStemTracksProxy.value > 0 ? 0 : 1
+    }
+    StemControls {
+        id: stemControls
+
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.leftMargin: 26
+        anchors.top: parent.top
+        group: root.group
+        visible: showStemControlsProxy.value > 0
+        width: Math.min(implicitWidth, Math.max(0, parent.width - 26))
+        z: 1
+    }
     BeatgridControls {
         id: beatgridControls
-        group: root.group
+
+        anchors.bottom: parent.bottom
         anchors.right: parent.right
-        anchors.verticalCenter: parent.verticalCenter
-        width: timingShiftButtonsProxy.value > 0 ? 130 : 104
+        anchors.rightMargin: 26
+        anchors.top: parent.top
+        group: root.group
         visible: showBeatgridControlsProxy.value > 0
+        width: Math.min(implicitWidth, Math.max(0, parent.width - 26))
+        z: 1
     }
 }

--- a/res/skins/LateNightQML/Waveforms/LateNightWaveformDisplay.qml
+++ b/res/skins/LateNightQML/Waveforms/LateNightWaveformDisplay.qml
@@ -14,20 +14,27 @@ Item {
         Scratching
     }
 
-    required property string group
-    property bool splitStemTracks: false
-    readonly property string zoomGroup: Mixxx.Config.waveformZoomSynchronization ? "[Channel1]" : group
-
-    readonly property bool isPrimaryDeck: group === "[Channel1]" || group === "[Channel2]"
-    readonly property color waveformBgColor: isPrimaryDeck
-            ? LateNightTheme.waveformPrimaryBackgroundColor
-            : LateNightTheme.waveformSecondaryBackgroundColor
-
-    readonly property color cueColor: LateNightTheme.waveformCueColor
-    readonly property color loopColor: LateNightTheme.waveformLoopColor
-    readonly property color introOutroColor: LateNightTheme.waveformIntroOutroColor
-    readonly property color playPosColor: LateNightTheme.waveformPlayPositionColor
     readonly property color beatAxesColor: LateNightTheme.waveformBeatAxesColor
+    readonly property color cueColor: LateNightTheme.waveformCueColor
+    required property string group
+    readonly property color introOutroColor: LateNightTheme.waveformIntroOutroColor
+    readonly property bool isPrimaryDeck: group === "[Channel1]" || group === "[Channel2]"
+    readonly property color loopColor: LateNightTheme.waveformLoopColor
+    readonly property color playPosColor: LateNightTheme.waveformPlayPositionColor
+    property bool splitStemTracks: false
+    readonly property color waveformBgColor: isPrimaryDeck ? LateNightTheme.waveformPrimaryBackgroundColor : LateNightTheme.waveformSecondaryBackgroundColor
+    readonly property color waveformSignalColor: isPrimaryDeck ? LateNightTheme.waveformPrimarySignalColor : LateNightTheme.waveformSecondarySignalColor
+    readonly property string zoomGroup: Mixxx.Config.waveformZoomSynchronization ? "[Channel1]" : group
+    readonly property bool trackLoaded: trackLoadedControl.value > 0
+
+    signal splitStemTracksToggleRequested
+
+    Mixxx.ControlProxy {
+        id: trackLoadedControl
+
+        group: root.group
+        key: "track_loaded"
+    }
 
     MixxxControls.WaveformDisplay {
         anchors.fill: parent
@@ -47,7 +54,7 @@ Item {
             endOfTrackWarningTime: 30
         }
         Mixxx.WaveformRendererPreroll {
-            color: LateNightTheme.waveformEndOfTrackWarningColor
+            color: root.waveformSignalColor
         }
         Mixxx.WaveformRendererMarkRange {
             // Loop
@@ -65,20 +72,20 @@ Item {
                 color: root.introOutroColor
                 durationTextColor: LateNightTheme.waveformMarkerTextColor
                 durationTextLocation: 'after'
-                startControl: "intro_start_position"
                 endControl: "intro_end_position"
-                visibilityControl: "[Skin],show_intro_outro_cues"
                 opacity: 0.1
+                startControl: "intro_start_position"
+                visibilityControl: "[Skin],show_intro_outro_cues"
             }
             // Outro
             Mixxx.WaveformMarkRange {
                 color: root.introOutroColor
                 durationTextColor: LateNightTheme.waveformMarkerTextColor
                 durationTextLocation: 'before'
-                startControl: "outro_start_position"
                 endControl: "outro_end_position"
-                visibilityControl: "[Skin],show_intro_outro_cues"
                 opacity: 0.1
+                startControl: "outro_start_position"
+                visibilityControl: "[Skin],show_intro_outro_cues"
             }
         }
         Mixxx.WaveformRendererFiltered {
@@ -87,9 +94,9 @@ Item {
             gainHigh: 1.0
             gainLow: 1.0
             gainMid: 1.0
-            highColor: LateNightTheme.waveformFilteredHighColor
-            lowColor: LateNightTheme.waveformFilteredLowColor
-            midColor: LateNightTheme.waveformFilteredMidColor
+            highColor: root.waveformSignalColor
+            lowColor: root.waveformSignalColor
+            midColor: root.waveformSignalColor
         }
         Mixxx.WaveformRendererStem {
             gainAll: root.splitStemTracks ? 2.0 : 1.0
@@ -99,8 +106,8 @@ Item {
             color: root.beatAxesColor
         }
         Mixxx.WaveformRendererMark {
-            playMarkerBackground: root.playPosColor
-            playMarkerColor: root.playPosColor
+            playMarkerBackground: root.trackLoaded ? root.playPosColor : "transparent"
+            playMarkerColor: root.trackLoaded ? root.playPosColor : "transparent"
             untilMark.align: Qt.AlignBottom
             untilMark.showBeats: true
             untilMark.showTime: true
@@ -126,8 +133,8 @@ Item {
                 align: 'top|left'
                 color: root.loopColor
                 control: "loop_start_position"
-                text: '↻'
                 icon: Qt.resolvedUrl("../../LateNight/classic/style/mark_loop.svg")
+                text: '↻'
                 textColor: LateNightTheme.waveformMarkerTextColor
             }
             Mixxx.WaveformMark {
@@ -140,111 +147,81 @@ Item {
                 align: 'top|right'
                 color: root.introOutroColor
                 control: "intro_start_position"
-                text: '◢'
                 icon: Qt.resolvedUrl("../../LateNight/classic/style/mark_intro.svg")
-                visibilityControl: "[Skin],show_intro_outro_cues"
+                text: '◢'
                 textColor: LateNightTheme.waveformMarkerTextColor
+                visibilityControl: "[Skin],show_intro_outro_cues"
             }
             Mixxx.WaveformMark {
                 align: 'top|left'
                 color: root.introOutroColor
                 control: "intro_end_position"
-                text: '◢'
                 icon: Qt.resolvedUrl("../../LateNight/classic/style/mark_intro.svg")
-                visibilityControl: "[Skin],show_intro_outro_cues"
+                text: '◢'
                 textColor: LateNightTheme.waveformMarkerTextColor
+                visibilityControl: "[Skin],show_intro_outro_cues"
             }
             Mixxx.WaveformMark {
                 align: 'top|right'
                 color: root.introOutroColor
                 control: "outro_start_position"
-                text: '◣'
                 icon: Qt.resolvedUrl("../../LateNight/classic/style/mark_outro.svg")
-                visibilityControl: "[Skin],show_intro_outro_cues"
+                text: '◣'
                 textColor: LateNightTheme.waveformMarkerTextColor
+                visibilityControl: "[Skin],show_intro_outro_cues"
             }
             Mixxx.WaveformMark {
                 align: 'top|left'
                 color: root.introOutroColor
                 control: "outro_end_position"
-                text: '◣'
                 icon: Qt.resolvedUrl("../../LateNight/classic/style/mark_outro.svg")
+                text: '◣'
                 visibilityControl: "[Skin],show_intro_outro_cues"
             }
         }
     }
-
-    Rectangle {
-        id: leftFader
-        anchors.left: parent.left
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        width: 125
-        enabled: false
-        gradient: Gradient {
-            orientation: Gradient.Horizontal
-            GradientStop {
-                position: 0.0
-                color: root.waveformBgColor
-            }
-            GradientStop {
-                position: 1.0
-                color: "transparent"
-            }
-        }
-    }
-
-    Rectangle {
-        id: rightFader
-        anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.bottom: parent.bottom
-        width: 125
-        enabled: false
-        gradient: Gradient {
-            orientation: Gradient.Horizontal
-            GradientStop {
-                position: 0.0
-                color: "transparent"
-            }
-            GradientStop {
-                position: 1.0
-                color: root.waveformBgColor
-            }
-        }
-    }
-
     Mixxx.ControlProxy {
         id: scratchPositionEnableControl
+
         group: root.group
         key: "scratch_position_enable"
     }
     Mixxx.ControlProxy {
         id: scratchPositionControl
+
         group: root.group
         key: "scratch_position"
     }
     Mixxx.ControlProxy {
         id: wheelControl
+
         group: root.group
         key: "wheel"
     }
     Mixxx.ControlProxy {
         id: rateRatioControl
+
         group: root.group
         key: "rate_ratio"
     }
     Mixxx.ControlProxy {
         id: zoomControl
+
         group: root.zoomGroup
         key: "waveform_zoom"
+
         Component.onCompleted: {
             if (zoomControl.group === root.group) {
-                zoomControl.value = Mixxx.Config.waveformDefaultZoom
+                zoomControl.value = Mixxx.Config.waveformDefaultZoom;
             }
         }
     }
+    TapHandler {
+        acceptedButtons: Qt.RightButton
+        grabPermissions: PointerHandler.CanTakeOverFromAnything
 
+        onDoubleTapped: root.splitStemTracksToggleRequested()
+    }
     MouseArea {
         property point mouseAnchor: Qt.point(0, 0)
         property int mouseStatus: LateNightWaveformDisplay.MouseStatus.Normal
@@ -252,12 +229,7 @@ Item {
         acceptedButtons: Qt.LeftButton | Qt.RightButton
         anchors.fill: parent
 
-        onDoubleClicked: function(mouse) {
-            if (mouse.button === Qt.RightButton) {
-                root.splitStemTracks = !root.splitStemTracks;
-            }
-        }
-        onPositionChanged: function(mouse) {
+        onPositionChanged: function (mouse) {
             const diff = mouse.x - mouseAnchor.x;
             switch (mouseStatus) {
             case LateNightWaveformDisplay.MouseStatus.Bending:
@@ -271,7 +243,7 @@ Item {
                 break;
             }
         }
-        onPressed: function(mouse) {
+        onPressed: function (mouse) {
             mouseAnchor = Qt.point(mouse.x, mouse.y);
             if (mouse.button === Qt.LeftButton) {
                 if (mouseStatus === LateNightWaveformDisplay.MouseStatus.Bending)
@@ -288,7 +260,7 @@ Item {
                 mouseStatus = LateNightWaveformDisplay.MouseStatus.Bending;
             }
         }
-        onReleased: function(mouse) {
+        onReleased: function (mouse) {
             switch (mouseStatus) {
             case LateNightWaveformDisplay.MouseStatus.Bending:
                 wheelControl.parameter = 0.5;
@@ -300,7 +272,7 @@ Item {
             }
             mouseStatus = LateNightWaveformDisplay.MouseStatus.Normal;
         }
-        onWheel: function(mouse) {
+        onWheel: function (mouse) {
             if (mouse.angleDelta.y < 0 && zoomControl.value > 1) {
                 zoomControl.value -= 1;
             } else if (mouse.angleDelta.y > 0 && zoomControl.value < 10.0) {

--- a/res/skins/LateNightQML/Waveforms/StemControls.qml
+++ b/res/skins/LateNightQML/Waveforms/StemControls.qml
@@ -1,0 +1,182 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import Mixxx 1.0 as Mixxx
+import "../Controls" as Controls
+import "../LateNightTheme"
+import "../Mixer" as Mixer
+
+Controls.Panel {
+    id: root
+
+    readonly property Mixxx.Track currentTrack: root.deckPlayer?.currentTrack ?? null
+    readonly property Mixxx.Player deckPlayer: Mixxx.PlayerManager.getPlayer(root.group)
+    required property string group
+    readonly property bool hasStems: stemCountProxy.value > 0 && root.currentTrack !== null
+    property var stemInfos: []
+
+    bottomBorderColor: LateNightTheme.isPaleMoon ? "#020202" : "#111111"
+    clip: true
+    color: LateNightTheme.waveformOverlayColor
+    implicitHeight: root.hasStems ? stemChannelHeight * stemChannelCount : 0
+    implicitWidth: 240
+    leftBorderColor: LateNightTheme.isPaleMoon ? "#1c1c1c" : "#222222"
+    rightBorderColor: "#111111"
+    topBorderColor: LateNightTheme.isPaleMoon ? "#1c1c1c" : "#222222"
+
+    readonly property int stemChannelCount: 4
+    readonly property int stemChannelHeight: 26
+
+    function refreshStemInfos() {
+        const infos = [];
+        for (let stemIdx = 0; stemIdx < root.stemChannelCount; stemIdx++) {
+            infos.push(root.currentTrack ? root.currentTrack.stemsModel.get(stemIdx) : null);
+        }
+        root.stemInfos = infos;
+    }
+
+    Mixxx.ControlProxy {
+        id: stemCountProxy
+
+        group: root.group
+        key: "stem_count"
+    }
+    Connections {
+        function onStemsChanged() {
+            root.refreshStemInfos();
+        }
+
+        target: root.currentTrack
+    }
+    Connections {
+        function onCurrentTrackChanged() {
+            root.refreshStemInfos();
+        }
+
+        target: root.deckPlayer
+    }
+    MouseArea {
+        acceptedButtons: Qt.AllButtons
+        anchors.fill: parent
+
+        onWheel: wheel => wheel.accepted = true
+    }
+    Text {
+        anchors.centerIn: parent
+        color: LateNightTheme.waveformNoStemLabelColor
+        font.family: "Open Sans"
+        font.pixelSize: 13
+        font.weight: Font.DemiBold
+        text: qsTr("Track has no STEMs")
+        visible: !root.hasStems
+    }
+    Column {
+        anchors.fill: parent
+        anchors.leftMargin: 4
+        anchors.rightMargin: 0
+        spacing: 0
+        visible: root.hasStems
+
+        Repeater {
+            model: root.hasStems ? root.stemChannelCount : 0
+
+            delegate: Item {
+                id: stem
+
+                required property int index
+                readonly property var stemInfo: root.stemInfos[index] ?? null
+                readonly property color stemColor: stemInfo && stemInfo.color
+                        ? stemInfo.color
+                        : "transparent"
+                readonly property string label: stemInfo && stemInfo.label
+                        ? stemInfo.label
+                        : ""
+                readonly property string quickEffectGroup: `[QuickEffectRack1_${stemGroup}]`
+                readonly property string stemGroup: `${root.group.substring(0, root.group.length - 1)}_Stem${index + 1}]`
+
+                height: Math.max(root.stemChannelHeight, parent.height / root.stemChannelCount)
+                width: parent.width
+
+                RowLayout {
+                    anchors.fill: parent
+                    spacing: 0
+
+                    Text {
+                        Layout.fillHeight: true
+                        Layout.preferredWidth: 50
+                        color: stem.stemColor
+                        elide: Text.ElideRight
+                        font.family: "Open Sans"
+                        font.pixelSize: 13
+                        font.weight: Font.DemiBold
+                        text: stem.label
+                        verticalAlignment: Text.AlignVCenter
+                    }
+                    StemMuteButton {
+                        Layout.preferredHeight: 18
+                        Layout.preferredWidth: 18
+                        group: stem.stemGroup
+                    }
+                    Item {
+                        Layout.preferredWidth: 2
+                    }
+                    Controls.Knob {
+                        Layout.preferredHeight: 26
+                        Layout.preferredWidth: 26
+                        backgroundSource: LateNightTheme.assetFxKnobBackground
+                        color: stem.stemColor
+                        displayArc: true
+                        displayArcColor: LateNightTheme.mixerArcGainColor
+                        displayArcStart: Controls.Knob.ArcStart.Minimum
+                        group: stem.stemGroup
+                        indicatorColor: "orange"
+                        key: "volume"
+                    }
+                    Item {
+                        Layout.preferredWidth: 4
+                    }
+                    Mixer.QuickEffectSelector {
+                        Layout.preferredHeight: 18
+                        Layout.preferredWidth: 85
+                        arrowOnRight: true
+                        group: stem.stemGroup
+                        popupWidth: 160
+                        textAlignRight: false
+                    }
+                    Item {
+                        Layout.preferredWidth: 2
+                    }
+                    Mixer.QuickEffectEnableButton {
+                        Layout.preferredHeight: 18
+                        Layout.preferredWidth: 18
+                        quickEffectGroup: stem.quickEffectGroup
+                    }
+                    Item {
+                        Layout.preferredWidth: 2
+                    }
+                    Controls.Knob {
+                        Layout.preferredHeight: 26
+                        Layout.preferredWidth: 26
+                        backgroundSource: LateNightTheme.assetFxKnobBackground
+                        color: stem.stemColor
+                        displayArc: true
+                        displayArcColor: LateNightTheme.mixerArcQuickEffectColor
+                        group: stem.quickEffectGroup
+                        indicatorColor: "green"
+                        key: "super1"
+                    }
+                }
+                Rectangle {
+                    anchors.bottom: parent.bottom
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    color: LateNightTheme.deckPanelBorderDark
+                    height: 1
+                }
+            }
+        }
+    }
+
+    Component.onCompleted: root.refreshStemInfos()
+}

--- a/res/skins/LateNightQML/Waveforms/StemMuteButton.qml
+++ b/res/skins/LateNightQML/Waveforms/StemMuteButton.qml
@@ -1,0 +1,33 @@
+import QtQuick
+import Mixxx 1.0 as Mixxx
+import "../LateNightTheme"
+
+Item {
+    id: root
+
+    readonly property bool active: muteProxy.value > 0
+    required property string group
+
+    Rectangle {
+        anchors.fill: parent
+        color: root.active ? LateNightTheme.mixerAccentOrange : LateNightTheme.mixerStemMuteInactiveColor
+    }
+    Image {
+        anchors.fill: parent
+        source: root.active ? LateNightTheme.assetMixerEqKillButtonActiveBackground : LateNightTheme.assetMixerEqKillButtonBackground
+    }
+    Image {
+        anchors.fill: parent
+        source: LateNightTheme.assetMixerStemMuteIcon
+        visible: !root.active
+    }
+    TapHandler {
+        onTapped: muteProxy.value = muteProxy.value > 0 ? 0 : 1
+    }
+    Mixxx.ControlProxy {
+        id: muteProxy
+
+        group: root.group
+        key: "mute"
+    }
+}

--- a/res/skins/LateNightQML/Waveforms/WaveformStack.qml
+++ b/res/skins/LateNightQML/Waveforms/WaveformStack.qml
@@ -1,6 +1,10 @@
+pragma ComponentBehavior: Bound
+
 import "../LateNightTheme"
 import "../../../qml" as Shared
 import QtQuick
+import Mixxx 1.0 as Mixxx
+import "../Deck"
 
 Item {
     id: root
@@ -9,6 +13,20 @@ Item {
     property string deck2Group: "[Channel2]"
     property string deck3Group: "[Channel3]"
     property string deck4Group: "[Channel4]"
+    readonly property int bottomGutterHeight: 3
+    readonly property var bottomDeck: root.show4decks ? deck4waveform.item : deck2waveform
+    readonly property int deckCount: root.show4decks ? 4 : 2
+    readonly property real deck3MinimumHeight: deck3waveform.item ? deck3waveform.item.minimumHeight : 30
+    readonly property real deck4MinimumHeight: deck4waveform.item ? deck4waveform.item.minimumHeight : 30
+    readonly property real minimumWaveformHeight: root.show4decks
+            ? root.deck3MinimumHeight + deck1waveform.minimumHeight + deck2waveform.minimumHeight + root.deck4MinimumHeight
+            : deck1waveform.minimumHeight + deck2waveform.minimumHeight
+    readonly property real extraHeightPerDeck: Math.max(
+            0,
+            root.waveformContentHeight - Math.max(52, root.minimumWaveformHeight)) / root.deckCount
+    readonly property int minimumContentHeight: root.bottomGutterHeight + Math.max(52, root.minimumWaveformHeight)
+    implicitHeight: root.minimumContentHeight
+    readonly property int waveformContentHeight: Math.max(0, root.height - root.bottomGutterHeight)
     property bool show4decks: false
 
     Loader {
@@ -18,7 +36,7 @@ Item {
 
         active: root.show4decks
         anchors.top: parent.top
-        height: parent.height / 4
+        height: root.deck3MinimumHeight + root.extraHeightPerDeck
         width: root.width
 
         sourceComponent: Component {
@@ -36,15 +54,15 @@ Item {
 
         anchors.top: root.show4decks ? deck3waveform.bottom : parent.top
         group: root.deck1Group
-        height: parent.height / (root.show4decks ? 4 : 2)
+        height: deck1waveform.minimumHeight + root.extraHeightPerDeck
         width: root.width
     }
     DeckWaveform {
         id: deck2waveform
 
-        anchors.bottom: root.show4decks ? deck4waveform.top : parent.bottom
+        anchors.bottom: root.show4decks ? deck4waveform.top : bottomGutter.top
         group: root.deck2Group
-        height: parent.height / (root.show4decks ? 4 : 2)
+        height: deck2waveform.minimumHeight + root.extraHeightPerDeck
         width: root.width
     }
     Loader {
@@ -53,8 +71,8 @@ Item {
         readonly property string group: root.deck4Group
 
         active: root.show4decks
-        anchors.bottom: parent.bottom
-        height: parent.height / 4
+        anchors.bottom: bottomGutter.top
+        height: root.deck4MinimumHeight + root.extraHeightPerDeck
         width: root.width
 
         sourceComponent: Component {
@@ -65,6 +83,113 @@ Item {
                     fadeTarget: deck4waveform
                 }
             }
+        }
+    }
+    Item {
+        id: bottomGutter
+
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: root.bottomGutterHeight
+        z: 20
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            color: LateNightTheme.waveformContainerColor
+            height: 1
+        }
+        Rectangle {
+            anchors.top: parent.top
+            color: LateNightTheme.waveformDeckBottomBorderColor
+            height: 1
+            x: 26
+            width: Math.max(0, parent.width - 52)
+        }
+        Rectangle {
+            anchors.top: parent.top
+            color: LateNightTheme.waveformContainerColor
+            height: 1
+            visible: bottomDeck ? bottomDeck.stemControlsVisible : false
+            width: bottomDeck ? bottomDeck.stemControlsWidth : 0
+            x: bottomDeck ? bottomDeck.stemControlsX : 0
+        }
+        Rectangle {
+            anchors.top: parent.top
+            color: LateNightTheme.waveformContainerColor
+            height: 1
+            visible: bottomDeck ? bottomDeck.beatgridControlsVisible : false
+            width: bottomDeck ? bottomDeck.beatgridControlsWidth : 0
+            x: bottomDeck ? bottomDeck.beatgridControlsX : 0
+        }
+        Rectangle {
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.topMargin: 1
+            color: LateNightTheme.waveformContainerColor
+            height: 1
+        }
+        Rectangle {
+            anchors.bottom: parent.bottom
+            anchors.left: parent.left
+            anchors.right: parent.right
+            color: LateNightTheme.waveformContainerBottomBorderColor
+            height: 1
+        }
+    }
+    Item {
+        anchors.bottom: bottomGutter.top
+        anchors.left: parent.left
+        anchors.top: parent.top
+        width: 26
+        z: 10
+
+        Rectangle {
+            anchors.fill: parent
+            color: LateNightTheme.waveformContainerColor
+        }
+        LateNightControlButton {
+            activeOpacity: 1.0
+            anchors.verticalCenter: parent.verticalCenter
+            backgroundSource: ""
+            group: "[Skin]"
+            height: 52
+            iconSource: isActive ? LateNightTheme.assetDeckStemControlsCollapseButton : LateNightTheme.assetDeckStemControlsExpandButton
+            inactiveFillEnabled: false
+            inactiveOpacity: 1.0
+            key: "show_stem_controls"
+            stretchIcon: true
+            toggleable: true
+            width: 26
+        }
+    }
+    Item {
+        anchors.bottom: bottomGutter.top
+        anchors.right: parent.right
+        anchors.top: parent.top
+        width: 26
+        z: 10
+
+        Rectangle {
+            anchors.fill: parent
+            color: LateNightTheme.waveformContainerColor
+        }
+        LateNightControlButton {
+            activeOpacity: 1.0
+            anchors.verticalCenter: parent.verticalCenter
+            backgroundSource: ""
+            group: "[Skin]"
+            height: 52
+            iconSource: isActive ? LateNightTheme.assetDeckBeatgridControlsCollapseButton : LateNightTheme.assetDeckBeatgridControlsExpandButton
+            inactiveFillEnabled: false
+            inactiveOpacity: 1.0
+            key: "show_beatgrid_controls"
+            stretchIcon: true
+            toggleable: true
+            width: 26
         }
     }
 }

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -881,7 +881,8 @@ bool CoreServices::initializeDatabase() {
     return MixxxDb::initDatabaseSchema(dbConnection);
 }
 
-std::shared_ptr<QDialog> CoreServices::makeDlgPreferences() const {
+std::shared_ptr<QDialog> CoreServices::makeDlgPreferences(
+        bool includeWaveformPreferences) const {
     // Note: We return here the base class pointer to make the coreservices.h usable
     // in test classes where header included from dlgpreferences.h are not accessible.
     auto pSkinLoader = std::make_shared<mixxx::skin::SkinLoader>(getSettings());
@@ -893,7 +894,8 @@ std::shared_ptr<QDialog> CoreServices::makeDlgPreferences() const {
             getVinylControlManager(),
             getEffectsManager(),
             getSettingsManager(),
-            getLibrary());
+            getLibrary(),
+            includeWaveformPreferences);
     return pDlgPreferences;
 }
 

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -100,7 +100,11 @@ class CoreServices : public QObject {
         return m_pScreensaverManager;
     }
 
-    std::shared_ptr<QDialog> makeDlgPreferences() const;
+    // Creates the native preferences dialog. QML can temporarily suppress
+    // the legacy Waveforms page while its dedicated settings page is being
+    // implemented.
+    std::shared_ptr<QDialog> makeDlgPreferences(
+            bool includeWaveformPreferences = true) const;
 
   signals:
     void initializationProgressUpdate(int progress, const QString& serviceName);

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -61,7 +61,8 @@ DlgPreferences::DlgPreferences(
         std::shared_ptr<VinylControlManager> pVCManager,
         std::shared_ptr<EffectsManager> pEffectsManager,
         std::shared_ptr<SettingsManager> pSettingsManager,
-        std::shared_ptr<Library> pLibrary)
+        std::shared_ptr<Library> pLibrary,
+        bool includeWaveformPreferences)
         : m_allPages(),
           m_pConfig(pSettingsManager->settings()),
           m_pageSizeHint(QSize(0, 0)) {
@@ -170,8 +171,10 @@ DlgPreferences::DlgPreferences(
                 "ic_preferences_interface.svg");
     }
 
-    // Check if the Waveform factory exists (it is not created in QML mode)
-    if (WaveformWidgetFactory::isCreated()) {
+    // QML has its own waveform settings page. Do not construct the native
+    // Waveforms page there while the QML preferences implementation is in
+    // progress; the QML waveform factory is still required by the renderer.
+    if (includeWaveformPreferences && WaveformWidgetFactory::isCreated()) {
         addPageWidget(PreferencesPage(
                               new DlgPrefWaveform(this, m_pConfig, pLibrary),
                               new QTreeWidgetItem(contentsTreeWidget, QTreeWidgetItem::Type)),

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -53,7 +53,8 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
             std::shared_ptr<VinylControlManager> pVCManager,
             std::shared_ptr<EffectsManager> pEffectsManager,
             std::shared_ptr<SettingsManager> pSettingsManager,
-            std::shared_ptr<Library> pLibrary);
+            std::shared_ptr<Library> pLibrary,
+            bool includeWaveformPreferences = true);
     virtual ~DlgPreferences();
 
     void addPageWidget(const PreferencesPage& page,

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -164,6 +164,12 @@ QmlApplication::QmlApplication(
     app->installEventFilter(m_pCoreServices->getKeyboardEventFilter().get());
     registerImageProvider();
 
+    if (!WaveformWidgetFactory::isCreated()) {
+        WaveformWidgetFactory::createInstance();
+        m_ownsWaveformWidgetFactory = true;
+    }
+    WaveformWidgetFactory::instance()->setConfig(m_pCoreServices->getSettings());
+
     QString configVersion = m_pCoreServices->getSettings()->getValue(
             ConfigKey("[Config]", "Version"), "");
 
@@ -221,7 +227,11 @@ QmlApplication::QmlApplication(
 
     // FIXME: DlgPreferences has some initialization logic that must be executed
     // before the GUI is shown, at least for the effects system.
-    std::shared_ptr<QDialog> pDlgPreferences = m_pCoreServices->makeDlgPreferences();
+    // Keep the native Waveforms preferences page out of the QML startup
+    // dialog until the dedicated QML preferences page is complete. The
+    // waveform factory is still initialized above for QML rendering.
+    std::shared_ptr<QDialog> pDlgPreferences =
+            m_pCoreServices->makeDlgPreferences(false);
     // Without this, QApplication will quit when the last QWidget QWindow is
     // closed because it does not take into account the window created by
     // the QQmlApplicationEngine.
@@ -385,8 +395,11 @@ QmlApplication::~QmlApplication() {
     // Delete all the QML singletons in order to prevent leak detection in CoreService
     QmlRecordingProxy::s_pRecordingManager.reset();
     QmlDlgPreferencesProxy::s_pInstance.reset();
-    m_visualsManager.reset();
     m_pAppEngine.reset();
+    if (m_ownsWaveformWidgetFactory) {
+        WaveformWidgetFactory::destroy();
+    }
+    m_visualsManager.reset();
     m_pCoreServices.reset();
 }
 

--- a/src/qml/qmlapplication.h
+++ b/src/qml/qmlapplication.h
@@ -65,6 +65,7 @@ class QmlApplication : public QObject {
     QString m_mainFilePath;
 
     std::unique_ptr<QQmlApplicationEngine> m_pAppEngine;
+    bool m_ownsWaveformWidgetFactory{false};
     bool m_loadSucceeded;
     QmlAutoReload m_autoReload;
 

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -530,7 +530,8 @@ void allshader::WaveformRenderMark::updatePlayPosMarkTexture(rendergraph::Contex
     const float height = m_waveformRenderer->getBreadth();
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
 
-    if (height == m_playPosHeight && devicePixelRatio == m_playPosDevicePixelRatio) {
+    if (!m_playPosColorsDirty && height == m_playPosHeight &&
+            devicePixelRatio == m_playPosDevicePixelRatio) {
         return;
     }
     m_playPosHeight = height;
@@ -598,6 +599,7 @@ void allshader::WaveformRenderMark::updatePlayPosMarkTexture(rendergraph::Contex
     dynamic_cast<TextureMaterial&>(m_pPlayPosNode->material())
             .setTexture(std::make_unique<Texture>(pContext, image));
     m_pPlayPosNode->markDirtyMaterial();
+    m_playPosColorsDirty = false;
 }
 
 void allshader::WaveformRenderMark::drawTriangle(QPainter* painter,

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -40,9 +40,11 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
   public slots:
     void setPlayMarkerForegroundColor(const QColor& fgPlayColor) {
         m_playMarkerForegroundColor = fgPlayColor;
+        m_playPosColorsDirty = true;
     }
     void setPlayMarkerBackgroundColor(const QColor& bgPlayColor) {
         m_playMarkerBackgroundColor = bgPlayColor;
+        m_playPosColorsDirty = true;
     }
     void setUntilMarkShowBeats(bool untilMarkShowBeats) {
         m_untilMarkShowBeats = untilMarkShowBeats;
@@ -99,6 +101,7 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
 
     QColor m_playMarkerForegroundColor;
     QColor m_playMarkerBackgroundColor;
+    bool m_playPosColorsDirty{true};
 
     bool m_untilMarkShowBeats;
     bool m_untilMarkShowTime;


### PR DESCRIPTION
This PR continues the LateNightQML skin work, focusing on bringing the waveform section to feature and visual parity with the legacy LateNight skin for both Classic and PaleMoon color schemes.

## Testing the Experimental Skin

Since this is an early experimental milestone, you must first run Mixxx with the developer flag:

    ./build/mixxx --developer

Once Mixxx is open, switch to the experimental skin:

    Preferences -> Interface -> LateNight QML (Experimental)

You can dynamically toggle between the Classic and PaleMoon color schemes under preferences.

## Previews

### Classic
<img width="1465" height="271" alt="image" src="https://github.com/user-attachments/assets/30bff8a7-fe8d-400f-a725-b421ac7577a0" />

### PaleMoon
<img width="1465" height="271" alt="image" src="https://github.com/user-attachments/assets/f0cc7b48-ac20-4f49-a8cd-8c3cc83b26c1" />

## Scope of Changes

## Styling Changes:
* With the help of QML, the stem controls and beatgrid controls are now overlays. That allows us to display the Controls without shifting our waveforms, something not possible to implement in qtWidget code. 

### Implemented in this PR:

* Matches legacy LateNight waveform styling in Classic and PaleMoon.
* Adds independent opaque beatgrid and stem overlays with legacy sizing and placement.
* Ports beatgrid and stem controls, including split-stem display.
* Restores legacy waveform backgrounds, markers, gutters, separators, and splitter states.
* Correct Stem filter-menu sizing, styling, and overflow in both schemes.
* Fixes QML waveform initialization and play-position marker updates.

## Tracking

GSoC: LateNightQML PR-18