### PR TITLE
Components: clear focus on the effect unit being switched away from

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -849,8 +849,19 @@
         };
 
         this.setCurrentUnit = function(newNumber) {
+            // Clear the unit being left before this.group is reassigned.
+            // Afterwards there is no reference to it, so its show_focus and
+            // controller_input_active would stay set and every unit the user
+            // cycled through would appear focused at once.
+            const previousGroup = this.group;
+
             this.currentUnitNumber = newNumber;
             this.group = "[EffectRack1_EffectUnit" + newNumber + "]";
+
+            if (previousGroup !== undefined && previousGroup !== this.group) {
+                engine.setValue(previousGroup, "show_focus", 0);
+                engine.setValue(previousGroup, "controller_input_active", 0);
+            }
 
             if (allowFocusWhenParametersHidden) {
                 engine.setValue(this.group, "show_focus", 0);


### PR DESCRIPTION
Fixes #17070.

`EffectUnit.setCurrentUnit()` reassigns `this.group` to the incoming unit on its second line and never refers to the outgoing unit again, so the unit being switched away from keeps its `show_focus` and `controller_input_active` set.

For a mapping that passes several unit numbers, every unit the user cycles through stays lit, so there is no way to tell which unit the knobs are currently driving.

Both branches are affected. With `allowFocusWhenParametersHidden`, the function clears and then re-sets `show_focus` on the same, incoming, group, so the clear is a no-op. Without it, the old `show_parameters` connection is disconnected but the outgoing unit's `show_focus` is never cleared.

This change captures the group before it is reassigned and clears both controls on it. The guard skips the first call, where there is no previous group, and a toggle that lands on the same unit.

Present since b8e0939678 (March 2017), which introduced `setCurrentUnit()` and unit toggling, and unchanged since. It only shows when a mapping passes more than one unit to `EffectUnit` and the user actually toggles between them.

Targeted at `2.5` per CONTRIBUTING, which asks for low risk bug fixes on the stable branch. The code is identical on `main`.

### Testing

Verified on hardware with a mapping passing `[1, 2, 3, 4]`:

- with the stock `midi-components-0.0.js`, cycling leaves the indicator lit on every unit visited
- with this change, the indicator follows the current unit

No other behaviour changed; the rest of `setCurrentUnit()` is untouched.
