### PR TITLE
fix dangling QmlCoreServices singleton on QmlApplication teardown

### DIFF
--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -389,6 +389,7 @@ QmlApplication::~QmlApplication() {
     QmlDlgPreferencesProxy::s_pInstance.reset();
     m_visualsManager.reset();
     m_pAppEngine.reset();
+    QmlCoreServices::destroy();
     QmlApplicationProxy::registerVinylControlManager(nullptr);
     m_pCoreServices.reset();
 }


### PR DESCRIPTION
[AI-generated text begins — written by SWE-2 High assisting the contributor]

`QmlCoreServices` is a `Singleton` created with the `QmlApplication` as
its QObject parent. when the `QmlApplication` is destroyed, the
singleton is deleted as a child QObject but `Singleton<T>::m_instance`
is never cleared. the next `QmlApplication` construction gets that
dangling pointer back from `createInstance()` and crashes inside
`QJSEngine::setObjectOwnership`.

observed via `QmlSkins/QmlStartupSmokeTest.Starts/NewUi`: the second
parameterised run of the QML startup smoke test segfaults
deterministically on a local run (Manjaro, Qt6). upstream CI stays
green because the freed heap happens to remain readable there — the
access is undefined behaviour either way. the same path could also be
hit at runtime if a QML skin reload ever recreates `QmlApplication`.

fix: call `QmlCoreServices::destroy()` in `~QmlApplication`, after the
QML engine teardown, so `m_instance` is reset together with the object.
verified locally — both `QmlSkins` parameters now pass.

[AI-generated text ends]