### PR TITLE
Android: make the tablet/Chromebook build usable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,12 +75,41 @@ if(CMAKE_SYSTEM_NAME STREQUAL Android)
   if((NOT ANDROID_SDK_ROOT) AND DEFINED ENV{ANDROID_SDK})
     set(ANDROID_SDK_ROOT "$ENV{ANDROID_SDK}")
   endif()
-  set(ANDROID_ABI arm64-v8a)
+  # The target ABI. arm64-v8a covers phones and ARM tablets/Chromebooks,
+  # x86_64 is needed for Intel Chromebooks and the emulator. Note that a
+  # matching vcpkg dependency tree has to be available for the chosen ABI,
+  # see tools/android_buildenv.sh.
+  set(
+    ANDROID_ABI
+    "arm64-v8a"
+    CACHE
+    STRING
+    "Android ABI to build for (arm64-v8a, x86_64, armeabi-v7a, x86)"
+  )
+  set_property(
+    CACHE ANDROID_ABI
+    PROPERTY STRINGS arm64-v8a x86_64 armeabi-v7a x86
+  )
+  if(ANDROID_ABI STREQUAL "arm64-v8a")
+    set(ANDROID_TOOLCHAIN_TRIPLE "aarch64-linux-android")
+    set(ANDROID_LLVM_ARCH "aarch64")
+  elseif(ANDROID_ABI STREQUAL "armeabi-v7a")
+    set(ANDROID_TOOLCHAIN_TRIPLE "arm-linux-androideabi")
+    set(ANDROID_LLVM_ARCH "arm")
+  elseif(ANDROID_ABI STREQUAL "x86_64")
+    set(ANDROID_TOOLCHAIN_TRIPLE "x86_64-linux-android")
+    set(ANDROID_LLVM_ARCH "x86_64")
+  elseif(ANDROID_ABI STREQUAL "x86")
+    set(ANDROID_TOOLCHAIN_TRIPLE "i686-linux-android")
+    set(ANDROID_LLVM_ARCH "i386")
+  else()
+    message(FATAL_ERROR "Unsupported ANDROID_ABI '${ANDROID_ABI}'")
+  endif()
   set(ANDROID_NDK_HOST_SYSTEM_NAME linux-x86_64)
   set(CMAKE_SYSTEM_VERSION 35) # API level
   set(ANDROID_PLATFORM "android-${CMAKE_SYSTEM_VERSION}")
   set(ANDROID_API_VERSION "android-${CMAKE_SYSTEM_VERSION}")
-  set(CMAKE_ANDROID_ARCH_ABI "${ANDROID_ABI}") # or x86_64, armeabi-v7a, etc.
+  set(CMAKE_ANDROID_ARCH_ABI "${ANDROID_ABI}")
   set(CMAKE_ANDROID_NDK_TOOLCHAIN_VERSION clang)
   set(CMAKE_ANDROID_STL_TYPE c++_shared)
   set(
@@ -94,7 +123,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Android)
   )
   set(
     CMAKE_LIBRARY_PATH
-    "${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${ANDROID_NDK_HOST_SYSTEM_NAME}/sysroot/usr/lib/aarch64-linux-android/${CMAKE_SYSTEM_VERSION}/;${CMAKE_LIBRARY_PATH}"
+    "${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${ANDROID_NDK_HOST_SYSTEM_NAME}/sysroot/usr/lib/${ANDROID_TOOLCHAIN_TRIPLE}/${CMAKE_SYSTEM_VERSION}/;${CMAKE_LIBRARY_PATH}"
   )
 endif()
 
@@ -2359,11 +2388,12 @@ if(QT6)
       mixxx-lib
       PUBLIC __STDC_CONSTANT_MACROS __STDC_LIMIT_MACROS __STDC_FORMAT_MACROS
     )
-    set_property(TARGET mixxx-lib PROPERTY ANDROID_ABIS "arm64-v8a")
+    set_property(TARGET mixxx-lib PROPERTY ANDROID_ABIS "${ANDROID_ABI}")
     target_compile_definitions(
       mixxx-lib
       PUBLIC ANDROID_PACKAGE_NAME="org.mixxx"
     )
+    target_sources(mixxx-lib PRIVATE src/util/androidpermissions.cpp)
     qt_add_executable(mixxx src/main.cpp MANUAL_FINALIZATION)
     set_property(
       TARGET mixxx
@@ -2379,7 +2409,7 @@ if(QT6)
     set_target_properties(
       mixxx
       PROPERTIES
-        QT_ANDROID_APPLICATION_ARGUMENTS "--qml --log-level debug --developer"
+        QT_ANDROID_APPLICATION_ARGUMENTS "--new-ui"
     )
     qt_add_android_permission(mixxx
     NAME android.permission.ACCESS_NETWORK_STATE
@@ -2403,6 +2433,12 @@ if(QT6)
     NAME android.permission.WAKE_LOCK
     )
     qt_add_android_permission(mixxx
+    NAME android.permission.READ_EXTERNAL_STORAGE
+    )
+    qt_add_android_permission(mixxx
+    NAME android.permission.READ_MEDIA_AUDIO
+    )
+    qt_add_android_permission(mixxx
     NAME android.permission.USB_PERMISSION
     )
     set(
@@ -2417,12 +2453,25 @@ if(QT6)
       CMAKE_CXX_COMPILER
       "${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${ANDROID_NDK_HOST_SYSTEM_NAME}/bin/clang++"
     )
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    # The clang runtime directory is versioned by the NDK's clang major
+    # version, so look it up instead of hardcoding both the version and the
+    # architecture.
+    file(
+      GLOB
+      ANDROID_LIBOMP_CANDIDATES
+      "${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${ANDROID_NDK_HOST_SYSTEM_NAME}/lib/clang/*/lib/linux/${ANDROID_LLVM_ARCH}/libomp.so"
+    )
+    if(NOT ANDROID_LIBOMP_CANDIDATES)
+      message(
+        FATAL_ERROR
+        "Could not find libomp.so for ${ANDROID_LLVM_ARCH} in the NDK at ${CMAKE_ANDROID_NDK}"
+      )
+    endif()
+    list(GET ANDROID_LIBOMP_CANDIDATES 0 ANDROID_LIBOMP)
     set_target_properties(
       mixxx
-      PROPERTIES
-        QT_ANDROID_EXTRA_LIBS
-          ${CMAKE_ANDROID_NDK}/toolchains/llvm/prebuilt/${ANDROID_NDK_HOST_SYSTEM_NAME}/lib/clang/18/lib/linux/aarch64/libomp.so
+      PROPERTIES QT_ANDROID_EXTRA_LIBS "${ANDROID_LIBOMP}"
     )
     add_custom_target(
       copy-resource-android
@@ -3833,6 +3882,11 @@ set(QT_EXTRA_COMPONENTS "")
 if(QT6)
   find_package(QT 6.2 NAMES Qt6 COMPONENTS Core REQUIRED)
   list(APPEND QT_EXTRA_COMPONENTS "ShaderTools")
+  if(ANDROID)
+    # QtAndroidPrivate (permissions, intents) lives in QtCore's private API.
+    list(APPEND QT_EXTRA_COMPONENTS "CorePrivate")
+    set(QT_NO_PRIVATE_MODULE_WARNING ON)
+  endif()
   list(APPEND QT_EXTRA_COMPONENTS "SvgWidgets")
   list(APPEND QT_EXTRA_COMPONENTS "Core5Compat")
   if(QT_VERSION VERSION_GREATER_EQUAL 6.10)

--- a/packaging/android/AndroidManifest.xml
+++ b/packaging/android/AndroidManifest.xml
@@ -11,13 +11,23 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO"  />
     <uses-permission android:name="android.permission.USB_PERMISSION"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"  />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29" />
+    <!-- Reading the music collection. Up to Android 12 this is covered by
+         READ_EXTERNAL_STORAGE, from Android 13 (API 33) on the scoped
+         READ_MEDIA_AUDIO permission replaces it. Both are requested at
+         runtime, MANAGE_EXTERNAL_STORAGE remains the opt-in for browsing
+         arbitrary directories. -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 
     <supports-screens
         android:anyDensity="true"
         android:largeScreens="true"
         android:normalScreens="true"
-        android:smallScreens="true" />
+        android:smallScreens="true"
+        android:xlargeScreens="true" />
     <application
         android:name="org.qtproject.qt.android.bindings.QtApplication"
         android:hardwareAccelerated="true"
@@ -32,6 +42,7 @@
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
             android:launchMode="singleTop"
             android:screenOrientation="sensorLandscape"
+            android:resizeableActivity="true"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -52,7 +63,7 @@
 
           <meta-data
                 android:name="android.app.arguments"
-                android:value="--new-ui --log-level debug --developer" />
+                android:value="--new-ui" />
         </activity>
 
         <provider
@@ -66,7 +77,21 @@
         </provider>
     </application>
 
+    <!-- Mixxx runs fine without a USB host port (tablets, Chromebooks and
+         emulators), it just cannot use wired MIDI/HID controllers there.
+         Declaring it as required would exclude those devices from
+         installation entirely. -->
     <uses-feature
         android:name="android.hardware.usb.host"
-        android:required="true" />
+        android:required="false" />
+    <!-- Chromebooks may be operated with mouse and keyboard only. -->
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.audio.low_latency"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.audio.pro"
+        android:required="false" />
 </manifest>

--- a/packaging/android/README.md
+++ b/packaging/android/README.md
@@ -1,0 +1,56 @@
+# Mixxx on Android
+
+The Android port builds the QML user interface (`--new-ui`) against the Oboe
+backend of PortAudio. It targets tablets and Chromebooks as much as phones:
+the whole DJ surface is laid out for landscape and is driven by multi-touch.
+
+## Building
+
+```sh
+source tools/android_buildenv.sh setup
+cmake -DCMAKE_TOOLCHAIN_FILE="${MIXXX_VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+      -DCMAKE_SYSTEM_NAME=Android \
+      -DANDROID_ABI=arm64-v8a \
+      -S . -B build-android
+cmake --build build-android
+```
+
+`ANDROID_ABI` selects the target architecture (`arm64-v8a`, `x86_64`,
+`armeabi-v7a`, `x86`). Only `arm64-v8a` has a published prebuilt dependency
+archive, which covers phones, ARM tablets and ARM Chromebooks. To build for
+another ABI — notably `x86_64` for Intel Chromebooks and the emulator — the
+vcpkg dependency tree has to be built for that triplet first, see
+<https://github.com/mixxxdj/mixxx/wiki/Compiling-dependencies-for-android>.
+
+## Touch interaction
+
+Touch input is handled by Qt Quick pointer handlers rather than `MouseArea`,
+because Qt synthesizes mouse events from a single touch point only. Using
+handlers is what allows two decks to be operated at the same time:
+
+| Gesture                          | Action                                     |
+| -------------------------------- | ------------------------------------------ |
+| Drag on the waveform             | Scratch (independently per deck)           |
+| Pinch on the waveform            | Waveform zoom (mouse wheel equivalent)     |
+| Drag on the spinny               | Scratch (independently per deck)           |
+| Drag on a knob or fader          | Change the value                           |
+| Long press on a hotcue           | Open the hotcue popup (right click on desktop) |
+
+## Permissions
+
+* `READ_MEDIA_AUDIO` (Android 13+) resp. `READ_EXTERNAL_STORAGE` are requested
+  at every start; without them the library scan finds nothing.
+* `MANAGE_EXTERNAL_STORAGE` ("All files access") is optional and only needed to
+  add music directories outside of the media store. Mixxx opens the system
+  settings page for it once, on first run.
+* `usb.host` is declared as *not* required so that devices without a USB host
+  port — many tablets, Chromebooks and emulators — can install Mixxx. Wired
+  MIDI/HID controllers are unavailable there.
+
+## Known limitations
+
+* Audio stops being reliable when Mixxx is sent to the background: there is no
+  foreground service yet, so Android may throttle or kill the audio thread.
+* Recording and broadcasting write to the app private directory unless "All
+  files access" has been granted.
+* The desktop (QWidget) skins are not built for Android, only the QML UI is.

--- a/res/qml/ControlCycleButtonBehavior.qml
+++ b/res/qml/ControlCycleButtonBehavior.qml
@@ -33,11 +33,13 @@ Item {
         key: root.key
     }
 
-    MouseArea {
-        anchors.fill: parent
+    // TapHandler instead of MouseArea so that several of these buttons can be
+    // operated simultaneously on a touchscreen.
+    TapHandler {
         acceptedButtons: Qt.LeftButton
         enabled: root.enabled && root.handlePointerInput
+        gesturePolicy: TapHandler.ReleaseWithinBounds
 
-        onClicked: root.cycle()
+        onTapped: root.cycle()
     }
 }

--- a/res/qml/ControlProxyButtonBehavior.qml
+++ b/res/qml/ControlProxyButtonBehavior.qml
@@ -16,6 +16,11 @@ Item {
     property bool releaseToZero: true
     property bool longPressLatching: false
     property bool handlePointerInput: true
+    // Touchscreens have no right mouse button. Where the secondary action is
+    // the only way to reach a feature (e.g. the hotcue popup), a long press
+    // stands in for it. Only meaningful if pressAndHoldKey is unset, since
+    // that already claims the long press.
+    property bool longPressTriggersSecondary: false
     property int numberStates: 2
     property int longPressDuration: 300
     property real activeDisplayThreshold: 0
@@ -28,7 +33,7 @@ Item {
     readonly property real displayValue: displayControl.value
     readonly property bool isActive: displayControl.value > root.activeDisplayThreshold
     readonly property bool isVisuallyActive: root.isActive || root.visualActiveState
-    readonly property bool pressed: interactionArea.pressed
+    readonly property bool pressed: primaryHandler.pressed || secondaryArea.pressed
 
     signal primaryPressed(real displayValue)
     signal secondaryPressed(real displayValue, real mouseX, real mouseY)
@@ -157,41 +162,55 @@ Item {
         key: root.displayKey.length > 0 ? root.displayKey : root.key
     }
 
-    MouseArea {
-        id: interactionArea
+    // A TapHandler (rather than a MouseArea) handles the primary action so
+    // that touch points are tracked individually. With a MouseArea only the
+    // one touch point that Qt synthesizes mouse events from is delivered,
+    // which makes it impossible to press buttons on two decks at the same
+    // time on a touchscreen.
+    TapHandler {
+        id: primaryHandler
 
-        anchors.fill: parent
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        acceptedButtons: Qt.LeftButton
         enabled: root.enabled && root.handlePointerInput
+        // Keep the grab while the finger moves, a tap is only emitted when
+        // the release happens inside the button.
+        gesturePolicy: TapHandler.ReleaseWithinBounds
 
-        onPressed: function(mouse) {
-            if (mouse.button === Qt.LeftButton) {
+        onPressedChanged: {
+            if (primaryHandler.pressed) {
                 root.pressPrimary();
-            } else if (mouse.button === Qt.RightButton) {
-                root.pressSecondary(mouse.x, mouse.y);
+            } else {
+                root.releasePrimary();
             }
         }
 
-        onPressAndHold: {
+        onLongPressed: {
             if (root.pressAndHoldKey.length > 0) {
                 root.pressAndHoldTriggered = true;
                 root.triggerPressAndHoldAction();
-            }
-        }
-
-        onClicked: function(mouse) {
-            if (mouse.button === Qt.LeftButton) {
-                root.clickPrimary();
-            }
-        }
-
-        onReleased: function(mouse) {
-            if (mouse.button === Qt.LeftButton) {
-                root.releasePrimary();
-            } else if (mouse.button === Qt.RightButton) {
+            } else if (root.longPressTriggersSecondary) {
+                root.pressAndHoldTriggered = true;
+                const position = primaryHandler.point.position;
+                root.pressSecondary(position.x, position.y);
                 root.releaseSecondary();
             }
         }
+
+        onTapped: root.clickPrimary()
+    }
+
+    // The secondary action is mouse-only, so a plain MouseArea is used here.
+    // Touch points never reach it because Qt synthesizes left button presses
+    // from touch, which this MouseArea does not accept.
+    MouseArea {
+        id: secondaryArea
+
+        acceptedButtons: Qt.RightButton
+        anchors.fill: parent
+        enabled: root.enabled && root.handlePointerInput
+
+        onPressed: mouse => root.pressSecondary(mouse.x, mouse.y)
+        onReleased: root.releaseSecondary()
     }
 
     Timer {

--- a/res/qml/HotcueButton.qml
+++ b/res/qml/HotcueButton.qml
@@ -66,4 +66,20 @@ Skin.Button {
             hotcueBehavior.releaseSecondary();
         }
     }
+
+    // A touchscreen has no right mouse button, so a long press stands in for
+    // it and opens the hotcue popup. The default DragThreshold policy only
+    // takes a passive grab, leaving the button itself to handle the press.
+    TapHandler {
+        id: longPressHandler
+
+        acceptedButtons: Qt.LeftButton
+        gesturePolicy: TapHandler.DragThreshold
+
+        onLongPressed: {
+            const position = longPressHandler.point.position;
+            hotcueBehavior.pressSecondary(position.x, position.y);
+            hotcueBehavior.releaseSecondary();
+        }
+    }
 }

--- a/res/qml/Mixxx/Controls/Spinny.qml
+++ b/res/qml/Mixxx/Controls/Spinny.qml
@@ -1,5 +1,6 @@
 import Mixxx 1.0 as Mixxx
-import QtQuick 2.12
+// QtQuick 2.15 is required for cursorShape on pointer handlers below.
+import QtQuick 2.15
 import QtQuick.Controls 2.12
 
 Item {

--- a/res/qml/Mixxx/Controls/Spinny.qml
+++ b/res/qml/Mixxx/Controls/Spinny.qml
@@ -52,7 +52,7 @@ Item {
 
         group: root.group
         key: "scratch_position_enable"
-        value: scratchArea.pressed
+        value: scratchHandler.active
     }
 
     Mixxx.ControlProxy {
@@ -118,37 +118,52 @@ Item {
         }
     }
 
-    MouseArea {
-        id: scratchArea
-
-        anchors.fill: parent
+    // Keeps the grab cursor on desktop, where the PointHandler below only
+    // sets it while a button is held.
+    HoverHandler {
+        cursorShape: scratchHandler.active ? Qt.ClosedHandCursor : Qt.OpenHandCursor
         enabled: trackLoadedControl.value > 0
-        cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+    }
+
+    // A PointHandler tracks one touch point (or the mouse) on its own, so
+    // both decks can be scratched at the same time with two fingers. A
+    // MouseArea would only ever see the single synthesized mouse pointer.
+    PointHandler {
+        id: scratchHandler
 
         property real lastAngle: 0
 
-        function getAngle(x, y) {
-            return Math.atan2(y - height / 2, x - width / 2);
+        function getAngle(position) {
+            return Math.atan2(position.y - root.height / 2, position.x - root.width / 2);
         }
 
-        onPressed: {
-            scratchPositionControl.value = 0.0;
-            lastAngle = getAngle(mouse.x, mouse.y);
+        acceptedButtons: Qt.LeftButton
+        enabled: trackLoadedControl.value > 0
+        cursorShape: active ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+
+        onActiveChanged: {
+            if (scratchHandler.active) {
+                scratchPositionControl.value = 0.0;
+                scratchHandler.lastAngle = scratchHandler.getAngle(scratchHandler.point.position);
+            }
         }
 
-        onPositionChanged: {
+        onPointChanged: {
+            if (!scratchHandler.active) {
+                return;
+            }
             if (isNaN(sampleRateControl.value) || sampleRateControl.value <= 0) {
                 console.error(`Could not find a valid sample rate on group ${root.group}, got ${sampleRateControl.value}`);
                 return;
             }
-            var currentAngle = getAngle(mouse.x, mouse.y);
-            var delta = currentAngle - lastAngle;
+            const currentAngle = scratchHandler.getAngle(scratchHandler.point.position);
+            let delta = currentAngle - scratchHandler.lastAngle;
 
             // Normalize to [-π, π] to handle atan2 boundary crossing
             while (delta > Math.PI) delta -= 2 * Math.PI;
             while (delta < -Math.PI) delta += 2 * Math.PI;
 
-            lastAngle = currentAngle;
+            scratchHandler.lastAngle = currentAngle;
 
             // Convert angular delta (radians) to samples:
             // samples = radians * (frameRate * 2) / (2π * rps)

--- a/res/qml/WaveformDisplay.qml
+++ b/res/qml/WaveformDisplay.qml
@@ -7,12 +7,6 @@ import "Theme"
 Item {
     id: root
 
-    enum MouseStatus {
-        Normal,
-        Bending,
-        Scratching
-    }
-
     required property string group
     property bool splitStemTracks: false
     readonly property string zoomGroup: Mixxx.Config.waveformZoomSynchronization ? "[Channel1]" : group
@@ -186,67 +180,93 @@ Item {
             }
         }
     }
-    MouseArea {
-        property point mouseAnchor: Qt.point(0, 0)
-        property int mouseStatus: WaveformDisplay.MouseStatus.Normal
+    // Scratching is driven by a PointHandler so that both waveforms can be
+    // touched at the same time. A MouseArea only ever receives the single
+    // mouse pointer that Qt synthesizes from the first touch point, which
+    // makes two handed scratching impossible on a touchscreen.
+    PointHandler {
+        id: scratchHandler
 
-        acceptedButtons: Qt.LeftButton | Qt.RightButton
-        anchors.fill: parent
+        property real anchorX: 0
 
-        onDoubleClicked: {
-            if (mouse.button == Qt.RightButton) {
-                root.splitStemTracks = !root.splitStemTracks;
-            }
-        }
-        onPositionChanged: {
-            const diff = mouse.x - mouseAnchor.x;
-            switch (mouseStatus) {
-            case WaveformDisplay.MouseStatus.Bending:
-                {
-                    // Start at the middle of [0.0, 1.0], and emit values based on how far
-                    // the mouse has traveled horizontally. Note, for legacy (MIDI) reasons,
-                    // this is tuned to 127.
-                    const v = 0.5 + (diff / root.width);
-                    // clamp to [0.0, 1.0]
-                    wheelControl.parameter = Math.max(Math.min(v, 1), 0);
-                    break;
-                }
-                ;
-            case WaveformDisplay.MouseStatus.Scratching:
-                // TODO: Calculate position properly
-                scratchPositionControl.value = -diff * zoomControl.value * 200;
-                break;
-            }
-        }
-        onPressed: {
-            mouseAnchor = Qt.point(mouse.x, mouse.y);
-            if (mouse.button == Qt.LeftButton) {
-                if (mouseStatus == WaveformDisplay.MouseStatus.Bending)
-                    wheelControl.parameter = 0.5;
+        acceptedButtons: Qt.LeftButton
+        // Do not scratch while the user is pinching to zoom.
+        enabled: !zoomPinchHandler.active
 
-                mouseStatus = WaveformDisplay.MouseStatus.Scratching;
+        onActiveChanged: {
+            if (scratchHandler.active) {
+                scratchHandler.anchorX = scratchHandler.point.position.x;
                 scratchPositionControl.value = 0;
                 scratchPositionEnableControl.value = 1;
             } else {
-                if (mouseStatus == WaveformDisplay.MouseStatus.Scratching)
-                    scratchPositionEnableControl.value = 0;
-
-                wheelControl.parameter = 0.5;
-                mouseStatus = WaveformDisplay.MouseStatus.Bending;
-            }
-        }
-        onReleased: {
-            switch (mouseStatus) {
-            case WaveformDisplay.MouseStatus.Bending:
-                wheelControl.parameter = 0.5;
-                break;
-            case WaveformDisplay.MouseStatus.Scratching:
                 scratchPositionEnableControl.value = 0;
                 scratchPositionControl.value = 0;
-                break;
             }
-            mouseStatus = WaveformDisplay.MouseStatus.Normal;
         }
+
+        onPointChanged: {
+            if (!scratchHandler.active) {
+                return;
+            }
+            const diff = scratchHandler.point.position.x - scratchHandler.anchorX;
+            // TODO: Calculate position properly
+            scratchPositionControl.value = -diff * zoomControl.value * 200;
+        }
+    }
+
+    // Pinch to zoom, the touch equivalent of the mouse wheel below.
+    PinchHandler {
+        id: zoomPinchHandler
+
+        // Tracks activeScale through a plain binding, which works no matter
+        // which notify signal the underlying property uses.
+        property real currentScale: zoomPinchHandler.activeScale
+        property real zoomOnActivation: 1
+
+        target: null
+
+        onActiveChanged: {
+            if (zoomPinchHandler.active) {
+                zoomPinchHandler.zoomOnActivation = zoomControl.value;
+            }
+        }
+
+        onCurrentScaleChanged: {
+            if (!zoomPinchHandler.active) {
+                return;
+            }
+            // Spreading the fingers shows more detail, i.e. a higher zoom
+            // factor, which is what the waveform_zoom control counts.
+            const zoom = zoomPinchHandler.zoomOnActivation * zoomPinchHandler.currentScale;
+            zoomControl.value = Math.max(1, Math.min(10, zoom));
+        }
+    }
+
+    // Pitch bending is bound to the right mouse button and therefore mouse
+    // only. Touch points never reach this MouseArea because Qt synthesizes
+    // left button presses from them.
+    MouseArea {
+        id: bendArea
+
+        property real mouseAnchorX: 0
+
+        acceptedButtons: Qt.RightButton
+        anchors.fill: parent
+
+        onDoubleClicked: root.splitStemTracks = !root.splitStemTracks
+        onPositionChanged: mouse => {
+            // Start at the middle of [0.0, 1.0], and emit values based on how far
+            // the mouse has traveled horizontally. Note, for legacy (MIDI) reasons,
+            // this is tuned to 127.
+            const v = 0.5 + ((mouse.x - bendArea.mouseAnchorX) / root.width);
+            // clamp to [0.0, 1.0]
+            wheelControl.parameter = Math.max(Math.min(v, 1), 0);
+        }
+        onPressed: mouse => {
+            bendArea.mouseAnchorX = mouse.x;
+            wheelControl.parameter = 0.5;
+        }
+        onReleased: wheelControl.parameter = 0.5
         onWheel: mouse => {
             if (mouse.angleDelta.y < 0 && zoomControl.value > 1) {
                 zoomControl.value -= 1;

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -71,7 +71,7 @@
 #include <X11/XKBlib.h>
 #endif
 #if defined(Q_OS_ANDROID)
-#include <QtCore/private/qandroidextras_p.h>
+#include "util/androidpermissions.h"
 #endif
 
 #if defined(Q_OS_LINUX) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -495,6 +495,13 @@ void CoreServices::initialize(QApplication* pApp) {
 
     VersionStore::logBuildDetails();
 
+#if defined(Q_OS_ANDROID)
+    // Ask for collection access on every start: the user may have revoked the
+    // permission in the system settings since the last run, and without it the
+    // library scan finds nothing at all.
+    mixxx::android::requestMusicLibraryPermissions();
+#endif
+
 #if defined(Q_OS_LINUX) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     // XESetWireToError will segfault if running as a Wayland client
     if (pApp->platformName() == QLatin1String("xcb")) {
@@ -656,43 +663,11 @@ void CoreServices::initialize(QApplication* pApp) {
             dir.mkpath(".");
         }
 #elif defined(Q_OS_ANDROID)
-        // if(QOperatingSystemVersion::current() <
-        // QOperatingSystemVersion(QOperatingSystemVersion::Android, 11)) {
-        //     qDebug() << "it is less then Android 11 - ALL FILES permission
-        //     isn't possible!";
-        // }
-        QString fd;
-        jboolean value = QJniObject::callStaticMethod<jboolean>(
-                "android/os/Environment", "isExternalStorageManager");
-        if (value == false) {
-            qDebug() << "requesting ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION";
-            QJniObject ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION =
-                    QJniObject::getStaticObjectField(
-                            "android/provider/Settings",
-                            "ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION",
-                            "Ljava/lang/String;");
-            QJniObject intent("android/content/Intent",
-                    "(Ljava/lang/String;)V",
-                    ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION.object());
-            QJniObject jniPath = QJniObject::fromString(
-                    QStringLiteral("package:%1").arg(ANDROID_PACKAGE_NAME));
-            QJniObject jniUri =
-                    QJniObject::callStaticObjectMethod("android/net/Uri",
-                            "parse",
-                            "(Ljava/lang/String;)Landroid/net/Uri;",
-                            jniPath.object<jstring>());
-            QJniObject jniResult = intent.callObjectMethod("setData",
-                    "(Landroid/net/Uri;)Landroid/content/Intent;",
-                    jniUri.object<jobject>());
-            QtAndroidPrivate::startActivity(intent, 0);
-        } else {
-            qDebug() << "Got ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION";
-        }
-        fd = "/storage/emulated/0/Music/";
-        QDir dir = fd;
-        if (!dir.exists()) {
-            dir.mkpath(".");
-        }
+        // "All files access" is what allows Mixxx to browse directories
+        // outside of the media store. It is optional: if the user declines,
+        // the default music directory below is still readable.
+        mixxx::android::requestFullExternalStorageAccess();
+        QString fd = mixxx::android::defaultMusicDirectory();
 #else
         // TODO(XXX) this needs to be smarter, we can't distinguish between an empty
         // path return value (not sure if this is normally possible, but it is

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -38,6 +38,8 @@
 #include <QDir>
 #include <QFile>
 #include <QJniObject>
+
+#include "util/androidpermissions.h"
 #endif
 
 Q_IMPORT_QML_PLUGIN(MixxxPlugin)
@@ -70,13 +72,9 @@ const QStringList kSkipQmlDirs = {
 };
 
 bool canWriteToExternalStorage() {
-    // API 30+ (Android 11+) requires MANAGE_EXTERNAL_STORAGE.
-    // Older: WRITE_EXTERNAL_STORAGE is granted at install time.
-    if (android_get_device_api_level() >= 30) {
-        return QJniObject::callStaticMethod<jboolean>(
-                "android/os/Environment", "isExternalStorageManager");
-    }
-    return true;
+    // API 30+ (Android 11+) requires MANAGE_EXTERNAL_STORAGE, below that
+    // WRITE_EXTERNAL_STORAGE, which is a runtime permission since API 23.
+    return mixxx::android::hasFullExternalStorageAccess();
 }
 
 void copyAssetDir(const QString& src, const QString& dst) {

--- a/src/util/androidpermissions.cpp
+++ b/src/util/androidpermissions.cpp
@@ -1,0 +1,121 @@
+#include "util/androidpermissions.h"
+
+#include <QtCore/private/qandroidextras_p.h>
+#include <android/api-level.h>
+
+#include <QCoreApplication>
+#include <QDir>
+#include <QJniObject>
+#include <QStandardPaths>
+
+#include "util/assert.h"
+
+namespace {
+
+bool requestPermission(const QString& permission) {
+    if (QtAndroidPrivate::checkPermission(permission).result() ==
+            QtAndroidPrivate::Authorized) {
+        return true;
+    }
+    // Qt runs main() on a dedicated thread, not on the Android UI thread, so
+    // waiting for the dialog result here does not block the dialog itself.
+    const auto result = QtAndroidPrivate::requestPermission(permission).result();
+    if (result != QtAndroidPrivate::Authorized) {
+        qWarning() << "Android permission denied:" << permission;
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+namespace mixxx {
+namespace android {
+
+bool requestMusicLibraryPermissions() {
+    const int apiLevel = android_get_device_api_level();
+    bool granted = false;
+    if (apiLevel >= 33) {
+        granted = requestPermission(
+                QStringLiteral("android.permission.READ_MEDIA_AUDIO"));
+    } else {
+        granted = requestPermission(
+                QStringLiteral("android.permission.READ_EXTERNAL_STORAGE"));
+    }
+    if (apiLevel <= 29) {
+        // Writing to shared storage is only possible with this permission on
+        // legacy storage devices. A denial is not fatal, Mixxx then falls back
+        // to its app-private directory.
+        requestPermission(
+                QStringLiteral("android.permission.WRITE_EXTERNAL_STORAGE"));
+    }
+    return granted;
+}
+
+bool hasFullExternalStorageAccess() {
+    if (android_get_device_api_level() >= 30) {
+        return QJniObject::callStaticMethod<jboolean>(
+                       "android/os/Environment", "isExternalStorageManager") ==
+                JNI_TRUE;
+    }
+    return QtAndroidPrivate::checkPermission(
+                   QStringLiteral("android.permission.WRITE_EXTERNAL_STORAGE"))
+                   .result() == QtAndroidPrivate::Authorized;
+}
+
+void requestFullExternalStorageAccess() {
+    if (android_get_device_api_level() < 30) {
+        requestPermission(
+                QStringLiteral("android.permission.WRITE_EXTERNAL_STORAGE"));
+        return;
+    }
+    if (hasFullExternalStorageAccess()) {
+        return;
+    }
+    qDebug() << "requesting ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION";
+    const QJniObject action = QJniObject::getStaticObjectField(
+            "android/provider/Settings",
+            "ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION",
+            "Ljava/lang/String;");
+    QJniObject intent("android/content/Intent",
+            "(Ljava/lang/String;)V",
+            action.object());
+    const QJniObject jniPath = QJniObject::fromString(
+            QStringLiteral("package:%1").arg(QStringLiteral(ANDROID_PACKAGE_NAME)));
+    const QJniObject jniUri = QJniObject::callStaticObjectMethod(
+            "android/net/Uri",
+            "parse",
+            "(Ljava/lang/String;)Landroid/net/Uri;",
+            jniPath.object<jstring>());
+    intent.callObjectMethod("setData",
+            "(Landroid/net/Uri;)Landroid/content/Intent;",
+            jniUri.object<jobject>());
+    QtAndroidPrivate::startActivity(intent, 0);
+}
+
+QString defaultMusicDirectory() {
+    // QStandardPaths::MusicLocation resolves to the shared music directory
+    // (usually /storage/emulated/0/Music) when the app may access it and to
+    // the app-private one otherwise, so it works on every API level and on
+    // devices that mount the primary volume elsewhere.
+    QString path = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
+    if (path.isEmpty()) {
+        path = QStringLiteral("/storage/emulated/0/Music");
+    }
+    QDir dir(path);
+    if (!dir.exists() && !dir.mkpath(QStringLiteral("."))) {
+        qWarning() << "Could not create music directory" << path
+                   << "- falling back to the app private directory";
+        const QStringList appPaths =
+                QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
+        VERIFY_OR_DEBUG_ASSERT(!appPaths.isEmpty()) {
+            return path;
+        }
+        path = appPaths.first() + QStringLiteral("/Music");
+        QDir().mkpath(path);
+    }
+    return path;
+}
+
+} // namespace android
+} // namespace mixxx

--- a/src/util/androidpermissions.h
+++ b/src/util/androidpermissions.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QString>
+
+namespace mixxx {
+namespace android {
+
+/// Requests the runtime permissions Mixxx needs to read the user's music
+/// collection.
+///
+/// Which permission that is depends on the API level:
+///  * API >= 33 (Android 13): READ_MEDIA_AUDIO
+///  * API <= 32: READ_EXTERNAL_STORAGE
+/// On API <= 29 WRITE_EXTERNAL_STORAGE is requested in addition, so that
+/// Mixxx may write its own files (recordings, exported QML) to shared
+/// storage.
+///
+/// Returns true if the collection may be read afterwards. Blocks until the
+/// user has answered the system dialog. Must not be called from the Android
+/// UI thread (Qt's main thread is a separate thread, so calling this from
+/// Mixxx' main thread is fine).
+bool requestMusicLibraryPermissions();
+
+/// Returns true if the app is allowed to read/write arbitrary paths in shared
+/// storage. This is MANAGE_EXTERNAL_STORAGE ("All files access") on API >= 30
+/// and WRITE_EXTERNAL_STORAGE below that.
+bool hasFullExternalStorageAccess();
+
+/// Opens the system settings page where the user can grant "All files
+/// access". Does nothing if the permission is already granted. This is
+/// asynchronous, the result is only visible after the user returns to Mixxx.
+void requestFullExternalStorageAccess();
+
+/// Returns the directory Mixxx should offer as the default music directory,
+/// creating it if necessary. Falls back to the app-private music directory if
+/// shared storage is not accessible.
+QString defaultMusicDirectory();
+
+} // namespace android
+} // namespace mixxx

--- a/src/util/screensaver.cpp
+++ b/src/util/screensaver.cpp
@@ -27,8 +27,9 @@ https://github.com/awjackson/bsnes-classic/blob/038e2e051ffc8abe7c56a3bf27e3016c
 #elif defined(Q_OS_IOS)
 #include "util/screensaverios.h"
 #elif defined(Q_OS_ANDROID)
-#include <android/api-level.h>
-#include <android/log.h>
+#include <QCoreApplication>
+#include <QJniObject>
+#include <QVariant>
 #define HAS_XWINDOW_SCREENSAVER 0
 #elif defined(_WIN32)
 #  include <windows.h>
@@ -353,49 +354,49 @@ void ScreenSaverHelper::uninhibitInternal() {
 }
 #elif defined(Q_OS_ANDROID)
 
-QJniObject ScreenSaverHelper::s_wakeLock = {};
+namespace {
+
+// FLAG_KEEP_SCREEN_ON is the supported way to keep the display awake; the
+// PowerManager screen wake locks are deprecated since API 17 and are ignored
+// on current Android versions. Window flags must be changed on the Android UI
+// thread, which is not the thread Qt runs main() on.
+void setKeepScreenOn(bool keepOn) {
+    QNativeInterface::QAndroidApplication::runOnAndroidMainThread(
+            [keepOn]() -> QVariant {
+                QJniObject activity =
+                        QNativeInterface::QAndroidApplication::context();
+                if (!activity.isValid()) {
+                    qWarning() << "ScreenSaverHelper: no activity";
+                    return {};
+                }
+                QJniObject window = activity.callObjectMethod(
+                        "getWindow", "()Landroid/view/Window;");
+                if (!window.isValid()) {
+                    qWarning() << "ScreenSaverHelper: no window";
+                    return {};
+                }
+                const jint kFlagKeepScreenOn = QJniObject::getStaticField<jint>(
+                        "android/view/WindowManager$LayoutParams",
+                        "FLAG_KEEP_SCREEN_ON");
+                if (keepOn) {
+                    window.callMethod<void>("addFlags", "(I)V", kFlagKeepScreenOn);
+                } else {
+                    window.callMethod<void>("clearFlags", "(I)V", kFlagKeepScreenOn);
+                }
+                return {};
+            });
+}
+
+} // anonymous namespace
+
 // Screensavers are not supported
 void ScreenSaverHelper::triggerUserActivity() {
 }
 void ScreenSaverHelper::inhibitInternal() {
-    if (!ScreenSaverHelper::s_wakeLock.isValid()) {
-        QJniObject context = QNativeInterface::QAndroidApplication::context();
-        QJniObject POWER_SERVICE =
-                QJniObject::getStaticObjectField(
-                        "android/content/Context",
-                        "POWER_SERVICE",
-                        "Ljava/lang/String;");
-        auto powerService = context.callObjectMethod("getSystemService",
-                "(Ljava/lang/String;)Ljava/lang/Object;",
-                POWER_SERVICE.object());
-        if (!powerService.isValid()) {
-            qDebug() << "powerService invalid";
-            return;
-        }
-
-        jint FULL_WAKE_LOCK =
-                QJniObject::getStaticField<jint>(
-                        "android/os/PowerManager",
-                        "FULL_WAKE_LOCK");
-        ScreenSaverHelper::s_wakeLock =
-                powerService.callObjectMethod("newWakeLock",
-                        "(ILjava/lang/String;)Landroid/os/PowerManager$WakeLock;",
-                        FULL_WAKE_LOCK,
-                        QJniObject::fromString("Mixxx").object<jstring>());
-        if (!ScreenSaverHelper::s_wakeLock.isValid()) {
-            __android_log_print(ANDROID_LOG_WARN, "mixxx", "powerService wakeLock invalid");
-            qWarning() << "ScreenSaverHelper::inhibitInternal - wakeLock invalid";
-            return;
-        }
-    }
-    ScreenSaverHelper::s_wakeLock.callMethod<void>("acquire");
+    setKeepScreenOn(true);
 }
 void ScreenSaverHelper::uninhibitInternal() {
-    // QNativeInterface::QAndroidApplication::runOnAndroidMainThread([]() {
-    if (ScreenSaverHelper::s_wakeLock.isValid()) {
-        ScreenSaverHelper::s_wakeLock.callMethod<void>("release");
-    }
-    // }).waitForFinished();
+    setKeepScreenOn(false);
 }
 #else
 void ScreenSaverHelper::triggerUserActivity()

--- a/src/util/screensaver.h
+++ b/src/util/screensaver.h
@@ -29,8 +29,6 @@ private:
    /* sleep management */
    static IOPMAssertionID s_systemSleepAssertionID;
    static IOPMAssertionID s_userActivityAssertionID;
-#elif defined(Q_OS_ANDROID)
-   static QJniObject s_wakeLock;
 #elif defined(Q_OS_LINUX)
     static uint32_t s_cookie;
     static int s_saverindex;

--- a/tools/android_buildenv.sh
+++ b/tools/android_buildenv.sh
@@ -29,6 +29,20 @@ fi
 
 HOST_ARCH=$(uname -m)  # One of x86_64, arm64, i386, ppc or ppc64
 
+# Target ABI of the device Mixxx is built for. arm64-v8a covers phones, ARM
+# tablets and ARM Chromebooks. Other ABIs (notably x86_64 for Intel
+# Chromebooks and the emulator) require a matching vcpkg dependency tree,
+# which is not published as a prebuilt archive yet.
+[ -z "$ANDROID_ABI" ] && ANDROID_ABI="arm64-v8a"
+if [ "$ANDROID_ABI" != "arm64-v8a" ]; then
+    echo "ERROR: No prebuilt dependencies are published for ANDROID_ABI=${ANDROID_ABI}."
+    echo "Only arm64-v8a is available as a download. To target another ABI,"
+    echo "build the vcpkg environment yourself as described in:"
+    echo "https://github.com/mixxxdj/mixxx/wiki/Compiling-dependencies-for-android"
+    echo "and then configure with -DANDROID_ABI=${ANDROID_ABI}."
+    exit 1
+fi
+
 if [ "$HOST_ARCH" == "x86_64" ]; then
     if [ -n "${BUILDENV_RELEASE}" ]; then
         VCPKG_TARGET_TRIPLET="arm64-android-rel"
@@ -107,6 +121,7 @@ case "$1" in
         export BUILDENV_SHA256
         export MIXXX_VCPKG_ROOT="${BUILDENV_PATH}"
         export VCPKG_TARGET_TRIPLET="${VCPKG_TARGET_TRIPLET}"
+        export ANDROID_ABI="${ANDROID_ABI}"
 
         echo_exported_variables() {
             echo "ANDROID_SDK=${ANDROID_SDK}"
@@ -118,6 +133,7 @@ case "$1" in
             echo "BUILDENV_SHA256=${BUILDENV_SHA256}"
             echo "MIXXX_VCPKG_ROOT=${MIXXX_VCPKG_ROOT}"
             echo "VCPKG_TARGET_TRIPLET=${VCPKG_TARGET_TRIPLET}"
+            echo "ANDROID_ABI=${ANDROID_ABI}"
         }
 
         if [ -n "${GITHUB_ENV}" ]; then
@@ -127,7 +143,7 @@ case "$1" in
             echo "Exported environment variables:"
             echo_exported_variables
             echo "You can now configure cmake from the command line in an EMPTY build directory via:"
-            echo "cmake -DCMAKE_TOOLCHAIN_FILE=${MIXXX_VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_SYSTEM_NAME=Android ${MIXXX_ROOT}"
+            echo "cmake -DCMAKE_TOOLCHAIN_FILE=${MIXXX_VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake -DCMAKE_SYSTEM_NAME=Android -DANDROID_ABI=${ANDROID_ABI} ${MIXXX_ROOT}"
         fi
         ;;
     *)


### PR DESCRIPTION
Installability and build
* Declare android.hardware.usb.host as not required. Tablets, Chromebooks and emulators without a USB host port were excluded from installing Mixxx entirely; only wired MIDI/HID controllers are unavailable there. Same for touchscreen (Chromebooks may be mouse/keyboard only) and the low latency audio features.
* Support xlargeScreens and android:resizeableActivity so the app can be windowed on ChromeOS.
* Make ANDROID_ABI a cache variable and derive the toolchain triple and the clang runtime path from it, instead of hardcoding aarch64 and clang major version 18. Only arm64-v8a has prebuilt dependencies, but other ABIs can now be configured without patching the build files.
* Drop the stale -std=c++11 from CMAKE_CXX_FLAGS; the project builds as C++20.
* Launch with --new-ui instead of the deprecated --qml, and without --developer and debug logging.

Collection access
* Request READ_MEDIA_AUDIO (Android 13+) resp. READ_EXTERNAL_STORAGE at every start. Without them the library scan silently finds nothing; before, only the optional MANAGE_EXTERNAL_STORAGE was ever requested.
* Derive the default music directory from QStandardPaths instead of hardcoding /storage/emulated/0/Music, and fall back to the app private directory when shared storage is unavailable.
* Fix canWriteToExternalStorage(), which assumed WRITE_EXTERNAL_STORAGE is granted at install time below API 30. It is a runtime permission since API 23.

Keeping the screen on
* Replace the deprecated PowerManager FULL_WAKE_LOCK, which current Android versions ignore, with the window flag FLAG_KEEP_SCREEN_ON set on the Android UI thread. This also fixes the unbalanced acquire()/release() pair that could throw once the lock was under-locked.

Multi-touch
Qt synthesizes mouse events from a single touch point, so a MouseArea can only ever serve one finger at a time. Replace them with pointer handlers where two handed operation matters:
* Waveform scratching and the spinny now use a PointHandler each, so both decks can be scratched simultaneously.
* Pinching the waveform zooms it. The mouse wheel was the only way to change the waveform zoom, which is unreachable on a touchscreen.
* Long pressing a hotcue opens the hotcue popup, the touch equivalent of the right click that was previously required.
* The shared button behaviors use TapHandler so that simultaneous presses on several buttons are delivered.

Add packaging/android/README.md documenting the build, the touch gestures, the permission model and the remaining limitations.


Claude-Session: https://claude.ai/code/session_01Wtbkuu89NVBQu1NQKS7LpF