### PR TITLE
Re-enable ogg decoding with libsndfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4832,7 +4832,7 @@ if(RUBBERBAND)
 endif()
 
 # SndFile
-find_package(SndFile REQUIRED)
+find_package(SndFile 1.1.0 REQUIRED)
 target_link_libraries(mixxx-lib PRIVATE SndFile::sndfile)
 target_compile_definitions(mixxx-lib PUBLIC __SNDFILE__)
 if(SndFile_SUPPORTS_SET_COMPRESSION_LEVEL)

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -22,16 +22,18 @@ const QStringList kSupportedFileTypes = {
         QStringLiteral("wav"),
 };
 
-// SoundSourceProxyTest fails for version >= 1.0.30 and OGG files
+// SoundSourceProxyTest fails for version >= 1.0.30 and < 1.1.0 and OGG files
 // https://github.com/libsndfile/libsndfile/issues/643
 const mixxx::SemanticVersion kVersionStringWithBrokenOggDecoding(1, 0, 30);
+const mixxx::SemanticVersion kVersionStringWithBrokenOggDecodingFixed(1, 1, 0);
 
 QStringList getSupportedFileTypesFiltered() {
     auto supportedFileTypes = kSupportedFileTypes;
     QString libsndfileVersion = sf_version_string();
     int separatorIndex = libsndfileVersion.lastIndexOf("-");
     auto semver = mixxx::SemanticVersion(libsndfileVersion.right(separatorIndex));
-    if (semver >= kVersionStringWithBrokenOggDecoding) {
+    if (semver >= kVersionStringWithBrokenOggDecoding &&
+            semver < kVersionStringWithBrokenOggDecodingFixed) {
         kLogger.info()
                 << "Disabling OGG decoding for"
                 << libsndfileVersion;

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -22,37 +22,13 @@ const QStringList kSupportedFileTypes = {
         QStringLiteral("wav"),
 };
 
-// SoundSourceProxyTest fails for version >= 1.0.30 and < 1.1.0 and OGG files
-// https://github.com/libsndfile/libsndfile/issues/643
-const mixxx::SemanticVersion kVersionStringWithBrokenOggDecoding(1, 0, 30);
-const mixxx::SemanticVersion kVersionStringWithBrokenOggDecodingFixed(1, 1, 0);
-
-QStringList getSupportedFileTypesFiltered() {
-    auto supportedFileTypes = kSupportedFileTypes;
-    QString libsndfileVersion = sf_version_string();
-    int separatorIndex = libsndfileVersion.lastIndexOf("-");
-    auto semver = mixxx::SemanticVersion(libsndfileVersion.right(separatorIndex));
-    if (semver >= kVersionStringWithBrokenOggDecoding &&
-            semver < kVersionStringWithBrokenOggDecodingFixed) {
-        kLogger.info()
-                << "Disabling OGG decoding for"
-                << libsndfileVersion;
-        supportedFileTypes.removeAll(QStringLiteral("ogg"));
-    }
-    return supportedFileTypes;
-};
-
 } // anonymous namespace
 
 //static
 const QString SoundSourceProviderSndFile::kDisplayName = QStringLiteral("libsndfile");
 
-SoundSourceProviderSndFile::SoundSourceProviderSndFile()
-        : m_supportedFileTypes(getSupportedFileTypesFiltered()) {
-}
-
 QStringList SoundSourceProviderSndFile::getSupportedFileTypes() const {
-    return m_supportedFileTypes;
+    return kSupportedFileTypes;
 }
 
 SoundSourceProviderPriority SoundSourceProviderSndFile::getPriorityHint(

--- a/src/sources/soundsourcesndfile.h
+++ b/src/sources/soundsourcesndfile.h
@@ -37,8 +37,6 @@ class SoundSourceProviderSndFile : public SoundSourceProvider {
   public:
     static const QString kDisplayName;
 
-    SoundSourceProviderSndFile();
-
     QString getDisplayName() const override {
         return kDisplayName;
     }
@@ -51,9 +49,6 @@ class SoundSourceProviderSndFile : public SoundSourceProvider {
     SoundSourcePointer newSoundSource(const QUrl& url) override {
         return newSoundSourceFromUrl<SoundSourceSndFile>(url);
     }
-
-  private:
-    const QStringList m_supportedFileTypes;
 };
 
 } // namespace mixxx


### PR DESCRIPTION
The bug that was preventing tests from passing was fixed in libsndfile/libsndfile#643 which was released in version 1.1.0 according to the changelog:

https://github.com/libsndfile/libsndfile/blob/master/CHANGELOG.md#fixed-4

Updates #10313

--

I am not sure if it matters that we merge this as it doesn't actually fix the underlying problem I wanted finally sorted on my end (the inability to play Ogg/Opus and Ogg/FLAC files). I ended up fixing this for me by allowing Ogg decoding using ffmpeg instead, but the fix for the broken test in ffmpeg is merged but not in a release version yet, so maybe it makes more sense to wait for that. Or do we just want both to support Ogg and fall back to whatever is installed?