### PR TITLE
waveform: use configured RGB colors in overview renderer

### DIFF
--- a/src/waveform/renderers/waveformoverviewrenderer.cpp
+++ b/src/waveform/renderers/waveformoverviewrenderer.cpp
@@ -126,9 +126,9 @@ void drawWaveformPartRGB(
             max = math_max3(red, green, blue);
             // Draw
             if (max > 0.0) {
-                color.setRgbF(static_cast<float>(low / max),
-                        static_cast<float>(mid / max),
-                        static_cast<float>(high / max));
+                color.setRgbF(static_cast<float>(red / max),
+                        static_cast<float>(green / max),
+                        static_cast<float>(blue / max));
                 pPainter->setPen(color);
                 pPainter->drawLine(x, static_cast<int>(all), x, 0);
             }
@@ -148,9 +148,9 @@ void drawWaveformPartRGB(
             max = math_max3(red, green, blue);
             // Draw
             if (max > 0.0) {
-                color.setRgbF(static_cast<float>(low / max),
-                        static_cast<float>(mid / max),
-                        static_cast<float>(high / max));
+                color.setRgbF(static_cast<float>(red / max),
+                        static_cast<float>(green / max),
+                        static_cast<float>(blue / max));
                 pPainter->setPen(color);
                 pPainter->drawLine(x, static_cast<int>(-all), x, 0);
             }
@@ -168,9 +168,9 @@ void drawWaveformPartRGB(
             max = math_max3(red, green, blue);
 
             if (max > 0.0) {
-                color.setRgbF(static_cast<float>(low / max),
-                        static_cast<float>(mid / max),
-                        static_cast<float>(high / max));
+                color.setRgbF(static_cast<float>(red / max),
+                        static_cast<float>(green / max),
+                        static_cast<float>(blue / max));
                 pPainter->setPen(color);
                 pPainter->drawLine(x, 0, x, static_cast<int>(all));
             }


### PR DESCRIPTION
This pull request description was generated autonomously by an AI Agent (devin, SWE-2 and GLM-5.2).

## Summary

`drawWaveformPartRGB` in `src/waveform/renderers/waveformoverviewrenderer.cpp` computed `red`/`green`/`blue` as the weighted sums of `low`/`mid`/`high` against the configured `SignalRGB*Color` values, then discarded them and set the pen to `low/max, mid/max, high/max`. That implicitly mapped low->red, mid->green, high->blue regardless of the configured colours.

The overview only matched the scrolling RGB renderers when `SignalRGB*Color` were the pure primaries (the code default), so any skin setting non-primary RGB signal colours saw the overview diverge from the zoomed waveform.

This sets the pen to `red/max, green/max, blue/max`, matching the allshader renderer (`src/waveform/renderers/allshader/waveformrendererrgb.cpp`) and the software RGB renderer (`src/waveform/renderers/waveformrendererrgb.cpp`).

Fixes #14813.

#### Test plan

- [ ] Build Mixxx with this change
- [ ] Load a skin that sets non-primary `SignalRGB*Color` values (e.g. deere-redo) and confirm the overview matches the zoomed RGB waveform
- [ ] Load a skin with default `SignalRGB*Color` (e.g. stock Deere) and confirm the overview is unchanged
- [ ] Test with both mono and stereo overview modes

This pull request description was generated autonomously by an AI Agent (devin, SWE-2 and GLM-5.2).